### PR TITLE
docs(problems): contributor-grade authoring DX — #1347

### DIFF
--- a/.claude/skills/create-problem/SKILL.md
+++ b/.claude/skills/create-problem/SKILL.md
@@ -6,7 +6,25 @@ allowed-tools: Bash(make validate-problems:*), Bash(bun run scripts/tenkacloud-p
 
 # create-problem (ADR-012 Phase 6 拡張版)
 
-TenkaCloud に新しい問題を追加する skill。**正本は [`problems/SCHEMA.json`](../../../problems/SCHEMA.json) と [`docs/problems/AUTHORING.html`](../../../docs/problems/AUTHORING.html)**。1 dir = 1 問題、`metadata.json` + `template.yaml` の 2 file が必須、 portal plugin (= `portal/<Slot>.tsx`) は任意。
+TenkaCloud に新しい問題を追加する skill。**正本は [`problems/SCHEMA.json`](../../../problems/SCHEMA.json) と [`docs/problems/AUTHORING.html`](../../../docs/problems/AUTHORING.html)**。 外部 contributor 向け quickstart は [`docs/problems/CONTRIBUTING.md`](../../../docs/problems/CONTRIBUTING.md)、 AI agent flow は [`docs/problems/AI-WORKFLOW.md`](../../../docs/problems/AI-WORKFLOW.md)。 1 dir = 1 問題、`metadata.json` + `template.yaml` の 2 file が必須、 portal plugin (= `portal/<Slot>.tsx`) は任意。
+
+## 対話 flow (= ユーザーに順に訊く)
+
+scaffold 生成の前に次を順番に聞き出す (= 答えが揃わないまま CLI を走らせない):
+
+1. **問題タイトル + 1 行 description** — UI に出る name と shortDescription の素材。
+2. **学習目標 (= learning goals)** — 「ユーザーが何を理解する?」 を bullet で 2〜3 つ。
+3. **想定 difficulty + duration** — difficulty 1〜5、 duration は free string (`60〜90 分` 等)。
+4. **scoring kind** — 下の決定木 / Step 0 を見て 5 種から 1 つに絞る。 迷っているうちは scaffold しない。
+5. **scaffold + 編集ガイド** — `bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>` で雛形を生成し、 残った `__PLACEHOLDER__` を上の回答で埋める。
+
+決定木 (= scoring kind):
+
+- 1 つの値 (= flag) を提出して終わる → `flag` (Challenge)
+- endpoint が 1 つ、 常時 200 で加点 → `uptime-flat` (Battle)
+- 複数 endpoint、 全部同時 200 で加点 → `uptime-multi` (Battle)
+- 時間経過で rule が変わる (= 移行 deadline 等) → `phased-polling` (Battle)
+- 攻撃検知数で勝敗が決まる → `attack-detection` (Battle)
 
 ## ディレクトリ規約
 
@@ -225,8 +243,11 @@ aws cloudformation deploy \
 ## 参考
 
 - 雛形 templates: [`.claude/templates/problems/<kind>/`](../../templates/problems/) — 5 kind 分の skeleton
-- 30 分 onboarding: [`docs/problems/AUTHORING.html`](../../../docs/problems/AUTHORING.html)
-- スキーマ: [`problems/SCHEMA.json`](../../../problems/SCHEMA.json)
+- 外部 contributor quickstart: [`docs/problems/CONTRIBUTING.md`](../../../docs/problems/CONTRIBUTING.md) — 30 分 quickstart + decision tree + lifecycle + validation error 表
+- 30 分 onboarding (= field reference): [`docs/problems/AUTHORING.html`](../../../docs/problems/AUTHORING.html)
+- 既存 5 問題の design 振り返り: [`docs/problems/EXAMPLES.md`](../../../docs/problems/EXAMPLES.md)
+- AI agent flow (= Claude Code / Codex CLI): [`docs/problems/AI-WORKFLOW.md`](../../../docs/problems/AI-WORKFLOW.md)
+- スキーマ正本: [`problems/SCHEMA.json`](../../../problems/SCHEMA.json)
 - 実例:
   - flag (Challenge): [`problems/challenges/hello-world/`](../../../problems/challenges/hello-world/)
   - uptime-flat (Battle): [`problems/battles/hello-world-battle/`](../../../problems/battles/hello-world-battle/)

--- a/docs/problems/AI-WORKFLOW.html
+++ b/docs/problems/AI-WORKFLOW.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>AI-assisted problem authoring workflow</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>AI-assisted problem authoring workflow</h1>
+<blockquote>
+<p>Audience: contributors who want to use Claude Code or Codex CLI as the <em>drafting tool</em> for a TenkaCloud problem.
+Prerequisite: read <a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> first. AI assistance is <strong>additive</strong>, not required.</p>
+</blockquote>
+<p>This document is the human-readable companion to the <code>/create-problem</code> Claude Code skill. The skill itself is at <code>.claude/skills/create-problem/SKILL.md</code>. Use this file when you want to understand the recommended human-driven prompts and review checkpoints around the skill, or when you are using Codex CLI (which does not load <code>.claude/skills/</code>).</p>
+<h2>When AI assistance helps</h2>
+<p>AI is good at:</p>
+<ul>
+<li>Filling in metadata fields once you have decided the design (= <code>name</code> / <code>description</code> / <code>learningGoals</code> translations, tag lists, hint copy).</li>
+<li>Catching missing <code>${NamePrefix}</code> prefixes by reading the template carefully.</li>
+<li>Drafting <code>i18n.en.*</code> mirrors from a Japanese-first description (or vice versa).</li>
+<li>Translating a vague &quot;I want a problem where the contestant must split a monolith&quot; into a concrete <code>scoring.kind</code> choice.</li>
+</ul>
+<p>AI is bad at:</p>
+<ul>
+<li>Knowing which AWS services are in the AWS Free Tier today.</li>
+<li>Estimating whether your disruption Lambda is genuinely idempotent.</li>
+<li>Knowing the deploy cost of your template without actually deploying it.</li>
+</ul>
+<p>Treat AI as a drafting partner. Every output still has to pass <code>make validate-problems</code>, <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code>, and a real sandbox-account deploy.</p>
+<h2>Recommended workflow with Claude Code</h2>
+<h3>Step 0. Set the role</h3>
+<p>Before any prompt, point Claude at <code>CLAUDE.md</code> and <code>AGENTS.md</code> (= top-level repository instructions) so it knows the platform&#39;s prohibitions (no <code>npx</code>, no <code>rm</code>, HTTP status codes via <code>StatusCodes.*</code>, polling over SSE, etc.). The repo&#39;s harness will catch obvious violations, but it is faster if Claude knows up front.</p>
+<h3>Step 1. Use the <code>/create-problem</code> skill</h3>
+<p>In the Claude Code REPL:</p>
+<pre><code class="language-text">/create-problem
+</code></pre>
+<p>The skill walks through:</p>
+<ol>
+<li><strong>Title and 1-line description.</strong> What is the problem called and what does the contestant do in one sentence?</li>
+<li><strong>Learning goals.</strong> Two or three bullets describing what the contestant should walk away understanding.</li>
+<li><strong>Difficulty and duration.</strong> 1 = entry, 5 = expert. Duration is a free-form string like <code>60〜90 分</code>.</li>
+<li><strong>Scoring kind.</strong> The skill walks you through the decision tree from <code>CONTRIBUTING.md</code>. Pick exactly one of the five built-ins.</li>
+<li><strong>Scaffold generation.</strong> The skill invokes <code>bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;</code> and shows the resulting files.</li>
+<li><strong>Edit guidance.</strong> The skill enumerates every <code>__PLACEHOLDER__</code> left in the scaffold and prompts for replacement values.</li>
+</ol>
+<p>After Step 5, <strong>stop and read the generated files yourself</strong> before letting the skill drive the placeholder edits. The fastest review is <code>git diff</code> against an empty branch.</p>
+<h3>Step 2. Hand-edit the riskiest parts</h3>
+<p>These need a human&#39;s eye, even after the skill suggests text:</p>
+<ul>
+<li><strong><code>template.yaml</code> resource names and IAM policies.</strong> AI is fluent in CFn syntax but routinely drops <code>${NamePrefix}</code> from at least one resource name. Grep the template for resource names that do not contain <code>!Sub</code>.</li>
+<li><strong>AWS cost estimate.</strong> Ask the skill to estimate, then verify against the AWS Pricing Calculator or your own knowledge. If the answer involves PAY_PER_REQUEST DynamoDB, NAT Gateway, or large EBS volumes, push back.</li>
+<li><strong>Disruption idempotency.</strong> If the problem uses an EventBridge Scheduler + Lambda, ask Claude to explain in plain English why the Lambda is safe to re-fire. If the explanation includes &quot;the first call creates a resource&quot;, the Lambda is not idempotent — fix it.</li>
+</ul>
+<h3>Step 3. Validate with the CLI</h3>
+<p>The skill prompts these, but verify manually:</p>
+<pre><code class="language-bash">make validate-problems
+bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;
+bun run scripts/tenkacloud-problem.ts dry-run &lt;id&gt; --submitted &quot;expected-flag-value&quot;
+bun run scripts/tenkacloud-problem.ts inspect &lt;id&gt;
+</code></pre>
+<p>If any fail, paste the full error back into Claude with &quot;what does this mean and how do I fix it?&quot; The CLI&#39;s error messages are designed to map to concrete fixes (see the table in <code>CONTRIBUTING.md</code>), but Claude can read the surrounding context to disambiguate.</p>
+<h3>Step 4. Deploy into a sandbox AWS account</h3>
+<p>This is the only step Claude cannot do for you. Use a personal AWS account, not a shared production account:</p>
+<pre><code class="language-bash">aws cloudformation deploy \
+  --template-file problems/&lt;category&gt;/&lt;id&gt;/template.yaml \
+  --stack-name tc-&lt;id&gt;-test \
+  --parameter-overrides NamePrefix=tc-&lt;id&gt;-test \
+  --capabilities CAPABILITY_NAMED_IAM
+</code></pre>
+<p>Exercise the scoring path (= submit a flag, hit the endpoints, wait for a phase, fire a disruption). Capture the AWS Console screenshots or the <code>aws cloudformation describe-stacks</code> output for the PR body.</p>
+<h3>Step 5. Tear down</h3>
+<pre><code class="language-bash">aws cloudformation delete-stack --stack-name tc-&lt;id&gt;-test
+</code></pre>
+<h3>Step 6. Open the PR</h3>
+<p>The catalog repo is a submodule, so the PR goes to <code>susumutomita/TenkaCloudChallenge</code>, not to <code>TenkaCloud</code>. See <code>CONTRIBUTING.md</code> for the exact commands. Claude can draft the PR body — ask it to include Summary, Test plan, Regression analysis, and Physical impact sections.</p>
+<h2>Workflow with Codex CLI</h2>
+<p>Codex CLI loads <code>AGENTS.md</code> (= the repository-level agent guide) but not the <code>.claude/skills/</code> directory. The <code>/create-problem</code> skill is therefore not available. Instead, give Codex plain natural-language instructions equivalent to the skill&#39;s steps:</p>
+<pre><code class="language-text">Draft a new TenkaCloud problem with these properties:
+- title: &quot;&lt;title&gt;&quot;
+- one-line description: &quot;&lt;sentence&gt;&quot;
+- learning goals: &lt;bullets&gt;
+- difficulty: &lt;1-5&gt;
+- duration: &quot;&lt;free text&gt;&quot;
+- scoring kind: &lt;one of flag / uptime-flat / uptime-multi / phased-polling / attack-detection&gt;
+
+Use the CLI:
+  bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;
+
+Then fill in the placeholders in metadata.json, write the template.yaml,
+and run:
+  make validate-problems
+  bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;
+
+Open a PR to susumutomita/TenkaCloudChallenge (the catalog submodule).
+The PR body must include Summary, Test plan, Regression analysis, and
+Physical impact sections.
+</code></pre>
+<p>Codex CLI follows the role split in <code>AGENTS.md</code>: it can write <code>apps/</code>, <code>scripts/</code>, and <code>problems/</code> content, but does not touch CDK (<code>infrastructure/</code>) or IAM templates on its own initiative. Problem authoring is fully in scope.</p>
+<h2>Prompts that work well</h2>
+<h3>&quot;Translate this problem statement into a scoring kind.&quot;</h3>
+<blockquote>
+<p>I want a problem where the contestant must keep a Lambda function healthy while operator-fired probes try to overload it. There is no flag. The score should reward sustained 200 responses. Which built-in scoring kind?</p>
+</blockquote>
+<p>Expected answer: <code>uptime-flat</code> (one endpoint, sustained health). If the contestant must keep multiple Lambdas healthy and a cycle pays only when all are green, <code>uptime-multi</code>.</p>
+<h3>&quot;Fill in <code>i18n.en.*</code> from the Japanese fields.&quot;</h3>
+<blockquote>
+<p>Given this Japanese <code>description</code>, write the matching <code>i18n.en.description</code> field. Keep the tone matter-of-fact, keep the fictional Kato-san narrative as &#39;Kato-san&#39; (no honorifics). Maintain code blocks verbatim.</p>
+</blockquote>
+<p>This is the highest-leverage AI use case. The output is almost always usable with light editing.</p>
+<h3>&quot;Why is my <code>validate</code> failing?&quot;</h3>
+<blockquote>
+<p>I ran <code>bun run scripts/tenkacloud-problem.ts validate my-problem</code> and got <code>scoring.flagOutputKey=&quot;FlagValue&quot; not found in template.yaml Outputs</code>. Here is my template.yaml. What is wrong?</p>
+</blockquote>
+<p>AI is good at reading the template and spotting that <code>Outputs:</code> has <code>FlagValueParam:</code> instead of <code>FlagValue:</code>.</p>
+<h3>&quot;Estimate the AWS cost of this template.&quot;</h3>
+<blockquote>
+<p>Estimate the per-hour AWS cost of this CFn template, assuming us-east-1 pricing as of today. Flag any resource that is not in the AWS Free Tier.</p>
+</blockquote>
+<p>The answer is a starting point, not authoritative. Always verify against the AWS Pricing Calculator before publishing.</p>
+<h2>Prompts that do not work well</h2>
+<h3>&quot;Decide whether this problem is a good idea.&quot;</h3>
+<p>AI cannot judge whether your problem teaches anything novel, fits the catalog&#39;s identity, or duplicates an existing problem. Ask a human reviewer.</p>
+<h3>&quot;Write the whole problem from a vague brief.&quot;</h3>
+<p>The author still has to make the design decisions (= what&#39;s the scoring axis, what&#39;s the failure mode, what&#39;s the cost ceiling). AI is good at filling forms once the design is fixed. It is bad at design itself.</p>
+<h3>&quot;Pick the AWS resources for me.&quot;</h3>
+<p>AWS Free Tier eligibility changes over time. NAT Gateway costs money. EBS gp3 volumes do not. RDS Free Tier eligibility resets per account. AI&#39;s training data on AWS pricing is not reliable enough to be a primary source.</p>
+<h2>Review checkpoints (= what a human must verify)</h2>
+<p>Before opening the PR, regardless of how much AI helped:</p>
+<ul>
+<li><input disabled="" type="checkbox"> The problem teaches something a human would want to learn.</li>
+<li><input disabled="" type="checkbox"> The <code>${NamePrefix}</code> prefix appears on every resource name in <code>template.yaml</code>.</li>
+<li><input disabled="" type="checkbox"> The Outputs referenced by <code>metadata.json</code> exist verbatim in <code>template.yaml</code>.</li>
+<li><input disabled="" type="checkbox"> The deploy cost is documented in the PR body (target: zero or near-zero per contestant セッション).</li>
+<li><input disabled="" type="checkbox"> The scoring kind matches the actual scoring axis (= no <code>flag</code> problems that need polling, no <code>uptime-flat</code> problems that should be <code>uptime-multi</code>).</li>
+<li><input disabled="" type="checkbox"> The Japanese and English descriptions tell the same story.</li>
+<li><input disabled="" type="checkbox"> At least one sandbox-account deploy + scoring run happened.</li>
+</ul>
+<p>The harness, validator, and <code>make before-commit</code> catch many bugs, but they cannot catch design mistakes. Human review is the last gate.</p>
+<h2>See also</h2>
+<ul>
+<li><a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> — the human workflow (start here).</li>
+<li><a href="./AUTHORING.html"><code>AUTHORING.html</code></a> — 30-minute onboarding with the full field reference.</li>
+<li><a href="./EXAMPLES.md"><code>EXAMPLES.md</code></a> — five reference problems with design retrospectives.</li>
+<li><code>.claude/skills/create-problem/SKILL.md</code> — the <code>/create-problem</code> skill source.</li>
+<li><a href="../../AGENTS.md"><code>AGENTS.md</code></a> — repository-level agent guide (loaded by both Claude Code and Codex CLI).</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/problems/AI-WORKFLOW.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/problems/AI-WORKFLOW.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/problems/AI-WORKFLOW.md
+++ b/docs/problems/AI-WORKFLOW.md
@@ -1,0 +1,183 @@
+# AI-assisted problem authoring workflow
+
+> Audience: contributors who want to use Claude Code or Codex CLI as the *drafting tool* for a TenkaCloud problem.
+> Prerequisite: read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first. AI assistance is **additive**, not required.
+
+This document is the human-readable companion to the `/create-problem` Claude Code skill. The skill itself is at `.claude/skills/create-problem/SKILL.md`. Use this file when you want to understand the recommended human-driven prompts and review checkpoints around the skill, or when you are using Codex CLI (which does not load `.claude/skills/`).
+
+## When AI assistance helps
+
+AI is good at:
+
+- Filling in metadata fields once you have decided the design (= `name` / `description` / `learningGoals` translations, tag lists, hint copy).
+- Catching missing `${NamePrefix}` prefixes by reading the template carefully.
+- Drafting `i18n.en.*` mirrors from a Japanese-first description (or vice versa).
+- Translating a vague "I want a problem where the contestant must split a monolith" into a concrete `scoring.kind` choice.
+
+AI is bad at:
+
+- Knowing which AWS services are in the AWS Free Tier today.
+- Estimating whether your disruption Lambda is genuinely idempotent.
+- Knowing the deploy cost of your template without actually deploying it.
+
+Treat AI as a drafting partner. Every output still has to pass `make validate-problems`, `bun run scripts/tenkacloud-problem.ts validate <id>`, and a real sandbox-account deploy.
+
+## Recommended workflow with Claude Code
+
+### Step 0. Set the role
+
+Before any prompt, point Claude at `CLAUDE.md` and `AGENTS.md` (= top-level repository instructions) so it knows the platform's prohibitions (no `npx`, no `rm`, HTTP status codes via `StatusCodes.*`, polling over SSE, etc.). The repo's harness will catch obvious violations, but it is faster if Claude knows up front.
+
+### Step 1. Use the `/create-problem` skill
+
+In the Claude Code REPL:
+
+```text
+/create-problem
+```
+
+The skill walks through:
+
+1. **Title and 1-line description.** What is the problem called and what does the contestant do in one sentence?
+2. **Learning goals.** Two or three bullets describing what the contestant should walk away understanding.
+3. **Difficulty and duration.** 1 = entry, 5 = expert. Duration is a free-form string like `60〜90 分`.
+4. **Scoring kind.** The skill walks you through the decision tree from `CONTRIBUTING.md`. Pick exactly one of the five built-ins.
+5. **Scaffold generation.** The skill invokes `bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>` and shows the resulting files.
+6. **Edit guidance.** The skill enumerates every `__PLACEHOLDER__` left in the scaffold and prompts for replacement values.
+
+After Step 5, **stop and read the generated files yourself** before letting the skill drive the placeholder edits. The fastest review is `git diff` against an empty branch.
+
+### Step 2. Hand-edit the riskiest parts
+
+These need a human's eye, even after the skill suggests text:
+
+- **`template.yaml` resource names and IAM policies.** AI is fluent in CFn syntax but routinely drops `${NamePrefix}` from at least one resource name. Grep the template for resource names that do not contain `!Sub`.
+- **AWS cost estimate.** Ask the skill to estimate, then verify against the AWS Pricing Calculator or your own knowledge. If the answer involves PAY_PER_REQUEST DynamoDB, NAT Gateway, or large EBS volumes, push back.
+- **Disruption idempotency.** If the problem uses an EventBridge Scheduler + Lambda, ask Claude to explain in plain English why the Lambda is safe to re-fire. If the explanation includes "the first call creates a resource", the Lambda is not idempotent — fix it.
+
+### Step 3. Validate with the CLI
+
+The skill prompts these, but verify manually:
+
+```bash
+make validate-problems
+bun run scripts/tenkacloud-problem.ts validate <id>
+bun run scripts/tenkacloud-problem.ts dry-run <id> --submitted "expected-flag-value"
+bun run scripts/tenkacloud-problem.ts inspect <id>
+```
+
+If any fail, paste the full error back into Claude with "what does this mean and how do I fix it?" The CLI's error messages are designed to map to concrete fixes (see the table in `CONTRIBUTING.md`), but Claude can read the surrounding context to disambiguate.
+
+### Step 4. Deploy into a sandbox AWS account
+
+This is the only step Claude cannot do for you. Use a personal AWS account, not a shared production account:
+
+```bash
+aws cloudformation deploy \
+  --template-file problems/<category>/<id>/template.yaml \
+  --stack-name tc-<id>-test \
+  --parameter-overrides NamePrefix=tc-<id>-test \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+Exercise the scoring path (= submit a flag, hit the endpoints, wait for a phase, fire a disruption). Capture the AWS Console screenshots or the `aws cloudformation describe-stacks` output for the PR body.
+
+### Step 5. Tear down
+
+```bash
+aws cloudformation delete-stack --stack-name tc-<id>-test
+```
+
+### Step 6. Open the PR
+
+The catalog repo is a submodule, so the PR goes to `susumutomita/TenkaCloudChallenge`, not to `TenkaCloud`. See `CONTRIBUTING.md` for the exact commands. Claude can draft the PR body — ask it to include Summary, Test plan, Regression analysis, and Physical impact sections.
+
+## Workflow with Codex CLI
+
+Codex CLI loads `AGENTS.md` (= the repository-level agent guide) but not the `.claude/skills/` directory. The `/create-problem` skill is therefore not available. Instead, give Codex plain natural-language instructions equivalent to the skill's steps:
+
+```text
+Draft a new TenkaCloud problem with these properties:
+- title: "<title>"
+- one-line description: "<sentence>"
+- learning goals: <bullets>
+- difficulty: <1-5>
+- duration: "<free text>"
+- scoring kind: <one of flag / uptime-flat / uptime-multi / phased-polling / attack-detection>
+
+Use the CLI:
+  bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>
+
+Then fill in the placeholders in metadata.json, write the template.yaml,
+and run:
+  make validate-problems
+  bun run scripts/tenkacloud-problem.ts validate <id>
+
+Open a PR to susumutomita/TenkaCloudChallenge (the catalog submodule).
+The PR body must include Summary, Test plan, Regression analysis, and
+Physical impact sections.
+```
+
+Codex CLI follows the role split in `AGENTS.md`: it can write `apps/`, `scripts/`, and `problems/` content, but does not touch CDK (`infrastructure/`) or IAM templates on its own initiative. Problem authoring is fully in scope.
+
+## Prompts that work well
+
+### "Translate this problem statement into a scoring kind."
+
+> I want a problem where the contestant must keep a Lambda function healthy while operator-fired probes try to overload it. There is no flag. The score should reward sustained 200 responses. Which built-in scoring kind?
+
+Expected answer: `uptime-flat` (one endpoint, sustained health). If the contestant must keep multiple Lambdas healthy and a cycle pays only when all are green, `uptime-multi`.
+
+### "Fill in `i18n.en.*` from the Japanese fields."
+
+> Given this Japanese `description`, write the matching `i18n.en.description` field. Keep the tone matter-of-fact, keep the fictional Kato-san narrative as 'Kato-san' (no honorifics). Maintain code blocks verbatim.
+
+This is the highest-leverage AI use case. The output is almost always usable with light editing.
+
+### "Why is my `validate` failing?"
+
+> I ran `bun run scripts/tenkacloud-problem.ts validate my-problem` and got `scoring.flagOutputKey="FlagValue" not found in template.yaml Outputs`. Here is my template.yaml. What is wrong?
+
+AI is good at reading the template and spotting that `Outputs:` has `FlagValueParam:` instead of `FlagValue:`.
+
+### "Estimate the AWS cost of this template."
+
+> Estimate the per-hour AWS cost of this CFn template, assuming us-east-1 pricing as of today. Flag any resource that is not in the AWS Free Tier.
+
+The answer is a starting point, not authoritative. Always verify against the AWS Pricing Calculator before publishing.
+
+## Prompts that do not work well
+
+### "Decide whether this problem is a good idea."
+
+AI cannot judge whether your problem teaches anything novel, fits the catalog's identity, or duplicates an existing problem. Ask a human reviewer.
+
+### "Write the whole problem from a vague brief."
+
+The author still has to make the design decisions (= what's the scoring axis, what's the failure mode, what's the cost ceiling). AI is good at filling forms once the design is fixed. It is bad at design itself.
+
+### "Pick the AWS resources for me."
+
+AWS Free Tier eligibility changes over time. NAT Gateway costs money. EBS gp3 volumes do not. RDS Free Tier eligibility resets per account. AI's training data on AWS pricing is not reliable enough to be a primary source.
+
+## Review checkpoints (= what a human must verify)
+
+Before opening the PR, regardless of how much AI helped:
+
+- [ ] The problem teaches something a human would want to learn.
+- [ ] The `${NamePrefix}` prefix appears on every resource name in `template.yaml`.
+- [ ] The Outputs referenced by `metadata.json` exist verbatim in `template.yaml`.
+- [ ] The deploy cost is documented in the PR body (target: zero or near-zero per contestant セッション).
+- [ ] The scoring kind matches the actual scoring axis (= no `flag` problems that need polling, no `uptime-flat` problems that should be `uptime-multi`).
+- [ ] The Japanese and English descriptions tell the same story.
+- [ ] At least one sandbox-account deploy + scoring run happened.
+
+The harness, validator, and `make before-commit` catch many bugs, but they cannot catch design mistakes. Human review is the last gate.
+
+## See also
+
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — the human workflow (start here).
+- [`AUTHORING.html`](./AUTHORING.html) — 30-minute onboarding with the full field reference.
+- [`EXAMPLES.md`](./EXAMPLES.md) — five reference problems with design retrospectives.
+- `.claude/skills/create-problem/SKILL.md` — the `/create-problem` skill source.
+- [`AGENTS.md`](../../AGENTS.md) — repository-level agent guide (loaded by both Claude Code and Codex CLI).

--- a/docs/problems/CONTRIBUTING.html
+++ b/docs/problems/CONTRIBUTING.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Contributing problems to TenkaCloud — 30-minute quickstart</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Contributing problems to TenkaCloud — 30-minute quickstart</h1>
+<blockquote>
+<p>Audience: external contributors who want to ship a new TenkaCloud problem in one focused PR.
+Source of truth for the file format: <a href="../../problems/SCHEMA.json"><code>problems/SCHEMA.json</code></a> + <a href="./AUTHORING.html"><code>AUTHORING.html</code></a>.
+Source of truth for catalog conventions: <a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md"><code>problems/AGENT.md</code></a> in the catalog submodule.</p>
+</blockquote>
+<p>This guide is the <strong>shortest path</strong> for someone outside the maintainer&#39;s head to get a problem reviewed and merged. It complements <code>AUTHORING.html</code> (= the 30-minute onboarding tour) and <code>AGENT.md</code> in the catalog submodule (= the invariant list). Read this first when you want to know <strong>what to do</strong>; read those when you want to know <strong>what each field means</strong>.</p>
+<p>Japanese mirror: <a href="./CONTRIBUTING.ja.md"><code>CONTRIBUTING.ja.md</code></a>.</p>
+<h2>Where problems live (= submodule, not this repo)</h2>
+<p>The platform repository (<code>TenkaCloud</code>) and the catalog repository (<code>TenkaCloudChallenge</code>) are physically decoupled.</p>
+<pre><code>TenkaCloud/                           ← platform (CDK + 3 SPAs + scoring engine)
+└── problems/                         ← git submodule
+    └── (real files live in github.com/susumutomita/TenkaCloudChallenge)
+</code></pre>
+<p>You submit problem PRs to <strong><code>susumutomita/TenkaCloudChallenge</code></strong>, not to <code>TenkaCloud</code>. The platform repo only needs a submodule pointer bump when a catalog change should ship.</p>
+<p>To work locally:</p>
+<pre><code class="language-bash">git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+# the working tree under problems/ is now a checkout of TenkaCloudChallenge
+</code></pre>
+<p>If you cloned without <code>--recurse-submodules</code>:</p>
+<pre><code class="language-bash">git submodule update --init --recursive problems
+</code></pre>
+<h2>30-minute quickstart (= scaffold → edit → validate → PR)</h2>
+<h3>1. Pick the scoring kind (= the most important decision)</h3>
+<p>A TenkaCloud problem ships exactly one of five built-in scoring kinds. The platform&#39;s generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a>.</p>
+<p>Use this decision tree:</p>
+<pre><code class="language-text">Does the competitor submit a single value (a &quot;flag&quot;) to win?
+├── Yes → kind = &quot;flag&quot;               (Challenge, e.g. read an SSM Parameter, find an S3 object)
+└── No
+    │
+    Does the competitor have to keep something running?
+    ├── Yes
+    │   │
+    │   Is there exactly one endpoint to keep alive?
+    │   ├── Yes → kind = &quot;uptime-flat&quot;    (Battle, one nginx, one API)
+    │   └── No, several endpoints together → kind = &quot;uptime-multi&quot;
+    │       (Battle, frontend + api + worker; scoring rewards &quot;all green at once&quot;)
+    │
+    └── No
+        │
+        Does the rule change over time (e.g. a migration deadline, a load surge)?
+        ├── Yes → kind = &quot;phased-polling&quot;
+        │   (Battle, phases[].afterMinutes shifts scoring; classic for migration races)
+        │
+        └── Is the goal to detect or block attacks?
+            └── Yes → kind = &quot;attack-detection&quot;
+                (Battle, WAF / SOC; scores +N per detected attack)
+</code></pre>
+<p>If none fits, the problem is probably <strong>not yet a TenkaCloud problem</strong> — file an issue first.</p>
+<h3>2. Scaffold the directory</h3>
+<pre><code class="language-bash">bun run scripts/tenkacloud-problem.ts create my-problem --kind flag
+# or for guided interactive input:
+bun run scripts/tenkacloud-problem.ts create
+</code></pre>
+<p>The CLI creates <code>problems/&lt;category&gt;/my-problem/{metadata.json,template.yaml}</code> from <code>.claude/templates/problems/&lt;kind&gt;/</code>. <code>&lt;category&gt;</code> is inferred from <code>&lt;kind&gt;</code> (flag → <code>challenges/</code>, otherwise <code>battles/</code>); override with <code>--category Battle|Challenge</code>.</p>
+<p>Alternative: in Claude Code, run <code>/create-problem</code>. The skill walks through the same steps interactively.</p>
+<h3>3. Edit the scaffold</h3>
+<p>The scaffold contains <code>__PROBLEM_NAME__</code>, <code>__TAG__</code>, <code>__LEARNING_GOAL_1__</code>, <code>__HINT_1__</code> and similar placeholders. <strong>Grep for <code>__</code> and replace every occurrence</strong> — JSON Schema accepts placeholders because they are strings, but the catalog UI and scoring engine will misbehave.</p>
+<p>Minimum edits:</p>
+<ul>
+<li><code>name</code>, <code>shortDescription</code>, <code>description</code> — write them as if the reader has zero context. Battles usually open with a one-paragraph fictional incident.</li>
+<li><code>tags</code> — kebab-case, at least one.</li>
+<li><code>learningGoals</code> — at least one bullet.</li>
+<li><code>i18n.en.*</code> — required mirror for <code>name</code> / <code>shortDescription</code> / <code>description</code> / <code>learningGoals</code>. Locale support is <code>ja</code> + <code>en</code> only (no other locales).</li>
+<li><code>template.yaml</code> — replace placeholder resources with real CFn. Every resource name, tag, and Group name must be prefixed with <code>${NamePrefix}</code> so multiple teams can deploy into the same AWS account.</li>
+</ul>
+<h3>4. Validate locally</h3>
+<pre><code class="language-bash"># JSON Schema validation across the whole catalog
+make validate-problems
+
+# Per-problem cross-checks (Outputs ↔ metadata wiring, dashboard slot files)
+bun run scripts/tenkacloud-problem.ts validate my-problem
+
+# Optional: dry-run the scoring engine without deploying CFn
+bun run scripts/tenkacloud-problem.ts dry-run my-problem --submitted &quot;expected-flag-value&quot;
+
+# Inspect the rendered metadata + template summary
+bun run scripts/tenkacloud-problem.ts inspect my-problem
+</code></pre>
+<p>If <code>make validate-problems</code> or <code>validate</code> errors, see <a href="#validation-errors-and-how-to-read-them">Validation errors</a> below.</p>
+<h3>5. Deploy once into a sandbox AWS account (= &quot;tested&quot; status)</h3>
+<p>The platform never marks a problem <code>ready</code> until at least one human has deployed it end to end. Use a personal sandbox AWS account:</p>
+<pre><code class="language-bash">aws cloudformation deploy \
+  --template-file problems/&lt;category&gt;/my-problem/template.yaml \
+  --stack-name tc-my-problem-test \
+  --parameter-overrides NamePrefix=tc-my-problem-test \
+  --capabilities CAPABILITY_NAMED_IAM
+</code></pre>
+<p>Then exercise the scoring path manually (submit the flag, hit the endpoints, wait for a disruption to fire — whichever applies). If it scores, the problem is &quot;tested&quot; in the lifecycle sense (see below).</p>
+<p>Tear down:</p>
+<pre><code class="language-bash">aws cloudformation delete-stack --stack-name tc-my-problem-test
+</code></pre>
+<h3>6. Open the PR (= against the submodule repo)</h3>
+<p>In the <code>problems/</code> working tree:</p>
+<pre><code class="language-bash">cd problems
+git checkout -b feat/my-problem
+git add battles/my-problem  # or challenges/my-problem
+git commit -m &quot;feat: add my-problem&quot;
+git push origin feat/my-problem
+gh pr create --repo susumutomita/TenkaCloudChallenge \
+  --title &quot;feat: add my-problem&quot; \
+  --body &quot;...&quot;
+</code></pre>
+<p>PR body checklist:</p>
+<ul>
+<li>What category, kind, and difficulty.</li>
+<li>Test plan: which <code>validate</code> / <code>dry-run</code> commands you ran, plus the AWS account you sandbox-deployed into (no account IDs).</li>
+<li>Whether the problem is <code>draft</code> (most first PRs), <code>tested</code>, or <code>ready</code> (see lifecycle below).</li>
+<li>Any cost the participant will incur (target: zero outside Free Tier).</li>
+</ul>
+<p>A submodule-pointer bump PR against <code>TenkaCloud</code> is <strong>not your responsibility</strong> — the maintainer or a separate PR handles that.</p>
+<h2>Lifecycle: draft → tested → ready → official → deprecated</h2>
+<p><code>metadata.json</code> <code>status</code> is a JSON Schema enum with three values: <code>draft</code>, <code>ready</code>, <code>deprecated</code>. The full five-stage lifecycle uses these three plus two conventions tracked in PR descriptions, the catalog <code>CATALOG.md</code>, or commit history.</p>
+<table>
+<thead>
+<tr>
+<th>Stage</th>
+<th><code>status</code> field</th>
+<th>Means</th>
+<th>Visible in catalog?</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>draft</strong></td>
+<td><code>&quot;status&quot;: &quot;draft&quot;</code></td>
+<td>Author work-in-progress. Scaffold compiles, schema passes, <strong>not yet deployed end-to-end.</strong></td>
+<td>No (filtered out)</td>
+</tr>
+<tr>
+<td><strong>tested</strong></td>
+<td><code>&quot;status&quot;: &quot;draft&quot;</code></td>
+<td>Author has deployed once into a sandbox AWS account and confirmed scoring. Note &quot;tested in AWS sandbox&quot; in PR body.</td>
+<td>No</td>
+</tr>
+<tr>
+<td><strong>ready</strong></td>
+<td><code>&quot;status&quot;: &quot;ready&quot;</code></td>
+<td>Maintainer review passed. Public catalog entry. Anyone can spin it up at an event.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><strong>official</strong></td>
+<td><code>&quot;status&quot;: &quot;ready&quot;</code></td>
+<td>Used at least once in a real public event (JAWS-UG, CCoE training). Add an <code>official-yyyy-mm</code> tag and link the event in <code>README.md</code>.</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><strong>deprecated</strong></td>
+<td><code>&quot;status&quot;: &quot;deprecated&quot;</code></td>
+<td>Replaced or no longer maintained. Catalog filters by default. Keep the dir for historical reference.</td>
+<td>No</td>
+</tr>
+</tbody></table>
+<p>Promotion from <code>draft</code> to <code>ready</code> is a separate PR (not the original add) so reviewers can compare before/after. Mention the test event or sandbox results in that PR body.</p>
+<h2>Validation errors and how to read them</h2>
+<p>The CLI validator (<code>scripts/tenkacloud-problem.ts validate</code>) and <code>make validate-problems</code> produce messages like the table below. Each row maps a real error to its fix.</p>
+<table>
+<thead>
+<tr>
+<th>Symptom (substring of the error)</th>
+<th>Likely cause</th>
+<th>Fix</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>scoring.kind=&quot;...&quot; is not a recognized kind</code></td>
+<td>Typo in <code>scoring.kind</code></td>
+<td>Set it to exactly one of <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>.</td>
+</tr>
+<tr>
+<td><code>scoring.flagOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td><code>metadata.scoring.flagOutputKey</code> references a CFn <code>Output</code> key that doesn&#39;t exist</td>
+<td>Open <code>template.yaml</code>, add an <code>Outputs.X:</code> entry, or fix the metadata key. Both sides must match exactly.</td>
+</tr>
+<tr>
+<td><code>scoring.statsOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td>Same as above for <code>attack-detection</code></td>
+<td>Add an <code>Outputs.X:</code> entry whose <code>Value</code> is the integer attack count.</td>
+</tr>
+<tr>
+<td><code>endpoints[slot=N].default.key=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td><code>endpoints[].default.key</code> points at a missing Output</td>
+<td>Add the <code>Outputs.X:</code> entry (typically the public URL of the endpoint slot).</td>
+</tr>
+<tr>
+<td><code>dashboard.slots[&quot;X&quot;]=&quot;path&quot; file not found at ...</code></td>
+<td>A <code>dashboard.slots</code> entry references a portal plugin file that does not exist</td>
+<td>Either create the <code>.tsx</code> file at the referenced path, or remove the slot entry.</td>
+</tr>
+<tr>
+<td><code>metadata.id=&quot;X&quot; does not match dir name &quot;Y&quot;</code></td>
+<td><code>metadata.id</code> and the directory name diverged</td>
+<td>Rename the directory or fix <code>metadata.id</code>. They must be identical.</td>
+</tr>
+<tr>
+<td><code>runtime block must declare provider / engine / entry</code></td>
+<td>Partial <code>runtime</code> field (e.g. only <code>entry</code>)</td>
+<td>Either set all three keys or drop the <code>runtime</code> block (the validator falls back to legacy <code>cfnTemplate</code>).</td>
+</tr>
+<tr>
+<td><code>runtime.entry=&quot;A&quot; and cfnTemplate=&quot;B&quot; must match</code></td>
+<td>Both <code>runtime</code> and <code>cfnTemplate</code> are set but disagree</td>
+<td>Make <code>runtime.entry === cfnTemplate</code> during the ADR-023 compatibility window.</td>
+</tr>
+<tr>
+<td><code>Runtime &lt;provider&gt;/&lt;engine&gt; is recognized but not executable</code></td>
+<td>Reserved future runtime (e.g. <code>azure/arm</code>, <code>kubernetes/helm</code>)</td>
+<td>Switch to <code>aws/cloudformation</code>. Other providers parse but are not yet executable.</td>
+</tr>
+<tr>
+<td><code>cfnTemplate file &quot;...&quot; not found</code></td>
+<td>Filename mismatch</td>
+<td>Ensure the file referenced by <code>cfnTemplate</code> (or <code>runtime.entry</code>) exists in the problem directory.</td>
+</tr>
+<tr>
+<td><code>metadata.json parse error: ...</code></td>
+<td>Invalid JSON (trailing comma, unquoted key)</td>
+<td>Run the file through a JSON formatter; placeholders must stay quoted.</td>
+</tr>
+</tbody></table>
+<p>For schema errors from <code>make validate-problems</code> that include <code>instancePath</code> (= JSON pointer like <code>/scoring/points</code>), open <code>metadata.json</code>, follow that path, and fix the offending value. The schema&#39;s <code>description</code> fields (<a href="../../problems/SCHEMA.json"><code>problems/SCHEMA.json</code></a>) explain each property.</p>
+<h3>Common <code>template.yaml</code> mistakes</h3>
+<p>These are not caught by JSON Schema but are caught by CFn at deploy time or by AWS cost surprise:</p>
+<ul>
+<li><strong>Missing <code>${NamePrefix}</code> on a resource name</strong> — two teams collide at deploy time. Always wrap names with <code>!Sub &quot;${NamePrefix}-...&quot;</code>.</li>
+<li><strong><code>!Sub</code> without closing brace</strong> — <code>!Sub &quot;tc-${NamePrefix-bucket&quot;</code> instead of <code>!Sub &quot;tc-${NamePrefix}-bucket&quot;</code>. Read the line CFn reports and look for the missing <code>}</code>.</li>
+<li><strong>Non-idempotent disruption Lambda</strong> — EventBridge Scheduler re-fires; wrap <code>tc qdisc add ...</code> with <code>|| true</code> so EEXIST does not crash later cycles.</li>
+<li><strong>PAY_PER_REQUEST DynamoDB</strong> — forbidden. Use <code>BillingMode: PROVISIONED</code> with 1 RCU / 1 WCU; the platform&#39;s CDK Aspect enforces this for platform tables, but problem templates must self-discipline.</li>
+<li><strong><code>Resource: &quot;*&quot;</code> IAM</strong> — only allowed for CloudShell and a documented list. The catalog&#39;s <code>AGENT.md</code> lists the exception comment markers; do not remove them.</li>
+</ul>
+<h2>AI-assisted authoring (= optional, additive)</h2>
+<p>Claude Code ships with a <code>/create-problem</code> skill that runs the same scaffold + edit flow with an AI in the loop. It is not required — every step is reproducible by hand. See <a href="./AI-WORKFLOW.md"><code>AI-WORKFLOW.md</code></a> for the recommended prompts.</p>
+<h2>Checklist before opening the PR</h2>
+<ul>
+<li><input disabled="" type="checkbox"> <code>metadata.id</code> matches the directory name.</li>
+<li><input disabled="" type="checkbox"> <code>category</code> is <code>&quot;Battle&quot;</code> or <code>&quot;Challenge&quot;</code> (capitalized).</li>
+<li><input disabled="" type="checkbox"> <code>status</code> is <code>&quot;draft&quot;</code> for a first submission.</li>
+<li><input disabled="" type="checkbox"> <code>scoring.kind</code> is one of the five built-ins.</li>
+<li><input disabled="" type="checkbox"> Every <code>__PLACEHOLDER__</code> in <code>metadata.json</code> has been replaced.</li>
+<li><input disabled="" type="checkbox"> Every endpoint / scoring key referenced from <code>metadata.json</code> exists as a key in <code>template.yaml</code> <code>Outputs:</code>.</li>
+<li><input disabled="" type="checkbox"> Every resource name in <code>template.yaml</code> is prefixed with <code>${NamePrefix}</code>.</li>
+<li><input disabled="" type="checkbox"> <code>make validate-problems</code> passes.</li>
+<li><input disabled="" type="checkbox"> <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code> passes.</li>
+<li><input disabled="" type="checkbox"> Deploy + scoring tested at least once in a sandbox AWS account (PR body mentions it).</li>
+<li><input disabled="" type="checkbox"> <code>i18n.en.*</code> mirrors are filled in for <code>name</code> / <code>shortDescription</code> / <code>description</code> / <code>learningGoals</code>.</li>
+<li><input disabled="" type="checkbox"> PR body describes Summary, Test plan, Regression analysis, Physical impact.</li>
+</ul>
+<h2>See also</h2>
+<ul>
+<li><a href="./AUTHORING.html"><code>AUTHORING.html</code></a> — 30-minute onboarding with the full field list.</li>
+<li><a href="./AI-WORKFLOW.md"><code>AI-WORKFLOW.md</code></a> — Claude Code / Codex CLI workflow for problem authoring.</li>
+<li><a href="./EXAMPLES.md"><code>EXAMPLES.md</code></a> — design retrospectives on the five reference problems.</li>
+<li><a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md"><code>problems/AGENT.md</code></a> — catalog repo invariants (deploy-time rules enforced by <code>bun run validate</code>).</li>
+<li><a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> — the plugin architecture that makes this possible.</li>
+<li><a href="../architecture/adr-023-provider-specific-problem-runtime.html">ADR-023</a> — the <code>runtime</code> field and future multi-provider support.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/problems/CONTRIBUTING.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/problems/CONTRIBUTING.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/problems/CONTRIBUTING.ja.html
+++ b/docs/problems/CONTRIBUTING.ja.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud 問題 contribution ガイド — 30 分 quickstart</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud 問題 contribution ガイド — 30 分 quickstart</h1>
+<blockquote>
+<p>対象: TenkaCloud に新規問題を 1 PR で送りたい外部 contributor。
+ファイル形式の正本: <a href="../../problems/SCHEMA.json"><code>problems/SCHEMA.json</code></a> + <a href="./AUTHORING.html"><code>AUTHORING.html</code></a>。
+Catalog 規約の正本: catalog submodule の <a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md"><code>problems/AGENT.md</code></a>。</p>
+</blockquote>
+<p>このドキュメントは「maintainer の頭の中を使うべきではない言葉なので修正してください人が、 reviewed + merged まで辿りつく最短経路」を書く。 <code>AUTHORING.html</code> (= 30 分 onboarding) と catalog submodule の <code>AGENT.md</code> (= invariant 一覧) の補助。 <strong>何をするか</strong> をこのファイルで掴み、 <strong>各 field の意味</strong> はそれらを読む。</p>
+<p>English mirror: <a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a>。</p>
+<h2>問題は submodule に住む (= この repo ではない)</h2>
+<p>Platform repository (<code>TenkaCloud</code>) と catalog repository (<code>TenkaCloudChallenge</code>) は物理的に切り離されている。</p>
+<pre><code>TenkaCloud/                           ← platform (CDK + 3 SPAs + scoring engine)
+└── problems/                         ← git submodule
+    └── (実体は github.com/susumutomita/TenkaCloudChallenge)
+</code></pre>
+<p>問題 PR は <strong><code>susumutomita/TenkaCloudChallenge</code></strong> に出す。 <code>TenkaCloud</code> には catalog 変更を ship する時の submodule pointer bump PR だけが入る (= maintainer 側で別 PR を切る)。</p>
+<p>ローカル作業の手順は次のとおりです。</p>
+<pre><code class="language-bash">git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+# problems/ の working tree が TenkaCloudChallenge の checkout になる
+</code></pre>
+<p><code>--recurse-submodules</code> 抜きで clone した場合は次を実行します。</p>
+<pre><code class="language-bash">git submodule update --init --recursive problems
+</code></pre>
+<h2>30 分 quickstart (= scaffold → edit → validate → PR)</h2>
+<h3>1. 採点 kind を選ぶ (= 最重要)</h3>
+<p>TenkaCloud の 1 問題は 5 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> で禁止。</p>
+<p>決定木は次のとおりです。</p>
+<pre><code class="language-text">競技者が 1 つの値 (= &quot;flag&quot;) を提出して終わるか?
+├── Yes → kind = &quot;flag&quot;               (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+└── No
+    │
+    競技者が何かを稼働させ続ける必要があるか?
+    ├── Yes
+    │   │
+    │   稼働させる endpoint は 1 つだけか?
+    │   ├── Yes → kind = &quot;uptime-flat&quot;    (Battle / nginx 1 つ、 API 1 つ)
+    │   └── No、 複数 endpoint をまとめて → kind = &quot;uptime-multi&quot;
+    │       (Battle / frontend + api + worker。 「全部同時 ok」 を採点軸にする)
+    │
+    └── No
+        │
+        時間経過で rule が変わるか? (= 移行 deadline、 負荷急増等)
+        ├── Yes → kind = &quot;phased-polling&quot;
+        │   (Battle / phases[].afterMinutes で採点切替。 マイクロサービス移行レースが典型)
+        │
+        └── 攻撃検知 / 防御が採点軸か?
+            └── Yes → kind = &quot;attack-detection&quot;
+                (Battle / WAF / SOC。 検出 1 件あたり +N)
+</code></pre>
+<p>どれにも当てはまらない → <strong>まだ TenkaCloud の問題ではない可能性</strong>。 先に issue で議論する。</p>
+<h3>2. ディレクトリ scaffold</h3>
+<pre><code class="language-bash">bun run scripts/tenkacloud-problem.ts create my-problem --kind flag
+# または対話的に:
+bun run scripts/tenkacloud-problem.ts create
+</code></pre>
+<p>CLI が <code>.claude/templates/problems/&lt;kind&gt;/</code> から <code>problems/&lt;category&gt;/my-problem/{metadata.json,template.yaml}</code> を生成する。 <code>&lt;category&gt;</code> は kind から決まる (flag → <code>challenges/</code>、 それ以外 → <code>battles/</code>)。 <code>--category Battle|Challenge</code> で上書き可。</p>
+<p>Alternative: Claude Code 上で <code>/create-problem</code> を起動すると同じ flow を AI 経由で進められる。</p>
+<h3>3. Scaffold を編集</h3>
+<p>Scaffold 内には <code>__PROBLEM_NAME__</code>、 <code>__TAG__</code>、 <code>__LEARNING_GOAL_1__</code>、 <code>__HINT_1__</code> 等の placeholder が残る。 <strong><code>__</code> を全部 grep して書き換える</strong> こと。 JSON Schema は placeholder を string として通すが、 catalog UI と scoring engine は誤動作する。</p>
+<p>最低限の編集箇所は次のとおりです。</p>
+<ul>
+<li><code>name</code>、 <code>shortDescription</code>、 <code>description</code> — 読み手が zero context な前提で書く。 Battle は架空の incident 一段落で導入するのが定型。</li>
+<li><code>tags</code> — kebab-case で 1 つ以上。</li>
+<li><code>learningGoals</code> — 1 bullet 以上。</li>
+<li><code>i18n.en.*</code> — <code>name</code> / <code>shortDescription</code> / <code>description</code> / <code>learningGoals</code> の英訳 mirror が必須。 サポート locale は <code>ja</code> + <code>en</code> のみ。</li>
+<li><code>template.yaml</code> — placeholder resource を実 CFn に置換。 全リソース名 / タグ / Group 名に <code>${NamePrefix}</code> を冠する (= 同一 AWS account に複数 team の stack が並ぶ前提)。</li>
+</ul>
+<h3>4. ローカル検証</h3>
+<pre><code class="language-bash"># JSON Schema 検証 (= 全 catalog)
+make validate-problems
+
+# 1 問題に対する cross-check (Outputs ↔ metadata 配線、 portal slot file 存在)
+bun run scripts/tenkacloud-problem.ts validate my-problem
+
+# Optional: scoring engine の dry-run (= CFn deploy 抜き)
+bun run scripts/tenkacloud-problem.ts dry-run my-problem --submitted &quot;expected-flag-value&quot;
+
+# metadata + template summary を眺める
+bun run scripts/tenkacloud-problem.ts inspect my-problem
+</code></pre>
+<p><code>make validate-problems</code> / <code>validate</code> でエラーが出たら <a href="#validation-%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%AE%E8%AA%AD%E3%81%BF%E6%96%B9">Validation エラーの読み方</a> を参照。</p>
+<h3>5. Sandbox AWS account に 1 回 deploy する (= &quot;tested&quot; 状態)</h3>
+<p>Platform は少なくとも 1 回の end-to-end deploy + scoring を確認した問題のみを <code>ready</code> にする。 個人 sandbox の AWS account を使う。</p>
+<pre><code class="language-bash">aws cloudformation deploy \
+  --template-file problems/&lt;category&gt;/my-problem/template.yaml \
+  --stack-name tc-my-problem-test \
+  --parameter-overrides NamePrefix=tc-my-problem-test \
+  --capabilities CAPABILITY_NAMED_IAM
+</code></pre>
+<p>そのあと scoring path を手で動かす (= flag 提出する / endpoint を叩く / disruption の発火を待つ etc。 問題により)。 加点が観測できたらライフサイクル上の &quot;tested&quot; に到達。</p>
+<p>Teardown:</p>
+<pre><code class="language-bash">aws cloudformation delete-stack --stack-name tc-my-problem-test
+</code></pre>
+<h3>6. PR を出す (= submodule repo に対して)</h3>
+<p>次のように <code>problems/</code> working tree 内で操作します。</p>
+<pre><code class="language-bash">cd problems
+git checkout -b feat/my-problem
+git add battles/my-problem   # または challenges/my-problem
+git commit -m &quot;feat: add my-problem&quot;
+git push origin feat/my-problem
+gh pr create --repo susumutomita/TenkaCloudChallenge \
+  --title &quot;feat: add my-problem&quot; \
+  --body &quot;...&quot;
+</code></pre>
+<p>PR body のチェックリストは次のとおりです。</p>
+<ul>
+<li>どの category、 kind、 difficulty なのか。</li>
+<li>Test plan: 走らせた <code>validate</code> / <code>dry-run</code>、 sandbox-deploy した AWS account の概要 (= account ID は書かない)。</li>
+<li>問題の status が <code>draft</code> (= ほとんどの初回 PR) / <code>tested</code> / <code>ready</code> のどれか (= 下記 lifecycle 参照)。</li>
+<li>競技者に発生する AWS コスト (= 目標: Free Tier 内 0 円)。</li>
+</ul>
+<p><code>TenkaCloud</code> 側への submodule pointer bump PR は <strong>contributor の責任ではない</strong> — maintainer 側で別 PR を切る。</p>
+<h2>Lifecycle: draft → tested → ready → official → deprecated</h2>
+<p><code>metadata.json</code> の <code>status</code> は JSON Schema enum で <code>draft</code> / <code>ready</code> / <code>deprecated</code> の 3 値のみ。 5 段階 lifecycle はこの 3 値 + 2 つの慣習 (= PR body / catalog <code>CATALOG.md</code> / commit 履歴で追う) で表現する。</p>
+<table>
+<thead>
+<tr>
+<th>Stage</th>
+<th><code>status</code> field</th>
+<th>意味</th>
+<th>Catalog 公開?</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong>draft</strong></td>
+<td><code>&quot;status&quot;: &quot;draft&quot;</code></td>
+<td>作者の進行中。 Scaffold は通る、 schema 通る、 <strong>end-to-end deploy 未確認</strong>。</td>
+<td>No (= filter)</td>
+</tr>
+<tr>
+<td><strong>tested</strong></td>
+<td><code>&quot;status&quot;: &quot;draft&quot;</code></td>
+<td>作者が sandbox account に 1 回以上 deploy + scoring 確認済。 PR body に &quot;tested in AWS sandbox&quot; を明記。</td>
+<td>No</td>
+</tr>
+<tr>
+<td><strong>ready</strong></td>
+<td><code>&quot;status&quot;: &quot;ready&quot;</code></td>
+<td>Maintainer review 通過。 公開 catalog エントリ。 誰でも event で使える。</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><strong>official</strong></td>
+<td><code>&quot;status&quot;: &quot;ready&quot;</code></td>
+<td>実 event で 1 回以上使用済 (= JAWS-UG / CCoE training 等)。 <code>official-yyyy-mm</code> tag + <code>README.md</code> に event link を追加。</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><strong>deprecated</strong></td>
+<td><code>&quot;status&quot;: &quot;deprecated&quot;</code></td>
+<td>置き換え / メンテナンス停止。 catalog は default で非表示。 履歴用に dir は残す。</td>
+<td>No</td>
+</tr>
+</tbody></table>
+<p><code>draft</code> → <code>ready</code> への昇格は別 PR で出す (= before/after が review しやすい)。 その PR body に test event / sandbox 結果を書く。</p>
+<h2>Validation エラーの読み方</h2>
+<p>CLI validator (<code>scripts/tenkacloud-problem.ts validate</code>) と <code>make validate-problems</code> のエラーを fix にマップする一覧。</p>
+<table>
+<thead>
+<tr>
+<th>エラー (= 部分一致)</th>
+<th>原因</th>
+<th>Fix</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>scoring.kind=&quot;...&quot; is not a recognized kind</code></td>
+<td><code>scoring.kind</code> の typo</td>
+<td>値を <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code> のどれかに修正する。</td>
+</tr>
+<tr>
+<td><code>scoring.flagOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td><code>metadata.scoring.flagOutputKey</code> の値が CFn <code>Output</code> key に存在しない</td>
+<td><code>template.yaml</code> に <code>Outputs.X:</code> を追加するか、 metadata 側の key を template の実際の Output key に揃える。</td>
+</tr>
+<tr>
+<td><code>scoring.statsOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td><code>attack-detection</code> で同上</td>
+<td><code>Outputs.X:</code> を追加。 <code>Value</code> は攻撃検知数 (= 整数 string)。</td>
+</tr>
+<tr>
+<td><code>endpoints[slot=N].default.key=&quot;X&quot; not found in template.yaml Outputs</code></td>
+<td><code>endpoints[].default.key</code> が存在しない Output を指す</td>
+<td><code>Outputs.X:</code> を追加 (= typically 公開 endpoint URL)。</td>
+</tr>
+<tr>
+<td><code>dashboard.slots[&quot;X&quot;]=&quot;path&quot; file not found at ...</code></td>
+<td><code>dashboard.slots</code> が存在しない portal plugin file を参照</td>
+<td><code>path</code> で示された場所に <code>.tsx</code> を作るか、 slot 宣言を消す。</td>
+</tr>
+<tr>
+<td><code>metadata.id=&quot;X&quot; does not match dir name &quot;Y&quot;</code></td>
+<td><code>metadata.id</code> と dir 名がズレた</td>
+<td>どちらかを揃える (= 完全一致が必須)。</td>
+</tr>
+<tr>
+<td><code>runtime block must declare provider / engine / entry</code></td>
+<td><code>runtime</code> が不完全 (= <code>entry</code> だけ等)</td>
+<td>3 key 全部書くか、 <code>runtime</code> block を削除する (= validator は legacy <code>cfnTemplate</code> から自動推論する)。</td>
+</tr>
+<tr>
+<td><code>runtime.entry=&quot;A&quot; and cfnTemplate=&quot;B&quot; must match</code></td>
+<td><code>runtime</code> と <code>cfnTemplate</code> の両方を書いて値が違う</td>
+<td>ADR-023 互換期間中は <code>runtime.entry === cfnTemplate</code> を強制。</td>
+</tr>
+<tr>
+<td><code>Runtime &lt;provider&gt;/&lt;engine&gt; is recognized but not executable</code></td>
+<td>将来予約された runtime (= <code>azure/arm</code>、 <code>kubernetes/helm</code> 等)</td>
+<td><code>aws/cloudformation</code> に変更する。 他は schema は通すが deploy worker が reject する。</td>
+</tr>
+<tr>
+<td><code>cfnTemplate file &quot;...&quot; not found</code></td>
+<td>filename mismatch</td>
+<td><code>cfnTemplate</code> (= または <code>runtime.entry</code>) が指す file が問題 dir に存在するか確認。</td>
+</tr>
+<tr>
+<td><code>metadata.json parse error: ...</code></td>
+<td>不正な JSON (= trailing comma、 unquoted key 等)</td>
+<td>JSON formatter を通す。 placeholder は quoted のままで OK。</td>
+</tr>
+</tbody></table>
+<p><code>make validate-problems</code> が <code>instancePath</code> (= JSON pointer 形式 <code>/scoring/points</code> 等) 付きのエラーを出した時は、 <code>metadata.json</code> を開いてその path を辿って fix する。 各 field の意味は <a href="../../problems/SCHEMA.json"><code>problems/SCHEMA.json</code></a> の <code>description</code> 参照。</p>
+<h3><code>template.yaml</code> のよくある罠</h3>
+<p>JSON Schema は catch しないが、 CFn deploy 時に死ぬ / AWS 請求が爆発するパターンを以下に挙げます。</p>
+<ul>
+<li><strong>リソース名に <code>${NamePrefix}</code> が無い</strong> — 2 team 目の deploy が衝突する。 必ず <code>!Sub &quot;${NamePrefix}-...&quot;</code> で囲む。</li>
+<li><strong><code>!Sub</code> の <code>}</code> 抜け</strong> — <code>!Sub &quot;tc-${NamePrefix-bucket&quot;</code> (= 閉じ無し) で CFn parse error。 CFn の行番号メッセージを見て <code>}</code> 抜けを探す。</li>
+<li><strong>disruption Lambda が idempotent でない</strong> — EventBridge Scheduler は再発火する。 <code>tc qdisc add ... || true</code> で EEXIST を握る。</li>
+<li><strong>PAY_PER_REQUEST DynamoDB</strong> — 禁止。 <code>BillingMode: PROVISIONED</code> + 1 RCU / 1 WCU で書く。 platform 側 table は CDK Aspect が強制するが、 問題 template は self-discipline。</li>
+<li><strong><code>Resource: &quot;*&quot;</code> IAM</strong> — CloudShell の例外 list 以外は禁止。 catalog の <code>AGENT.md</code> に例外コメント marker が定義されている (= 動かさないこと)。</li>
+</ul>
+<h2>AI-assisted authoring (= optional、 上乗せ)</h2>
+<p>Claude Code には <code>/create-problem</code> skill が同梱されており、 同じ scaffold + edit flow を AI in the loop で走らせる。 必須ではない (= 全 step は手で再現可能)。 推奨 prompt は <a href="./AI-WORKFLOW.md"><code>AI-WORKFLOW.md</code></a> 参照。</p>
+<h2>PR を出す前の checklist</h2>
+<ul>
+<li><input disabled="" type="checkbox"> <code>metadata.id</code> と dir 名が完全一致。</li>
+<li><input disabled="" type="checkbox"> <code>category</code> は <code>&quot;Battle&quot;</code> または <code>&quot;Challenge&quot;</code> (= 大文字始まり)。</li>
+<li><input disabled="" type="checkbox"> <code>status</code> は <code>&quot;draft&quot;</code> (= 初回 submission)。</li>
+<li><input disabled="" type="checkbox"> <code>scoring.kind</code> は 5 種のいずれか。</li>
+<li><input disabled="" type="checkbox"> <code>metadata.json</code> 内の <code>__PLACEHOLDER__</code> を全部置換済。</li>
+<li><input disabled="" type="checkbox"> <code>metadata.json</code> が参照する endpoint / scoring key が <code>template.yaml</code> <code>Outputs:</code> に存在する。</li>
+<li><input disabled="" type="checkbox"> <code>template.yaml</code> の全リソース名に <code>${NamePrefix}</code> が冠されている。</li>
+<li><input disabled="" type="checkbox"> <code>make validate-problems</code> 通過。</li>
+<li><input disabled="" type="checkbox"> <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code> 通過。</li>
+<li><input disabled="" type="checkbox"> Sandbox AWS account に 1 回 deploy + scoring 確認 (= PR body に明記)。</li>
+<li><input disabled="" type="checkbox"> <code>i18n.en.*</code> mirror が埋まっている (= <code>name</code> / <code>shortDescription</code> / <code>description</code> / <code>learningGoals</code>)。</li>
+<li><input disabled="" type="checkbox"> PR body に Summary、 Test plan、 Regression analysis、 Physical impact を書いた。</li>
+</ul>
+<h2>See also</h2>
+<ul>
+<li><a href="./AUTHORING.html"><code>AUTHORING.html</code></a> — 30 分 onboarding (= 全 field 一覧)。</li>
+<li><a href="./AI-WORKFLOW.md"><code>AI-WORKFLOW.md</code></a> — Claude Code / Codex CLI を使った問題作成 flow。</li>
+<li><a href="./EXAMPLES.md"><code>EXAMPLES.md</code></a> — 既存 5 問題の design 振り返り。</li>
+<li><a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md"><code>problems/AGENT.md</code></a> — catalog repo invariant (= <code>bun run validate</code> で強制)。</li>
+<li><a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> — plugin architecture (= これが土台)。</li>
+<li><a href="../architecture/adr-023-provider-specific-problem-runtime.html">ADR-023</a> — <code>runtime</code> field と将来の multi-provider 対応。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/problems/CONTRIBUTING.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/problems/CONTRIBUTING.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/problems/CONTRIBUTING.ja.md
+++ b/docs/problems/CONTRIBUTING.ja.md
@@ -1,0 +1,228 @@
+# TenkaCloud 問題 contribution ガイド — 30 分 quickstart
+
+> 対象: TenkaCloud に新規問題を 1 PR で送りたい外部 contributor。
+> ファイル形式の正本: [`problems/SCHEMA.json`](../../problems/SCHEMA.json) + [`AUTHORING.html`](./AUTHORING.html)。
+> Catalog 規約の正本: catalog submodule の [`problems/AGENT.md`](https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md)。
+
+このドキュメントは「maintainer の頭の中を使うべきではない言葉なので修正してください人が、 reviewed + merged まで辿りつく最短経路」を書く。 `AUTHORING.html` (= 30 分 onboarding) と catalog submodule の `AGENT.md` (= invariant 一覧) の補助。 **何をするか** をこのファイルで掴み、 **各 field の意味** はそれらを読む。
+
+English mirror: [`CONTRIBUTING.md`](./CONTRIBUTING.md)。
+
+## 問題は submodule に住む (= この repo ではない)
+
+Platform repository (`TenkaCloud`) と catalog repository (`TenkaCloudChallenge`) は物理的に切り離されている。
+
+```
+TenkaCloud/                           ← platform (CDK + 3 SPAs + scoring engine)
+└── problems/                         ← git submodule
+    └── (実体は github.com/susumutomita/TenkaCloudChallenge)
+```
+
+問題 PR は **`susumutomita/TenkaCloudChallenge`** に出す。 `TenkaCloud` には catalog 変更を ship する時の submodule pointer bump PR だけが入る (= maintainer 側で別 PR を切る)。
+
+ローカル作業の手順は次のとおりです。
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+# problems/ の working tree が TenkaCloudChallenge の checkout になる
+```
+
+`--recurse-submodules` 抜きで clone した場合は次を実行します。
+
+```bash
+git submodule update --init --recursive problems
+```
+
+## 30 分 quickstart (= scaffold → edit → validate → PR)
+
+### 1. 採点 kind を選ぶ (= 最重要)
+
+TenkaCloud の 1 問題は 5 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) で禁止。
+
+決定木は次のとおりです。
+
+```text
+競技者が 1 つの値 (= "flag") を提出して終わるか?
+├── Yes → kind = "flag"               (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+└── No
+    │
+    競技者が何かを稼働させ続ける必要があるか?
+    ├── Yes
+    │   │
+    │   稼働させる endpoint は 1 つだけか?
+    │   ├── Yes → kind = "uptime-flat"    (Battle / nginx 1 つ、 API 1 つ)
+    │   └── No、 複数 endpoint をまとめて → kind = "uptime-multi"
+    │       (Battle / frontend + api + worker。 「全部同時 ok」 を採点軸にする)
+    │
+    └── No
+        │
+        時間経過で rule が変わるか? (= 移行 deadline、 負荷急増等)
+        ├── Yes → kind = "phased-polling"
+        │   (Battle / phases[].afterMinutes で採点切替。 マイクロサービス移行レースが典型)
+        │
+        └── 攻撃検知 / 防御が採点軸か?
+            └── Yes → kind = "attack-detection"
+                (Battle / WAF / SOC。 検出 1 件あたり +N)
+```
+
+どれにも当てはまらない → **まだ TenkaCloud の問題ではない可能性**。 先に issue で議論する。
+
+### 2. ディレクトリ scaffold
+
+```bash
+bun run scripts/tenkacloud-problem.ts create my-problem --kind flag
+# または対話的に:
+bun run scripts/tenkacloud-problem.ts create
+```
+
+CLI が `.claude/templates/problems/<kind>/` から `problems/<category>/my-problem/{metadata.json,template.yaml}` を生成する。 `<category>` は kind から決まる (flag → `challenges/`、 それ以外 → `battles/`)。 `--category Battle|Challenge` で上書き可。
+
+Alternative: Claude Code 上で `/create-problem` を起動すると同じ flow を AI 経由で進められる。
+
+### 3. Scaffold を編集
+
+Scaffold 内には `__PROBLEM_NAME__`、 `__TAG__`、 `__LEARNING_GOAL_1__`、 `__HINT_1__` 等の placeholder が残る。 **`__` を全部 grep して書き換える** こと。 JSON Schema は placeholder を string として通すが、 catalog UI と scoring engine は誤動作する。
+
+最低限の編集箇所は次のとおりです。
+
+- `name`、 `shortDescription`、 `description` — 読み手が zero context な前提で書く。 Battle は架空の incident 一段落で導入するのが定型。
+- `tags` — kebab-case で 1 つ以上。
+- `learningGoals` — 1 bullet 以上。
+- `i18n.en.*` — `name` / `shortDescription` / `description` / `learningGoals` の英訳 mirror が必須。 サポート locale は `ja` + `en` のみ。
+- `template.yaml` — placeholder resource を実 CFn に置換。 全リソース名 / タグ / Group 名に `${NamePrefix}` を冠する (= 同一 AWS account に複数 team の stack が並ぶ前提)。
+
+### 4. ローカル検証
+
+```bash
+# JSON Schema 検証 (= 全 catalog)
+make validate-problems
+
+# 1 問題に対する cross-check (Outputs ↔ metadata 配線、 portal slot file 存在)
+bun run scripts/tenkacloud-problem.ts validate my-problem
+
+# Optional: scoring engine の dry-run (= CFn deploy 抜き)
+bun run scripts/tenkacloud-problem.ts dry-run my-problem --submitted "expected-flag-value"
+
+# metadata + template summary を眺める
+bun run scripts/tenkacloud-problem.ts inspect my-problem
+```
+
+`make validate-problems` / `validate` でエラーが出たら [Validation エラーの読み方](#validation-エラーの読み方) を参照。
+
+### 5. Sandbox AWS account に 1 回 deploy する (= "tested" 状態)
+
+Platform は少なくとも 1 回の end-to-end deploy + scoring を確認した問題のみを `ready` にする。 個人 sandbox の AWS account を使う。
+
+```bash
+aws cloudformation deploy \
+  --template-file problems/<category>/my-problem/template.yaml \
+  --stack-name tc-my-problem-test \
+  --parameter-overrides NamePrefix=tc-my-problem-test \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+そのあと scoring path を手で動かす (= flag 提出する / endpoint を叩く / disruption の発火を待つ etc。 問題により)。 加点が観測できたらライフサイクル上の "tested" に到達。
+
+Teardown:
+
+```bash
+aws cloudformation delete-stack --stack-name tc-my-problem-test
+```
+
+### 6. PR を出す (= submodule repo に対して)
+
+次のように `problems/` working tree 内で操作します。
+
+```bash
+cd problems
+git checkout -b feat/my-problem
+git add battles/my-problem   # または challenges/my-problem
+git commit -m "feat: add my-problem"
+git push origin feat/my-problem
+gh pr create --repo susumutomita/TenkaCloudChallenge \
+  --title "feat: add my-problem" \
+  --body "..."
+```
+
+PR body のチェックリストは次のとおりです。
+
+- どの category、 kind、 difficulty なのか。
+- Test plan: 走らせた `validate` / `dry-run`、 sandbox-deploy した AWS account の概要 (= account ID は書かない)。
+- 問題の status が `draft` (= ほとんどの初回 PR) / `tested` / `ready` のどれか (= 下記 lifecycle 参照)。
+- 競技者に発生する AWS コスト (= 目標: Free Tier 内 0 円)。
+
+`TenkaCloud` 側への submodule pointer bump PR は **contributor の責任ではない** — maintainer 側で別 PR を切る。
+
+## Lifecycle: draft → tested → ready → official → deprecated
+
+`metadata.json` の `status` は JSON Schema enum で `draft` / `ready` / `deprecated` の 3 値のみ。 5 段階 lifecycle はこの 3 値 + 2 つの慣習 (= PR body / catalog `CATALOG.md` / commit 履歴で追う) で表現する。
+
+| Stage          | `status` field      | 意味                                                                          | Catalog 公開? |
+| -------------- | ------------------- | ----------------------------------------------------------------------------- | ------------- |
+| **draft**      | `"status": "draft"` | 作者の進行中。 Scaffold は通る、 schema 通る、 **end-to-end deploy 未確認**。 | No (= filter) |
+| **tested**     | `"status": "draft"` | 作者が sandbox account に 1 回以上 deploy + scoring 確認済。 PR body に "tested in AWS sandbox" を明記。 | No            |
+| **ready**      | `"status": "ready"` | Maintainer review 通過。 公開 catalog エントリ。 誰でも event で使える。     | Yes           |
+| **official**   | `"status": "ready"` | 実 event で 1 回以上使用済 (= JAWS-UG / CCoE training 等)。 `official-yyyy-mm` tag + `README.md` に event link を追加。 | Yes           |
+| **deprecated** | `"status": "deprecated"` | 置き換え / メンテナンス停止。 catalog は default で非表示。 履歴用に dir は残す。 | No            |
+
+`draft` → `ready` への昇格は別 PR で出す (= before/after が review しやすい)。 その PR body に test event / sandbox 結果を書く。
+
+## Validation エラーの読み方
+
+CLI validator (`scripts/tenkacloud-problem.ts validate`) と `make validate-problems` のエラーを fix にマップする一覧。
+
+| エラー (= 部分一致)                                                       | 原因                                                                              | Fix                                                                                                                       |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `scoring.kind="..." is not a recognized kind`                            | `scoring.kind` の typo                                                            | 値を `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection` のどれかに修正する。                  |
+| `scoring.flagOutputKey="X" not found in template.yaml Outputs`           | `metadata.scoring.flagOutputKey` の値が CFn `Output` key に存在しない              | `template.yaml` に `Outputs.X:` を追加するか、 metadata 側の key を template の実際の Output key に揃える。               |
+| `scoring.statsOutputKey="X" not found in template.yaml Outputs`          | `attack-detection` で同上                                                          | `Outputs.X:` を追加。 `Value` は攻撃検知数 (= 整数 string)。                                                              |
+| `endpoints[slot=N].default.key="X" not found in template.yaml Outputs`   | `endpoints[].default.key` が存在しない Output を指す                              | `Outputs.X:` を追加 (= typically 公開 endpoint URL)。                                                                     |
+| `dashboard.slots["X"]="path" file not found at ...`                      | `dashboard.slots` が存在しない portal plugin file を参照                          | `path` で示された場所に `.tsx` を作るか、 slot 宣言を消す。                                                              |
+| `metadata.id="X" does not match dir name "Y"`                            | `metadata.id` と dir 名がズレた                                                    | どちらかを揃える (= 完全一致が必須)。                                                                                    |
+| `runtime block must declare provider / engine / entry`                   | `runtime` が不完全 (= `entry` だけ等)                                              | 3 key 全部書くか、 `runtime` block を削除する (= validator は legacy `cfnTemplate` から自動推論する)。                  |
+| `runtime.entry="A" and cfnTemplate="B" must match`                       | `runtime` と `cfnTemplate` の両方を書いて値が違う                                 | ADR-023 互換期間中は `runtime.entry === cfnTemplate` を強制。                                                            |
+| `Runtime <provider>/<engine> is recognized but not executable`           | 将来予約された runtime (= `azure/arm`、 `kubernetes/helm` 等)                     | `aws/cloudformation` に変更する。 他は schema は通すが deploy worker が reject する。                                  |
+| `cfnTemplate file "..." not found`                                       | filename mismatch                                                                  | `cfnTemplate` (= または `runtime.entry`) が指す file が問題 dir に存在するか確認。                                       |
+| `metadata.json parse error: ...`                                         | 不正な JSON (= trailing comma、 unquoted key 等)                                  | JSON formatter を通す。 placeholder は quoted のままで OK。                                                              |
+
+`make validate-problems` が `instancePath` (= JSON pointer 形式 `/scoring/points` 等) 付きのエラーを出した時は、 `metadata.json` を開いてその path を辿って fix する。 各 field の意味は [`problems/SCHEMA.json`](../../problems/SCHEMA.json) の `description` 参照。
+
+### `template.yaml` のよくある罠
+
+JSON Schema は catch しないが、 CFn deploy 時に死ぬ / AWS 請求が爆発するパターンを以下に挙げます。
+
+- **リソース名に `${NamePrefix}` が無い** — 2 team 目の deploy が衝突する。 必ず `!Sub "${NamePrefix}-..."` で囲む。
+- **`!Sub` の `}` 抜け** — `!Sub "tc-${NamePrefix-bucket"` (= 閉じ無し) で CFn parse error。 CFn の行番号メッセージを見て `}` 抜けを探す。
+- **disruption Lambda が idempotent でない** — EventBridge Scheduler は再発火する。 `tc qdisc add ... || true` で EEXIST を握る。
+- **PAY_PER_REQUEST DynamoDB** — 禁止。 `BillingMode: PROVISIONED` + 1 RCU / 1 WCU で書く。 platform 側 table は CDK Aspect が強制するが、 問題 template は self-discipline。
+- **`Resource: "*"` IAM** — CloudShell の例外 list 以外は禁止。 catalog の `AGENT.md` に例外コメント marker が定義されている (= 動かさないこと)。
+
+## AI-assisted authoring (= optional、 上乗せ)
+
+Claude Code には `/create-problem` skill が同梱されており、 同じ scaffold + edit flow を AI in the loop で走らせる。 必須ではない (= 全 step は手で再現可能)。 推奨 prompt は [`AI-WORKFLOW.md`](./AI-WORKFLOW.md) 参照。
+
+## PR を出す前の checklist
+
+- [ ] `metadata.id` と dir 名が完全一致。
+- [ ] `category` は `"Battle"` または `"Challenge"` (= 大文字始まり)。
+- [ ] `status` は `"draft"` (= 初回 submission)。
+- [ ] `scoring.kind` は 5 種のいずれか。
+- [ ] `metadata.json` 内の `__PLACEHOLDER__` を全部置換済。
+- [ ] `metadata.json` が参照する endpoint / scoring key が `template.yaml` `Outputs:` に存在する。
+- [ ] `template.yaml` の全リソース名に `${NamePrefix}` が冠されている。
+- [ ] `make validate-problems` 通過。
+- [ ] `bun run scripts/tenkacloud-problem.ts validate <id>` 通過。
+- [ ] Sandbox AWS account に 1 回 deploy + scoring 確認 (= PR body に明記)。
+- [ ] `i18n.en.*` mirror が埋まっている (= `name` / `shortDescription` / `description` / `learningGoals`)。
+- [ ] PR body に Summary、 Test plan、 Regression analysis、 Physical impact を書いた。
+
+## See also
+
+- [`AUTHORING.html`](./AUTHORING.html) — 30 分 onboarding (= 全 field 一覧)。
+- [`AI-WORKFLOW.md`](./AI-WORKFLOW.md) — Claude Code / Codex CLI を使った問題作成 flow。
+- [`EXAMPLES.md`](./EXAMPLES.md) — 既存 5 問題の design 振り返り。
+- [`problems/AGENT.md`](https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md) — catalog repo invariant (= `bun run validate` で強制)。
+- [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) — plugin architecture (= これが土台)。
+- [ADR-023](../architecture/adr-023-provider-specific-problem-runtime.html) — `runtime` field と将来の multi-provider 対応。

--- a/docs/problems/CONTRIBUTING.md
+++ b/docs/problems/CONTRIBUTING.md
@@ -1,0 +1,228 @@
+# Contributing problems to TenkaCloud — 30-minute quickstart
+
+> Audience: external contributors who want to ship a new TenkaCloud problem in one focused PR.
+> Source of truth for the file format: [`problems/SCHEMA.json`](../../problems/SCHEMA.json) + [`AUTHORING.html`](./AUTHORING.html).
+> Source of truth for catalog conventions: [`problems/AGENT.md`](https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md) in the catalog submodule.
+
+This guide is the **shortest path** for someone outside the maintainer's head to get a problem reviewed and merged. It complements `AUTHORING.html` (= the 30-minute onboarding tour) and `AGENT.md` in the catalog submodule (= the invariant list). Read this first when you want to know **what to do**; read those when you want to know **what each field means**.
+
+Japanese mirror: [`CONTRIBUTING.ja.md`](./CONTRIBUTING.ja.md).
+
+## Where problems live (= submodule, not this repo)
+
+The platform repository (`TenkaCloud`) and the catalog repository (`TenkaCloudChallenge`) are physically decoupled.
+
+```
+TenkaCloud/                           ← platform (CDK + 3 SPAs + scoring engine)
+└── problems/                         ← git submodule
+    └── (real files live in github.com/susumutomita/TenkaCloudChallenge)
+```
+
+You submit problem PRs to **`susumutomita/TenkaCloudChallenge`**, not to `TenkaCloud`. The platform repo only needs a submodule pointer bump when a catalog change should ship.
+
+To work locally:
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+# the working tree under problems/ is now a checkout of TenkaCloudChallenge
+```
+
+If you cloned without `--recurse-submodules`:
+
+```bash
+git submodule update --init --recursive problems
+```
+
+## 30-minute quickstart (= scaffold → edit → validate → PR)
+
+### 1. Pick the scoring kind (= the most important decision)
+
+A TenkaCloud problem ships exactly one of five built-in scoring kinds. The platform's generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by [ADR-012](../architecture/adr-012-problem-plugin-architecture.html).
+
+Use this decision tree:
+
+```text
+Does the competitor submit a single value (a "flag") to win?
+├── Yes → kind = "flag"               (Challenge, e.g. read an SSM Parameter, find an S3 object)
+└── No
+    │
+    Does the competitor have to keep something running?
+    ├── Yes
+    │   │
+    │   Is there exactly one endpoint to keep alive?
+    │   ├── Yes → kind = "uptime-flat"    (Battle, one nginx, one API)
+    │   └── No, several endpoints together → kind = "uptime-multi"
+    │       (Battle, frontend + api + worker; scoring rewards "all green at once")
+    │
+    └── No
+        │
+        Does the rule change over time (e.g. a migration deadline, a load surge)?
+        ├── Yes → kind = "phased-polling"
+        │   (Battle, phases[].afterMinutes shifts scoring; classic for migration races)
+        │
+        └── Is the goal to detect or block attacks?
+            └── Yes → kind = "attack-detection"
+                (Battle, WAF / SOC; scores +N per detected attack)
+```
+
+If none fits, the problem is probably **not yet a TenkaCloud problem** — file an issue first.
+
+### 2. Scaffold the directory
+
+```bash
+bun run scripts/tenkacloud-problem.ts create my-problem --kind flag
+# or for guided interactive input:
+bun run scripts/tenkacloud-problem.ts create
+```
+
+The CLI creates `problems/<category>/my-problem/{metadata.json,template.yaml}` from `.claude/templates/problems/<kind>/`. `<category>` is inferred from `<kind>` (flag → `challenges/`, otherwise `battles/`); override with `--category Battle|Challenge`.
+
+Alternative: in Claude Code, run `/create-problem`. The skill walks through the same steps interactively.
+
+### 3. Edit the scaffold
+
+The scaffold contains `__PROBLEM_NAME__`, `__TAG__`, `__LEARNING_GOAL_1__`, `__HINT_1__` and similar placeholders. **Grep for `__` and replace every occurrence** — JSON Schema accepts placeholders because they are strings, but the catalog UI and scoring engine will misbehave.
+
+Minimum edits:
+
+- `name`, `shortDescription`, `description` — write them as if the reader has zero context. Battles usually open with a one-paragraph fictional incident.
+- `tags` — kebab-case, at least one.
+- `learningGoals` — at least one bullet.
+- `i18n.en.*` — required mirror for `name` / `shortDescription` / `description` / `learningGoals`. Locale support is `ja` + `en` only (no other locales).
+- `template.yaml` — replace placeholder resources with real CFn. Every resource name, tag, and Group name must be prefixed with `${NamePrefix}` so multiple teams can deploy into the same AWS account.
+
+### 4. Validate locally
+
+```bash
+# JSON Schema validation across the whole catalog
+make validate-problems
+
+# Per-problem cross-checks (Outputs ↔ metadata wiring, dashboard slot files)
+bun run scripts/tenkacloud-problem.ts validate my-problem
+
+# Optional: dry-run the scoring engine without deploying CFn
+bun run scripts/tenkacloud-problem.ts dry-run my-problem --submitted "expected-flag-value"
+
+# Inspect the rendered metadata + template summary
+bun run scripts/tenkacloud-problem.ts inspect my-problem
+```
+
+If `make validate-problems` or `validate` errors, see [Validation errors](#validation-errors-and-how-to-read-them) below.
+
+### 5. Deploy once into a sandbox AWS account (= "tested" status)
+
+The platform never marks a problem `ready` until at least one human has deployed it end to end. Use a personal sandbox AWS account:
+
+```bash
+aws cloudformation deploy \
+  --template-file problems/<category>/my-problem/template.yaml \
+  --stack-name tc-my-problem-test \
+  --parameter-overrides NamePrefix=tc-my-problem-test \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+Then exercise the scoring path manually (submit the flag, hit the endpoints, wait for a disruption to fire — whichever applies). If it scores, the problem is "tested" in the lifecycle sense (see below).
+
+Tear down:
+
+```bash
+aws cloudformation delete-stack --stack-name tc-my-problem-test
+```
+
+### 6. Open the PR (= against the submodule repo)
+
+In the `problems/` working tree:
+
+```bash
+cd problems
+git checkout -b feat/my-problem
+git add battles/my-problem  # or challenges/my-problem
+git commit -m "feat: add my-problem"
+git push origin feat/my-problem
+gh pr create --repo susumutomita/TenkaCloudChallenge \
+  --title "feat: add my-problem" \
+  --body "..."
+```
+
+PR body checklist:
+
+- What category, kind, and difficulty.
+- Test plan: which `validate` / `dry-run` commands you ran, plus the AWS account you sandbox-deployed into (no account IDs).
+- Whether the problem is `draft` (most first PRs), `tested`, or `ready` (see lifecycle below).
+- Any cost the participant will incur (target: zero outside Free Tier).
+
+A submodule-pointer bump PR against `TenkaCloud` is **not your responsibility** — the maintainer or a separate PR handles that.
+
+## Lifecycle: draft → tested → ready → official → deprecated
+
+`metadata.json` `status` is a JSON Schema enum with three values: `draft`, `ready`, `deprecated`. The full five-stage lifecycle uses these three plus two conventions tracked in PR descriptions, the catalog `CATALOG.md`, or commit history.
+
+| Stage          | `status` field      | Means                                                                       | Visible in catalog? |
+| -------------- | ------------------- | --------------------------------------------------------------------------- | ------------------- |
+| **draft**      | `"status": "draft"` | Author work-in-progress. Scaffold compiles, schema passes, **not yet deployed end-to-end.** | No (filtered out)   |
+| **tested**     | `"status": "draft"` | Author has deployed once into a sandbox AWS account and confirmed scoring. Note "tested in AWS sandbox" in PR body. | No                  |
+| **ready**      | `"status": "ready"` | Maintainer review passed. Public catalog entry. Anyone can spin it up at an event. | Yes                 |
+| **official**   | `"status": "ready"` | Used at least once in a real public event (JAWS-UG, CCoE training). Add an `official-yyyy-mm` tag and link the event in `README.md`. | Yes                 |
+| **deprecated** | `"status": "deprecated"` | Replaced or no longer maintained. Catalog filters by default. Keep the dir for historical reference. | No                  |
+
+Promotion from `draft` to `ready` is a separate PR (not the original add) so reviewers can compare before/after. Mention the test event or sandbox results in that PR body.
+
+## Validation errors and how to read them
+
+The CLI validator (`scripts/tenkacloud-problem.ts validate`) and `make validate-problems` produce messages like the table below. Each row maps a real error to its fix.
+
+| Symptom (substring of the error)                                            | Likely cause                                                                       | Fix                                                                                                                                  |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `scoring.kind="..." is not a recognized kind`                               | Typo in `scoring.kind`                                                             | Set it to exactly one of `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`.                            |
+| `scoring.flagOutputKey="X" not found in template.yaml Outputs`              | `metadata.scoring.flagOutputKey` references a CFn `Output` key that doesn't exist  | Open `template.yaml`, add an `Outputs.X:` entry, or fix the metadata key. Both sides must match exactly.                             |
+| `scoring.statsOutputKey="X" not found in template.yaml Outputs`             | Same as above for `attack-detection`                                               | Add an `Outputs.X:` entry whose `Value` is the integer attack count.                                                                 |
+| `endpoints[slot=N].default.key="X" not found in template.yaml Outputs`      | `endpoints[].default.key` points at a missing Output                               | Add the `Outputs.X:` entry (typically the public URL of the endpoint slot).                                                          |
+| `dashboard.slots["X"]="path" file not found at ...`                         | A `dashboard.slots` entry references a portal plugin file that does not exist      | Either create the `.tsx` file at the referenced path, or remove the slot entry.                                                      |
+| `metadata.id="X" does not match dir name "Y"`                               | `metadata.id` and the directory name diverged                                      | Rename the directory or fix `metadata.id`. They must be identical.                                                                   |
+| `runtime block must declare provider / engine / entry`                      | Partial `runtime` field (e.g. only `entry`)                                        | Either set all three keys or drop the `runtime` block (the validator falls back to legacy `cfnTemplate`).                            |
+| `runtime.entry="A" and cfnTemplate="B" must match`                          | Both `runtime` and `cfnTemplate` are set but disagree                              | Make `runtime.entry === cfnTemplate` during the ADR-023 compatibility window.                                                        |
+| `Runtime <provider>/<engine> is recognized but not executable`              | Reserved future runtime (e.g. `azure/arm`, `kubernetes/helm`)                      | Switch to `aws/cloudformation`. Other providers parse but are not yet executable.                                                    |
+| `cfnTemplate file "..." not found`                                          | Filename mismatch                                                                  | Ensure the file referenced by `cfnTemplate` (or `runtime.entry`) exists in the problem directory.                                    |
+| `metadata.json parse error: ...`                                            | Invalid JSON (trailing comma, unquoted key)                                        | Run the file through a JSON formatter; placeholders must stay quoted.                                                                |
+
+For schema errors from `make validate-problems` that include `instancePath` (= JSON pointer like `/scoring/points`), open `metadata.json`, follow that path, and fix the offending value. The schema's `description` fields ([`problems/SCHEMA.json`](../../problems/SCHEMA.json)) explain each property.
+
+### Common `template.yaml` mistakes
+
+These are not caught by JSON Schema but are caught by CFn at deploy time or by AWS cost surprise:
+
+- **Missing `${NamePrefix}` on a resource name** — two teams collide at deploy time. Always wrap names with `!Sub "${NamePrefix}-..."`.
+- **`!Sub` without closing brace** — `!Sub "tc-${NamePrefix-bucket"` instead of `!Sub "tc-${NamePrefix}-bucket"`. Read the line CFn reports and look for the missing `}`.
+- **Non-idempotent disruption Lambda** — EventBridge Scheduler re-fires; wrap `tc qdisc add ...` with `|| true` so EEXIST does not crash later cycles.
+- **PAY_PER_REQUEST DynamoDB** — forbidden. Use `BillingMode: PROVISIONED` with 1 RCU / 1 WCU; the platform's CDK Aspect enforces this for platform tables, but problem templates must self-discipline.
+- **`Resource: "*"` IAM** — only allowed for CloudShell and a documented list. The catalog's `AGENT.md` lists the exception comment markers; do not remove them.
+
+## AI-assisted authoring (= optional, additive)
+
+Claude Code ships with a `/create-problem` skill that runs the same scaffold + edit flow with an AI in the loop. It is not required — every step is reproducible by hand. See [`AI-WORKFLOW.md`](./AI-WORKFLOW.md) for the recommended prompts.
+
+## Checklist before opening the PR
+
+- [ ] `metadata.id` matches the directory name.
+- [ ] `category` is `"Battle"` or `"Challenge"` (capitalized).
+- [ ] `status` is `"draft"` for a first submission.
+- [ ] `scoring.kind` is one of the five built-ins.
+- [ ] Every `__PLACEHOLDER__` in `metadata.json` has been replaced.
+- [ ] Every endpoint / scoring key referenced from `metadata.json` exists as a key in `template.yaml` `Outputs:`.
+- [ ] Every resource name in `template.yaml` is prefixed with `${NamePrefix}`.
+- [ ] `make validate-problems` passes.
+- [ ] `bun run scripts/tenkacloud-problem.ts validate <id>` passes.
+- [ ] Deploy + scoring tested at least once in a sandbox AWS account (PR body mentions it).
+- [ ] `i18n.en.*` mirrors are filled in for `name` / `shortDescription` / `description` / `learningGoals`.
+- [ ] PR body describes Summary, Test plan, Regression analysis, Physical impact.
+
+## See also
+
+- [`AUTHORING.html`](./AUTHORING.html) — 30-minute onboarding with the full field list.
+- [`AI-WORKFLOW.md`](./AI-WORKFLOW.md) — Claude Code / Codex CLI workflow for problem authoring.
+- [`EXAMPLES.md`](./EXAMPLES.md) — design retrospectives on the five reference problems.
+- [`problems/AGENT.md`](https://github.com/susumutomita/TenkaCloudChallenge/blob/main/AGENT.md) — catalog repo invariants (deploy-time rules enforced by `bun run validate`).
+- [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) — the plugin architecture that makes this possible.
+- [ADR-023](../architecture/adr-023-provider-specific-problem-runtime.html) — the `runtime` field and future multi-provider support.

--- a/docs/problems/EXAMPLES.html
+++ b/docs/problems/EXAMPLES.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Problem design retrospectives — five reference problems</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Problem design retrospectives — five reference problems</h1>
+<blockquote>
+<p>Audience: new problem authors who want to learn from existing problems before writing their own.
+Read alongside <a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> (= how to ship) and <a href="./AUTHORING.html"><code>AUTHORING.html</code></a> (= 30-minute onboarding).</p>
+</blockquote>
+<p>This file is a design post-mortem of the five reference problems currently in the catalog. The goal is to make the <em>why</em> explicit — the constraints that shaped each problem and the trade-offs the author accepted. Reading these saves you from rediscovering the same lessons.</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Problem</th>
+<th>Category</th>
+<th>Kind</th>
+<th>Difficulty</th>
+<th>Cost target</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td><a href="#1-hello-world-flag"><code>hello-world</code></a></td>
+<td>Challenge</td>
+<td>flag</td>
+<td>1</td>
+<td>Zero (SSM Standard)</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="#2-hello-world-battle-uptime-flat"><code>hello-world-battle</code></a></td>
+<td>Battle</td>
+<td>uptime-flat</td>
+<td>1</td>
+<td>Free Tier (t3.micro)</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="#3-security-battle-royale-uptime-multi"><code>security-battle-royale</code></a></td>
+<td>Battle</td>
+<td>uptime-multi</td>
+<td>4</td>
+<td>&lt; $0.10 / 90 min</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="#4-microservice-migration-battle-phased-polling"><code>microservice-migration-battle</code></a></td>
+<td>Battle</td>
+<td>phased-polling</td>
+<td>4</td>
+<td>&lt; $0.50 / 120 min</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="#5-stackstack-phased-polling--disruptions"><code>stackstack</code></a></td>
+<td>Battle</td>
+<td>phased-polling</td>
+<td>4</td>
+<td>&lt; $0.50 / 120 min</td>
+</tr>
+</tbody></table>
+<p>The problems are listed by increasing complexity. If you are writing your first problem, study <code>hello-world</code> and <code>hello-world-battle</code> first.</p>
+<h2>1. <code>hello-world</code> (flag)</h2>
+<p><strong>One-line design intent.</strong> Smoke-test the entire deploy → flag-submission → score pipeline with zero AWS cost.</p>
+<p><strong>Why this design.</strong></p>
+<ul>
+<li><code>flag</code> is the simplest kind: one CFn deploy, one SSM Parameter, one submission, one comparison.</li>
+<li>Only resource is an SSM Parameter Store entry on Standard tier. Free, scoped to one team via <code>${NamePrefix}</code>.</li>
+<li>The Output <code>ParameterConsoleUrl</code> deeplinks straight to the AWS Console. That makes the &quot;find the value&quot; UX a single click rather than a CLI quest, which keeps difficulty=1 honest.</li>
+<li>Hints carry penalties (10 / 20 pt out of 100) so the system can be exercised end-to-end without making the problem trivial.</li>
+</ul>
+<p><strong>Trade-off accepted.</strong></p>
+<ul>
+<li>&quot;Read a parameter&quot; is not a realistic SRE scenario. The fictional Kato-san narrative (= predecessor left it behind) is there purely so the problem <strong>feels</strong> like an SRE situation. The mechanism is sanity-check; the <em>story</em> is character-building.</li>
+</ul>
+<p><strong>Reusable patterns.</strong></p>
+<ul>
+<li>Single-Parameter-Store flag is the right shape for any &quot;verify the candidate can find X in the AWS Console&quot; Challenge.</li>
+<li>Console deeplink Output (<code>ParameterConsoleUrl</code>) is more discoverable than CLI guidance. Copy this pattern when teaching navigation.</li>
+</ul>
+<h2>2. <code>hello-world-battle</code> (uptime-flat)</h2>
+<p><strong>One-line design intent.</strong> Smallest Battle that exercises the platform&#39;s per-minute polling scoring engine, on free-tier EC2.</p>
+<p><strong>Why this design.</strong></p>
+<ul>
+<li>One VPC, one t3.micro, one nginx, one Python <code>/healthz</code>. The CFn surface is intentionally minimal so new authors can read the whole template in one sitting.</li>
+<li>The <code>FrontendUrl</code> / <code>ApiUrl</code> Outputs are emitted <strong>empty</strong> by design (= invariant #9 in the catalog <code>AGENT.md</code>). Competitors must paste the URLs into the Participant Portal override fields. This prevents &quot;deploy auto-earns points&quot; and forces the contestant to engage with the portal before scoring starts.</li>
+<li>SSM セッション Manager is used instead of SSH. No key management, no inbound port 22, and the same recovery flow works for every team.</li>
+</ul>
+<p><strong>Trade-off accepted.</strong></p>
+<ul>
+<li>Two endpoint slots could have been <code>uptime-multi</code>, but <code>uptime-flat</code> with a single combined success condition is simpler to author. The cost is that partial recovery (frontend up, API down) does not earn partial credit. Author judged that &quot;all-or-nothing&quot; is the right teaching message for &quot;uptime is binary in a Battle context&quot;.</li>
+</ul>
+<p><strong>Reusable patterns.</strong></p>
+<ul>
+<li>Empty Output + portal override is the canonical way to gate scoring on competitor action.</li>
+<li><code>Ec2HostHint</code> Output (= public DNS hint) makes the override step a copy-paste rather than a discovery puzzle.</li>
+<li>t3.micro within Free Tier is a hard ceiling. Heavier compute belongs in a difficulty=3+ problem with cost warnings.</li>
+</ul>
+<h2>3. <code>security-battle-royale</code> (uptime-multi)</h2>
+<p><strong>One-line design intent.</strong> Force the contestant to keep two services (nginx + Flask) returning 200 <em>simultaneously</em> while patching a real codebase under operator-fired attack probes.</p>
+<p><strong>Why this design.</strong></p>
+<ul>
+<li>Two endpoint slots scored with <code>uptime-multi</code>: a cycle pays out only when <em>both</em> are green. This rewards holistic uptime over single-service heroics.</li>
+<li>Real code (MySQL + Flask + nginx in docker-compose on one EC2) so the contestant has to read someone else&#39;s code under time pressure, which is the actual SRE incident-response skill.</li>
+<li><code>${NamePrefix}</code> isolation per team means cross-tenant attacks are physically impossible. The &quot;Battle&quot; framing is intra-team — operator probes, not other teams.</li>
+<li>Default <code>AllowedCidr: 0.0.0.0/0</code> because the problem is designed to be played publicly. The operator can tighten this via CFn parameter for closed events.</li>
+</ul>
+<p><strong>Trade-off accepted.</strong></p>
+<ul>
+<li>A real Flask app introduces an authoring burden (the code has to be both vulnerable enough to teach and stable enough to demo). Author chose pre-baked vulnerable patterns rather than CVE-grade exploits, keeping the difficulty at 4 rather than 5.</li>
+<li>Cost rises to ~$0.10 per 90 minutes (t3.small). Free Tier no longer covers it. This is the cost ceiling for an unfunded contestant practice セッション.</li>
+</ul>
+<p><strong>Reusable patterns.</strong></p>
+<ul>
+<li><code>uptime-multi</code> with <code>failurePenalty</code> rewards graceful hardening (= &quot;let some attacks through, keep 200 returning&quot;) over perfect hardening (= &quot;lock everything down, app dies&quot;).</li>
+<li>&quot;Inherited codebase&quot; narrative removes the &quot;this is contrived&quot; complaint. The Kato-san character is the platform-wide convention for this kind of story setup.</li>
+</ul>
+<h2>4. <code>microservice-migration-battle</code> (phased-polling)</h2>
+<p><strong>One-line design intent.</strong> Teach the strangler-fig migration pattern by paying out <em>more</em> per minute as the contestant peels services off an EC2 monolith onto managed runtimes.</p>
+<p><strong>Why this design.</strong></p>
+<ul>
+<li>Three services (users / orders / catalog) initially co-located on one EC2 behind nginx. Each service exposes <code>GET /meta</code> so the scoring engine can ask &quot;where do you live now?&quot; and pay out per hosting tier.</li>
+<li><code>phased-polling</code> with <code>platformRules</code> (= per-hosting payout table) is the only kind where the <em>scoring weight changes with the contestant&#39;s own infrastructure choices</em>. EC2 pays the least, Lambda / ECS / App Runner pay progressively more.</li>
+<li><code>phases[].afterMinutes</code> shifts the rules at fixed offsets. This makes &quot;you waited too long to migrate&quot; a measurable score penalty rather than a vibe.</li>
+<li>Three endpoint slots, all <code>overridable: true</code>. The default URL is the EC2 monolith; the override is the new managed-runtime URL. The scoring engine probes whichever is current.</li>
+</ul>
+<p><strong>Trade-off accepted.</strong></p>
+<ul>
+<li>The author had to ship Dockerfiles that load cleanly on three different runtimes (Lambda, ECS Fargate, App Runner). That is non-trivial portage work. The reward is that the contestant gets to pick which service goes where, which is the actual product decision.</li>
+<li>IAM permissions for the contestant to deploy Lambda / ECS / App Runner are a separate concern, called out as a follow-up. As-shipped, the problem assumes the contestant has those rights in the sandbox account.</li>
+</ul>
+<p><strong>Reusable patterns.</strong></p>
+<ul>
+<li><code>/meta</code> self-report endpoint is the canonical way to let a contestant <em>change</em> their hosting tier without the platform having to detect it. Copy this when the contestant&#39;s choice of architecture is the answer.</li>
+<li><code>appendPath</code> in <code>endpoints[].default</code> lets one CFn Output (<code>BaseUrl</code>) serve multiple slots (<code>/users</code> / <code>/orders</code> / <code>/catalog</code>) cleanly.</li>
+<li>Phased polling without disruption is the minimum viable phase mechanic. Add disruption (see <code>stackstack</code>) when the rule-change should be operator-triggered rather than time-triggered.</li>
+</ul>
+<h2>5. <code>stackstack</code> (phased-polling + disruptions)</h2>
+<p><strong>One-line design intent.</strong> The five-axis Platform Engineering Battle: harden an AI-generated app along five control axes (auth / network / rate / audit / ux) while time-based phases and random org-event disruptions punish stalling.</p>
+<p><strong>Why this design.</strong></p>
+<ul>
+<li>Five endpoint slots, each representing a <em>control axis</em> rather than a service. This is the most ambitious shape currently in the catalog: the contestant is not migrating one app, but applying five different control disciplines in parallel.</li>
+<li>Each slot pays 10× more on a managed runtime than on EC2 (100 → 1,000 pt/cycle). The +30,000 all-managed bonus rewards complete migration, not partial credit.</li>
+<li>Phases at 30 / 60 / 90 minutes (<code>production-ramp</code>, <code>compliance-audit</code>, <code>incident-response</code>) degrade <em>every slot still on EC2</em>, not just the slow ones. This forces parallel work rather than sequential migration.</li>
+<li>Disruption catalog (CEO 5000-user demand, MFA mandate, PII finding, .env leak, AI-committed secret) fires at operator discretion. The contestant cannot plan the order in advance.</li>
+</ul>
+<p><strong>Trade-off accepted.</strong></p>
+<ul>
+<li>The metadata.json is much larger than the other four problems. The <code>phases[]</code> × <code>disruptions[]</code> × five slots combinatorial space pushes the schema near its expressivity limit. Authors should treat <code>stackstack</code> as the upper bound on how much should live in a single problem — beyond this, split into multiple problems.</li>
+<li>Cost and runtime grow accordingly. Author chose to keep deploy targets that fit within sandbox-account economics, but a &quot;real&quot; version of this problem would burn more.</li>
+</ul>
+<p><strong>Reusable patterns.</strong></p>
+<ul>
+<li>Five-axis control framing (auth / network / rate / audit / ux) is portable to other Platform Engineering scenarios. Copy the slot list and rework only the underlying app.</li>
+<li>Disruption catalog (= named events with <code>defaultAfterMinutes</code> and <code>operatorEditable</code> fields) is the right primitive for &quot;the operator should be able to fire chaos at will&quot;. Avoid hardcoding the disruption schedule when the operator wants discretion.</li>
+<li>All-managed bonus (= one-shot large payout for completing all slots) is a clean way to model &quot;production-ready certification&quot; without inflating per-cycle scores.</li>
+</ul>
+<h2>Patterns shared across all five</h2>
+<ul>
+<li><strong>Fictional Kato-san predecessor narrative.</strong> Every Battle problem opens with &quot;the previous SRE left this behind&quot;. This is the platform&#39;s standard way to make a synthetic problem feel like a real situation. Use it.</li>
+<li><strong><code>${NamePrefix}</code> on every resource.</strong> Without exception. Every author who skipped this discovered the bug on the second team&#39;s deploy.</li>
+<li><strong>Empty URL Output, override required (Battles).</strong> This is invariant #9 in the catalog <code>AGENT.md</code>. The Battle starts when the contestant says it does, not when CFn finishes.</li>
+<li><strong><code>i18n.en.*</code> mirrors.</strong> Every catalog problem is published in both Japanese and English. The platform&#39;s locale fallback chain is <code>en → ja → top-level</code>. Locale support is <code>ja</code> + <code>en</code> only (no other locales).</li>
+<li><strong>SSM セッション Manager over SSH.</strong> No key management, no port 22, works for every contestant. This is the canonical recovery channel.</li>
+<li><strong>Free Tier or near-Free Tier cost.</strong> The cost ceiling is a per-contestant practice セッション, not a funded event. Every problem author should be able to justify the cost line in the PR body.</li>
+</ul>
+<h2>See also</h2>
+<ul>
+<li><a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> — how to ship a new problem.</li>
+<li><a href="./AUTHORING.html"><code>AUTHORING.html</code></a> — 30-minute onboarding with the full field reference.</li>
+<li><a href="./AI-WORKFLOW.md"><code>AI-WORKFLOW.md</code></a> — using Claude Code / Codex CLI to draft a problem.</li>
+<li><a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> — the plugin architecture underpinning all five.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/problems/EXAMPLES.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/problems/EXAMPLES.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/problems/EXAMPLES.md
+++ b/docs/problems/EXAMPLES.md
@@ -1,0 +1,137 @@
+# Problem design retrospectives — five reference problems
+
+> Audience: new problem authors who want to learn from existing problems before writing their own.
+> Read alongside [`CONTRIBUTING.md`](./CONTRIBUTING.md) (= how to ship) and [`AUTHORING.html`](./AUTHORING.html) (= 30-minute onboarding).
+
+This file is a design post-mortem of the five reference problems currently in the catalog. The goal is to make the *why* explicit — the constraints that shaped each problem and the trade-offs the author accepted. Reading these saves you from rediscovering the same lessons.
+
+| # | Problem                                                                                       | Category  | Kind             | Difficulty | Cost target          |
+| - | --------------------------------------------------------------------------------------------- | --------- | ---------------- | ---------- | -------------------- |
+| 1 | [`hello-world`](#1-hello-world-flag)                                                          | Challenge | flag             | 1          | Zero (SSM Standard)  |
+| 2 | [`hello-world-battle`](#2-hello-world-battle-uptime-flat)                                     | Battle    | uptime-flat      | 1          | Free Tier (t3.micro) |
+| 3 | [`security-battle-royale`](#3-security-battle-royale-uptime-multi)                            | Battle    | uptime-multi     | 4          | < $0.10 / 90 min     |
+| 4 | [`microservice-migration-battle`](#4-microservice-migration-battle-phased-polling)            | Battle    | phased-polling   | 4          | < $0.50 / 120 min    |
+| 5 | [`stackstack`](#5-stackstack-phased-polling--disruptions)                                     | Battle    | phased-polling   | 4          | < $0.50 / 120 min    |
+
+The problems are listed by increasing complexity. If you are writing your first problem, study `hello-world` and `hello-world-battle` first.
+
+## 1. `hello-world` (flag)
+
+**One-line design intent.** Smoke-test the entire deploy → flag-submission → score pipeline with zero AWS cost.
+
+**Why this design.**
+
+- `flag` is the simplest kind: one CFn deploy, one SSM Parameter, one submission, one comparison.
+- Only resource is an SSM Parameter Store entry on Standard tier. Free, scoped to one team via `${NamePrefix}`.
+- The Output `ParameterConsoleUrl` deeplinks straight to the AWS Console. That makes the "find the value" UX a single click rather than a CLI quest, which keeps difficulty=1 honest.
+- Hints carry penalties (10 / 20 pt out of 100) so the system can be exercised end-to-end without making the problem trivial.
+
+**Trade-off accepted.**
+
+- "Read a parameter" is not a realistic SRE scenario. The fictional Kato-san narrative (= predecessor left it behind) is there purely so the problem **feels** like an SRE situation. The mechanism is sanity-check; the *story* is character-building.
+
+**Reusable patterns.**
+
+- Single-Parameter-Store flag is the right shape for any "verify the candidate can find X in the AWS Console" Challenge.
+- Console deeplink Output (`ParameterConsoleUrl`) is more discoverable than CLI guidance. Copy this pattern when teaching navigation.
+
+## 2. `hello-world-battle` (uptime-flat)
+
+**One-line design intent.** Smallest Battle that exercises the platform's per-minute polling scoring engine, on free-tier EC2.
+
+**Why this design.**
+
+- One VPC, one t3.micro, one nginx, one Python `/healthz`. The CFn surface is intentionally minimal so new authors can read the whole template in one sitting.
+- The `FrontendUrl` / `ApiUrl` Outputs are emitted **empty** by design (= invariant #9 in the catalog `AGENT.md`). Competitors must paste the URLs into the Participant Portal override fields. This prevents "deploy auto-earns points" and forces the contestant to engage with the portal before scoring starts.
+- SSM セッション Manager is used instead of SSH. No key management, no inbound port 22, and the same recovery flow works for every team.
+
+**Trade-off accepted.**
+
+- Two endpoint slots could have been `uptime-multi`, but `uptime-flat` with a single combined success condition is simpler to author. The cost is that partial recovery (frontend up, API down) does not earn partial credit. Author judged that "all-or-nothing" is the right teaching message for "uptime is binary in a Battle context".
+
+**Reusable patterns.**
+
+- Empty Output + portal override is the canonical way to gate scoring on competitor action.
+- `Ec2HostHint` Output (= public DNS hint) makes the override step a copy-paste rather than a discovery puzzle.
+- t3.micro within Free Tier is a hard ceiling. Heavier compute belongs in a difficulty=3+ problem with cost warnings.
+
+## 3. `security-battle-royale` (uptime-multi)
+
+**One-line design intent.** Force the contestant to keep two services (nginx + Flask) returning 200 *simultaneously* while patching a real codebase under operator-fired attack probes.
+
+**Why this design.**
+
+- Two endpoint slots scored with `uptime-multi`: a cycle pays out only when *both* are green. This rewards holistic uptime over single-service heroics.
+- Real code (MySQL + Flask + nginx in docker-compose on one EC2) so the contestant has to read someone else's code under time pressure, which is the actual SRE incident-response skill.
+- `${NamePrefix}` isolation per team means cross-tenant attacks are physically impossible. The "Battle" framing is intra-team — operator probes, not other teams.
+- Default `AllowedCidr: 0.0.0.0/0` because the problem is designed to be played publicly. The operator can tighten this via CFn parameter for closed events.
+
+**Trade-off accepted.**
+
+- A real Flask app introduces an authoring burden (the code has to be both vulnerable enough to teach and stable enough to demo). Author chose pre-baked vulnerable patterns rather than CVE-grade exploits, keeping the difficulty at 4 rather than 5.
+- Cost rises to ~$0.10 per 90 minutes (t3.small). Free Tier no longer covers it. This is the cost ceiling for an unfunded contestant practice セッション.
+
+**Reusable patterns.**
+
+- `uptime-multi` with `failurePenalty` rewards graceful hardening (= "let some attacks through, keep 200 returning") over perfect hardening (= "lock everything down, app dies").
+- "Inherited codebase" narrative removes the "this is contrived" complaint. The Kato-san character is the platform-wide convention for this kind of story setup.
+
+## 4. `microservice-migration-battle` (phased-polling)
+
+**One-line design intent.** Teach the strangler-fig migration pattern by paying out *more* per minute as the contestant peels services off an EC2 monolith onto managed runtimes.
+
+**Why this design.**
+
+- Three services (users / orders / catalog) initially co-located on one EC2 behind nginx. Each service exposes `GET /meta` so the scoring engine can ask "where do you live now?" and pay out per hosting tier.
+- `phased-polling` with `platformRules` (= per-hosting payout table) is the only kind where the *scoring weight changes with the contestant's own infrastructure choices*. EC2 pays the least, Lambda / ECS / App Runner pay progressively more.
+- `phases[].afterMinutes` shifts the rules at fixed offsets. This makes "you waited too long to migrate" a measurable score penalty rather than a vibe.
+- Three endpoint slots, all `overridable: true`. The default URL is the EC2 monolith; the override is the new managed-runtime URL. The scoring engine probes whichever is current.
+
+**Trade-off accepted.**
+
+- The author had to ship Dockerfiles that load cleanly on three different runtimes (Lambda, ECS Fargate, App Runner). That is non-trivial portage work. The reward is that the contestant gets to pick which service goes where, which is the actual product decision.
+- IAM permissions for the contestant to deploy Lambda / ECS / App Runner are a separate concern, called out as a follow-up. As-shipped, the problem assumes the contestant has those rights in the sandbox account.
+
+**Reusable patterns.**
+
+- `/meta` self-report endpoint is the canonical way to let a contestant *change* their hosting tier without the platform having to detect it. Copy this when the contestant's choice of architecture is the answer.
+- `appendPath` in `endpoints[].default` lets one CFn Output (`BaseUrl`) serve multiple slots (`/users` / `/orders` / `/catalog`) cleanly.
+- Phased polling without disruption is the minimum viable phase mechanic. Add disruption (see `stackstack`) when the rule-change should be operator-triggered rather than time-triggered.
+
+## 5. `stackstack` (phased-polling + disruptions)
+
+**One-line design intent.** The five-axis Platform Engineering Battle: harden an AI-generated app along five control axes (auth / network / rate / audit / ux) while time-based phases and random org-event disruptions punish stalling.
+
+**Why this design.**
+
+- Five endpoint slots, each representing a *control axis* rather than a service. This is the most ambitious shape currently in the catalog: the contestant is not migrating one app, but applying five different control disciplines in parallel.
+- Each slot pays 10× more on a managed runtime than on EC2 (100 → 1,000 pt/cycle). The +30,000 all-managed bonus rewards complete migration, not partial credit.
+- Phases at 30 / 60 / 90 minutes (`production-ramp`, `compliance-audit`, `incident-response`) degrade *every slot still on EC2*, not just the slow ones. This forces parallel work rather than sequential migration.
+- Disruption catalog (CEO 5000-user demand, MFA mandate, PII finding, .env leak, AI-committed secret) fires at operator discretion. The contestant cannot plan the order in advance.
+
+**Trade-off accepted.**
+
+- The metadata.json is much larger than the other four problems. The `phases[]` × `disruptions[]` × five slots combinatorial space pushes the schema near its expressivity limit. Authors should treat `stackstack` as the upper bound on how much should live in a single problem — beyond this, split into multiple problems.
+- Cost and runtime grow accordingly. Author chose to keep deploy targets that fit within sandbox-account economics, but a "real" version of this problem would burn more.
+
+**Reusable patterns.**
+
+- Five-axis control framing (auth / network / rate / audit / ux) is portable to other Platform Engineering scenarios. Copy the slot list and rework only the underlying app.
+- Disruption catalog (= named events with `defaultAfterMinutes` and `operatorEditable` fields) is the right primitive for "the operator should be able to fire chaos at will". Avoid hardcoding the disruption schedule when the operator wants discretion.
+- All-managed bonus (= one-shot large payout for completing all slots) is a clean way to model "production-ready certification" without inflating per-cycle scores.
+
+## Patterns shared across all five
+
+- **Fictional Kato-san predecessor narrative.** Every Battle problem opens with "the previous SRE left this behind". This is the platform's standard way to make a synthetic problem feel like a real situation. Use it.
+- **`${NamePrefix}` on every resource.** Without exception. Every author who skipped this discovered the bug on the second team's deploy.
+- **Empty URL Output, override required (Battles).** This is invariant #9 in the catalog `AGENT.md`. The Battle starts when the contestant says it does, not when CFn finishes.
+- **`i18n.en.*` mirrors.** Every catalog problem is published in both Japanese and English. The platform's locale fallback chain is `en → ja → top-level`. Locale support is `ja` + `en` only (no other locales).
+- **SSM セッション Manager over SSH.** No key management, no port 22, works for every contestant. This is the canonical recovery channel.
+- **Free Tier or near-Free Tier cost.** The cost ceiling is a per-contestant practice セッション, not a funded event. Every problem author should be able to justify the cost line in the PR body.
+
+## See also
+
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — how to ship a new problem.
+- [`AUTHORING.html`](./AUTHORING.html) — 30-minute onboarding with the full field reference.
+- [`AI-WORKFLOW.md`](./AI-WORKFLOW.md) — using Claude Code / Codex CLI to draft a problem.
+- [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) — the plugin architecture underpinning all five.

--- a/infrastructure/test/scripts/validate-problems-error-messages.test.ts
+++ b/infrastructure/test/scripts/validate-problems-error-messages.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { describeAjvError } from "../../../scripts/validate-problems";
+
+/**
+ * Issue #1347: Ajv の raw error を author-friendly な hint に変換するロジックを pin する。
+ *
+ * `scripts/validate-problems.ts` の `describeAjvError` は Ajv の keyword / params から
+ * `必須 field "X" がありません` / `有効値は ...` 等の具体的指示を派生させる。
+ * 想定外 keyword は元の message を素通す (= regression を作らない)。
+ */
+describe("describeAjvError (#1347)", () => {
+  it("should turn 'required' into a 'add this missing field' message", () => {
+    const msg = describeAjvError({
+      keyword: "required",
+      instancePath: "/scoring",
+      params: { missingProperty: "kind" },
+      message: "must have required property 'kind'",
+      schemaPath: "#/required",
+    });
+    expect(msg).toContain('"kind"');
+    expect(msg).toContain("必須 field");
+    expect(msg).toContain("/scoring");
+  });
+
+  it("should turn 'enum' into a 'choose one of these allowed values' message", () => {
+    const msg = describeAjvError({
+      keyword: "enum",
+      instancePath: "/scoring/kind",
+      params: {
+        allowedValues: [
+          "flag",
+          "uptime-flat",
+          "uptime-multi",
+          "phased-polling",
+          "attack-detection",
+        ],
+      },
+      message: "must be equal to one of the allowed values",
+      schemaPath: "#/properties/scoring/properties/kind/enum",
+    });
+    expect(msg).toContain("有効値は");
+    expect(msg).toContain('"flag"');
+    expect(msg).toContain('"attack-detection"');
+  });
+
+  it("should turn 'type' into a 'wrong type' message", () => {
+    const msg = describeAjvError({
+      keyword: "type",
+      instancePath: "/scoring/points",
+      params: { type: "number" },
+      message: "must be number",
+      schemaPath: "#/properties/scoring/properties/points/type",
+    });
+    expect(msg).toContain("number");
+    expect(msg).toContain("/scoring/points");
+  });
+
+  it("should turn 'additionalProperties' into a 'unknown field' message", () => {
+    const msg = describeAjvError({
+      keyword: "additionalProperties",
+      instancePath: "/scoring",
+      params: { additionalProperty: "typoField" },
+      message: "must NOT have additional properties",
+      schemaPath: "#/properties/scoring/additionalProperties",
+    });
+    expect(msg).toContain("typoField");
+    expect(msg).toContain("未知の field");
+  });
+
+  it("should default to passing through the Ajv message for unknown keywords", () => {
+    const msg = describeAjvError({
+      keyword: "format" as never,
+      instancePath: "/whatever",
+      params: { format: "uri" },
+      message: 'must match format "uri"',
+      schemaPath: "#/properties/whatever/format",
+    });
+    expect(msg).toContain("must match format");
+  });
+});

--- a/scripts/problem-cli/help.ts
+++ b/scripts/problem-cli/help.ts
@@ -25,9 +25,12 @@ Examples:
   bun run scripts/tenkacloud-problem.ts inspect hello-world
 
 See also:
-  docs/problems/AUTHORING.html  — 30 分 onboarding guide
-  problems/SCHEMA.json          — metadata.json schema
-  .claude/skills/create-problem — Claude Code skill (= /create-problem)
+  docs/problems/CONTRIBUTING.md  — external contributor quickstart (decision tree + lifecycle)
+  docs/problems/AUTHORING.html   — 30 分 onboarding guide (full field reference)
+  docs/problems/EXAMPLES.md      — design retrospectives on the 5 reference problems
+  docs/problems/AI-WORKFLOW.md   — Claude Code / Codex CLI authoring workflow
+  problems/SCHEMA.json           — metadata.json schema
+  .claude/skills/create-problem  — Claude Code skill (= /create-problem)
 `);
 }
 

