### PR TITLE
feat(catalog): bump submodule + AUTHORING + LP for starter catalog — #1346

### DIFF
--- a/docs/problems/AUTHORING.html
+++ b/docs/problems/AUTHORING.html
@@ -418,30 +418,63 @@ aws cloudformation deploy \
 </section>
 
 <section id="examples">
-<h2>9. 実例 4 問題</h2>
+<h2>9. 実例 (catalog 一覧)</h2>
+
+<p>Issue #1346 で構築された starter catalog は <strong>ready 5 問 + draft 2 問 + 1 イベント bundle</strong>。 各問題は <code>difficulty</code> / <code>estimatedDuration</code> / <code>learningGoals</code> を SCHEMA 必須項目として持つ (= UI catalog でフィルタ可)。</p>
 
 <table>
-<thead><tr><th>問題</th><th>kind</th><th>portal plugin?</th><th>disruption?</th><th>狙い</th></tr></thead>
+<thead><tr><th>問題</th><th>kind</th><th>status</th><th>difficulty</th><th>duration</th><th>狙い</th></tr></thead>
 <tbody>
   <tr>
     <td><a href="../../problems/challenges/hello-world/"><code>hello-world</code></a></td>
-    <td>flag</td><td>—</td><td>—</td>
+    <td>flag</td><td>ready</td><td>1</td><td>1 分</td>
     <td>1 回提出で完結する最小 Challenge。 SSM Parameter の値を当てる</td>
   </tr>
   <tr>
     <td><a href="../../problems/battles/hello-world-battle/"><code>hello-world-battle</code></a></td>
-    <td>uptime-flat</td><td>—</td><td>—</td>
-    <td>1 endpoint の uptime を保つ最小 Battle</td>
+    <td>uptime-flat</td><td>ready</td><td>1</td><td>30 分</td>
+    <td>2 endpoint の uptime を保つ最小 Battle (uptime warm-up)</td>
   </tr>
   <tr>
     <td><a href="../../problems/battles/security-battle-royale/"><code>security-battle-royale</code></a></td>
-    <td>uptime-multi</td><td>—</td><td>—</td>
+    <td>uptime-multi</td><td>ready</td><td>4</td><td>60〜90 分</td>
     <td>frontend + api 2 slot の同時稼働。 攻撃 / 防御の人間 vs 人間</td>
   </tr>
   <tr>
     <td><a href="../../problems/battles/microservice-migration-battle/"><code>microservice-migration-battle</code></a></td>
-    <td>phased-polling</td><td>○</td><td>○</td>
+    <td>phased-polling</td><td>ready</td><td>4</td><td>90〜120 分</td>
     <td>3 service を EC2 → Lambda/ECS/App Runner に分割。 phase + disruption + 専用 portal plugin の総合例</td>
