### PR TITLE
feat(enterprise): per-tenant SAML SSO + audit (Phase 2) — #1340

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -37,7 +37,7 @@ export function App({ config }: { config: AppConfig }) {
   return (
     <AuthProvider config={config}>
       <Routes>
-        <Route path="/login" element={<LoginPage />} />
+        <Route path="/login" element={<LoginPage config={config} />} />
         <Route path="/callback" element={<CallbackPage config={config} />} />
         <Route path="/" element={guarded(<HomePage />)} />
         <Route path="/problems" element={guarded(<ProblemsPage />)} />

--- a/apps/application-admin-console/src/auth/AuthProvider.tsx
+++ b/apps/application-admin-console/src/auth/AuthProvider.tsx
@@ -1,4 +1,10 @@
-import { beginLogin, beginLogout, loadStoredTokens, type TokenSet } from "@tenkacloud/auth-client";
+import {
+  type BeginLoginOptions,
+  beginLogin,
+  beginLogout,
+  loadStoredTokens,
+  type TokenSet,
+} from "@tenkacloud/auth-client";
 import {
   createContext,
   type ReactNode,
@@ -18,8 +24,10 @@ interface AuthState {
    * Cognito Hosted UI へ redirect する。 Issue #1329: LoginPage が signing-in /
    * error UI 状態を出せるよう Promise を返す (= 旧 fire-and-forget の `void` 戻り値だと
    * PKCE 派生 / redirect URL 構築の失敗を UI に出せなかった)。
+   * Issue #1340 Phase 2: `identityProvider` 未指定なら local Cognito sign-in、 指定すると
+   * `identity_provider=` を付けて SAML IdP に直接飛ばす (= SP-initiated HRD bypass)。
    */
-  login: () => Promise<void>;
+  login: (options?: BeginLoginOptions) => Promise<void>;
   logout: () => void;
   setTokens: (tokens: TokenSet) => void;
 }
@@ -76,7 +84,7 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
     () => ({
       tokens,
       ready,
-      login: () => beginLogin(config),
+      login: (options) => beginLogin(config, options),
       logout,
       setTokens: (t) => setTokensState(t),
     }),

--- a/apps/application-admin-console/src/auth/idp-resolution.ts
+++ b/apps/application-admin-console/src/auth/idp-resolution.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #1340 Phase 2: per-tenant SP-initiated SAML SSO の Home Realm Discovery (HRD) 解決ロジック。
+ *
+ * Phase 1 (admin-console) で実装した HRD pure-function を application-admin-console (= L2 /
+ * Tenant Admin Console) にも移植する。 同一 email ドメインに複数 IdP が並立しうるため、
+ * domain → 単一 IdP の自動振り分けは破綻する。 本モジュールは email から **IdP 候補集合** を
+ * 引き、 候補数で挙動を分ける純粋関数を提供する:
+ *   - 0 件: Cognito local auth (or 拒否) にフォールバック
+ *   - 1 件: その IdP へ自動 redirect
+ *   - 複数: IdP 選択画面を出す (「Entra でログイン / Okta でログイン」)
+ *
+ * 解決した provider は Cognito の `/oauth2/authorize?identity_provider=<provider>` に渡し、
+ * managed login の email-domain lookup を bypass して特定 IdP に飛ばす (AWS 公式の方式)。
+ *
+ * directory (domain → provider[]) の供給元 (= per-tenant runtime-config.json) は本モジュールの
+ * 関心外 — 注入された directory に対する決定だけを行う。 tenant A の Login 画面は自分の
+ * CloudFront に置かれた runtime-config.json しか読まないため、 tenant B の directory を覗くことは
+ * できない (= 物理的 isolation、 ADR-018 と整合)。
+ *
+ * Phase 1 (admin-console) の同名 module と挙動は完全に同一。 両 SPA で実装を共有しない理由は
+ * cross-SPA 依存 (= packages/auth-client) を増やさず、 monorepo の app boundary を明確に
+ * 保つため。 機能 drift を避けるため両側を等しくテストする。
+ */
+
+/** email ドメイン → 接続済み SAML provider 名の配列。 */
+export type IdpDirectory = Record<string, readonly string[]>;
+
+export type IdpResolution =
+  | { readonly kind: "local" }
+  | { readonly kind: "redirect"; readonly provider: string }
+  | { readonly kind: "select"; readonly providers: readonly string[] };
+
+/**
+ * directory 全体に含まれる distinct な provider 名一覧。 Login の出し分けに使う:
+ *   - 0 件 = SSO 未設定 → email を聞かず直接 local サインイン (= 既存挙動互換)
+ *   - 1 件 = 単一 IdP → その IdP へ直接リダイレクト (振り分け不要)
+ *   - 複数 = email で振り分け (HRD) が初めて必要
+ */
+export function distinctProviders(directory: IdpDirectory): string[] {
+  const set = new Set<string>();
+  for (const list of Object.values(directory)) {
+    for (const p of list) {
+      const t = p.trim();
+      if (t) set.add(t);
+    }
+  }
+  return [...set];
+}
+
+/**
+ * email から小文字化したドメイン部を取り出す。 `@` を含まない / ドメインが空なら undefined。
+ */
+export function emailDomain(email: string): string | undefined {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return undefined;
+  const domain = email
+    .slice(at + 1)
+    .trim()
+    .toLowerCase();
+  return domain.length > 0 ? domain : undefined;
+}
+
+/**
+ * email と IdP directory から HRD の決定を返す。
+ * directory のキーは小文字ドメイン前提 (email 側も小文字化して照合)。
+ */
+export function resolveIdp(email: string, directory: IdpDirectory): IdpResolution {
+  const domain = emailDomain(email);
+  if (!domain) return { kind: "local" };
+
+  const raw = directory[domain] ?? [];
+  // 空文字・重複を除いた候補集合
+  const providers = Array.from(new Set(raw.map((p) => p.trim()).filter((p) => p.length > 0)));
+
+  if (providers.length === 0) return { kind: "local" };
+  if (providers.length === 1) return { kind: "redirect", provider: providers[0] as string };
+  return { kind: "select", providers };
+}

--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -35,6 +35,14 @@ export interface AppConfig {
    * 未注入 / undefined は安全側に倒して "pooled" 扱い (= SAML SSO 隠す)。
    */
   readonly isolation?: "pooled" | "silo";
+  /**
+   * Issue #1340 Phase 2: per-tenant SAML HRD directory (= email ドメイン → 接続済み SAML
+   * provider 名)。 Login 画面が email から候補 IdP を解決して `identity_provider=` を組み立てる。
+   * SAML 未設定なら空 object `{}` (= 全 email が Cognito local auth に流れる、 既存挙動互換)。
+   * tenant A の Login 画面は自分の CloudFront に置かれた runtime-config.json しか読まないため、
+   * 物理的に tenant B の directory は見えない (= isolation は infra layer で担保)。
+   */
+  readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
 }
 
 interface RuntimeConfig {
@@ -46,6 +54,7 @@ interface RuntimeConfig {
   readonly participantPortalUrl?: string;
   readonly competitorBootstrapTemplateUrl?: string;
   readonly isolation?: "pooled" | "silo";
+  readonly samlIdpDirectory?: Readonly<Record<string, readonly string[]>>;
 }
 
 // Issue #871 / #1246: runtime-config.json URL validators (isHttpsUrl / isCognitoDomain) are
@@ -90,6 +99,11 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
           ? data.competitorBootstrapTemplateUrl
           : undefined,
       isolation: data.isolation === "silo" ? "silo" : "pooled",
+      // Issue #1340 Phase 2: SAML 未設定 stack も無音で動かすため空 object fallback。
+      samlIdpDirectory:
+        data.samlIdpDirectory && typeof data.samlIdpDirectory === "object"
+          ? data.samlIdpDirectory
+          : {},
     };
   } catch {
     return null;
@@ -117,6 +131,8 @@ export async function loadConfig(
       participantPortalUrl: runtime.participantPortalUrl,
       competitorBootstrapTemplateUrl: runtime.competitorBootstrapTemplateUrl,
       isolation: runtime.isolation ?? "pooled",
+      // Issue #1340 Phase 2: SAML 未設定 stack も無音で動かすため空 object fallback。
+      samlIdpDirectory: runtime.samlIdpDirectory ?? {},
       redirectUri,
       scope,
     };
@@ -134,6 +150,8 @@ export async function loadConfig(
     tenantName: DEV_FALLBACK_TENANT_NAME,
     apiBaseUrl: env.VITE_API_BASE_URL ?? DEV_FALLBACK_API_BASE_URL,
     isolation: env.VITE_ISOLATION === "silo" ? "silo" : "pooled",
+    // Issue #1340 Phase 2: dev では SAML 経路を出さない (= 空 directory で local 一択)。
+    samlIdpDirectory: {},
     redirectUri,
     scope,
   };

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -39,7 +39,10 @@
     "footer_privacy": "Privacy policy",
     "footer_terms": "Terms of use",
     "footer_tokushoho": "Specified Commercial Transactions Act disclosure",
-    "language_switcher_aria": "Language switcher"
+    "language_switcher_aria": "Language switcher",
+    "saml_email_label": "Work email",
+    "saml_pick_idp": "Multiple identity providers are connected for this domain. Pick one to continue.",
+    "saml_back_to_email": "Use a different email"
   },
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — Tenant admin console",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -39,7 +39,10 @@
     "footer_privacy": "プライバシーポリシー",
     "footer_terms": "利用規約",
     "footer_tokushoho": "特定商取引法に基づく表記",
-    "language_switcher_aria": "言語切替 / Language"
+    "language_switcher_aria": "言語切替 / Language",
+    "saml_email_label": "会社のメールアドレス",
+    "saml_pick_idp": "このドメインには複数の ID プロバイダが接続されています。サインインする IdP を選択してください。",
+    "saml_back_to_email": "別のメールアドレスを使用する"
   },
   "home": {
     "header_description": "TenkaCloud Battle / Challenge — テナント管理コンソール",

--- a/apps/application-admin-console/src/pages/EventReport.test.tsx
+++ b/apps/application-admin-console/src/pages/EventReport.test.tsx
@@ -88,6 +88,7 @@ const CONFIG: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "ACME Cloud Academy",
   apiBaseUrl: "https://api.example.com",
+  samlIdpDirectory: {},
 };
 
 function renderPage(detail: EventDetail) {

--- a/apps/application-admin-console/src/pages/Login.tsx
+++ b/apps/application-admin-console/src/pages/Login.tsx
@@ -3,38 +3,64 @@
  * branding を適用し、 「Application Admin Console」 + dev jargon の文言を商用 SaaS
  * のログイン画面へ refresh。
  *
- * Issue #1360: SAML IdP picker を表示する余地が application-admin-console には存在
- * しない (= tenant の Cognito UserPool は SAML を直接持たない / pooled 共有 UserPool)
- * ため、 中間 「サインイン」 button は常に冗長な 1 click でしかなかった。 Mount 直後に
- * `beginLogin()` を発火させて Cognito Hosted UI に直接 redirect する。
+ * Issue #1340 Phase 2 + #1360 統合:
+ *   - SAML 未設定 (samlIdpDirectory が空):
+ *       mount 直後に `beginLogin()` を発火させて Cognito Hosted UI に直接 redirect する
+ *       (#1360)。中間 「サインイン」 button は冗長な 1 click でしかない。
+ *   - SAML 設定済 (= directory に 1 つ以上 provider, #1340 Phase 2):
+ *       a) email 入力フォームを表示
+ *       b) submit 時に `resolveIdp(email, directory)` で候補解決:
+ *          - kind: "local"    → `beginLogin()` で local sign-in (= fallback)
+ *          - kind: "redirect" → `beginLogin({ identityProvider })` で IdP に直接 redirect
+ *          - kind: "select"   → 候補 IdP の button 列を表示 (= 同一 domain 複数 IdP)
  *
  * 表示状態:
- *   1) signing  : Cognito へ redirect 中 spinner (= 初期状態)
- *   2) error    : beginLogin throw 時の fallback alert + mailto link
+ *   1) signing  : Cognito へ redirect 中 spinner (= SAML 未設定時の初期状態)
+ *   2) idle     : title + subtitle + email 入力 (= SAML 設定済時の初期状態)
+ *   3) error    : beginLogin throw 時の fallback alert + mailto link
  *                 (= button を再表示し再 sign-in 試行を許可)
  */
 
-import { useEffect, useRef, useState } from "react";
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import FormField from "@cloudscape-design/components/form-field";
+import Input from "@cloudscape-design/components/input";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { distinctProviders, type IdpResolution, resolveIdp } from "../auth/idp-resolution";
 import { ProductLoginShell } from "../components/ProductLoginShell";