--- a/scripts/problem-cli/interactive.ts
+++ b/scripts/problem-cli/interactive.ts
@@ -58,6 +58,16 @@ export async function runInteractive(prompts: InteractivePrompts): Promise<RunIn
 
 async function promptKind({ ask, print }: InteractivePrompts): Promise<Kind> {
   print("どの 種別 (= scoring kind) で問題を作成しますか?");
+  print("");
+  print("決定木 (= 迷ったら):");
+  print("  競技者が 1 つの値 (flag) を提出して終わる        → 1 (flag)");
+  print("  endpoint が 1 つ、 常時 200 で加点               → 2 (uptime-flat)");
+  print("  endpoint が複数、 全部同時 200 で加点             → 3 (uptime-multi)");
+  print("  時間経過で rule が変わる (= 移行 deadline 等)     → 4 (phased-polling)");
+  print("  攻撃検知数で勝敗が決まる                          → 5 (attack-detection)");
+  print("");
+  print("(詳細: docs/problems/CONTRIBUTING.md 'Pick the scoring kind')");
+  print("");
   const orderedKinds: readonly Kind[] = getOrderedKinds();
   for (const [i, k] of orderedKinds.entries()) {
     print(`  ${i + 1}) ${KIND_INTERACTIVE_LABELS[k]}`);
@@ -181,8 +191,11 @@ function printCreatedFiles(
   print("  4. make validate-problems");
   print("");
   print("参照:");
-  print("  - docs/problems/AUTHORING.html  (= 30 分 onboarding guide)");
-  print("  - problems/SCHEMA.json          (= metadata.json schema)");
+  print("  - docs/problems/CONTRIBUTING.md (= 外部 contributor 向け quickstart)");
+  print("  - docs/problems/AUTHORING.html  (= 30 分 onboarding guide / 全 field 一覧)");
+  print("  - docs/problems/EXAMPLES.md     (= 既存 5 問題の design 振り返り)");
+  print("  - docs/problems/AI-WORKFLOW.md  (= Claude Code / Codex CLI flow)");
+  print("  - problems/SCHEMA.json          (= metadata.json schema 正本)");
   print("  - /create-problem               (= Claude Code skill、 同等の対話を AI で進める)");
 }
 

--- a/scripts/problem-cli/validate.ts
+++ b/scripts/problem-cli/validate.ts
@@ -111,7 +111,9 @@ function validateScoringKind(ctx: ValidationContext, errors: string[]): void {
   const kind = scoring?.kind;
   if (typeof kind !== "string") return;
   if (!(KINDS as readonly string[]).includes(kind) && kind !== "uptime") {
-    errors.push(`scoring.kind="${kind}" is not a recognized kind`);
+    errors.push(
+      `scoring.kind="${kind}" is not a recognized kind — set it to one of ${KINDS.map((k) => `"${k}"`).join(" | ")}`,
+    );
   }
   if (!existsSync(templatePath)) return;
   const yaml = readFileSync(templatePath, "utf8");
@@ -128,14 +130,16 @@ function validateScoringOutputKey(
     const flagKey = scoring.flagOutputKey;
     if (typeof flagKey === "string" && !yaml.includes(`${flagKey}:`)) {
       errors.push(
-        `scoring.flagOutputKey="${flagKey}" not found in template.yaml Outputs (= scoring engine が読めない)`,
+        `scoring.flagOutputKey="${flagKey}" not found in template.yaml Outputs (= scoring engine が読めない) — add an "Outputs.${flagKey}:" entry to template.yaml or fix the metadata key`,
       );
     }
   }
   if (kind === "attack-detection") {
     const statsKey = scoring.statsOutputKey;
     if (typeof statsKey === "string" && !yaml.includes(`${statsKey}:`)) {
-      errors.push(`scoring.statsOutputKey="${statsKey}" not found in template.yaml Outputs`);
+      errors.push(
+        `scoring.statsOutputKey="${statsKey}" not found in template.yaml Outputs — add an "Outputs.${statsKey}:" entry whose Value is the integer attack count`,
+      );
     }
   }
 }
@@ -150,7 +154,7 @@ function validateEndpointOutputs(ctx: ValidationContext, errors: string[]): void
     const key = def?.key;
     if (typeof key === "string" && !yaml.includes(`${key}:`)) {
       errors.push(
-        `endpoints[slot=${String(ep.slot)}].default.key="${key}" not found in template.yaml Outputs`,
+        `endpoints[slot=${String(ep.slot)}].default.key="${key}" not found in template.yaml Outputs — add an "Outputs.${key}:" entry exposing the public URL`,
       );
     }
   }
@@ -165,7 +169,9 @@ function validateDashboardSlots(ctx: ValidationContext, errors: string[]): void 
     if (typeof slotPath === "string") {
       const physical = join(dir, slotPath);
       if (!existsSync(physical)) {
-        errors.push(`dashboard.slots["${slotName}"]="${slotPath}" file not found at ${physical}`);
+        errors.push(
+          `dashboard.slots["${slotName}"]="${slotPath}" file not found at ${physical} — create the .tsx file at that path, or remove the slot from metadata.json`,
+        );
       }
     }
   }

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -262,6 +262,46 @@ function validateMetadataFiles(
   return failed;
 }
 