+  </tr>
+  <tr>
+    <td><a href="../../problems/battles/stackstack/"><code>stackstack</code></a></td>
+    <td>phased-polling</td><td>ready</td><td>4</td><td>90〜120 分</td>
+    <td>AI 量産アプリを 5 軸 (auth / network / rate / audit / ux) で本番化する Platform Team Battle</td>
+  </tr>
+  <tr>
+    <td><a href="../../problems/challenges/public-s3-remediation/"><code>public-s3-remediation</code></a></td>
+    <td>flag</td><td>draft</td><td>2</td><td>20〜30 分</td>
+    <td>S3 公開設定の点検 + remediation の最小 CCoE 1 day example (Issue #1346 で追加)</td>
+  </tr>
+  <tr>
+    <td><a href="../../problems/challenges/iam-least-privilege/"><code>iam-least-privilege</code></a></td>
+    <td>flag</td><td>draft</td><td>2</td><td>20〜30 分</td>
+    <td>過剰権限 IAM Role の点検 + scope-down の最小 CCoE 1 day example (Issue #1346 で追加)</td>
+  </tr>
+</tbody>
+</table>
+
+<h3>Bundle (= 複数問題のセット)</h3>
+
+<p>Organizer が 1 イベント分の問題を一括で picker するための reference。 各 bundle は問題 ID 列 + 推奨順序 + 推定時間 + 学習目的 を JSON で持つ (= <a href="../../problems/bundles/README.md"><code>problems/bundles/README.md</code></a>)。 schema は WIP (Issue #1346 follow-up)。</p>
+
+<table>
+<thead><tr><th>Bundle</th><th>難易度</th><th>所要</th><th>構成</th><th>狙い</th></tr></thead>
+<tbody>
+  <tr>
+    <td><a href="../../problems/bundles/starter-event.json"><code>starter-event</code></a></td>
+    <td>beginner</td><td>60〜90 分</td>
+    <td>1 Challenge + 2 Battles (<code>hello-world</code> → <code>hello-world-battle</code> → <code>microservice-migration-battle</code>)</td>
+    <td>初めて TenkaCloud を流す organizer 向け 'drop-in 1 イベント' プリセット (CCoE / JAWS-UG meetup)</td>
   </tr>
 </tbody>
 </table>

--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -27,14 +27,20 @@ import {
 const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
 
 describe("check-template-cfn-refs script (#951 sub-2)", () => {
-  it("all 5 existing problem templates should pass (smoke test)", () => {
+  // Smoke test against the live problems/ catalog. The count grows with each
+  // new problem added; bump this assertion when adding a new template (so the
+  // test remains a regression boundary instead of a moving target).
+  // Current count: 7 (= 5 ready + 2 draft after Issue #1346 starter-catalog
+  // expansion: hello-world / hello-world-battle / microservice-migration-battle
+  // / security-battle-royale / stackstack / public-s3-remediation / iam-least-privilege).
+  it("all existing problem templates should pass (smoke test)", () => {
     const result = spawnSync("bun", ["run", "scripts/check-template-cfn-refs.ts"], {
       cwd: REPO_ROOT,
       encoding: "utf-8",
     });
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("OK:");
-    expect(result.stdout).toContain("5 template(s)");
+    expect(result.stdout).toContain("7 template(s)");
   });
 });
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -373,6 +373,7 @@
     <div class="eyebrow" data-i18n="extend.eyebrow">問題は、増やせる</div>
     <h2 data-i18n="extend.h2">足りない問題は、自分で作ればいい。</h2>
     <p class="lead" data-i18n="extend.lead">問題カタログは <a href="https://github.com/susumutomita/TenkaCloudChallenge" target="_blank" rel="noopener noreferrer">TenkaCloudChallenge</a> リポジトリで完全に開かれていて、 metadata.json + template.yaml の 2 ファイルを書けば 1 問追加できます。 Claude Code 等のコーディングエージェント向けに 問題作成 skill (<code>new-problem</code>) も同梱されているので、 「こういう問題を作りたい」 とアイデアを話すだけで、 初めてでも 1 問が形になります。</p>
+    <p class="lead" data-i18n="extend.starter">スターターカタログは <strong>ready 5 問 + draft 2 問 + 1 イベント bundle</strong> (= 1 Challenge + 2 Battles を 60〜90 分で回す <a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/bundles/starter-event.json" target="_blank" rel="noopener noreferrer"><code>starter-event</code></a>)。 CCoE / JAWS-UG meetup で 「今日これ流せばいい」 が即決できる credible なラインナップです。</p>
     <div class="extend-cta">
       <a class="more" href="https://github.com/susumutomita/TenkaCloudChallenge#readme" target="_blank" rel="noopener noreferrer"><span data-i18n="extend.cta1">問題カタログを見る</span> ›</a>
       <a class="more" href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/.claude/skills/new-problem/SKILL.md#new-problem--scaffold-a-tenkacloudchallenge-problem" target="_blank" rel="noopener noreferrer"><span data-i18n="extend.cta2">new-problem skill</span> ›</a>


### PR DESCRIPTION
## Summary

Brings the platform repo in sync with the [TenkaCloudChallenge starter catalog expansion](https://github.com/susumutomita/TenkaCloudChallenge/pull/26). After merge, the catalog surfaces:

- **5 ready problems** (`hello-world` Challenge + `hello-world-battle` / `microservice-migration-battle` / `security-battle-royale` / `stackstack` Battles)
- **2 draft Challenges** added this PR: `public-s3-remediation`, `iam-least-privilege`
- **1 event-ready scenario bundle**: `bundles/starter-event.json` (1 Challenge + 2 Battles, 60-90 min)

That is the minimum commercially-credible target Issue #1346 calls for (3 ready + 2 draft + 1 bundle + difficulty / duration / learning goals on every problem).

## What changed in this PR

- **Submodule bump** `problems/`: `23f25e9` -> `ad6a5b2`
- **`docs/problems/AUTHORING.html`** — rewrote the "実例" section to a full 7-row catalog matrix (status / difficulty / duration columns) instead of the previous 4 cherry-picked examples; added a Bundle table referencing the `starter-event` preset. Reflects acceptance criterion 3 of #1346 ("clear learning goals, difficulty, duration").
- **`landing/index.html`** — added a credibility note to the `#extend` section pointing at the 3 ready + 2 draft + bundle line-up so the homepage "Problem catalog" answer is no longer ambiguous.
- **`infrastructure/test/scripts/check-template-cfn-refs.test.ts`** — bumped the smoke-test count from 5 to 7 problem templates (= `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE`; tests change in the same PR as the catalog expansion). Added an inline comment with the rebump rule for future problems.

## Regression analysis

What could break:

- **Existing problem deploys**: not modified. Validator + cfn-ref check + security check pass on the 5 pre-existing templates and the 2 new draft ones.
- **Submodule pin**: bumped to `ad6a5b2` on the catalog repo's `feat/starter-catalog-1346` branch. The catalog PR-26 is open at time of writing; this PR will sit behind it until merge so the pin lands on a stable commit. If catalog CI reveals an issue we will re-roll the submodule commit, not break this PR's shape.
- **`check-template-cfn-refs.test.ts` count assertion**: deliberate boundary that catches "someone added a template without understanding the contract." Bumping for legit catalog growth is the intended workflow; the inline comment now documents that explicitly.
- **`make harness`**: no findings (info-only note about cdk.out not present).
- **`make before-commit`**: passes locally (lint + 1607 tests pass + validate-problems 7/7 + template-ascii / -security / -cfn-refs + no-conflicts + audit-deps + cdk synth).

## Physical impact

- **CFn artifacts** (= what the platform deploys when a competitor picks a problem from the catalog):
  - **CREATE** `problems/challenges/public-s3-remediation/template.yaml` — 1 S3 Bucket (intentionally permissive PAB) + 1 BucketPolicy + 1 SSM Parameter + 1 IAM Role (ParticipantViewerRole). All `${NamePrefix}`-scoped.
  - **CREATE** `problems/challenges/iam-least-privilege/template.yaml` — 1 IAM Role (deliberately over-privileged `legacy-batch`, `ec2.amazonaws.com` AssumeRole principal so blast radius is audit-only) + 1 SSM Parameter + 1 IAM Role (ParticipantViewerRole). All `${NamePrefix}`-scoped.
  - **NO-OP** for existing 5 problems.
- **Platform-side artifacts**:
  - **UPDATE** `docs/problems/AUTHORING.html` (Examples section + Bundle table).
  - **UPDATE** `landing/index.html` (one new `<p>` in `#extend`).
  - **UPDATE** `infrastructure/test/scripts/check-template-cfn-refs.test.ts` (count + comment).
  - **UPDATE** submodule pin to `ad6a5b2`.

## Test plan

- [x] `make harness` clean (info-only note about cdk.out)
- [x] `make before-commit` green (`bun run validate:problems`: 7/7 OK; `check-template-cfn-refs`: 7 templates pass; `check-template-security`: 0 危険パターン; `check-template-ascii`: 9 yaml all safe; cdk synth: OK; 1606 vitest pass)
- [ ] Catalog-side CI green on PR-26 (schema + cross-ref check) → unblocks submodule pin from "open PR" to "merged ref"
- [ ] Real-AWS deploy of `public-s3-remediation` and `iam-least-privilege` (DRAFT-tier acceptance — both currently shipped as `status: "draft"`)

Pairs with submodule PR https://github.com/susumutomita/TenkaCloudChallenge/pull/26.

Relates #1346
Part of #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)