+import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 
-export function LoginPage() {
+export function LoginPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const t = useT();
-  // mount 直後に auto-redirect を 1 回だけ走らせる guard。 React StrictMode の 2 度
+  // mount 直後に auto-redirect を 1 回だけ走らせる guard (#1360)。 React StrictMode の 2 度
   // mount / re-render での重複発火を防ぐ。 error 発生時は user 操作で再試行できるよう
-  // この flag は触らず、 button の onSignIn から再度 `signIn` を呼ぶ経路に倒す。
+  // この flag は触らず、 button の onSignIn から再度 `startLogin` を呼ぶ経路に倒す。
   const autoStartedRef = useRef(false);
-  const [signingIn, setSigningIn] = useState(true);
+  const samlEnabled = useMemo(
+    () => distinctProviders(config.samlIdpDirectory).length > 0,
+    [config.samlIdpDirectory],
+  );
+  // SAML 未設定時は mount 直後に redirect → signing の初期 true で spinner を出す。
+  // SAML 設定済時は email 入力を待つので idle 初期 false。
+  const [signingIn, setSigningIn] = useState(!samlEnabled);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [email, setEmail] = useState("");
+  // SAML 有効時に email 解決後 「複数候補」 で picker を出す状態。
+  const [pickerProviders, setPickerProviders] = useState<readonly string[] | undefined>();
 
-  const signIn = async () => {
+  const startLogin = async (options?: { identityProvider?: string }) => {
     setSigningIn(true);
     setErrorMessage(undefined);
     try {
-      await auth.login();
-      // 成功時は Cognito Hosted UI への redirect で browser が unload されるため到達せず。
+      await auth.login(options);
+      // 成功時は Cognito Hosted UI への redirect が走るため、 ここに到達しない (= browser
+      // が unload される)。 finally の setSigningIn(false) を打つと redirect 直前に
+      // button が一瞬戻ってしまう UX 劣化があるため、 成功 path では state を保持。
     } catch (err) {
       setSigningIn(false);
       setErrorMessage(
@@ -45,25 +71,170 @@ export function LoginPage() {
     }
   };
 
-  // SAML 候補なし → mount 即 Cognito へ。 error からの再試行は button で。 signIn を
-  // 依存に入れると毎 render で hook 再評価されるため空 array に固定し、 重複発火は
-  // autoStartedRef で 1 度に絞り込む (Issue #1360)。
+  // SAML 候補なし → mount 即 Cognito へ (#1360)。 error からの再試行は button で。
+  // signIn を依存に入れると毎 render で hook 再評価されるため空 array に固定し、 重複発火は
+  // autoStartedRef で 1 度に絞り込む。
   // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above (#1360).
   useEffect(() => {
+    if (samlEnabled) return;
     if (autoStartedRef.current) return;
     autoStartedRef.current = true;
-    void signIn();
+    void startLogin();
   }, []);
 
+  // === SAML 未設定: #1360 auto-redirect flow (mount 時に startLogin が走る) ===
+  if (!samlEnabled) {
+    return (
+      <ProductLoginShell
+        title={t("login.title")}
+        subtitle={t("login.subtitle")}
+        signInLabel={t("login.sign_in_button")}
+        signingInLabel={t("login.signing_in")}
+        signingIn={signingIn}
+        errorMessage={errorMessage}
+        onSignIn={() => startLogin()}
+      />
+    );
+  }
+
+  // === SAML 設定済 (#1340 Phase 2) ===
+  // email を入力 → resolveIdp で振り分け。 1 件 redirect / 複数 picker / 0 件 local。
+  const onSubmitEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    const decision: IdpResolution = resolveIdp(trimmed, config.samlIdpDirectory);
+    if (decision.kind === "local") {
+      await startLogin();
+      return;
+    }
+    if (decision.kind === "redirect") {
+      await startLogin({ identityProvider: decision.provider });
+      return;
+    }
+    // kind: "select" — 候補 IdP の button 列を出す。
+    setPickerProviders(decision.providers);
+  };
+
   return (
-    <ProductLoginShell
+    <ProductLoginShellSaml
       title={t("login.title")}
       subtitle={t("login.subtitle")}
-      signInLabel={t("login.sign_in_button")}
-      signingInLabel={t("login.signing_in")}
       signingIn={signingIn}
       errorMessage={errorMessage}
-      onSignIn={signIn}
+      email={email}
+      onEmailChange={setEmail}
+      onSubmitEmail={onSubmitEmail}
+      pickerProviders={pickerProviders}
+      onPick={(provider) => startLogin({ identityProvider: provider })}
+      onCancelPicker={() => setPickerProviders(undefined)}
     />
+  );
+}
+
+/**
+ * SAML 有効時に表示する email→IdP 解決つき login UI。 既存 `ProductLoginShell` は SSO ボタン
+ * 1 個前提なので、 内部で同じ wordmark / footer / branding を流用しつつ form を組む。
+ * shell の重複は将来 refactor で 1 つに統合する (本 PR では追加なし優先)。 Phase 1
+ * (admin-console/src/pages/Login.tsx) の同名 component と branding は揃えてある。
+ */
+function ProductLoginShellSaml(props: {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly signingIn: boolean;
+  readonly errorMessage?: string;
+  readonly email: string;
+  readonly onEmailChange: (value: string) => void;
+  readonly onSubmitEmail: (e: React.FormEvent) => void | Promise<void>;
+  readonly pickerProviders?: readonly string[];
+  readonly onPick: (provider: string) => void;
+  readonly onCancelPicker: () => void;
+}) {
+  const t = useT();
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "radial-gradient(circle at 20% 10%, #eef5ff 0%, #f6f7fb 45%, #ffffff 100%)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px 16px",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 480,
+          background: "#ffffff",
+          padding: 32,
+          borderRadius: 12,
+          boxShadow: "0 4px 24px rgba(0,0,0,0.06)",
+        }}
+      >
+        <SpaceBetween size="l">
+          <div>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 24,
+                fontWeight: 800,
+                letterSpacing: "-0.02em",
+                color: "#07111f",
+              }}
+            >
+              {props.title}
+            </h1>
+            <Box variant="p" margin={{ top: "s" }} color="text-body-secondary">
+              {props.subtitle}
+            </Box>
+          </div>
+          {props.errorMessage ? (
+            <Alert type="error" header={t("login.error_header")}>
+              {props.errorMessage}{" "}
+              <a href="mailto:support@tenkacloud.cloud">support@tenkacloud.cloud</a>
+            </Alert>
+          ) : null}
+          {props.pickerProviders ? (
+            <SpaceBetween size="m">
+              <Box variant="p">{t("login.saml_pick_idp")}</Box>
+              {props.pickerProviders.map((p) => (
+                <Button
+                  key={p}
+                  variant="primary"
+                  fullWidth
+                  loading={props.signingIn}
+                  onClick={() => props.onPick(p)}
+                >
+                  {p}
+                </Button>
+              ))}
+              <Button variant="link" onClick={props.onCancelPicker}>
+                {t("login.saml_back_to_email")}
+              </Button>
+            </SpaceBetween>
+          ) : (
+            <form onSubmit={props.onSubmitEmail}>
+              <SpaceBetween size="m">
+                <FormField label={t("login.saml_email_label")}>
+                  <Input
+                    type="email"
+                    value={props.email}
+                    onChange={(e) => props.onEmailChange(e.detail.value)}
+                    placeholder="you@example.com"
+                    autoComplete="email"
+                    disabled={props.signingIn}
+                  />
+                </FormField>
+                <Button variant="primary" loading={props.signingIn} fullWidth>
+                  {t("login.sign_in_button")}
+                </Button>
+              </SpaceBetween>
+            </form>
+          )}
+        </SpaceBetween>
+      </div>
+    </div>
   );
 }

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -13,6 +13,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Shared Pooled Tenant", // ← intentionally placeholder; runtime should not display this
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 function makeIdToken(claims: Record<string, string>): string {

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -10,6 +10,7 @@ const config: AppConfig = {
   tenantId: "t-1",
   tenantName: "T1",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 describe("createApiClient", () => {

--- a/apps/application-admin-console/test/api/idp-client.test.ts
+++ b/apps/application-admin-console/test/api/idp-client.test.ts
@@ -15,6 +15,7 @@ const baseConfig: AppConfig = {
   tenantName: "Acme",
   apiBaseUrl: "https://tenant.example.com/",
   isolation: "silo",
+  samlIdpDirectory: {},
 };
 
 describe("createTenantIdpClient", () => {

--- a/apps/application-admin-console/test/auth/cognito.test.ts
+++ b/apps/application-admin-console/test/auth/cognito.test.ts
@@ -17,6 +17,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "テスト事業部",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 describe("loadStoredTokens", () => {

--- a/apps/application-admin-console/test/auth/idp-resolution.test.ts
+++ b/apps/application-admin-console/test/auth/idp-resolution.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { distinctProviders, emailDomain, resolveIdp } from "../../src/auth/idp-resolution";
+
+/**
+ * Issue #1340 Phase 2: per-tenant Home Realm Discovery pure-function logic。 Phase 1 (admin-console)
+ * の同名テストを Application Plane に移植して並列に pinning する (= 両 SPA で挙動 drift が起きない
+ * よう同じ仕様を 2 箇所で固定)。
+ */
+describe("emailDomain (#1340)", () => {
+  it("should return the lowercased domain", () => {
+    expect(emailDomain("Alice@Example.COM")).toBe("example.com");
+  });
+
+  it("should return undefined when there is no @", () => {
+    expect(emailDomain("alice")).toBeUndefined();
+  });
+
+  it("should return undefined when domain part is empty", () => {
+    expect(emailDomain("alice@")).toBeUndefined();
+  });
+});
+
+describe("distinctProviders (#1340)", () => {
+  it("should return [] for an empty directory", () => {
+    expect(distinctProviders({})).toEqual([]);
+  });
+
+  it("should dedupe providers across multiple domains", () => {
+    const out = distinctProviders({
+      "a.com": ["corp-entra"],
+      "b.com": ["corp-entra", "corp-okta"],
+    });
+    expect(new Set(out)).toEqual(new Set(["corp-entra", "corp-okta"]));
+  });
+});
+
+describe("resolveIdp (#1340)", () => {
+  it("should resolve `local` when the email has no matching domain", () => {
+    expect(resolveIdp("alice@nope.com", { "example.com": ["corp-entra"] })).toEqual({
+      kind: "local",
+    });
+  });
+
+  it("should auto-redirect when exactly one provider serves the domain", () => {
+    expect(resolveIdp("alice@example.com", { "example.com": ["corp-entra"] })).toEqual({
+      kind: "redirect",
+      provider: "corp-entra",
+    });
+  });
+
+  it("should return select with all candidates when multiple providers serve the domain", () => {
+    expect(
+      resolveIdp("alice@example.com", {
+        "example.com": ["corp-entra", "corp-okta"],
+      }),
+    ).toEqual({
+      kind: "select",
+      providers: ["corp-entra", "corp-okta"],
+    });
+  });
+
+  it("should treat email domain case-insensitively (= directory keys are lowercase)", () => {
+    expect(resolveIdp("Alice@EXAMPLE.com", { "example.com": ["corp-entra"] })).toEqual({
+      kind: "redirect",
+      provider: "corp-entra",
+    });
+  });
+
+  it("should resolve `local` when the resolved candidates after trimming are empty (= defensive)", () => {
+    expect(
+      resolveIdp("alice@example.com", { "example.com": ["", "  "] as unknown as string[] }),
+    ).toEqual({
+      kind: "local",
+    });
+  });
+
+  it("should isolate tenants by reading only the directory it was given (= no cross-tenant leak)", () => {
+    // 注入された directory に対する純粋な決定のみ。 tenant A の Login が tenant B の
+    // directory を見ない isolation は infra layer (= per-tenant runtime-config.json) で
+    // 担保されるが、 本関数も第二引数以外を読まない契約を pin する。
+    const tenantA = { "example.com": ["corp-entra"] } as const;
+    expect(resolveIdp("alice@example.com", tenantA)).toEqual({
+      kind: "redirect",
+      provider: "corp-entra",
+    });
+    // 別 directory を渡すと別の結論になる (= グローバル state 不在を pin)
+    const tenantB = { "example.com": ["partner-okta"] } as const;
+    expect(resolveIdp("alice@example.com", tenantB)).toEqual({
+      kind: "redirect",
+      provider: "partner-okta",
+    });
+  });
+});

--- a/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
+++ b/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
@@ -33,6 +33,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -187,4 +187,58 @@ describe("loadConfig", () => {
       expect(config.scope).toBe("openid email profile");
     });
   });
+
+  // Issue #1340 Phase 2: per-tenant SAML directory が runtime-config から取り出されること。
+  describe("samlIdpDirectory (#1340)", () => {
+    it("should be empty object when runtime-config does not include the field (= legacy stacks)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "https://a.example.com",
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      const config = await loadConfig(env);
+      expect(config.samlIdpDirectory).toEqual({});
+    });
+
+    it("should pass through runtime-config.samlIdpDirectory verbatim", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "https://a.example.com",
+              samlIdpDirectory: {
+                "acme.example": ["tenant-entra"],
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      const config = await loadConfig(env);
+      expect(config.samlIdpDirectory).toEqual({
+        "acme.example": ["tenant-entra"],
+      });
+    });
+
+    it("should default to empty object in dev fallback (= no /runtime-config.json available)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      const config = await loadConfig(env);
+      expect(config.samlIdpDirectory).toEqual({});
+    });
+  });
 });

--- a/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
@@ -39,6 +39,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const JOB_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.no-verified-hint.test.tsx
@@ -34,6 +34,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const { EventCreatePage } = await import("../../src/pages/EventCreate");

--- a/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
@@ -45,6 +45,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const { EventCreatePage, buildVerifiedAccountOption, formatVerifiedAccountSummary } = await import(

--- a/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.end-now-schedule.test.tsx
@@ -37,6 +37,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.ends-at-validation.test.tsx
@@ -37,6 +37,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.force-archive.test.tsx
@@ -37,6 +37,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.operations-tab.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.operations-tab.test.tsx
@@ -43,6 +43,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.retry-failed.test.tsx
@@ -37,6 +37,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.tabs.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.tabs.test.tsx
@@ -47,6 +47,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.wizard.test.tsx
@@ -34,6 +34,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Test Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";

--- a/apps/application-admin-console/test/pages/login.test.tsx
+++ b/apps/application-admin-console/test/pages/login.test.tsx
@@ -11,7 +11,7 @@
  * auto-redirect to Cognito on mount (= no intermediate "Sign in" click).
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const beginLoginMock = vi.fn();
@@ -38,6 +38,7 @@ const config: AppConfig = {
   tenantId: "tenant-test",
   tenantName: "Shared Pooled Tenant",
   apiBaseUrl: "https://api.example.com/prod",
+  samlIdpDirectory: {},
 };
 
 function renderLogin() {
@@ -45,7 +46,7 @@ function renderLogin() {
   return render(
     <I18nProvider>
       <AuthProvider config={config}>
-        <LoginPage />
+        <LoginPage config={config} />
       </AuthProvider>
     </I18nProvider>,
   );
@@ -91,7 +92,7 @@ describe("application-admin-console LoginPage (#1329)", () => {
     expect(mailto).toHaveAttribute("href", "mailto:support@tenkacloud.cloud");
   });
 
-  it("should not re-fire beginLogin on re-render after error", async () => {
+  it("should not re-fire beginLogin on re-render after error (#1360)", async () => {
     beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
     const { rerender } = renderLogin();
     await waitFor(() => {
@@ -100,11 +101,37 @@ describe("application-admin-console LoginPage (#1329)", () => {
     rerender(
       <I18nProvider>
         <AuthProvider config={config}>
-          <LoginPage />
+          <LoginPage config={config} />
         </AuthProvider>
       </I18nProvider>,
     );
     await new Promise((r) => setTimeout(r, 20));
     expect(beginLoginMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Issue #1340 Phase 2: SAML directory が入ると Login が email 入力 → IdP 解決 flow に切り替わる。
+
+  it("should switch to the email-driven SAML flow when samlIdpDirectory has at least one provider (#1340)", async () => {
+    beginLoginMock.mockResolvedValue(undefined);
+    const samlConfig: AppConfig = {
+      ...config,
+      samlIdpDirectory: { "acme.example": ["tenant-entra"] },
+    };
+    localStorage.setItem("tenkacloud.application-admin.locale", "ja");
+    render(
+      <I18nProvider>
+        <AuthProvider config={samlConfig}>
+          <LoginPage config={samlConfig} />
+        </AuthProvider>
+      </I18nProvider>,
+    );
+    // SAML 有効時は email FormField が出る (= 旧 1-step button flow ではない / auto-redirect も走らない)。
+    const emailInput = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(emailInput, { target: { value: "alice@acme.example" } });
+    // Cloudscape Input の onChange shape との互換のため value 反映だけ確認 → submit。
+    fireEvent.submit(emailInput.closest("form")!);
+    await waitFor(() => {
+      expect(beginLoginMock).toHaveBeenCalledWith(samlConfig, { identityProvider: "tenant-entra" });
+    });
   });
 });

--- a/docs/operations/application-plane-saml-setup.html
+++ b/docs/operations/application-plane-saml-setup.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Application Plane SAML SSO setup (Issue #1340 Phase 2)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Application Plane SAML SSO setup (Issue #1340 Phase 2)</h1>
+<p>Tenant Admin 用 application-admin-console (<code>apps/application-admin-console</code>) を、 テナント運営者
+組織の IdP (Entra ID / Okta 等) による SAML SSO でサインインできるようにする手順。 <strong>Phase 1</strong>
+(Control Plane / Issue #1335) と同じ multi-IdP / provider 束縛 allowlist の仕組みを、
+<strong>per-tenant</strong> な Application Plane UserPool に適用する。</p>
+<blockquote>
+<p>本書のドメイン・IdP 名はすべて記入例 (<code>example.com</code> / <code>corp-entra</code> / <code>corp-okta</code>)。 実値に
+置き換えること。</p>
+</blockquote>
+<h2>全体像</h2>
+<ul>
+<li>各テナントの Application Plane Cognito UserPool に、 環境変数 <code>TENANT_SAML_IDPS</code> で宣言した
+IdP 群を SAML provider として attach する。 opt-in で、 未設定なら従来通り Cognito local auth
+と MFA 強制のみ (= Issue #1035 と同じ)。</li>
+<li>どのメールを TenantAdmin として認可するかは <code>TENANT_SAML_ADMIN_ALLOWLIST</code> (provider 束縛
+allowlist) で明示する。 <strong>ここに無い federated ユーザーはサインイン不可</strong> (空 = 全拒否の
+fail-safe)。</li>
+<li>サインイン経路は Phase 1 と同じく <strong>SP-initiated</strong> (application-admin-console の Login 画面で
+email 入力 → IdP 解決) と <strong>IdP-initiated</strong> (Entra MyApps / Okta タイル経由) の 2 通り。</li>
+<li>サインイン成功 / 拒否はテナント別の <code>AdminAuditLogTable</code> partition (<code>TENANT#&lt;tenantId&gt;</code>) に
+<code>auth.sign_in_succeeded</code> / <code>auth.sign_in_denied</code> として記録される (= CloudTrail / EventBridge
+Lambda 経由)。 Tenant Admin (= <code>/audit-log</code> page、 自テナント scope only) で確認できる。</li>
+</ul>
+<h2>Pooled 共有 UserPool では SAML を有効化しない (ADR-018)</h2>
+<p>TenkaCloud の pooled tier (BASIC / STANDARD / PREMIUM) はテナント間で 1 つの Cognito UserPool を
+共有するため、 そこに SAML provider を attach すると <strong>他テナントの sign-in にも副作用を及ぼす</strong>
+(= 1 IdP の障害がすべてのテナントに伝播する、 allowlist が他テナントを巻き込む等)。</p>
+<p>このため Phase 2 は次の 2 経路でだけ SAML attach を許容する。</p>
+<table>
+<thead>
+<tr>
+<th>経路</th>
+<th>UserPool</th>
+<th>SAML attach</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>pooled tier (BASIC / STANDARD / PREMIUM)</td>
+<td>全 pooled tenant 共有</td>
+<td><strong>しない</strong> (ADR-018)</td>
+</tr>
+<tr>
+<td>silo tier (PLATINUM)</td>
+<td>per-tenant 専用</td>
+<td>する</td>
+</tr>
+<tr>
+<td>Lite mode (<code>make deploy</code>)</td>
+<td>単一 tenant = 1 UserPool</td>
+<td>する</td>
+</tr>
+</tbody></table>
+<p>CDK 側は <code>TenantTemplateStack</code> が <code>isPooledDeploy=true</code> のとき env を受け取っても ignore する
+ため、「pooled stack を間違って enterprise IdP に繋いでしまう」構成事故は発生しない (= 物理
+的に attach されない)。 PLATINUM へのアップグレード時に SAML を有効化する想定。</p>
+<h2>L2 (TenantAdmin) と L3 (競技参加者) の分離</h2>
+<p>TenkaCloud の Application Plane には 2 種類の Cognito UserPool / 認証経路がある。</p>
+<table>
+<thead>
+<tr>
+<th>層</th>
+<th>コンソール</th>
+<th>UserPool</th>
+<th>この Phase の対象</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>L2 (TenantAdmin)</strong></td>
+<td>application-admin-console</td>
+<td>per-tenant UserPool (本書)</td>
+<td><strong>Yes</strong></td>
+</tr>
+<tr>
+<td><strong>L3 (競技参加者)</strong></td>
+<td>participant-portal</td>
+<td>短命の per-team login key (UserPool 不使用)</td>
+<td><strong>No</strong></td>
+</tr>
+</tbody></table>
+<p>L3 は per-team login key (= 短命な credential、 個人情報を抱えない設計) で運用される。 これは
+「運営者が participant 個人情報の管理義務を抱えない」ための明確な意思決定で、 enterprise IdP
+連携の対象外。 SAML SSO は L2 (= 運営者) にだけ適用する。</p>
+<h2>手順 1: IdP 側で TenkaCloud Tenant を SP として登録</h2>
+<p>IdP に SAML アプリケーションを 1 つ作成し、 以下を設定する。 <code>&lt;tenant-cognito-domain&gt;</code> と
+<code>&lt;tenant-user-pool-id&gt;</code> はデプロイ時に払い出される (= application-admin-console の
+<code>runtime-config.json</code> の <code>cognitoDomain</code> / <code>TenantTemplateStack</code> の CFn output
+<code>TenantUserpoolId</code> で確認できる)。</p>
+<table>
+<thead>
+<tr>
+<th>項目</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>SP エンティティ ID (Audience)</td>
+<td><code>urn:amazon:cognito:sp:&lt;tenant-user-pool-id&gt;</code></td>
+</tr>
+<tr>
+<td>ACS URL (Reply / Assertion Consumer Service)</td>
+<td><code>https://&lt;tenant-cognito-domain&gt;/saml2/idpresponse</code></td>
+</tr>
+<tr>
+<td>NameID format</td>
+<td><strong>persistent</strong> (immutable subject)</td>
+</tr>
+<tr>
+<td>必須属性マッピング</td>
+<td><code>email</code> → <code>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress</code></td>
+</tr>
+</tbody></table>
+<p>要件は Phase 1 と同じ。</p>
+<ul>
+<li>有効な署名証明書を持つ metadata を発行できること。</li>
+<li>NameID は <strong>persistent</strong> (<code>{provider}_{subject}</code> の subject に使う immutable ID)。</li>
+<li>IdP-initiated を使う場合は IdP 側でタイルを有効化する。</li>
+</ul>
+<p>登録後、 IdP の <strong>federation metadata URL</strong> を控える。</p>
+<h2>手順 2: TenkaCloud 側で IdP を宣言する</h2>
+<p>silo tier テナント (PLATINUM) または Lite mode のデプロイ時に、 環境変数で設定する
+(= <code>infrastructure/environments/&lt;env&gt;/.env</code>)。</p>
+<h3><code>TENANT_SAML_IDPS</code> — attach する IdP 群 (JSON 配列)</h3>
+<pre><code class="language-json">[
+  { &quot;name&quot;: &quot;corp-entra&quot;, &quot;metadataUrl&quot;: &quot;https://login.example/meta&quot;, &quot;emailDomains&quot;: [&quot;example.com&quot;] },
+  { &quot;name&quot;: &quot;corp-okta&quot;,  &quot;metadataUrl&quot;: &quot;https://okta.example/meta&quot;,  &quot;emailDomains&quot;: [&quot;example.com&quot;] }
+]
+</code></pre>
+<ul>
+<li><code>name</code>: Cognito provider 名 (Phase 1 と同じ命名規約)。</li>
+<li><code>metadataUrl</code>: 手順 1 で控えた IdP の metadata URL (https 必須)。</li>
+<li><code>emailDomains</code>: この IdP で認証するメールドメイン (1 件以上)。 同一ドメイン複数 IdP 可。</li>
+</ul>
+<p>未設定 (または空) なら SAML 無効。 pooled tier では値を渡しても <strong>ignore</strong> される (ADR-018)。</p>
+<h3><code>TENANT_SAML_ADMIN_ALLOWLIST</code> — TenantAdmin として認可するメール (provider 束縛)</h3>
+<pre><code class="language-text">corp-entra/alice@example.com,corp-okta/bob@example.com
+</code></pre>
+<p>(JSON 配列形式でも可)</p>
+<ul>
+<li>各エントリは <code>provider/email</code>。「どの IdP 経由で来た、 どのメールを TenantAdmin とみなすか」を
+明示する。</li>
+<li><strong>空 = federated サインイン全拒否</strong> (fail-safe)。 SAML を有効化したのに allowlist 未設定、 という
+事故で「テナント外の federated user が全員 TenantAdmin」になる構成事故を防ぐ。</li>
+</ul>
+<blockquote>
+<p>tenant API の JWT authorizer は token issuer + audience を検証し、 さらに handler 側で
+<code>cognito:groups ⊇ {TenantAdmin}</code> を再検査する (= Phase 1 の 2 段防御と同じ)。 allowlist は
+「federated user に Cognito アカウントを払い出す権利」 を絞る位置付けで、 後段の role gate と
+合わせて全 admin 操作を保護する。</p>
+</blockquote>
+<h2>手順 3: デプロイと動作確認</h2>
+<ol>
+<li>上記 env を設定して silo tier テナント (<code>scripts/provision-tenant.sh</code>) または Lite mode
+(<code>make deploy</code>) を再デプロイする。 Cognito UserPool に SAML provider が attach され、
+per-tenant <code>runtime-config.json</code> に <code>samlIdpDirectory</code> (ドメイン → provider 名配列) が
+配信される。</li>
+<li><strong>SP-initiated</strong>: application-admin-console を開き、 メールを入力する。<ul>
+<li>候補 1 件: その IdP に自動で飛ぶ。</li>
+<li>候補複数 (同一ドメインに Entra + Okta 等): IdP 選択画面が出る。</li>
+<li>候補 0 件: Cognito local auth (= 既存 MFA 経路)。</li>
+</ul>
+</li>
+<li><strong>IdP-initiated</strong>: IdP のタイルから入り、 そのままサインインできること。</li>
+<li>allowlist に無いメールではサインインが拒否されること
+(<code>This federated identity is not authorized to access the admin console.</code>)。</li>
+<li>Tenant Admin の <code>/audit-log</code> (= 自テナント scope only) で <code>auth.sign_in_succeeded</code> 行が
+増えていること。 <code>extra.idp</code> に解決した provider 名または <code>COGNITO</code> (local) が入る。</li>
+</ol>
+<h2>失効 (アクセス権の取り消し)</h2>
+<p>Phase 1 と同様、 2 段階の手順。</p>
+<ol>
+<li><code>TENANT_SAML_ADMIN_ALLOWLIST</code> から該当 <code>provider/email</code> を削除して再デプロイ
+(= 以後の新規 federated サインインは拒否される)。</li>
+<li>既存 user は <code>aws cognito-idp admin-delete-user</code> で per-tenant UserPool から削除する
+(= 再 federation 時に Pre sign-up を再経由するため、 新 allowlist が効く)。</li>
+</ol>
+<h2>テナント isolation の保証</h2>
+<ul>
+<li><strong>frontend</strong>: tenant A の application-admin-console は自分の CloudFront に置かれた
+<code>/runtime-config.json</code> しか読まない。 そこには tenant A の <code>samlIdpDirectory</code> だけが
+焼かれており、 tenant B の directory は <strong>物理的に見えない</strong>。</li>
+<li><strong>CDK</strong>: tenant A の <code>TENANT_SAML_IDPS</code> は tenant A の <code>provision-tenant.sh</code> 実行時のみ
+attach される (CodeBuild env に envFromConfig で渡る)。 同一 env で複数 tenant に供給する
+運用は禁止 (= tenant pipeline で env を tenant 別に注入する)。</li>
+<li><strong>audit</strong>: tenant A の sign-in events は <code>TENANT#&lt;tenantA&gt;</code> partition にのみ書かれる
+(= <code>AUDIT_TENANT_ID</code> env で per-tenant Lambda を分離)。 tenant Admin の <code>/audit-log</code> は
+JWT 由来 <code>custom:tenantId</code> で query を絞るため、 tenant B の行は読めない。</li>
+</ul>
+<h2>監査ログとの連携</h2>
+<p>per-tenant sign-in audit 行は ADR-020 Phase D / Issue #1292 の audit UI で読める。 Phase 1 の
+<code>SYSTEM#&lt;env&gt;</code> partition と並列で、 <code>TENANT#&lt;tenantId&gt;</code> partition に同形式の行が増える。</p>
+<ul>
+<li>action: <code>auth.sign_in_succeeded</code> / <code>auth.sign_in_denied</code></li>
+<li>tenantId: 当該テナント ID (= ULID / Lite mode は <code>local</code>)</li>
+<li>actor: Cognito <code>sub</code></li>
+<li>actorUsername: email / federated username</li>
+<li>extra.idp: 解決した provider 名 (= <code>corp-entra</code> 等) または <code>COGNITO</code></li>
+</ul>
+<h2>関連</h2>
+<ul>
+<li><code>infrastructure/lib/tenant-template/saml-identity-providers.ts</code> — SAML attach 本体 (Phase 1 の wrapper)</li>
+<li><code>infrastructure/lib/tenant-template/saml-admin-allowlist.ts</code> — provider 束縛 allowlist</li>
+<li><code>infrastructure/lib/control-plane/sign-in-audit-lambda.ts</code> — CloudTrail / EventBridge Lambda
+(Phase 2 で per-tenant 配線、 <code>AUDIT_TENANT_ID</code> env で partition を切り替え)</li>
+<li><code>apps/application-admin-console/src/auth/idp-resolution.ts</code> — HRD 解決</li>
+<li><code>docs/operations/control-plane-saml-setup.md</code> — Phase 1 (Control Plane 側) 設定手順</li>
+<li><code>docs/architecture/adr-018-pooled-userpool-saml-isolation.html</code> — pooled UserPool に SAML を
+attach しない設計判断</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/application-plane-saml-setup.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/application-plane-saml-setup.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/application-plane-saml-setup.md
+++ b/docs/operations/application-plane-saml-setup.md
@@ -1,0 +1,173 @@
+# Application Plane SAML SSO setup (Issue #1340 Phase 2)
+
+Tenant Admin 用 application-admin-console (`apps/application-admin-console`) を、 テナント運営者
+組織の IdP (Entra ID / Okta 等) による SAML SSO でサインインできるようにする手順。 **Phase 1**
+(Control Plane / Issue #1335) と同じ multi-IdP / provider 束縛 allowlist の仕組みを、
+**per-tenant** な Application Plane UserPool に適用する。
+
+> 本書のドメイン・IdP 名はすべて記入例 (`example.com` / `corp-entra` / `corp-okta`)。 実値に
+> 置き換えること。
+
+## 全体像
+
+- 各テナントの Application Plane Cognito UserPool に、 環境変数 `TENANT_SAML_IDPS` で宣言した
+  IdP 群を SAML provider として attach する。 opt-in で、 未設定なら従来通り Cognito local auth
+  と MFA 強制のみ (= Issue #1035 と同じ)。
+- どのメールを TenantAdmin として認可するかは `TENANT_SAML_ADMIN_ALLOWLIST` (provider 束縛
+  allowlist) で明示する。 **ここに無い federated ユーザーはサインイン不可** (空 = 全拒否の
+  fail-safe)。
+- サインイン経路は Phase 1 と同じく **SP-initiated** (application-admin-console の Login 画面で
+  email 入力 → IdP 解決) と **IdP-initiated** (Entra MyApps / Okta タイル経由) の 2 通り。
+- サインイン成功 / 拒否はテナント別の `AdminAuditLogTable` partition (`TENANT#<tenantId>`) に
+  `auth.sign_in_succeeded` / `auth.sign_in_denied` として記録される (= CloudTrail / EventBridge
+  Lambda 経由)。 Tenant Admin (= `/audit-log` page、 自テナント scope only) で確認できる。
+
+## Pooled 共有 UserPool では SAML を有効化しない (ADR-018)
+
+TenkaCloud の pooled tier (BASIC / STANDARD / PREMIUM) はテナント間で 1 つの Cognito UserPool を
+共有するため、 そこに SAML provider を attach すると **他テナントの sign-in にも副作用を及ぼす**
+(= 1 IdP の障害がすべてのテナントに伝播する、 allowlist が他テナントを巻き込む等)。
+
+このため Phase 2 は次の 2 経路でだけ SAML attach を許容する。
+
+| 経路 | UserPool | SAML attach |
+| --- | --- | --- |
+| pooled tier (BASIC / STANDARD / PREMIUM) | 全 pooled tenant 共有 | **しない** (ADR-018) |
+| silo tier (PLATINUM) | per-tenant 専用 | する |
+| Lite mode (`make deploy`) | 単一 tenant = 1 UserPool | する |
+
+CDK 側は `TenantTemplateStack` が `isPooledDeploy=true` のとき env を受け取っても ignore する
+ため、「pooled stack を間違って enterprise IdP に繋いでしまう」構成事故は発生しない (= 物理
+的に attach されない)。 PLATINUM へのアップグレード時に SAML を有効化する想定。
+
+## L2 (TenantAdmin) と L3 (競技参加者) の分離
+
+TenkaCloud の Application Plane には 2 種類の Cognito UserPool / 認証経路がある。
+
+| 層 | コンソール | UserPool | この Phase の対象 |
+| --- | --- | --- | --- |
+| **L2 (TenantAdmin)** | application-admin-console | per-tenant UserPool (本書) | **Yes** |
+| **L3 (競技参加者)** | participant-portal | 短命の per-team login key (UserPool 不使用) | **No** |
+
+L3 は per-team login key (= 短命な credential、 個人情報を抱えない設計) で運用される。 これは
+「運営者が participant 個人情報の管理義務を抱えない」ための明確な意思決定で、 enterprise IdP
+連携の対象外。 SAML SSO は L2 (= 運営者) にだけ適用する。
+
+## 手順 1: IdP 側で TenkaCloud Tenant を SP として登録
+
+IdP に SAML アプリケーションを 1 つ作成し、 以下を設定する。 `<tenant-cognito-domain>` と
+`<tenant-user-pool-id>` はデプロイ時に払い出される (= application-admin-console の
+`runtime-config.json` の `cognitoDomain` / `TenantTemplateStack` の CFn output
+`TenantUserpoolId` で確認できる)。
+
+| 項目 | 値 |
+| --- | --- |
+| SP エンティティ ID (Audience) | `urn:amazon:cognito:sp:<tenant-user-pool-id>` |
+| ACS URL (Reply / Assertion Consumer Service) | `https://<tenant-cognito-domain>/saml2/idpresponse` |
+| NameID format | **persistent** (immutable subject) |
+| 必須属性マッピング | `email` → `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` |
+
+要件は Phase 1 と同じ。
+
+- 有効な署名証明書を持つ metadata を発行できること。
+- NameID は **persistent** (`{provider}_{subject}` の subject に使う immutable ID)。
+- IdP-initiated を使う場合は IdP 側でタイルを有効化する。
+
+登録後、 IdP の **federation metadata URL** を控える。
+
+## 手順 2: TenkaCloud 側で IdP を宣言する
+
+silo tier テナント (PLATINUM) または Lite mode のデプロイ時に、 環境変数で設定する
+(= `infrastructure/environments/<env>/.env`)。
+
+### `TENANT_SAML_IDPS` — attach する IdP 群 (JSON 配列)
+
+```json
+[
+  { "name": "corp-entra", "metadataUrl": "https://login.example/meta", "emailDomains": ["example.com"] },
+  { "name": "corp-okta",  "metadataUrl": "https://okta.example/meta",  "emailDomains": ["example.com"] }
+]
+```
+
+- `name`: Cognito provider 名 (Phase 1 と同じ命名規約)。
+- `metadataUrl`: 手順 1 で控えた IdP の metadata URL (https 必須)。
+- `emailDomains`: この IdP で認証するメールドメイン (1 件以上)。 同一ドメイン複数 IdP 可。
+
+未設定 (または空) なら SAML 無効。 pooled tier では値を渡しても **ignore** される (ADR-018)。
+
+### `TENANT_SAML_ADMIN_ALLOWLIST` — TenantAdmin として認可するメール (provider 束縛)
+
+```text
+corp-entra/alice@example.com,corp-okta/bob@example.com
+```
+
+(JSON 配列形式でも可)
+
+- 各エントリは `provider/email`。「どの IdP 経由で来た、 どのメールを TenantAdmin とみなすか」を
+  明示する。
+- **空 = federated サインイン全拒否** (fail-safe)。 SAML を有効化したのに allowlist 未設定、 という
+  事故で「テナント外の federated user が全員 TenantAdmin」になる構成事故を防ぐ。
+
+> tenant API の JWT authorizer は token issuer + audience を検証し、 さらに handler 側で
+> `cognito:groups ⊇ {TenantAdmin}` を再検査する (= Phase 1 の 2 段防御と同じ)。 allowlist は
+> 「federated user に Cognito アカウントを払い出す権利」 を絞る位置付けで、 後段の role gate と
+> 合わせて全 admin 操作を保護する。
+
+## 手順 3: デプロイと動作確認
+
+1. 上記 env を設定して silo tier テナント (`scripts/provision-tenant.sh`) または Lite mode
+   (`make deploy`) を再デプロイする。 Cognito UserPool に SAML provider が attach され、
+   per-tenant `runtime-config.json` に `samlIdpDirectory` (ドメイン → provider 名配列) が
+   配信される。
+2. **SP-initiated**: application-admin-console を開き、 メールを入力する。
+   - 候補 1 件: その IdP に自動で飛ぶ。
+   - 候補複数 (同一ドメインに Entra + Okta 等): IdP 選択画面が出る。
+   - 候補 0 件: Cognito local auth (= 既存 MFA 経路)。
+3. **IdP-initiated**: IdP のタイルから入り、 そのままサインインできること。
+4. allowlist に無いメールではサインインが拒否されること
+   (`This federated identity is not authorized to access the admin console.`)。
+5. Tenant Admin の `/audit-log` (= 自テナント scope only) で `auth.sign_in_succeeded` 行が
+   増えていること。 `extra.idp` に解決した provider 名または `COGNITO` (local) が入る。
+
+## 失効 (アクセス権の取り消し)
+
+Phase 1 と同様、 2 段階の手順。
+
+1. `TENANT_SAML_ADMIN_ALLOWLIST` から該当 `provider/email` を削除して再デプロイ
+   (= 以後の新規 federated サインインは拒否される)。
+2. 既存 user は `aws cognito-idp admin-delete-user` で per-tenant UserPool から削除する
+   (= 再 federation 時に Pre sign-up を再経由するため、 新 allowlist が効く)。
+
+## テナント isolation の保証
+
+- **frontend**: tenant A の application-admin-console は自分の CloudFront に置かれた
+  `/runtime-config.json` しか読まない。 そこには tenant A の `samlIdpDirectory` だけが
+  焼かれており、 tenant B の directory は **物理的に見えない**。
+- **CDK**: tenant A の `TENANT_SAML_IDPS` は tenant A の `provision-tenant.sh` 実行時のみ
+  attach される (CodeBuild env に envFromConfig で渡る)。 同一 env で複数 tenant に供給する
+  運用は禁止 (= tenant pipeline で env を tenant 別に注入する)。
+- **audit**: tenant A の sign-in events は `TENANT#<tenantA>` partition にのみ書かれる
+  (= `AUDIT_TENANT_ID` env で per-tenant Lambda を分離)。 tenant Admin の `/audit-log` は
+  JWT 由来 `custom:tenantId` で query を絞るため、 tenant B の行は読めない。
+
+## 監査ログとの連携
+
+per-tenant sign-in audit 行は ADR-020 Phase D / Issue #1292 の audit UI で読める。 Phase 1 の
+`SYSTEM#<env>` partition と並列で、 `TENANT#<tenantId>` partition に同形式の行が増える。
+
+- action: `auth.sign_in_succeeded` / `auth.sign_in_denied`
+- tenantId: 当該テナント ID (= ULID / Lite mode は `local`)
+- actor: Cognito `sub`
+- actorUsername: email / federated username
+- extra.idp: 解決した provider 名 (= `corp-entra` 等) または `COGNITO`
+
+## 関連
+
+- `infrastructure/lib/tenant-template/saml-identity-providers.ts` — SAML attach 本体 (Phase 1 の wrapper)
+- `infrastructure/lib/tenant-template/saml-admin-allowlist.ts` — provider 束縛 allowlist
+- `infrastructure/lib/control-plane/sign-in-audit-lambda.ts` — CloudTrail / EventBridge Lambda
+  (Phase 2 で per-tenant 配線、 `AUDIT_TENANT_ID` env で partition を切り替え)
+- `apps/application-admin-console/src/auth/idp-resolution.ts` — HRD 解決
+- `docs/operations/control-plane-saml-setup.md` — Phase 1 (Control Plane 側) 設定手順
+- `docs/architecture/adr-018-pooled-userpool-saml-isolation.html` — pooled UserPool に SAML を
+  attach しない設計判断

--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -91,6 +91,9 @@ const liteStack = new TenkaCloudLiteStack(app, stackId("tenkacloud-lite"), {
   ...(problemDeployBackend.participantPortalUrl
     ? { participantPortalUrl: problemDeployBackend.participantPortalUrl }
     : {}),
+  // Issue #1340 Phase 2: opt-in per-tenant SAML (= 未設定なら空配列で no-op)。
+  samlIdps: config.tenantSamlIdps,
+  samlAdminAllowlist: config.tenantSamlAdminAllowlist,
 });
 cdk.Aspects.of(liteStack).add(
   new DynamoDbLowCapacity(config.dynamoReadCapacity, config.dynamoWriteCapacity),

--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -70,6 +70,23 @@ export interface AdminConsoleInsightStackProps extends cdk.StackProps {
    * 未指定なら 90 日 default (OSS / self-hosted)。
    */
   readonly auditRetentionDays?: number;
+  /**
+   * Issue #1340 Phase 2: per-tenant sign-in audit を attach する tenant 群。 各エントリは
+   *   - `tenantId` (= `TENANT#<tenantId>` partition)
+   *   - `userPoolId` (= CloudTrail event filter で使う文字列 ID、 cross-stack ref で TenantTemplateStack
+   *     / TenkaCloudLiteStack から渡す)
+   * を持つ。 空 / 未指定なら audit Lambda は作らない (= 後方互換、 Phase 1 のみ動作)。
+   *
+   * 同 stack に集約する理由: `adminAuditLogTable` は ProblemDeployBackendStack 所有で、 cross-stack
+   * ref として AdminConsoleInsightStack に流れている。 tenant 側 stack から adminAuditLogTable を
+   * 直接読みに行くと逆向きの cross-stack ref が増え cyclic 化する。 AdminConsoleInsightStack は
+   * Control Plane (Phase 1 audit Lambda) + Application Plane (Phase 2 audit Lambda) の両方を
+   * 同じ table に書き込ませる **観測ハブ** として位置付ける (= ADR-011 D6 の admin insight 集約)。
+   */
+  readonly tenantSignInAudit?: ReadonlyArray<{
+    readonly tenantId: string;
+    readonly userPoolId: string;
+  }>;
 }
 
 /**
@@ -258,7 +275,25 @@ export class AdminConsoleInsightStack extends cdk.Stack {
         userPoolId: props.cognitoUserPool.userPoolId,
         adminAuditLogTable: props.adminAuditLogTable,
         environmentName: props.environmentName,
+        // Phase 1 は tenantId 未指定 → handler が SYSTEM にフォールバック (= 既存挙動)。
       });
+    }
+
+    // Issue #1340 Phase 2: per-tenant SAML sign-in events も同 audit log table に書く。
+    // `tenantSignInAudit` は 0..N tenant の (tenantId, userPoolId) pair を持ち、 tenant ごとに
+    // CloudTrail Cognito event filter + Lambda + EventBridge Rule を 1 セット立てる。
+    // 各 Lambda には AUDIT_TENANT_ID env を渡し、 `TENANT#<tenantId>` partition に書く。
+    if (props.adminAuditLogTable && props.environmentName && props.tenantSignInAudit) {
+      for (const tenant of props.tenantSignInAudit) {
+        // construct id は tenantId を含めて衝突回避 (= ULID / "pooled" / "local" のいずれも CFn 識別子に使える)。
+        // `.` / 非英数 はサニタイズ済の前提 (= ULID / 既知 reserved tenantId 規約)。
+        new SignInAuditLambda(this, `SignInAudit-${tenant.tenantId}`, {
+          userPoolId: tenant.userPoolId,
+          adminAuditLogTable: props.adminAuditLogTable,
+          environmentName: props.environmentName,
+          auditTenantId: tenant.tenantId,
+        });
+      }
     }
 
     this.apiUrl = httpApi.apiEndpoint;

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -6,6 +6,8 @@ import { parseAdminAllowlist } from "../control-plane/saml-admin-allowlist.js";
 import { parseSamlIdpConfig } from "../control-plane/saml-identity-providers.js";
 import { getEnv } from "../helper-functions.js";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
+import { parseTenantAdminAllowlist } from "../tenant-template/saml-admin-allowlist.js";
+import { parseTenantSamlIdpConfig } from "../tenant-template/saml-identity-providers.js";
 import { loadConfig } from "../utils/config-loader.js";
 import {
   discoverProblemsCatalog,
@@ -87,6 +89,12 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     env.CONTROL_PLANE_SAML_ADMIN_ALLOWLIST,
   );
 
+  // Issue #1340 Phase 2: per-tenant Application Plane SAML opt-in env を parse (= 未設定なら
+  // 空配列、 既存 pooled / silo / Lite mode の CFn 物理差分は 0 件)。 Phase 1 と同じ
+  // parser を `TENANT_SAML_IDPS` / `TENANT_SAML_ADMIN_ALLOWLIST` env で呼び出す。
+  const tenantSamlIdps = parseTenantSamlIdpConfig(env.TENANT_SAML_IDPS);
+  const tenantSamlAdminAllowlist = parseTenantAdminAllowlist(env.TENANT_SAML_ADMIN_ALLOWLIST);
+
   return {
     environment,
     ...naming,
@@ -108,6 +116,8 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     deployConcurrentBuildLimit,
     controlPlaneSamlIdps,
     controlPlaneSamlAdminAllowlist,
+    tenantSamlIdps,
+    tenantSamlAdminAllowlist,
     ...budget,
   };
 }

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -119,6 +119,24 @@ export interface AppConfig {
   readonly controlPlaneSamlAdminAllowlist: readonly string[];
 
   /**
+   * Issue #1340 Phase 2: per-tenant Application Plane SAML IdP 群。 env
+   * `TENANT_SAML_IDPS` (JSON 配列) を parse 済み。 空配列なら SAML 無効。 pooled tier には
+   * attach されない (= ADR-018 で `TenantTemplateStack` が `isPooledDeploy` を見て ignore する)。
+   * silo (PLATINUM) instance / Lite mode (= 1 UserPool) のみ attach 可能。
+   */
+  readonly tenantSamlIdps: ReadonlyArray<{
+    readonly name: string;
+    readonly metadataUrl: string;
+    readonly emailDomains: readonly string[];
+  }>;
+  /**
+   * Issue #1340 Phase 2: per-tenant federated TenantAdmin allowlist (`provider/email`)。 env
+   * `TENANT_SAML_ADMIN_ALLOWLIST` を parse 済み。 `tenantSamlIdps` 設定時のみ意味を持つ。
+   * 空配列 = federated sign-in 全拒否 (fail-safe)。
+   */
+  readonly tenantSamlAdminAllowlist: readonly string[];
+
+  /**
    * Issue #952 epic / cost guardrails: AWS Budgets monthly limit (USD)。 未指定 / 0 なら
    * budget を立てない (= 旧挙動互換)。 development: 50, production: 200 を推奨。
    */

--- a/infrastructure/lib/app-plane-core/app-plane-core.ts
+++ b/infrastructure/lib/app-plane-core/app-plane-core.ts
@@ -6,6 +6,12 @@ import { SamlIdpLambda } from "../problem-deploy/saml-idp-lambda.js";
 import { ApiGateway } from "../tenant-template/api-gateway.js";
 import { ApplicationAdminConsoleHosting } from "../tenant-template/application-admin-console-hosting.js";
 import { IdentityProvider } from "../tenant-template/identity-provider.js";
+import { attachTenantFederatedAdminAllowlist } from "../tenant-template/saml-admin-allowlist.js";
+import {
+  attachTenantSamlIdentityProviders,
+  type IdpDirectory,
+  type SamlIdpConfig,
+} from "../tenant-template/saml-identity-providers.js";
 import { LiteAdminClaimsLambda } from "./lite-admin-claims-lambda.js";
 
 /**
@@ -77,7 +83,22 @@ export interface AppPlaneCoreProps {
    * 既定 `false` にすることで、 既存 SaaS / Full mode の CFn 物理差分を 0 件に保つ。
    */
   readonly liteAdminClaimsInjection?: boolean;
-  // Issue #1066: SAML IdP 機能を廃止 (= MFA 必須化 #1035 で代替)。
+  /**
+   * Issue #1340 Phase 2: per-tenant SAML IdP 群 (= env `TENANT_SAML_IDPS` を parse 済)。
+   * 未指定 / 空配列なら従来 Cognito local auth + MFA 強制のみ (= 既存 SaaS / Full mode の
+   * CFn 物理差分を 0 件に保つ opt-in)。
+   *
+   * pooled UserPool を共有する pooled tier (BASIC / STANDARD / PREMIUM) では SAML attach を
+   * **配線しない**。 caller 側 (= `TenantTemplateStack`) で pooled tier を判定して props を
+   * 渡さない (= ADR-018 `pooled-userpool-saml-isolation` と整合)。 Lite mode (= 単一 tenant、
+   * 1 UserPool) と silo (PLATINUM) tier では tenant 内で完結するため安全に attach できる。
+   */
+  readonly samlIdps?: readonly SamlIdpConfig[];
+  /**
+   * Issue #1340 Phase 2: federated 管理者 allowlist (`provider/email`)。 `samlIdps` 設定時
+   * のみ意味を持つ。 空配列 = federated sign-in 全拒否 (fail-safe)。
+   */
+  readonly samlAdminAllowlist?: readonly string[];
 }
 
 export interface AppPlaneCoreHandles {
@@ -95,6 +116,13 @@ export interface AppPlaneCoreHandles {
    * SaaS mode 経路では undefined のまま (= attach なし)。
    */
   readonly liteAdminClaimsLambda?: LiteAdminClaimsLambda;
+  /**
+   * Issue #1340 Phase 2: SAML HRD directory (= domain → providerName[])。 application-admin-console
+   * の Login が email から候補 IdP を解決して `identity_provider=` を組み立てる public metadata。
+   * SAML 未設定なら `{}` (= 全 email が Cognito local auth に流れる、 旧動作互換)。
+   * `runtime-config.json` の `samlIdpDirectory` field に焼き込まれる。
+   */
+  readonly samlIdpDirectory: IdpDirectory;
 }
 
 /**
@@ -144,6 +172,33 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
       })
     : undefined;
 
+  // Issue #1340 Phase 2: opt-in で per-tenant SAML IdP を UserPool に attach する。
+  //
+  // 1. attach: samlIdps 未指定 / 空なら何もしない (= 既存 CFn 物理差分 0 件)。 設定時は
+  //    UserPool に SAML provider を attach し、 client の SupportedIdentityProviders を
+  //    COGNITO + 各 provider に拡張。 directory は per-tenant runtime-config.json に焼く
+  //    (= tenant 越境はしない、 物理的 isolation)。
+  // 2. federated admin allowlist: SAML が attach された tenant でのみ Pre sign-up Lambda を
+  //    attach する。 空配列でも attach する (= fail-safe、 「テナント外 federated user が
+  //    全員 TenantAdmin」 構成事故を防ぐ)。
+  // 3. pooled tier の判定は caller (= `TenantTemplateStack`) が担う。 builder 自身は同 UserPool
+  //    instance に対して attach するだけで、 pooled / silo の境界を持たない (= ADR-018 相当の
+  //    pooled UserPool 共有 SAML を防ぐ責務は外側にある)。
+  const samlIdps = props.samlIdps ?? [];
+  const samlIdpDirectory = attachTenantSamlIdentityProviders(
+    scope,
+    identityProvider.tenantUserPool,
+    identityProvider.cfnTenantUserPoolClient,
+    samlIdps,
+  );
+  if (samlIdps.length > 0) {
+    attachTenantFederatedAdminAllowlist(
+      scope,
+      identityProvider.tenantUserPool,
+      props.samlAdminAllowlist ?? [],
+    );
+  }
+
   const apiGateway = new ApiGateway(scope, "ApiGateway", {
     tenantId: props.tenantId,
     isPooledDeploy: props.isPooledDeploy,
@@ -186,6 +241,9 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
     // UserPool mutate を伴う機能は他 tenant に副作用を及ぼす。 frontend は isolation を見て
     // pooled では SAML SSO page を隠し、 silo (PLATINUM) でのみ有効にする。
     isolation: props.isPooledDeploy ? "pooled" : "silo",
+    // Issue #1340 Phase 2: HRD directory を runtime-config.json に焼く (= 未認証 Login が読む
+    // public metadata、 非秘匿)。 SAML 未設定なら `{}`。
+    samlIdpDirectory,
   });
 
   return {
@@ -193,6 +251,7 @@ export function buildAppPlaneCore(scope: Stack, props: AppPlaneCoreProps): AppPl
     identityProvider,
     apiGateway,
     applicationAdminConsoleUrl: applicationAdminConsoleHosting.distributionUrl,
+    samlIdpDirectory,
     ...(samlIdpLambda ? { samlIdpLambda } : {}),
     ...(liteAdminClaimsLambda ? { liteAdminClaimsLambda } : {}),
   };

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -163,6 +163,50 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
   );
   cdk.Aspects.of(bootstrapTemplateStack).add(new DestroyPolicySetter());
 
+  const tenantTemplateStack = new TenantTemplateStack(
+    app,
+    stackId(`tenkacloud-tenant-template-${config.tenantId}`, config.environment),
+    {
+      ...config.stackEnv,
+      tenantId: config.tenantId,
+      tenantName: config.tenantName,
+      environment: config.environment,
+      stageName: config.stageName,
+      lambdaReserveConcurrency: config.lambdaReserveConcurrency,
+      lambdaCanaryDeploymentPreference: config.lambdaCanaryDeploymentPreference,
+      isPooledDeploy: config.isPooledDeploy,
+      ApiKeySSMParameterNames: config.apiKeySSMParameterNames,
+      tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
+      commitId: config.commitId,
+      deployApiLambda: problemDeployBackendStack.deployApiLambda,
+      eventApiLambda: problemDeployBackendStack.eventApiLambda,
+      competitorAccountsApiLambda: problemDeployBackendStack.competitorAccountsApiLambda,
+      participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
+      // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 cross-stack ref で
+      // URL を受ける。 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance は廃止。
+      competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
+      // Issue #1340 Phase 2: opt-in per-tenant SAML SSO (= 未設定なら空配列で no-op)。
+      // pooled tier では本 props を受けても TenantTemplateStack が `isPooledDeploy` で
+      // ignore するため、 pooled / silo どちらでも同 env を渡してよい (ADR-018 と整合)。
+      samlIdps: config.tenantSamlIdps,
+      samlAdminAllowlist: config.tenantSamlAdminAllowlist,
+    },
+  );
+  tenantTemplateStack.addDependency(problemDeployBackendStack);
+  tenantTemplateStack.addDependency(bootstrapTemplateStack);
+  cdk.Tags.of(tenantTemplateStack).add("TenantId", config.tenantId);
+  cdk.Tags.of(tenantTemplateStack).add("IsPooledDeploy", String(config.isPooledDeploy));
+  cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());
+
+  // Issue #1340 Phase 2: tenant SAML が有効なときだけ per-tenant SignInAuditLambda を立てる
+  // (= 未設定 / pooled tier 経路では空配列 → AdminConsoleInsightStack は何も attach しない、
+  // 既存 stack の CFn 物理差分 0 件)。 silo / Lite 経路で SAML が attach されたときのみ
+  // tenantUserPoolId を渡し、 `TENANT#<tenantId>` partition に書く Lambda を集約する。
+  const tenantSignInAudit =
+    config.tenantSamlIdps.length > 0 && !config.isPooledDeploy
+      ? [{ tenantId: config.tenantId, userPoolId: tenantTemplateStack.tenantUserPoolId }]
+      : undefined;
+
   const adminConsoleInsightStack = new AdminConsoleInsightStack(
     app,
     stackId("tenkacloud-admin-console-insight", config.environment),
@@ -189,41 +233,14 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       // cross-stack で渡す。 ProblemDeployBackendStack の AuditArchiveBucket がここで bind される。
       auditArchiveBucket: problemDeployBackendStack.auditArchiveBucket,
       auditRetentionDays: 365,
+      // Issue #1340 Phase 2: tenant SAML 有効時のみ per-tenant audit Lambda を集約配線する。
+      ...(tenantSignInAudit ? { tenantSignInAudit } : {}),
     },
   );
   adminConsoleInsightStack.addDependency(controlPlaneStack);
   adminConsoleInsightStack.addDependency(problemDeployBackendStack);
   adminConsoleInsightStack.addDependency(bootstrapTemplateStack);
-
-  const tenantTemplateStack = new TenantTemplateStack(
-    app,
-    stackId(`tenkacloud-tenant-template-${config.tenantId}`, config.environment),
-    {
-      ...config.stackEnv,
-      tenantId: config.tenantId,
-      tenantName: config.tenantName,
-      environment: config.environment,
-      stageName: config.stageName,
-      lambdaReserveConcurrency: config.lambdaReserveConcurrency,
-      lambdaCanaryDeploymentPreference: config.lambdaCanaryDeploymentPreference,
-      isPooledDeploy: config.isPooledDeploy,
-      ApiKeySSMParameterNames: config.apiKeySSMParameterNames,
-      tenantMappingTable: bootstrapTemplateStack.tenantMappingTable,
-      commitId: config.commitId,
-      deployApiLambda: problemDeployBackendStack.deployApiLambda,
-      eventApiLambda: problemDeployBackendStack.eventApiLambda,
-      competitorAccountsApiLambda: problemDeployBackendStack.competitorAccountsApiLambda,
-      participantPortalUrl: problemDeployBackendStack.participantPortalUrl,
-      // Issue #1053: hosting を ProblemDeployBackendStack に移管したため、 cross-stack ref で
-      // URL を受ける。 旧 `CDK_PARAM_COMPETITOR_BOOTSTRAP_TEMPLATE_URL` env-var dance は廃止。
-      competitorBootstrapTemplateUrl: problemDeployBackendStack.competitorBootstrapTemplateUrl,
-    },
-  );
-  tenantTemplateStack.addDependency(problemDeployBackendStack);
-  tenantTemplateStack.addDependency(bootstrapTemplateStack);
-  cdk.Tags.of(tenantTemplateStack).add("TenantId", config.tenantId);
-  cdk.Tags.of(tenantTemplateStack).add("IsPooledDeploy", String(config.isPooledDeploy));
-  cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());
+  adminConsoleInsightStack.addDependency(tenantTemplateStack);
 
   const serverlessSaaSPipeline = new ServerlessSaaSPipeline(
     app,

--- a/infrastructure/lib/control-plane/handlers/sign-in-audit/index.ts
+++ b/infrastructure/lib/control-plane/handlers/sign-in-audit/index.ts
@@ -65,6 +65,23 @@ const SIGN_IN_EVENT_NAMES = new Set([
 const SYSTEM_TENANT = "SYSTEM";
 const COGNITO_LOCAL_IDP = "COGNITO";
 
+/**
+ * Issue #1340 Phase 2: 監査行の partition (tenantId) を env で切り替える。
+ *
+ *   - `AUDIT_TENANT_ID = "SYSTEM"` (Phase 1 既定): `writeAuditEvent` が `SYSTEM#<env>` に書く。
+ *     Control Plane (= SystemAdmin) UserPool 用の Lambda はこの値で配線される。
+ *   - `AUDIT_TENANT_ID = "<tenantId>"` (Phase 2 / Application Plane): per-tenant Lambda に
+ *     CDK 側で tenantId を渡し、 `TENANT#<tenantId>` partition に書く (= 既存 admin-audit
+ *     log の規約と整合、 `audit-log.ts` の writeAuditEvent が SYSTEM 以外なら自動 TENANT#)。
+ *
+ * 未設定なら Phase 1 互換で `SYSTEM` (= Control Plane UserPool 用の Lambda は env を
+ * 明示しなくても旧動作のまま)。
+ */
+function getAuditTenantId(): string {
+  const raw = process.env.AUDIT_TENANT_ID?.trim();
+  return raw && raw.length > 0 ? raw : SYSTEM_TENANT;
+}
+
 export function resolveIdpName(username: string | undefined): string {
   if (!username) return COGNITO_LOCAL_IDP;
   // Cognito federated username 規約: `{providerName}_{subject}`。 local Cognito user は
@@ -131,7 +148,9 @@ export async function handler(
   const occurredAtMs = event.time ? new Date(event.time).getTime() : Date.now();
   try {
     await writeAuditEvent({
-      tenantId: SYSTEM_TENANT,
+      // Issue #1340 Phase 2: tenantId は env 経由 (= Phase 1 Control Plane 配線は未指定で SYSTEM
+      // のまま、 Phase 2 per-tenant 配線では `<tenantId>` を渡して `TENANT#<tenantId>` partition に書く)。
+      tenantId: getAuditTenantId(),
       actor: row.actor,
       ...(row.actorUsername ? { actorUsername: row.actorUsername } : {}),
       action: row.action,

--- a/infrastructure/lib/control-plane/sign-in-audit-lambda.ts
+++ b/infrastructure/lib/control-plane/sign-in-audit-lambda.ts
@@ -13,7 +13,7 @@ import {
 } from "../utils/lambda-runtime.js";
 
 export interface SignInAuditLambdaProps {
-  /** ADR-020 Phase D の admin audit log table (= `PK=SYSTEM#<env>` の sign-in 行を書く)。 */
+  /** ADR-020 Phase D の admin audit log table (= `PK=SYSTEM#<env>` 又は `PK=TENANT#<id>` の sign-in 行を書く)。 */
   readonly adminAuditLogTable: Table;
   /** `SYSTEM#<env>` の env suffix (= writeAuditEvent が `DEPLOY_ENVIRONMENT` を読む)。 */
   readonly environmentName: string;
@@ -24,6 +24,13 @@ export interface SignInAuditLambdaProps {
    * 循環依存を回避)。 文字列 ID で event filter する。
    */
   readonly userPoolId: string;
+  /**
+   * Issue #1340 Phase 2: 監査行 partition の tenantId。 Control Plane (Phase 1) は未指定で
+   * `SYSTEM` 既定にし `SYSTEM#<env>` に書く (= 旧動作互換)。 Application Plane (Phase 2) は
+   * tenantId を渡し、 `TENANT#<tenantId>` に書く (= 既存 admin-audit log の規約と整合)。
+   * 値は AUDIT_TENANT_ID env として Lambda に流す (= handler が tenant 分岐に使う)。
+   */
+  readonly auditTenantId?: string;
 }
 
 /**
@@ -62,6 +69,9 @@ export class SignInAuditLambda extends Construct {
         ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable.tableName,
         DEPLOY_ENVIRONMENT: props.environmentName,
         CONTROL_PLANE_USER_POOL_ID: props.userPoolId,
+        // Issue #1340 Phase 2: tenant 配線時のみ tenantId env を渡す (= 未指定なら handler が
+        // SYSTEM にフォールバック、 Phase 1 Control Plane 動作互換)。
+        ...(props.auditTenantId ? { AUDIT_TENANT_ID: props.auditTenantId } : {}),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -68,6 +68,14 @@ interface RuntimeConfigProps {
    * "silo" は PLATINUM tier の独立 UserPool。 SAML SSO 設定が安全に有効化できる。
    */
   readonly isolation: "pooled" | "silo";
+  /**
+   * Issue #1340 Phase 2: SAML HRD directory (= email ドメイン → 接続済み SAML provider 名)。
+   * application-admin-console の Login 画面が email から候補 IdP を解決して
+   * `identity_provider=` を組み立てる public metadata。 SAML 未設定なら空 object `{}`
+   * (= 全 email が Cognito local auth に流れる、 既存動作互換)。 未認証 Login が読む値なので
+   * 非秘匿で runtime-config.json に書き込んで OK。
+   */
+  readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
 }
 
 /**
@@ -180,13 +188,17 @@ export class ApplicationAdminConsoleHosting extends Construct {
    *   - participantPortalUrl: 競技者向け Portal の CloudFront URL (sparse、未設定なら field 自体を出さない)
    */
   deployRuntimeConfig(props: RuntimeConfigProps): void {
-    const data: Record<string, string> = {
+    const data: Record<string, unknown> = {
       cognitoDomain: props.cognitoDomain,
       userClientId: props.cognitoClientId,
       tenantId: props.tenantId,
       tenantName: props.tenantName,
       apiUrl: props.apiUrl.replace(/\/$/, ""),
       isolation: props.isolation,
+      // Issue #1340 Phase 2: SAML 未設定なら空 object `{}` で焼く (= frontend は loadConfig 側で
+      // 空 fallback 済、 値の有無で動作分岐させる必要は無いが空でも 「key 自体は存在する」 が
+      // 望ましい (= future-proof の defensive defaults))。
+      samlIdpDirectory: props.samlIdpDirectory,
       ...(props.participantPortalUrl ? { participantPortalUrl: props.participantPortalUrl } : {}),
       ...(props.competitorBootstrapTemplateUrl
         ? { competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl }

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -114,6 +114,13 @@ export class IdentityProvider extends Construct {
    */
   public readonly cognitoDomainUrl: string;
   public readonly identityDetails: IdentityDetails;
+  /**
+   * Issue #1340 Phase 2: SAML IdP attach 用に CfnUserPoolClient (L1) を expose する。
+   * `attachTenantSamlIdentityProviders` が SupportedIdentityProviders に追加するため
+   * (= L2 `UserPoolClient` は addPropertyOverride を持たない)。 L2 から `node.defaultChild`
+   * で取り出した escape hatch。 SAML 未設定なら本 ref は使われない (= NO-OP)。
+   */
+  public readonly cfnTenantUserPoolClient: aws_cognito.CfnUserPoolClient;
 
   constructor(scope: Construct, id: string, props: IdentityProviderProps) {
     super(scope, id);
@@ -269,6 +276,11 @@ export class IdentityProvider extends Construct {
         ],
       },
     });
+    // Issue #1340 Phase 2: SAML IdP の SupportedIdentityProviders 上書きで L1 escape hatch を使う。
+    // L2 `UserPoolClient.node.defaultChild` は L1 `CfnUserPoolClient` を返す (CDK 仕様)。
+    this.cfnTenantUserPoolClient = this.tenantUserPoolClient.node
+      .defaultChild as aws_cognito.CfnUserPoolClient;
+
     this.identityDetails = {
       name: "Cognito",
       details: {

--- a/infrastructure/lib/tenant-template/saml-admin-allowlist.ts
+++ b/infrastructure/lib/tenant-template/saml-admin-allowlist.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue #1340 Phase 2: per-tenant Application Plane 用 federated 管理者 allowlist wrapper。
+ *
+ * Phase 1 (`lib/control-plane/saml-admin-allowlist.ts`) と同じ provider 束縛 allowlist の
+ * 仕組みを per-tenant UserPool (= silo / Lite mode の `IdentityProvider.tenantUserPool`) に
+ * attach する thin wrapper。 fail-safe 契約 (= 空 = federated sign-in 全拒否) は Phase 1 と同一。
+ *
+ * tenant-template / Control Plane の分割 (= L2 vs L3 ではなく、 plane 境界):
+ *   - Control Plane: SystemAdmin (= 全 tenant 横断、 plane の operator)
+ *   - Application Plane (本 module): per-tenant の TenantAdmin (= L2、 application-admin-console)
+ *
+ * Participant Portal (= L3 / 競技参加者) は SAML を attach しない。 L3 は per-team login key
+ * (= 短命な credential、 個人情報を抱えない設計) で運用されており、 enterprise IdP 連携の対象では
+ * ない。 SAML SSO は L2 (= tenant 運営者) にだけ適用する (= ProtoShip docs の "L2/L3 separation"
+ * の TenkaCloud 写経)。
+ */
+
+import type { UserPool } from "aws-cdk-lib/aws-cognito";
+import type { Construct } from "constructs";
+import {
+  attachFederatedAdminAllowlist as attachFederatedAdminAllowlistBase,
+  parseAdminAllowlist as parseAdminAllowlistBase,
+} from "../control-plane/saml-admin-allowlist.js";
+
+/**
+ * `TENANT_SAML_ADMIN_ALLOWLIST` env を parse する thin wrapper。 Phase 1 の汎用 parser を
+ * tenant 既定 envVarName で呼び出す。
+ *   - 各エントリは `provider/email` 形式 (例 `corp-entra/admin@example.com`)。
+ *   - 未設定 / 空なら空配列 = **federated sign-in 全拒否** (fail-safe)。
+ *   - 不正な形は fail-loud で throw (silent fallback で誤設定を見逃さない)。
+ */
+export function parseTenantAdminAllowlist(raw: string | undefined): string[] {
+  return parseAdminAllowlistBase(raw, "TENANT_SAML_ADMIN_ALLOWLIST");
+}
+
+/**
+ * Per-tenant UserPool に federated 管理者 allowlist の Pre sign-up trigger を attach する。
+ * SAML が有効な tenant でだけ呼ぶこと (= 未設定 tenant では federation 経路が無いので不要)。
+ * `allowlist` が空でも attach する — 空配列 = federated sign-in 全拒否 (= SAML を誤って
+ * 有効化したのに allowlist 未設定、 という構成事故で 「テナント外の federated user が
+ * 全員 TenantAdmin」 になるのを防ぐ)。
+ */
+export function attachTenantFederatedAdminAllowlist(
+  scope: Construct,
+  userPool: UserPool,
+  allowlist: readonly string[],
+): void {
+  attachFederatedAdminAllowlistBase(scope, userPool, allowlist);
+}

--- a/infrastructure/lib/tenant-template/saml-identity-providers.ts
+++ b/infrastructure/lib/tenant-template/saml-identity-providers.ts
@@ -1,0 +1,55 @@
+/**
+ * Issue #1340 Phase 2: per-tenant Application Plane 用 SAML IdP attach wrapper。
+ *
+ * Phase 1 (Control Plane / #1335) で `lib/control-plane/saml-identity-providers.ts` に
+ * 純関数 `parseSamlIdpConfig` + CDK helper `attachSamlIdentityProviders` を実装済。 ロジック自体は
+ * UserPool 構造体に依存しない (= scope / UserPool / CfnUserPoolClient を引数で受ける) ので
+ * Application Plane でもそのまま再利用できる。 本 module は **import 元の意図** (= tenant-template
+ * が自分の namespace から SAML を引いて attach する) を tenant-template/ 配下から読めるよう
+ * re-export しつつ、 tenant 固有の env 変数名 (`TENANT_SAML_IDPS`) を default に持たせた helper を
+ * 追加する。
+ *
+ * Phase 1 との違い:
+ *   - 既定 envVarName を `TENANT_SAML_IDPS` にする (= ops debuggability)。
+ *   - 適用先 UserPool は per-tenant の `IdentityProvider.tenantUserPool` (= silo / Lite mode)。
+ *   - directory は per-tenant runtime-config.json に焼く (= tenant 越境はしない、 物理的 isolation)。
+ *
+ * Phase 1 の re-export ではなく **薄い wrapper** にしたのは、 将来 tenant 側だけに必要な
+ * carve-out (例: pooled UserPool で SAML を NO-OP、 silo only enforcement 等) が出てきたとき、
+ * Control Plane 側に逆流させないため。
+ */
+
+import type { CfnUserPoolClient, UserPool } from "aws-cdk-lib/aws-cognito";
+import type { Construct } from "constructs";
+import {
+  attachSamlIdentityProviders as attachSamlIdentityProvidersBase,
+  type IdpDirectory,
+  parseSamlIdpConfig as parseSamlIdpConfigBase,
+  type SamlIdpConfig,
+} from "../control-plane/saml-identity-providers.js";
+
+export type { IdpDirectory, SamlIdpConfig } from "../control-plane/saml-identity-providers.js";
+
+/**
+ * `TENANT_SAML_IDPS` (JSON 配列) を parse・validate する。 Phase 1 の汎用 parser を
+ * tenant 既定 envVarName で呼び出すだけの薄い wrapper。 未設定 / 空なら空配列 (= SAML 無効、
+ * 既存 Cognito local auth + MFA 強制のまま)。
+ */
+export function parseTenantSamlIdpConfig(raw: string | undefined): SamlIdpConfig[] {
+  return parseSamlIdpConfigBase(raw, "TENANT_SAML_IDPS");
+}
+
+/**
+ * Per-tenant UserPool に複数 SAML IdP を attach する thin wrapper。 ロジックは Phase 1 と
+ * 同じ (= 自動 HRD `identifiers` を付けず、 SP-initiated で `identity_provider=` を明示)。
+ * 返り値 directory は per-tenant runtime-config.json に焼かれる (= tenant A の Login 画面が
+ * tenant B の directory を見ない、 物理的 isolation)。
+ */
+export function attachTenantSamlIdentityProviders(
+  scope: Construct,
+  userPool: UserPool,
+  cfnUserClient: CfnUserPoolClient,
+  configs: readonly SamlIdpConfig[],
+): IdpDirectory {
+  return attachSamlIdentityProvidersBase(scope, userPool, cfnUserClient, configs);
+}

--- a/infrastructure/lib/tenant-template/tenant-template-stack.ts
+++ b/infrastructure/lib/tenant-template/tenant-template-stack.ts
@@ -10,6 +10,7 @@ import {
 import type { Construct } from "constructs";
 import { buildAppPlaneCore } from "../app-plane-core/index.js";
 import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
+import type { SamlIdpConfig } from "./saml-identity-providers.js";
 
 interface TenantTemplateStackProps extends StackProps {
   stageName: string;
@@ -64,7 +65,21 @@ interface TenantTemplateStackProps extends StackProps {
    * install.sh が tenant-template-pooled を再 deploy するときに埋まる。
    */
   competitorBootstrapTemplateUrl?: string;
-  // Issue #1066: SAML IdP 連携は廃止 (= MFA 必須化 #1035 で代替)。
+  /**
+   * Issue #1340 Phase 2: opt-in で attach する per-tenant SAML IdP 群 (= env `TENANT_SAML_IDPS`
+   * を bin/infrastructure → app-config で parse 済の正規化 list)。 未指定 / 空配列なら従来
+   * Cognito local auth + MFA 強制のみ。 設定時のみ allowlist が動く。
+   *
+   * **ADR-018**: pooled tier (BASIC / STANDARD / PREMIUM) は UserPool を全 pooled tenant が
+   * 共有するため、 SAML attach は他 tenant に副作用を及ぼす。 本 stack は `isPooledDeploy=true`
+   * のとき samlIdps を ignore し、 silo (PLATINUM) instance / Lite mode のみ attach する。
+   */
+  samlIdps?: readonly SamlIdpConfig[];
+  /**
+   * Issue #1340 Phase 2: per-tenant federated 管理者 allowlist (`provider/email`)。
+   * `samlIdps` 設定時のみ意味を持つ。 空配列 = federated sign-in 全拒否 (fail-safe)。
+   */
+  samlAdminAllowlist?: readonly string[];
 }
 
 export class TenantTemplateStack extends Stack {
@@ -81,6 +96,19 @@ export class TenantTemplateStack extends Stack {
    * admin-console は pooled URL のみを runtime-config 経由で表示する。
    */
   public readonly applicationAdminConsoleUrl: string;
+  /**
+   * Issue #1340 Phase 2: tenant UserPool ID (= 文字列、 cross-stack ref で sign-in audit Lambda
+   * の EventBridge rule filter に渡す)。 audit Lambda は CloudTrail Cognito events を default
+   * EventBridge bus 経由で listen するため、 UserPool 構造体への直接 ref は持たない (= cross-stack
+   * の cyclic 依存を回避)。
+   */
+  public readonly tenantUserPoolId: string;
+  /**
+   * Issue #1340 Phase 2: per-tenant SAML HRD directory (domain → providerName[])。 SAML 未設定
+   * なら空 object。 既に `runtime-config.json` に焼かれて Login が読むため stack 外に公開する
+   * 必要は無いが、 cross-stack 配線テスト / audit 用に expose しておく。
+   */
+  public readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
 
   constructor(scope: Construct, id: string, props: TenantTemplateStackProps) {
     super(scope, id, props);
@@ -100,6 +128,14 @@ export class TenantTemplateStack extends Stack {
     // pooled / silo どちらの TenantTemplateStack インスタンスでも同じ構造を立てる。
     //   - pooled: install.sh phase 1 で 1 度だけ立つ共有 console
     //   - silo:   provision-tenant.sh が PLATINUM tier で per-tenant に立てる
+    // Issue #1340 Phase 2: pooled tier (= UserPool 共有) では SAML attach を一切しない
+    // (= ADR-018 と整合)。 silo / per-tenant deploy のときだけ env-driven SAML 設定を渡す。
+    // pooled 経路の CFn 物理差分は本 PR で 0 件 (= props.samlIdps を渡しても force-empty)。
+    const effectiveSamlIdps = props.isPooledDeploy ? [] : (props.samlIdps ?? []);
+    const effectiveSamlAdminAllowlist = props.isPooledDeploy
+      ? []
+      : (props.samlAdminAllowlist ?? []);
+
     const appPlaneCore = buildAppPlaneCore(this, {
       tenantId: props.tenantId,
       tenantName: props.tenantName,
@@ -110,6 +146,8 @@ export class TenantTemplateStack extends Stack {
       competitorAccountsApiLambda: props.competitorAccountsApiLambda,
       participantPortalUrl: props.participantPortalUrl,
       competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+      samlIdps: effectiveSamlIdps,
+      samlAdminAllowlist: effectiveSamlAdminAllowlist,
       apiKeyConfig: {
         ssmParameterNames: props.ApiKeySSMParameterNames,
         ssmLookup: (name) => this.ssmLookup(name),
@@ -122,6 +160,8 @@ export class TenantTemplateStack extends Stack {
     this.tenantApiName = apiGateway.restApi.restApiName;
     this.tenantApiStageName = apiGateway.restApi.deploymentStage.stageName;
     this.applicationAdminConsoleUrl = applicationAdminConsoleHosting.distributionUrl;
+    this.tenantUserPoolId = identityProvider.tenantUserPool.userPoolId;
+    this.samlIdpDirectory = appPlaneCore.samlIdpDirectory;
 
     new AwsCustomResource(this, "CreateTenantMapping", {
       installLatestAwsSdk: true,

--- a/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
+++ b/infrastructure/lib/tenkacloud-lite/tenkacloud-lite-stack.ts
@@ -3,6 +3,7 @@ import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import type { Construct } from "constructs";
 import { buildAppPlaneCore } from "../app-plane-core/index.js";
 import { SamlIdpsTable } from "../problem-deploy/saml-idps-table.js";
+import type { SamlIdpConfig } from "../tenant-template/saml-identity-providers.js";
 
 /**
  * Issue #778 ADR-016 Phase 3: TenkaCloud Lite mode の専用 stack。
@@ -41,7 +42,17 @@ export interface TenkaCloudLiteStackProps extends StackProps {
    * `buildAppPlaneCore` 経由で `ApplicationAdminConsoleHosting` の runtime-config に焼く。
    */
   readonly competitorBootstrapTemplateUrl: string;
-  // Issue #1066: SAML IdP 連携は廃止 (= MFA 必須化 #1035 で代替)。
+  /**
+   * Issue #1340 Phase 2: opt-in per-tenant SAML IdP 群 (= env `TENANT_SAML_IDPS` を parse 済)。
+   * Lite mode は単一 tenant の 1 UserPool 固定なので、 silo / per-tenant deploy と同じ扱いで
+   * attach できる (= pooled 経路は持たない)。 未指定 / 空配列なら従来 Cognito local auth + MFA のみ。
+   */
+  readonly samlIdps?: readonly SamlIdpConfig[];
+  /**
+   * Issue #1340 Phase 2: federated 管理者 allowlist (`provider/email`)。 `samlIdps` 設定時のみ意味を持つ。
+   * 空配列 = federated sign-in 全拒否 (fail-safe)。
+   */
+  readonly samlAdminAllowlist?: readonly string[];
 }
 
 /**
@@ -61,6 +72,17 @@ export class TenkaCloudLiteStack extends Stack {
   public readonly cognitoDomainUrl: string;
   /** tenant API の REST URL。 frontend が deploy / event CRUD に使う。 */
   public readonly tenantApiUrl: string;
+  /**
+   * Issue #1340 Phase 2: tenant UserPool ID (= 文字列、 sign-in audit Lambda の EventBridge
+   * rule filter に渡す cross-stack ref 用)。 Lite mode で SAML attach した tenant UserPool への
+   * sign-in event を別 stack が listen するためのフック。
+   */
+  public readonly tenantUserPoolId: string;
+  /**
+   * Issue #1340 Phase 2: per-tenant SAML HRD directory。 SAML 未設定なら空 object。
+   * 既に runtime-config.json に焼かれているため stack 外公開は cross-stack 配線テスト用。
+   */
+  public readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
 
   constructor(scope: Construct, id: string, props: TenkaCloudLiteStackProps) {
     super(scope, id, props);
@@ -90,6 +112,10 @@ export class TenkaCloudLiteStack extends Stack {
       samlIdpsTable: samlIdps.table,
       participantPortalUrl: props.participantPortalUrl,
       competitorBootstrapTemplateUrl: props.competitorBootstrapTemplateUrl,
+      // Issue #1340 Phase 2: env-driven SAML attach (Lite mode は単一 tenant なので
+      // pooled / silo の判定不要、 そのまま渡す)。 未指定なら no-op。
+      samlIdps: props.samlIdps ?? [],
+      samlAdminAllowlist: props.samlAdminAllowlist ?? [],
       // Issue #1327: Lite mode は 1 tenant 専用 (tenantId="local") なので全 user が
       // 暗黙に TenantAdmin。 Cognito Pre-Token Generation trigger で JWT 発行時に
       // `custom:userRole=TenantAdmin` + `custom:tenantId=local` を注入し、
@@ -110,6 +136,8 @@ export class TenkaCloudLiteStack extends Stack {
     this.applicationAdminConsoleUrl = appPlane.applicationAdminConsoleUrl;
     this.cognitoDomainUrl = appPlane.identityProvider.cognitoDomainUrl;
     this.tenantApiUrl = appPlane.apiGateway.restApi.url;
+    this.tenantUserPoolId = appPlane.identityProvider.tenantUserPool.userPoolId;
+    this.samlIdpDirectory = appPlane.samlIdpDirectory;
 
     new CfnOutput(this, "ApplicationAdminConsoleUrl", {
       value: this.applicationAdminConsoleUrl,

--- a/infrastructure/test/app-config/resolve.test.ts
+++ b/infrastructure/test/app-config/resolve.test.ts
@@ -294,4 +294,54 @@ describe("resolveApiKeyValue", () => {
       }),
     ).toThrow(/MY_KEY が production 環境で未設定/);
   });
+
+  // Issue #1340 Phase 2: per-tenant SAML env を resolveAppConfig が正しく parse して AppConfig に
+  // 載せること。 未設定なら空配列、 不正値は fail-loud。
+  describe("tenant SAML env (#1340)", () => {
+    it("should default tenantSamlIdps / tenantSamlAdminAllowlist to empty when env is unset", () => {
+      const cfg = resolveAppConfig({
+        env: baseEnv(),
+        binDir: BIN_DIR,
+        fs: fsAlwaysMissing,
+        dotenvConfig: noopDotenv,
+        discoverProblems: stubProblems,
+      });
+      expect(cfg.tenantSamlIdps).toEqual([]);
+      expect(cfg.tenantSamlAdminAllowlist).toEqual([]);
+    });
+
+    it("should parse TENANT_SAML_IDPS JSON array and TENANT_SAML_ADMIN_ALLOWLIST comma list", () => {
+      const cfg = resolveAppConfig({
+        env: baseEnv({
+          TENANT_SAML_IDPS: JSON.stringify([
+            {
+              name: "tenant-entra",
+              metadataUrl: "https://meta.example",
+              emailDomains: ["acme.example"],
+            },
+          ]),
+          TENANT_SAML_ADMIN_ALLOWLIST: "tenant-entra/admin@acme.example",
+        }),
+        binDir: BIN_DIR,
+        fs: fsAlwaysMissing,
+        dotenvConfig: noopDotenv,
+        discoverProblems: stubProblems,
+      });
+      expect(cfg.tenantSamlIdps).toHaveLength(1);
+      expect(cfg.tenantSamlIdps[0]?.name).toBe("tenant-entra");
+      expect(cfg.tenantSamlAdminAllowlist).toEqual(["tenant-entra/admin@acme.example"]);
+    });
+
+    it("should fail-loud with the TENANT_SAML_IDPS env name when JSON is invalid (= ops debuggability)", () => {
+      expect(() =>
+        resolveAppConfig({
+          env: baseEnv({ TENANT_SAML_IDPS: "not-json" }),
+          binDir: BIN_DIR,
+          fs: fsAlwaysMissing,
+          dotenvConfig: noopDotenv,
+          discoverProblems: stubProblems,
+        }),
+      ).toThrow(/TENANT_SAML_IDPS/);
+    });
+  });
 });

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -1,8 +1,27 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { buildAppPlaneCore } from "../../lib/app-plane-core";
+
+/**
+ * BucketDeployment(Source.asset(dist)) は synth 時に path 存在を検証する。
+ * CI は make build より前に make test-coverage を走らせるため SPA dist が無く、
+ * `CannotFindAsset` で fail する。 application-admin-console-hosting.test.ts と
+ * 同じ pattern で placeholder dist を mkdir する。
+ */
+const distDir = path.join(__dirname, "..", "..", "..", "apps", "application-admin-console", "dist");
+beforeAll(() => {
+  if (!fs.existsSync(distDir)) {
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(distDir, "index.html"),
+      "<!doctype html><html><body>placeholder</body></html>",
+    );
+  }
+});
 
 /**
  * Issue #778 ADR-016 Phase 1: AppPlaneCore builder の契約 pin。

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -159,4 +159,92 @@ describe("buildAppPlaneCore", () => {
       handles.applicationAdminConsoleHosting.distributionUrl,
     );
   });
+
+  // Issue #1340 Phase 2: SAML attach の挙動 (= 未指定で no-op、 指定時のみ provider + allowlist 配線)。
+
+  it("should NOT create a UserPoolIdentityProvider when samlIdps is omitted (= no CFn physical diff for existing tenants)", () => {
+    const template = synth();
+    template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 0);
+  });
+
+  it("should attach SAML provider + allowlist Pre sign-up Lambda when samlIdps is non-empty (#1340)", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    const handles = buildAppPlaneCore(stack, {
+      tenantId: "tenant-1",
+      tenantName: "Tenant 1",
+      environment: "development",
+      isPooledDeploy: false,
+      deployApiLambda: buildStubLambda(stack, "StubDeploy"),
+      eventApiLambda: buildStubLambda(stack, "StubEvent"),
+      competitorAccountsApiLambda: buildStubLambda(stack, "StubCompetitorAccounts"),
+      samlIdps: [
+        {
+          name: "tenant-entra",
+          metadataUrl: "https://meta.example",
+          emailDomains: ["acme.example"],
+        },
+      ],
+      samlAdminAllowlist: ["tenant-entra/admin@acme.example"],
+      apiKeyConfig: {
+        ssmParameterNames: {
+          basic: { keyId: "b", value: "b" },
+          standard: { keyId: "s", value: "s" },
+          premium: { keyId: "p", value: "p" },
+          platinum: { keyId: "pl", value: "pl" },
+        },
+        ssmLookup: () => "SSM:x",
+      },
+    });
+    expect(handles.samlIdpDirectory).toEqual({ "acme.example": ["tenant-entra"] });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 1);
+    template.hasResourceProperties("AWS::Cognito::UserPoolIdentityProvider", {
+      ProviderName: "tenant-entra",
+      ProviderType: "SAML",
+    });
+    // Pre sign-up trigger (= federated admin allowlist) が UserPool に attach されている
+    template.hasResourceProperties("AWS::Cognito::UserPool", {
+      LambdaConfig: Match.objectLike({ PreSignUp: Match.anyValue() }),
+    });
+  });
+
+  it("should NOT attach the federated allowlist Lambda when samlIdps is empty even if samlAdminAllowlist is provided", () => {
+    // 「allowlist だけ設定して SAML は未設定」 のケース。 SAML 経路が無いので allowlist の意味は無く、
+    // attach すると無駄な Pre sign-up trigger が UserPool に乗ってしまう。 builder は samlIdps が
+    // 空のとき allowlist Lambda を立てない契約 (= app-plane-core.ts の if guard) を pin する。
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "ap-northeast-1" },
+    });
+    buildAppPlaneCore(stack, {
+      tenantId: "tenant-1",
+      tenantName: "Tenant 1",
+      environment: "development",
+      isPooledDeploy: false,
+      deployApiLambda: buildStubLambda(stack, "StubDeploy"),
+      eventApiLambda: buildStubLambda(stack, "StubEvent"),
+      competitorAccountsApiLambda: buildStubLambda(stack, "StubCompetitorAccounts"),
+      samlIdps: [],
+      samlAdminAllowlist: ["tenant-entra/admin@acme.example"],
+      apiKeyConfig: {
+        ssmParameterNames: {
+          basic: { keyId: "b", value: "b" },
+          standard: { keyId: "s", value: "s" },
+          premium: { keyId: "p", value: "p" },
+          platinum: { keyId: "pl", value: "pl" },
+        },
+        ssmLookup: () => "SSM:x",
+      },
+    });
+    const template = Template.fromStack(stack);
+    const userPools = template.findResources("AWS::Cognito::UserPool");
+    const userPool = Object.values(userPools)[0];
+    const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
+      ?.LambdaConfig;
+    expect(lambdaConfig?.PreSignUp).toBeUndefined();
+  });
 });

--- a/infrastructure/test/control-plane/handlers/sign-in-audit.test.ts
+++ b/infrastructure/test/control-plane/handlers/sign-in-audit.test.ts
@@ -151,4 +151,44 @@ describe("control-plane sign-in audit handler (#1335)", () => {
     ).resolves.toBeUndefined();
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  // Issue #1340 Phase 2: per-tenant 配線では AUDIT_TENANT_ID env で partition を切り替える。
+  // Phase 1 (env 未指定) は SYSTEM のまま、 Phase 2 (env=<tenantId>) は writeAuditEvent に
+  // tenantId が伝わって `TENANT#<tenantId>` partition に書かれる動作を pin する。
+
+  it("should fall back to tenantId='SYSTEM' when AUDIT_TENANT_ID env is unset (Phase 1 compat)", async () => {
+    delete process.env.AUDIT_TENANT_ID;
+    const spy = vi.spyOn(auditLog, "writeAuditEvent").mockResolvedValue(true);
+    const { handler } = await importHandler();
+    await handler(
+      buildCloudTrailEvent({
+        eventName: "InitiateAuth",
+        responseElements: {
+          authenticationResult: { IdToken: "..." },
+          user: { Username: "u@example.com" },
+        },
+      }),
+    );
+    expect(spy.mock.calls[0]?.[0]?.tenantId).toBe("SYSTEM");
+  });
+
+  it("should write to tenantId=<value> when AUDIT_TENANT_ID env is set (= per-tenant Phase 2 wiring)", async () => {
+    process.env.AUDIT_TENANT_ID = "tenant-acme-1";
+    try {
+      const spy = vi.spyOn(auditLog, "writeAuditEvent").mockResolvedValue(true);
+      const { handler } = await importHandler();
+      await handler(
+        buildCloudTrailEvent({
+          eventName: "InitiateAuth",
+          responseElements: {
+            authenticationResult: { IdToken: "..." },
+            user: { Username: "alice@acme.example" },
+          },
+        }),
+      );
+      expect(spy.mock.calls[0]?.[0]?.tenantId).toBe("tenant-acme-1");
+    } finally {
+      delete process.env.AUDIT_TENANT_ID;
+    }
+  });
 });

--- a/infrastructure/test/tenant-template/saml-admin-allowlist.test.ts
+++ b/infrastructure/test/tenant-template/saml-admin-allowlist.test.ts
@@ -1,0 +1,61 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { UserPool } from "aws-cdk-lib/aws-cognito";
+import { describe, expect, it } from "vitest";
+import {
+  attachTenantFederatedAdminAllowlist,
+  parseTenantAdminAllowlist,
+} from "../../lib/tenant-template/saml-admin-allowlist";
+
+/**
+ * Issue #1340 Phase 2: per-tenant federated TenantAdmin allowlist wrapper の動作と
+ * tenant 既定 envVarName (`TENANT_SAML_ADMIN_ALLOWLIST`) を pinning する。
+ */
+describe("parseTenantAdminAllowlist (#1340)", () => {
+  it("should return empty array for undefined / empty input (= fail-safe = deny all federated)", () => {
+    expect(parseTenantAdminAllowlist(undefined)).toEqual([]);
+    expect(parseTenantAdminAllowlist("")).toEqual([]);
+  });
+
+  it("should parse comma-separated entries", () => {
+    const out = parseTenantAdminAllowlist("corp-entra/admin@example.com,corp-okta/dev@example.com");
+    expect(out).toEqual(["corp-entra/admin@example.com", "corp-okta/dev@example.com"]);
+  });
+
+  it("should surface the tenant env var name in error messages", () => {
+    expect(() => parseTenantAdminAllowlist("bad")).toThrow(/TENANT_SAML_ADMIN_ALLOWLIST/);
+  });
+
+  it("should reject malformed provider/email", () => {
+    expect(() => parseTenantAdminAllowlist("no-slash")).toThrow(/must be 'provider\/email'/);
+  });
+});
+
+describe("attachTenantFederatedAdminAllowlist (CDK) (#1340)", () => {
+  it("should attach a Pre sign-up Lambda trigger on the per-tenant UserPool with allowlist env", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const userPool = new UserPool(stack, "Pool");
+    attachTenantFederatedAdminAllowlist(stack, userPool, ["corp-entra/admin@example.com"]);
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          ADMIN_ALLOWLIST: "corp-entra/admin@example.com",
+        },
+      },
+    });
+    tpl.hasResourceProperties("AWS::Cognito::UserPool", {
+      LambdaConfig: { PreSignUp: {} },
+    });
+  });
+
+  it("should still attach the trigger when allowlist is empty (= fail-safe deny-all)", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const userPool = new UserPool(stack, "Pool");
+    attachTenantFederatedAdminAllowlist(stack, userPool, []);
+    const tpl = Template.fromStack(stack);
+    tpl.resourceCountIs("AWS::Lambda::Function", 1);
+  });
+});

--- a/infrastructure/test/tenant-template/saml-identity-providers.test.ts
+++ b/infrastructure/test/tenant-template/saml-identity-providers.test.ts
@@ -1,0 +1,88 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { type CfnUserPoolClient, UserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { describe, expect, it } from "vitest";
+import {
+  attachTenantSamlIdentityProviders,
+  parseTenantSamlIdpConfig,
+} from "../../lib/tenant-template/saml-identity-providers";
+
+/**
+ * Issue #1340 Phase 2: per-tenant SAML IdP env parsing + CDK attach。 Phase 1 の汎用 helper を
+ * tenant-template namespace から呼び出す wrapper の動作と env 変数名 (`TENANT_SAML_IDPS`) を
+ * pinning する。
+ */
+describe("parseTenantSamlIdpConfig (#1340)", () => {
+  it("should return empty array for undefined / empty input", () => {
+    expect(parseTenantSamlIdpConfig(undefined)).toEqual([]);
+    expect(parseTenantSamlIdpConfig("")).toEqual([]);
+  });
+
+  it("should parse a valid single-IdP JSON array", () => {
+    const raw = JSON.stringify([
+      {
+        name: "corp-entra",
+        metadataUrl: "https://example/meta.xml",
+        emailDomains: ["example.com"],
+      },
+    ]);
+    const out = parseTenantSamlIdpConfig(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("corp-entra");
+  });
+
+  it("should fail-loud on invalid JSON with the tenant env var name in the message", () => {
+    expect(() => parseTenantSamlIdpConfig("not-json")).toThrow(/TENANT_SAML_IDPS/);
+  });
+
+  it("should reject metadataUrl that is not https", () => {
+    const raw = JSON.stringify([
+      { name: "corp-entra", metadataUrl: "http://insecure/meta", emailDomains: ["example.com"] },
+    ]);
+    expect(() => parseTenantSamlIdpConfig(raw)).toThrow(/metadataUrl must be an https URL/);
+  });
+});
+
+describe("attachTenantSamlIdentityProviders (CDK) (#1340)", () => {
+  function makeStack() {
+    const app = new App();
+    const stack = new Stack(app, "TestStack");
+    const userPool = new UserPool(stack, "Pool");
+    const client = new UserPoolClient(stack, "Client", { userPool });
+    const cfnClient = client.node.defaultChild as CfnUserPoolClient;
+    return { stack, userPool, cfnClient };
+  }
+
+  it("should return an empty directory and create no SAML provider when configs is empty", () => {
+    const { stack, userPool, cfnClient } = makeStack();
+    const directory = attachTenantSamlIdentityProviders(stack, userPool, cfnClient, []);
+    expect(directory).toEqual({});
+    const tpl = Template.fromStack(stack);
+    tpl.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 0);
+  });
+
+  it("should attach 1 IdP to the per-tenant UserPool and produce a domain → [provider] directory", () => {
+    const { stack, userPool, cfnClient } = makeStack();
+    const directory = attachTenantSamlIdentityProviders(stack, userPool, cfnClient, [
+      { name: "tenant-entra", metadataUrl: "https://meta", emailDomains: ["acme.example"] },
+    ]);
+    expect(directory).toEqual({ "acme.example": ["tenant-entra"] });
+    const tpl = Template.fromStack(stack);
+    tpl.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 1);
+    tpl.hasResourceProperties("AWS::Cognito::UserPoolIdentityProvider", {
+      ProviderName: "tenant-entra",
+      ProviderType: "SAML",
+    });
+  });
+
+  it("should keep COGNITO in SupportedIdentityProviders so local auth is preserved (= MFA fallback)", () => {
+    const { stack, userPool, cfnClient } = makeStack();
+    attachTenantSamlIdentityProviders(stack, userPool, cfnClient, [
+      { name: "tenant-entra", metadataUrl: "https://meta", emailDomains: ["acme.example"] },
+    ]);
+    const tpl = Template.fromStack(stack);
+    tpl.hasResourceProperties("AWS::Cognito::UserPoolClient", {
+      SupportedIdentityProviders: ["COGNITO", "tenant-entra"],
+    });
+  });
+});

--- a/infrastructure/test/tenant-template/tenant-template-stack-saml.test.ts
+++ b/infrastructure/test/tenant-template/tenant-template-stack-saml.test.ts
@@ -1,0 +1,117 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { describe, expect, it } from "vitest";
+import { TenantTemplateStack } from "../../lib/tenant-template/tenant-template-stack";
+
+/**
+ * Issue #1340 Phase 2: `TenantTemplateStack` の SAML attach 契約。
+ *
+ * 主目的 (= ADR-018 整合):
+ *   - pooled tier (= 全 pooled tenant が UserPool 共有) では `samlIdps` を props で受けても
+ *     attach しない (= 物理的に他テナントへの副作用を作らない)。
+ *   - silo tier (= per-tenant UserPool) では `samlIdps` を attach し、 directory が表に出る。
+ *
+ * 既存テナント (= samlIdps 未指定) の CFn 物理差分 0 件も併せて pin する。
+ */
+function makeSupportTable(stack: cdk.Stack, id: string): Table {
+  return new Table(stack, id, {
+    partitionKey: { name: "tenantId", type: AttributeType.STRING },
+    billingMode: BillingMode.PROVISIONED,
+    readCapacity: 1,
+    writeCapacity: 1,
+  });
+}
+
+function makeStubLambda(stack: cdk.Stack, id: string): LambdaFunction {
+  return new LambdaFunction(stack, id, {
+    runtime: Runtime.NODEJS_20_X,
+    handler: "index.handler",
+    code: Code.fromInline("exports.handler = async () => ({});"),
+  });
+}
+
+function makeTenantTemplate(args: {
+  readonly isPooledDeploy: boolean;
+  readonly samlIdps?: ReadonlyArray<{
+    readonly name: string;
+    readonly metadataUrl: string;
+    readonly emailDomains: readonly string[];
+  }>;
+  readonly samlAdminAllowlist?: readonly string[];
+}): Template {
+  const app = new cdk.App();
+  const supportStack = new cdk.Stack(app, "Support", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const tenantMappingTable = makeSupportTable(supportStack, "TenantMapping");
+  const deployApiLambda = makeStubLambda(supportStack, "DeployApi");
+  const eventApiLambda = makeStubLambda(supportStack, "EventApi");
+  const competitorAccountsApiLambda = makeStubLambda(supportStack, "CompetitorAccountsApi");
+
+  const stack = new TenantTemplateStack(app, "TenantTemplateUnderTest", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+    tenantId: args.isPooledDeploy ? "pooled" : "tenant-1",
+    tenantName: args.isPooledDeploy ? "Shared Pooled" : "Tenant 1",
+    environment: "development",
+    stageName: "prod",
+    lambdaReserveConcurrency: 1,
+    lambdaCanaryDeploymentPreference: "True",
+    isPooledDeploy: args.isPooledDeploy,
+    ApiKeySSMParameterNames: {
+      basic: { keyId: "b", value: "b" },
+      standard: { keyId: "s", value: "s" },
+      premium: { keyId: "p", value: "p" },
+      platinum: { keyId: "pl", value: "pl" },
+    },
+    tenantMappingTable,
+    commitId: "test",
+    deployApiLambda,
+    eventApiLambda,
+    competitorAccountsApiLambda,
+    ...(args.samlIdps ? { samlIdps: args.samlIdps } : {}),
+    ...(args.samlAdminAllowlist ? { samlAdminAllowlist: args.samlAdminAllowlist } : {}),
+  });
+  return Template.fromStack(stack);
+}
+
+describe("TenantTemplateStack SAML props (#1340)", () => {
+  it("should NOT attach a SAML IdP when samlIdps is omitted (= existing tenants stay byte-for-byte identical)", () => {
+    const template = makeTenantTemplate({ isPooledDeploy: false });
+    template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 0);
+  });
+
+  it("should IGNORE samlIdps on pooled tier even when env provides them (= ADR-018 pooled isolation)", () => {
+    const template = makeTenantTemplate({
+      isPooledDeploy: true,
+      samlIdps: [
+        { name: "corp-entra", metadataUrl: "https://meta", emailDomains: ["example.com"] },
+      ],
+      samlAdminAllowlist: ["corp-entra/admin@example.com"],
+    });
+    // pooled では UserPool が共有なので SAML attach は禁止 → 0 件のままが正解。
+    template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 0);
+    // Pre sign-up Lambda も attach されない (= allowlist Lambda が立たない)
+    const userPools = template.findResources("AWS::Cognito::UserPool");
+    const userPool = Object.values(userPools)[0];
+    const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
+      ?.LambdaConfig;
+    expect(lambdaConfig?.PreSignUp).toBeUndefined();
+  });
+
+  it("should ATTACH samlIdps on silo tier (= per-tenant UserPool)", () => {
+    const template = makeTenantTemplate({
+      isPooledDeploy: false,
+      samlIdps: [
+        { name: "tenant-entra", metadataUrl: "https://meta", emailDomains: ["acme.example"] },
+      ],
+      samlAdminAllowlist: ["tenant-entra/admin@acme.example"],
+    });
+    template.resourceCountIs("AWS::Cognito::UserPoolIdentityProvider", 1);
+    template.hasResourceProperties("AWS::Cognito::UserPoolIdentityProvider", {
+      ProviderName: "tenant-entra",
+      ProviderType: "SAML",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the SAML SSO rollout (Phase 1 = #1342 shipped on Control Plane). Extends the multi-IdP / provider-bound allowlist / sign-in audit pipeline to **per-tenant Application Plane UserPools** so enterprise tenants can wire their own IdP into the Tenant Admin Console (= L2). ProtoShip pattern attribution: per-tenant SAML attach + audit. See `docs/operations/application-plane-saml-setup.md` for the operator-side recipe.

Key design points:

- **L2 (TenantAdmin) only** — SAML SSO applies to `application-admin-console`. **L3 (`participant-portal`) stays on per-team login keys** by design (operators take on no participant PII; enterprise IdP federation is out of scope for L3).
- **ADR-018 pooled isolation** — pooled tier (BASIC / STANDARD / PREMIUM) shares one UserPool, so `TenantTemplateStack` force-empties `samlIdps` when `isPooledDeploy=true`. Zero CFn diff on pooled stacks even if env vars are set. SAML enabled on silo (PLATINUM) + Lite mode only.
- **Tenant isolation** — `samlIdpDirectory` is baked into per-tenant `runtime-config.json`; tenant A's Login physically cannot read tenant B's directory. Per-tenant audit Lambda writes to `TENANT#<tenantId>` partition (via new `AUDIT_TENANT_ID` env on the Phase 1 handler, default fallback = `SYSTEM`).
- **Opt-in via env** — `TENANT_SAML_IDPS` / `TENANT_SAML_ADMIN_ALLOWLIST`. Unset = no behaviour change (= existing pooled / silo / Lite stacks remain byte-for-byte identical at synth).

Closes #1340
Relates #1335
Relates #1336

## Regression analysis

- Existing tenant UserPool unchanged when env is unset (`samlIdps=[]` short-circuits attach + allowlist Lambda; runtime-config carries `samlIdpDirectory: {}` fallback).
- pooled tier UserPool unchanged **regardless of env** (TenantTemplateStack filters `samlIdps` to `[]` before passing to `buildAppPlaneCore`).
- `application-admin-console` `samlIdpDirectory` consumers handle empty object — `loadConfig()` defaults to `{}` for legacy runtime-configs.
- Phase 1 Control Plane audit Lambda still defaults to `tenantId="SYSTEM"` when `AUDIT_TENANT_ID` env is unset (= no behaviour change).
- `AdminConsoleInsightStack` reordered to instantiate after `TenantTemplateStack`; downstream consumers (`observabilityStack`, `adminConsoleRuntimeConfigStack`) keep the same `apiUrl` / `lambdaFunctionName` refs.

## Physical impact

- **CREATE**: `Saml-<name>` `AWS::Cognito::UserPoolIdentityProvider` per tenant IdP (when env enables SAML on silo / Lite).
- **UPDATE**: tenant `UserPoolClient.SupportedIdentityProviders` += `[each provider]` (when SAML enabled).
- **CREATE**: `FederatedAdminAllowlistGuard` `AWS::Lambda::Function` + UserPool `LambdaConfig.PreSignUp` (when SAML enabled).
- **CREATE**: `SignInAudit-<tenantId>/Function` `AWS::Lambda::Function` + `AWS::Events::Rule` in `AdminConsoleInsightStack` (when tenant SAML enabled on a non-pooled stack).
- **UPDATE**: per-tenant `runtime-config.json` carries `samlIdpDirectory` (`{}` when SAML disabled, non-empty when enabled).
- **NO-OP**: pooled tier stacks, existing silo / Lite stacks with env unset, Phase 1 Control Plane Lambda (default `tenantId="SYSTEM"` fallback path).

## Test plan

- [x] `make harness` — 0 findings
- [x] `make before-commit` — lint / typecheck / tests / synth / docs all pass (102 infra tests in tenant-template + app-plane-core + control-plane + app-config; 364 application-admin-console tests; auth-client / saml-utils unchanged)
- [x] New unit tests pin per-tenant attach + pooled-skip + AUDIT_TENANT_ID env semantics
- [x] `cdk synth` produces expected resources only when SAML env is set (validated via Template assertions)
- [ ] Manual: silo tier tenant + IdP attach + email picker + audit row visible in Tenant Admin `/audit-log` (= follow-up smoke)
- [ ] Manual: pooled tier tenant with env set → no IdP attached (CFn diff = 0)

[USER-REVIEW]: CDK additions (`infrastructure/lib/tenant-template/saml-*.ts`, `identity-provider.ts` L1 escape hatch, `tenant-template-stack.ts` SAML wiring, `app-plane-core` builder, `app-wiring` reorder, `admin-console-insight-stack` per-tenant audit Lambda, `control-plane/sign-in-audit-lambda.ts` env). Application code changes (`apps/application-admin-console/*` + tests) are agent-owned per AGENTS.md role split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAML-based identity provider (IdP) support for tenant administrator login with email-first authentication flow
  * Implemented automatic IdP detection based on email domain and interactive IdP selection for multiple matching providers
  * Added federated admin allowlist to control which federated users can sign in as administrators
  * Introduced per-tenant audit logging for sign-in events

* **Documentation**
  * Added SAML SSO setup guide for Application Plane tenant administrators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->