+/**
+ * Issue #1347: Ajv raw error -> author-friendly hint。 metadata.json はほぼ全ての contributor が
+ * 初見で開く file なので、 「何が悪い + どう fix するか」 を 1 行で返す。 Ajv の `keyword` / `params`
+ * から派生する典型 case を抑える。 想定外 case は元の `err.message` をそのまま出す。
+ */
+type AjvError = NonNullable<ReturnType<Ajv2020["compile"]>["errors"]>[number];
+
+function paramStr(err: AjvError, key: string): string {
+  return String((err.params as Record<string, unknown>)[key] ?? "");
+}
+
+const AJV_HINT_HANDLERS: Record<string, (path: string, err: AjvError) => string> = {
+  required: (path, err) =>
+    `${path} 必須 field "${paramStr(err, "missingProperty")}" がありません — SCHEMA.json の description を参照、 値を追加してください`,
+  enum: (path, err) => {
+    const allowed = (err.params as Record<string, unknown>).allowedValues;
+    const list = Array.isArray(allowed) ? allowed.map((v) => JSON.stringify(v)).join(" | ") : "";
+    return `${path} ${err.message ?? ""} — 有効値は ${list}`;
+  },
+  type: (path, err) => `${path} 型が違います (expected: ${paramStr(err, "type")})`,
+  pattern: (path, err) =>
+    `${path} 値が pattern /${paramStr(err, "pattern")}/ に一致しません (例: kebab-case 制約等)`,
+  minLength: (path, err) => `${path} 文字数が短すぎ (limit: ${paramStr(err, "limit")})`,
+  maxLength: (path, err) => `${path} 文字数が長すぎ (limit: ${paramStr(err, "limit")})`,
+  minItems: (path, err) => `${path} 要素数が少なすぎ (limit: ${paramStr(err, "limit")})`,
+  maxItems: (path, err) => `${path} 要素数が多すぎ (limit: ${paramStr(err, "limit")})`,
+  additionalProperties: (path, err) =>
+    `${path} 未知の field "${paramStr(err, "additionalProperty")}" — typo か、 SCHEMA.json に未定義の field`,
+  const: (path, err) => {
+    const want = JSON.stringify((err.params as Record<string, unknown>).allowedValue);
+    return `${path} 値は ${want} でなければなりません`;
+  },
+};
+
+export function describeAjvError(err: AjvError): string {
+  const path = err.instancePath || "(root)";
+  const handler = AJV_HINT_HANDLERS[err.keyword];
+  return handler ? handler(path, err) : `${path} ${err.message ?? ""}`;
+}
+
 function printSchemaErrors(
   file: string,
   data: Metadata,
@@ -269,12 +309,15 @@ function printSchemaErrors(
 ): void {
   console.error(`NG  ${relative(REPO_ROOT, file)}`);
   for (const err of errors) {
-    console.error(`     ${err.instancePath || "(root)"} ${err.message ?? ""}`);
+    console.error(`     ${describeAjvError(err)}`);
   }
   const expectedId = file.split("/").slice(-2, -1)[0];
   if (data.id && data.id !== expectedId) {
     console.error(`     id (${data.id}) はディレクトリ名 (${expectedId}) と一致させてください`);
   }
+  console.error(
+    `     詳細: docs/problems/CONTRIBUTING.md "Validation errors and how to read them" 参照`,
+  );
 }
 
 function printCrossRefErrors(file: string, errors: ValidationError[]): void {


### PR DESCRIPTION
## Summary

External contributor が 30 分以内で 1 問作れる authoring DX。 5 doc artifacts + CLI error message 改善 + interactive flow。

### Artifacts

- `docs/problems/CONTRIBUTING.{md,ja.md}` (+ HTML) — 30-min quickstart + scoring kind decision tree + lifecycle (draft → tested → ready → official) + PR 先 (= submodule TenkaCloudChallenge)
- `docs/problems/AI-WORKFLOW.md` — Claude Code / Codex CLI workflow
- `docs/problems/EXAMPLES.md` — 既存 5 問題の design analysis
- `.claude/skills/create-problem/SKILL.md` 改善 — interactive Q&A flow
- `scripts/problem-cli/validate.ts` 等 — schema error の post-process で人間向けメッセージ
- `infrastructure/test/scripts/validate-problems-error-messages.test.ts` — error pin

Closes #1347
Relates #1336

## Regression analysis

- Docs only + CLI error message format change. 既存 validation 通過パターン不変。
- Schema 構造変更なし、 後方互換維持。

## Physical impact

- NO-OP runtime / CFn / Lambda
- NEW docs (= 5 markdown + HTML siblings)
- UPDATE: scripts/problem-cli/ error message post-process