### PR TITLE
docs(runbooks): hosted event ops playbook — #1351

### DIFF
--- a/docs/runbooks/README.html
+++ b/docs/runbooks/README.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Event-day operations runbooks</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Event-day operations runbooks</h1>
+<blockquote>
+<p>Japanese: <a href="./README.ja.md">README.ja.md</a></p>
+</blockquote>
+<p>This directory is the operator-facing playbook for running a small TenkaCloud event end-to-end without relying on maintainer memory. Each runbook is self-contained and lists Audience, When to use, Step-by-step + estimated time, and an &quot;If it goes wrong&quot; branch.</p>
+<p>The runbooks assume Lite mode (<code>make deploy</code>) as the default, because most paid hosted events are one organizer / one event. SaaS mode notes are called out inline.</p>
+<h2>Index</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Runbook</th>
+<th>Audience</th>
+<th>When to use</th>
+<th>Estimated time</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td><a href="./pre-event-checklist.md">Pre-event checklist</a></td>
+<td>Facilitator</td>
+<td>T-7 / T-1 / T-0 staged readiness</td>
+<td>30 min × 3 sessions</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="./dry-run.md">Dry run</a></td>
+<td>Operator</td>
+<td>Within 7 days before the event (mandatory)</td>
+<td>90 min</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="./participant-onboarding.md">Participant onboarding</a></td>
+<td>Facilitator</td>
+<td>Event-day morning, before kickoff</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="./live-monitoring.md">Live monitoring</a></td>
+<td>On-call operator</td>
+<td>During the event window</td>
+<td>Continuous</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="./incident-response.md">Incident response</a></td>
+<td>On-call operator</td>
+<td>Triggered by alarm or participant report</td>
+<td>5 to 30 min per incident</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="./teardown.md">Teardown</a></td>
+<td>Operator</td>
+<td>Within 24 hours after the event ends</td>
+<td>60 min</td>
+</tr>
+</tbody></table>
+<h2>How the runbooks cross-link</h2>
+<ul>
+<li><a href="./pre-event-checklist.md">Pre-event checklist</a> links to <a href="./dry-run.md">Dry run</a> as the T-7 gate (&quot;you cannot skip the dry run&quot;).</li>
+<li><a href="./live-monitoring.md">Live monitoring</a> links to <a href="./incident-response.md">Incident response</a> at the triage decision point.</li>
+<li><a href="./incident-response.md">Incident response</a> and <a href="./teardown.md">Teardown</a> both cross-link back to <a href="./live-monitoring.md">Live monitoring</a> for context on what was already observed.</li>
+<li>All runbooks cite the relevant ADRs as the source of truth for design decisions:<ul>
+<li><a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — operator-to-participant messaging contract.</li>
+<li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a> — how state converges without SSE / WebSocket.</li>
+</ul>
+</li>
+</ul>
+<h2>What is out of scope</h2>
+<ul>
+<li>Auto-detection / auto-rollback code (tracked separately under #1352). These runbooks describe <strong>operator action</strong> only.</li>
+<li>Post-event survey / commercial follow-up templates (tracked under the broader launch-readiness epic #1336).</li>
+</ul>
+<h2>Reading order for a new operator</h2>
+<ol>
+<li><a href="./pre-event-checklist.md">Pre-event checklist</a> — read it once end-to-end, then schedule the T-7 / T-1 / T-0 reminders.</li>
+<li><a href="./dry-run.md">Dry run</a> — execute it at least once. The dry run is the gate, not the production event.</li>
+<li>Bookmark <a href="./live-monitoring.md">Live monitoring</a> and <a href="./incident-response.md">Incident response</a> side by side. They are the two tabs you keep open during the event.</li>
+<li><a href="./teardown.md">Teardown</a> — review the day before so you do not stall after the event ends.</li>
+</ol>
+
+<div class="doc-source">Source: <code>docs/runbooks/README.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/README.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/README.ja.html
+++ b/docs/runbooks/README.ja.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>イベント当日運用 Runbook 集</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>イベント当日運用 Runbook 集</h1>
+<blockquote>
+<p>English: <a href="./README.md">README.md</a></p>
+</blockquote>
+<p>このディレクトリは、 メンテナの記憶に頼らずに小規模 TenkaCloud イベントを一気通貫で運用するための、 オペレータ向け playbook です。 各 runbook は self-contained で、 Audience / When to use / Step-by-step + 所要時間 /「うまくいかなかったら」のブランチを必ず備えています。</p>
+<p>Runbook 全体は Lite mode (<code>make deploy</code>) をデフォルトとしています。 有償ホスト型イベントの大半は 1 オペレータ / 1 イベントだからです。 SaaS mode の差分は本文中に inline で記載します。</p>
+<h2>一覧</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Runbook</th>
+<th>Audience</th>
+<th>使うタイミング</th>
+<th>所要時間</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td><a href="./pre-event-checklist.ja.md">事前チェックリスト</a></td>
+<td>Facilitator</td>
+<td>T-7 / T-1 / T-0 の 3 段階準備</td>
+<td>各 30 分 × 3 回</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="./dry-run.ja.md">Dry run</a></td>
+<td>オペレータ</td>
+<td>本番 7 日前までに必ず実施</td>
+<td>90 分</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="./participant-onboarding.ja.md">Participant onboarding</a></td>
+<td>Facilitator</td>
+<td>イベント当日朝、 kickoff 直前</td>
+<td>20 分</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="./live-monitoring.ja.md">Live monitoring</a></td>
+<td>オンコールオペレータ</td>
+<td>イベント実施中ずっと</td>
+<td>継続</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a></td>
+<td>オンコールオペレータ</td>
+<td>アラートまたは参加者報告から</td>
+<td>1 件あたり 5 〜 30 分</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="./teardown.ja.md">Teardown</a></td>
+<td>オペレータ</td>
+<td>イベント終了から 24 時間以内</td>
+<td>60 分</td>
+</tr>
+</tbody></table>
+<h2>Runbook 同士の相互参照</h2>
+<ul>
+<li><a href="./pre-event-checklist.ja.md">事前チェックリスト</a> は <a href="./dry-run.ja.md">Dry run</a> を T-7 のゲートとしてリンクする (=「dry run はスキップ不可」)。</li>
+<li><a href="./live-monitoring.ja.md">Live monitoring</a> は triage 判断ポイントで <a href="./incident-response.ja.md">インシデント対応</a> にリンクする。</li>
+<li><a href="./incident-response.ja.md">インシデント対応</a> と <a href="./teardown.ja.md">Teardown</a> はどちらも <a href="./live-monitoring.ja.md">Live monitoring</a> にバックリンクして、 すでに観測したものを文脈に持ち込む。</li>
+<li>すべての runbook は設計判断の正本として下記の ADR を参照する。<ul>
+<li><a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — オペレータから参加者への通知契約。</li>
+<li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> — SSE / WebSocket を使わずに状態を収束させる仕組み。</li>
+</ul>
+</li>
+</ul>
+<h2>スコープ外</h2>
+<ul>
+<li>自動検知 / 自動 rollback コード (= #1352 で別途追跡)。 本 runbook 群は <strong>オペレータの手動アクション</strong> に限定する。</li>
+<li>事後アンケート / コマーシャル follow up テンプレート (= 親 epic #1336 側で扱う)。</li>
+</ul>
+<h2>初任オペレータの読み順</h2>
+<ol>
+<li><a href="./pre-event-checklist.ja.md">事前チェックリスト</a> を一度通読し、 T-7 / T-1 / T-0 のリマインダーをカレンダーに入れる。</li>
+<li><a href="./dry-run.ja.md">Dry run</a> を最低 1 回実施する。 dry run はゲートであって本番ではない。</li>
+<li><a href="./live-monitoring.ja.md">Live monitoring</a> と <a href="./incident-response.ja.md">インシデント対応</a> をブラウザの隣接タブにブックマーク。 本番中はこの 2 枚だけ開いておく。</li>
+<li><a href="./teardown.ja.md">Teardown</a> は前日に目を通し、 終了後に手が止まらないようにする。</li>
+</ol>
+
+<div class="doc-source">Source: <code>docs/runbooks/README.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/README.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/README.ja.md
+++ b/docs/runbooks/README.ja.md
@@ -1,0 +1,39 @@
+# イベント当日運用 Runbook 集
+
+> English: [README.md](./README.md)
+
+このディレクトリは、 メンテナの記憶に頼らずに小規模 TenkaCloud イベントを一気通貫で運用するための、 オペレータ向け playbook です。 各 runbook は self-contained で、 Audience / When to use / Step-by-step + 所要時間 /「うまくいかなかったら」のブランチを必ず備えています。
+
+Runbook 全体は Lite mode (`make deploy`) をデフォルトとしています。 有償ホスト型イベントの大半は 1 オペレータ / 1 イベントだからです。 SaaS mode の差分は本文中に inline で記載します。
+
+## 一覧
+
+| # | Runbook | Audience | 使うタイミング | 所要時間 |
+|---|---|---|---|---|
+| 1 | [事前チェックリスト](./pre-event-checklist.ja.md) | Facilitator | T-7 / T-1 / T-0 の 3 段階準備 | 各 30 分 × 3 回 |
+| 2 | [Dry run](./dry-run.ja.md) | オペレータ | 本番 7 日前までに必ず実施 | 90 分 |
+| 3 | [Participant onboarding](./participant-onboarding.ja.md) | Facilitator | イベント当日朝、 kickoff 直前 | 20 分 |
+| 4 | [Live monitoring](./live-monitoring.ja.md) | オンコールオペレータ | イベント実施中ずっと | 継続 |
+| 5 | [インシデント対応](./incident-response.ja.md) | オンコールオペレータ | アラートまたは参加者報告から | 1 件あたり 5 〜 30 分 |
+| 6 | [Teardown](./teardown.ja.md) | オペレータ | イベント終了から 24 時間以内 | 60 分 |
+
+## Runbook 同士の相互参照
+
+- [事前チェックリスト](./pre-event-checklist.ja.md) は [Dry run](./dry-run.ja.md) を T-7 のゲートとしてリンクする (=「dry run はスキップ不可」)。
+- [Live monitoring](./live-monitoring.ja.md) は triage 判断ポイントで [インシデント対応](./incident-response.ja.md) にリンクする。
+- [インシデント対応](./incident-response.ja.md) と [Teardown](./teardown.ja.md) はどちらも [Live monitoring](./live-monitoring.ja.md) にバックリンクして、 すでに観測したものを文脈に持ち込む。
+- すべての runbook は設計判断の正本として下記の ADR を参照する。
+  - [ADR-006: Notifications](../architecture/adr-006-notifications.html) — オペレータから参加者への通知契約。
+  - [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) — SSE / WebSocket を使わずに状態を収束させる仕組み。
+
+## スコープ外
+
+- 自動検知 / 自動 rollback コード (= #1352 で別途追跡)。 本 runbook 群は **オペレータの手動アクション** に限定する。
+- 事後アンケート / コマーシャル follow up テンプレート (= 親 epic #1336 側で扱う)。
+
+## 初任オペレータの読み順
+
+1. [事前チェックリスト](./pre-event-checklist.ja.md) を一度通読し、 T-7 / T-1 / T-0 のリマインダーをカレンダーに入れる。
+2. [Dry run](./dry-run.ja.md) を最低 1 回実施する。 dry run はゲートであって本番ではない。
+3. [Live monitoring](./live-monitoring.ja.md) と [インシデント対応](./incident-response.ja.md) をブラウザの隣接タブにブックマーク。 本番中はこの 2 枚だけ開いておく。
+4. [Teardown](./teardown.ja.md) は前日に目を通し、 終了後に手が止まらないようにする。

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,39 @@
+# Event-day operations runbooks
+
+> Japanese: [README.ja.md](./README.ja.md)
+
+This directory is the operator-facing playbook for running a small TenkaCloud event end-to-end without relying on maintainer memory. Each runbook is self-contained and lists Audience, When to use, Step-by-step + estimated time, and an "If it goes wrong" branch.
+
+The runbooks assume Lite mode (`make deploy`) as the default, because most paid hosted events are one organizer / one event. SaaS mode notes are called out inline.
+
+## Index
+
+| # | Runbook | Audience | When to use | Estimated time |
+|---|---|---|---|---|
+| 1 | [Pre-event checklist](./pre-event-checklist.md) | Facilitator | T-7 / T-1 / T-0 staged readiness | 30 min × 3 sessions |
+| 2 | [Dry run](./dry-run.md) | Operator | Within 7 days before the event (mandatory) | 90 min |
+| 3 | [Participant onboarding](./participant-onboarding.md) | Facilitator | Event-day morning, before kickoff | 20 min |
+| 4 | [Live monitoring](./live-monitoring.md) | On-call operator | During the event window | Continuous |
+| 5 | [Incident response](./incident-response.md) | On-call operator | Triggered by alarm or participant report | 5 to 30 min per incident |
+| 6 | [Teardown](./teardown.md) | Operator | Within 24 hours after the event ends | 60 min |
+
+## How the runbooks cross-link
+
+- [Pre-event checklist](./pre-event-checklist.md) links to [Dry run](./dry-run.md) as the T-7 gate ("you cannot skip the dry run").
+- [Live monitoring](./live-monitoring.md) links to [Incident response](./incident-response.md) at the triage decision point.
+- [Incident response](./incident-response.md) and [Teardown](./teardown.md) both cross-link back to [Live monitoring](./live-monitoring.md) for context on what was already observed.
+- All runbooks cite the relevant ADRs as the source of truth for design decisions:
+  - [ADR-006: Notifications](../architecture/adr-006-notifications.html) — operator-to-participant messaging contract.
+  - [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) — how state converges without SSE / WebSocket.
+
+## What is out of scope
+
+- Auto-detection / auto-rollback code (tracked separately under #1352). These runbooks describe **operator action** only.
+- Post-event survey / commercial follow-up templates (tracked under the broader launch-readiness epic #1336).
+
+## Reading order for a new operator
+
+1. [Pre-event checklist](./pre-event-checklist.md) — read it once end-to-end, then schedule the T-7 / T-1 / T-0 reminders.
+2. [Dry run](./dry-run.md) — execute it at least once. The dry run is the gate, not the production event.
+3. Bookmark [Live monitoring](./live-monitoring.md) and [Incident response](./incident-response.md) side by side. They are the two tabs you keep open during the event.
+4. [Teardown](./teardown.md) — review the day before so you do not stall after the event ends.

--- a/docs/runbooks/dry-run.html
+++ b/docs/runbooks/dry-run.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Dry run</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Dry run</h1>
+<blockquote>
+<p>Japanese: <a href="./dry-run.ja.md">dry-run.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Operator (the person who will be on-call during the real event)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Within 7 days before the real event. Hard prerequisite, not optional.</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>90 minutes start to finish</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>A signed-off dry-run report listing every gap found and either fixed or accepted in writing</td>
+</tr>
+</tbody></table>
+<p>The dry run exists because the only failure modes that matter on event day are the ones nobody anticipated. Running through the entire flow once on the same configuration you will ship is the cheapest way to discover them.</p>
+<blockquote>
+<p><strong>Do not skip the dry run.</strong> If the schedule does not allow a dry run, reschedule the event. The <a href="./pre-event-checklist.md#dry-run-scheduled-hard-gate">pre-event checklist T-7 row</a> treats this as a hard gate.</p>
+</blockquote>
+<h2>Scope of the dry run</h2>
+<p>The dry run must exercise the same path the participants will exercise.</p>
+<table>
+<thead>
+<tr>
+<th>Layer</th>
+<th>What you deploy or invoke</th>
+<th>Why it matters</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Platform</td>
+<td>Lite mode (<code>make deploy</code>) or SaaS mode (<code>make deploy-saas</code>) for the event environment</td>
+<td>Catches IAM / Cognito / DNS issues at the platform layer before the event</td>
+</tr>
+<tr>
+<td>Problem catalog</td>
+<td>Every problem you plan to deliver at the event, deployed to one rehearsal team</td>
+<td>Catches CFn template drift, region restrictions, account quota issues</td>
+</tr>
+<tr>
+<td>Participant flow</td>
+<td>Log into the participant portal, accept the problem, submit a flag / observe scoring</td>
+<td>Catches scoring kind misconfiguration, missing portal slots, broken endpoints</td>
+</tr>
+<tr>
+<td>Operator flow</td>
+<td>Send <code>info</code> and <code>warning</code> notifications, observe via <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a></td>
+<td>Catches notification path failures and the ADR-006 polling delay surprises</td>
+</tr>
+<tr>
+<td>Teardown</td>
+<td>Tear down the rehearsal team&#39;s stacks via the participant portal teardown UI</td>
+<td>Catches the teardown failure modes that are hardest to recover from after the real event</td>
+</tr>
+</tbody></table>
+<p>If a problem cannot be exercised end-to-end during the dry run, treat the problem as not ready and drop it from the event catalog.</p>
+<h2>Step-by-step</h2>
+<h3>Step 0: pre-flight (10 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Confirm the dry-run AWS environment matches the production event environment (same region, same Lite vs SaaS choice, same problem catalog pin).</li>
+<li><input disabled="" type="checkbox"> <code>make harness &amp;&amp; make before-commit</code> green on the branch under test.</li>
+<li><input disabled="" type="checkbox"> Free up a rehearsal team AWS account with <code>infrastructure/templates/competitor-bootstrap.yaml</code> already rolled out (or use the organizer-rented account flow).</li>
+</ul>
+<h3>Step 1: platform deploy (15 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Run <code>make deploy</code> (Lite) or <code>make deploy-saas</code> (SaaS).</li>
+<li><input disabled="" type="checkbox"> Wait for every stack to reach <code>CREATE_COMPLETE</code> / <code>UPDATE_COMPLETE</code>.</li>
+<li><input disabled="" type="checkbox"> Capture the output URLs (<code>make lite-portal-url</code>, <code>make lite-console-url</code>, or the SaaS Admin Console URL).</li>
+</ul>
+<p><strong>If it goes wrong:</strong> A failed stack is the most expensive thing to discover on event day. If a stack fails here, debug the root cause and re-run the dry run from Step 0. Do not work around it with manual fixes that the production deploy will not have.</p>
+<h3>Step 2: deploy each selected problem (20 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> For each problem you plan to run, file a <code>DeployRequested</code> event (Application Admin Console UI is the supported entry point).</li>
+<li><input disabled="" type="checkbox"> Observe the deploy chain trace using <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a>. Confirm <code>deploy.cfn.deploy.succeeded</code> appears within the expected window.</li>
+<li><input disabled="" type="checkbox"> Verify the resulting stack name, region, and resource list in the rehearsal team&#39;s AWS account match what the template intended.</li>
+</ul>
+<p><strong>If it goes wrong:</strong> Capture the failing CFn stack events into the dry-run report. If the failure is region-specific, decide before the real event whether to drop the problem or change the region.</p>
+<h3>Step 3: participant portal flow (15 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Open the participant portal URL and log in with a dummy team account.</li>
+<li><input disabled="" type="checkbox"> Confirm every deployed problem renders the expected dashboard slots.</li>
+<li><input disabled="" type="checkbox"> Submit a flag (for <code>flag</code> scoring), wait for the polling tick (uptime / phased-polling scoring), or trigger the attack (<code>attack-detection</code> scoring). Confirm the scoreboard reflects the result.</li>
+</ul>
+<p><strong>If it goes wrong:</strong> Mismatched scoring rendering is a signal that the <code>metadata.json</code> scoring kind does not match the template behavior. Fix the metadata, not the platform.</p>
+<h3>Step 4: operator flow (10 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Open the Application Admin Console as the organizer.</li>
+<li><input disabled="" type="checkbox"> Send one <code>info</code> and one <code>warning</code> notification.</li>
+<li><input disabled="" type="checkbox"> Confirm both appear in the participant portal within one polling tick (5 seconds, see <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>).</li>
+<li><input disabled="" type="checkbox"> Confirm dashboards (CloudWatch, scoreboard) update as expected.</li>
+</ul>
+<h3>Step 5: teardown (15 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Initiate teardown for each deployed problem via the operator UI.</li>
+<li><input disabled="" type="checkbox"> Confirm each stack reaches <code>DELETE_COMPLETE</code> and <code>deploy.cfn.delete.succeeded</code> appears in the deploy trace.</li>
+<li><input disabled="" type="checkbox"> Confirm no leftover resources (S3 buckets, ENIs, EBS volumes) remain in the rehearsal team&#39;s account. See <a href="./teardown.md">teardown runbook</a> for the audit procedure.</li>
+</ul>
+<h3>Step 6: write the report (5 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Record every gap (broken problem, slow scoring, confusing portal copy, missing notification) in the dry-run report.</li>
+<li><input disabled="" type="checkbox"> Decide for each gap whether to fix it before the event, or accept the risk and explain why.</li>
+</ul>
+<h2>If it goes wrong (overall)</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>First response</th>
+<th>Escalation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Multiple problems fail to deploy</td>
+<td>The dry run is signaling that the production deploy will too. Stop here and triage with <a href="./incident-response.md">incident response</a>.</td>
+<td>Postpone the event if you cannot resolve every failed problem before T-1.</td>
+</tr>
+<tr>
+<td>Scoring kind does not match what participants will see</td>
+<td>Update the problem <code>metadata.json</code> and re-run the dry run for that problem only.</td>
+<td>If you cannot fix it before T-1, drop the problem from the event catalog.</td>
+</tr>
+<tr>
+<td>Teardown leaves orphaned resources</td>
+<td>Document the resource type and the manual cleanup path in the <a href="./teardown.md">teardown runbook</a>.</td>
+<td>If the orphaned resources cost money, escalate the cleanup with the team account owner.</td>
+</tr>
+<tr>
+<td>Notification delivery is broken</td>
+<td>Check the EventBridge bus ARN wiring per <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>.</td>
+<td>If you cannot fix it before T-1, the event must run without notifications; brief the facilitator.</td>
+</tr>
+</tbody></table>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Previous: <a href="./pre-event-checklist.md">pre-event checklist</a> (T-7 gate).</li>
+<li>Next: <a href="./participant-onboarding.md">participant onboarding</a>, <a href="./live-monitoring.md">live monitoring</a>.</li>
+<li>During event: <a href="./incident-response.md">incident response</a>.</li>
+<li>After event: <a href="./teardown.md">teardown</a>.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a>, <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a>, <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a>.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/dry-run.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/dry-run.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/dry-run.ja.html
+++ b/docs/runbooks/dry-run.ja.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Dry run</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Dry run</h1>
+<blockquote>
+<p>English: <a href="./dry-run.md">dry-run.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>オペレータ (= 本番でオンコールに入る人)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>本番 7 日以内。 必須前提であって任意ではない。</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>90 分 (= 着手から終了まで)</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>発見した gap をすべて記録し、 修正済みまたは明示的に許容したかを sign off した dry run レポート</td>
+</tr>
+</tbody></table>
+<p>Dry run が必要な理由は、 本番で問題になる失敗は誰も予期していないものだけだからです。 本番と同一設定で 1 度フローを通すのが、 そうした失敗をもっとも安価に発掘する手段です。</p>
+<blockquote>
+<p><strong>Dry run をスキップしない</strong>。 スケジュール上不可能なら、 イベント自体を再調整する。 <a href="./pre-event-checklist.ja.md#dry-run-%E3%81%AE%E4%BA%88%E5%AE%9A%E7%A2%BA%E4%BF%9D-%E3%83%8F%E3%83%BC%E3%83%89%E3%82%B2%E3%83%BC%E3%83%88">事前チェックリスト T-7</a> はこれをハードゲートとして扱う。</p>
+</blockquote>
+<h2>Dry run のスコープ</h2>
+<p>参加者と同じ経路を必ず通すこと。</p>
+<table>
+<thead>
+<tr>
+<th>レイヤ</th>
+<th>何を deploy / invoke するか</th>
+<th>何が拾えるか</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Platform</td>
+<td>Lite mode (<code>make deploy</code>) または SaaS mode (<code>make deploy-saas</code>) で当該環境</td>
+<td>IAM / Cognito / DNS の platform 層障害</td>
+</tr>
+<tr>
+<td>Problem catalog</td>
+<td>本番で出す全問題を 1 リハーサルチームに deploy</td>
+<td>CFn template drift / region 制約 / アカウント quota</td>
+</tr>
+<tr>
+<td>参加者フロー</td>
+<td>Participant portal にログイン / 問題を受領 / flag 提出か scoring 観測</td>
+<td>Scoring kind 誤設定 / portal slot 欠落 / endpoint 不通</td>
+</tr>
+<tr>
+<td>オペレータフロー</td>
+<td><code>info</code> / <code>warning</code> 通知の送信、 <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a> で確認</td>
+<td>通知配信失敗、 ADR-006 polling 遅延の体感</td>
+</tr>
+<tr>
+<td>Teardown</td>
+<td>リハーサルチームのスタックを participant portal teardown UI で破棄</td>
+<td>本番後にもっとも復旧しづらい teardown 失敗パターン</td>
+</tr>
+</tbody></table>
+<p>End-to-end で通せない問題は「未準備」とみなし、 本番カタログから外すこと。</p>
+<h2>Step-by-step</h2>
+<h3>Step 0: pre-flight (10 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Dry run 用 AWS 環境が本番イベント環境と一致 (= 同 region / 同 Lite vs SaaS / 同 catalog pin) であることを確認。</li>
+<li><input disabled="" type="checkbox"> 検証対象ブランチで <code>make harness &amp;&amp; make before-commit</code> が green。</li>
+<li><input disabled="" type="checkbox"> <code>infrastructure/templates/competitor-bootstrap.yaml</code> が展開済みのリハーサル AWS アカウントを 1 つ確保 (= または主催者払い出しフローを使う)。</li>
+</ul>
+<h3>Step 1: Platform deploy (15 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <code>make deploy</code> (Lite) または <code>make deploy-saas</code> (SaaS) を実行。</li>
+<li><input disabled="" type="checkbox"> すべての stack が <code>CREATE_COMPLETE</code> / <code>UPDATE_COMPLETE</code> に到達するまで待機。</li>
+<li><input disabled="" type="checkbox"> 出力 URL (<code>make lite-portal-url</code> / <code>make lite-console-url</code> / SaaS の Admin Console URL) を控える。</li>
+</ul>
+<p><strong>うまくいかなかったら</strong>: スタック失敗は本番でもっとも高くつく発見。 ここで失敗したら根本原因をデバッグし、 Step 0 から dry run をやり直す。「本番の deploy には存在しない手作業 fix」でごまかさない。</p>
+<h3>Step 2: 各問題を deploy (20 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 本番で出す各問題について <code>DeployRequested</code> event を発行する (= Application Admin Console UI が正規入口)。</li>
+<li><input disabled="" type="checkbox"> <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a> で deploy chain trace を観測。 想定 window 内に <code>deploy.cfn.deploy.succeeded</code> が出ることを確認。</li>
+<li><input disabled="" type="checkbox"> リハーサルチームの AWS アカウントで stack 名 / region / リソース一覧がテンプレート意図と一致することを確認。</li>
+</ul>
+<p><strong>うまくいかなかったら</strong>: 失敗 stack の CFn event を dry run レポートにキャプチャする。 region 固有の失敗なら、 本番までに「問題を落とす」か「region を変える」かを決める。</p>
+<h3>Step 3: Participant portal フロー (15 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> ダミーのチームアカウントで participant portal にログイン。</li>
+<li><input disabled="" type="checkbox"> Deploy 済みの各問題が想定どおりの dashboard slot を描画していることを確認。</li>
+<li><input disabled="" type="checkbox"> Flag 提出 (<code>flag</code> scoring) / 1 polling tick 待機 (uptime / phased-polling) / 攻撃の trigger (<code>attack-detection</code>) を行い、 scoreboard に反映されることを確認。</li>
+</ul>
+<p><strong>うまくいかなかったら</strong>: Scoring の描画ずれは <code>metadata.json</code> の scoring kind が template 挙動と噛み合っていない signal。 platform ではなく metadata 側を直す。</p>
+<h3>Step 4: オペレータフロー (10 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 主催者として Application Admin Console を開く。</li>
+<li><input disabled="" type="checkbox"> <code>info</code> を 1 件、 <code>warning</code> を 1 件送る。</li>
+<li><input disabled="" type="checkbox"> Participant portal に 1 polling tick (= 5 秒、 <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>) 以内に両方表示されることを確認。</li>
+<li><input disabled="" type="checkbox"> ダッシュボード (CloudWatch / scoreboard) が期待どおり更新することを確認。</li>
+</ul>
+<h3>Step 5: Teardown (15 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Deploy した各問題について teardown を発行する。</li>
+<li><input disabled="" type="checkbox"> 各 stack が <code>DELETE_COMPLETE</code> に到達し、 deploy trace に <code>deploy.cfn.delete.succeeded</code> が出ることを確認。</li>
+<li><input disabled="" type="checkbox"> リハーサルチームアカウントに残存リソース (S3 バケット / ENI / EBS volume) が無いことを確認。 監査手順は <a href="./teardown.ja.md">teardown runbook</a> を参照。</li>
+</ul>
+<h3>Step 6: レポート (5 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 発見した gap (= 問題不具合 / scoring 遅延 / portal 表記の混乱 / 通知欠落) を dry run レポートに記録する。</li>
+<li><input disabled="" type="checkbox"> 各 gap について「本番前に直す」か「リスクを受容する」かを明示する。</li>
+</ul>
+<h2>うまくいかなかったら (全体)</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>1st response</th>
+<th>エスカレーション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>複数の問題が deploy 失敗</td>
+<td>Dry run が 「本番でも失敗する」 と告げている signal。 ここで止めて <a href="./incident-response.ja.md">インシデント対応</a> で triage する。</td>
+<td>T-1 までに全失敗問題を解消できなければイベント再スケジュール。</td>
+</tr>
+<tr>
+<td>Scoring kind と portal 描画が噛み合わない</td>
+<td>当該 <code>metadata.json</code> を直し、 その問題だけ dry run を再実行。</td>
+<td>T-1 までに直せなければカタログから外す。</td>
+</tr>
+<tr>
+<td>Teardown でリソースが残る</td>
+<td>種別と手動 cleanup 経路を <a href="./teardown.ja.md">teardown runbook</a> に書き残す。</td>
+<td>残存リソースがコストを生むなら、 チームアカウントオーナーに即時エスカレーション。</td>
+</tr>
+<tr>
+<td>通知配信が壊れている</td>
+<td>EventBridge bus ARN 配線を <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> と突き合わせる。</td>
+<td>T-1 までに直らなければ、 通知無しで運用する旨を facilitator に共有。</td>
+</tr>
+</tbody></table>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>前: <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> (T-7 ゲート)。</li>
+<li>次: <a href="./participant-onboarding.ja.md">participant onboarding</a> / <a href="./live-monitoring.ja.md">live monitoring</a>。</li>
+<li>イベント中: <a href="./incident-response.ja.md">インシデント対応</a>。</li>
+<li>イベント後: <a href="./teardown.ja.md">Teardown</a>。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> / <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> / <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a>。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/dry-run.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/dry-run.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/dry-run.ja.md
+++ b/docs/runbooks/dry-run.ja.md
@@ -1,0 +1,95 @@
+# Dry run
+
+> English: [dry-run.md](./dry-run.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | オペレータ (= 本番でオンコールに入る人) |
+| 使うタイミング | 本番 7 日以内。 必須前提であって任意ではない。 |
+| 所要時間 | 90 分 (= 着手から終了まで) |
+| 出力 | 発見した gap をすべて記録し、 修正済みまたは明示的に許容したかを sign off した dry run レポート |
+
+Dry run が必要な理由は、 本番で問題になる失敗は誰も予期していないものだけだからです。 本番と同一設定で 1 度フローを通すのが、 そうした失敗をもっとも安価に発掘する手段です。
+
+> **Dry run をスキップしない**。 スケジュール上不可能なら、 イベント自体を再調整する。 [事前チェックリスト T-7](./pre-event-checklist.ja.md#dry-run-%E3%81%AE%E4%BA%88%E5%AE%9A%E7%A2%BA%E4%BF%9D-%E3%83%8F%E3%83%BC%E3%83%89%E3%82%B2%E3%83%BC%E3%83%88) はこれをハードゲートとして扱う。
+
+## Dry run のスコープ
+
+参加者と同じ経路を必ず通すこと。
+
+| レイヤ | 何を deploy / invoke するか | 何が拾えるか |
+|---|---|---|
+| Platform | Lite mode (`make deploy`) または SaaS mode (`make deploy-saas`) で当該環境 | IAM / Cognito / DNS の platform 層障害 |
+| Problem catalog | 本番で出す全問題を 1 リハーサルチームに deploy | CFn template drift / region 制約 / アカウント quota |
+| 参加者フロー | Participant portal にログイン / 問題を受領 / flag 提出か scoring 観測 | Scoring kind 誤設定 / portal slot 欠落 / endpoint 不通 |
+| オペレータフロー | `info` / `warning` 通知の送信、 [`docs/operations/notifications.md`](../operations/notifications.md) で確認 | 通知配信失敗、 ADR-006 polling 遅延の体感 |
+| Teardown | リハーサルチームのスタックを participant portal teardown UI で破棄 | 本番後にもっとも復旧しづらい teardown 失敗パターン |
+
+End-to-end で通せない問題は「未準備」とみなし、 本番カタログから外すこと。
+
+## Step-by-step
+
+### Step 0: pre-flight (10 分)
+
+- [ ] Dry run 用 AWS 環境が本番イベント環境と一致 (= 同 region / 同 Lite vs SaaS / 同 catalog pin) であることを確認。
+- [ ] 検証対象ブランチで `make harness && make before-commit` が green。
+- [ ] `infrastructure/templates/competitor-bootstrap.yaml` が展開済みのリハーサル AWS アカウントを 1 つ確保 (= または主催者払い出しフローを使う)。
+
+### Step 1: Platform deploy (15 分)
+
+- [ ] `make deploy` (Lite) または `make deploy-saas` (SaaS) を実行。
+- [ ] すべての stack が `CREATE_COMPLETE` / `UPDATE_COMPLETE` に到達するまで待機。
+- [ ] 出力 URL (`make lite-portal-url` / `make lite-console-url` / SaaS の Admin Console URL) を控える。
+
+**うまくいかなかったら**: スタック失敗は本番でもっとも高くつく発見。 ここで失敗したら根本原因をデバッグし、 Step 0 から dry run をやり直す。「本番の deploy には存在しない手作業 fix」でごまかさない。
+
+### Step 2: 各問題を deploy (20 分)
+
+- [ ] 本番で出す各問題について `DeployRequested` event を発行する (= Application Admin Console UI が正規入口)。
+- [ ] [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md) で deploy chain trace を観測。 想定 window 内に `deploy.cfn.deploy.succeeded` が出ることを確認。
+- [ ] リハーサルチームの AWS アカウントで stack 名 / region / リソース一覧がテンプレート意図と一致することを確認。
+
+**うまくいかなかったら**: 失敗 stack の CFn event を dry run レポートにキャプチャする。 region 固有の失敗なら、 本番までに「問題を落とす」か「region を変える」かを決める。
+
+### Step 3: Participant portal フロー (15 分)
+
+- [ ] ダミーのチームアカウントで participant portal にログイン。
+- [ ] Deploy 済みの各問題が想定どおりの dashboard slot を描画していることを確認。
+- [ ] Flag 提出 (`flag` scoring) / 1 polling tick 待機 (uptime / phased-polling) / 攻撃の trigger (`attack-detection`) を行い、 scoreboard に反映されることを確認。
+
+**うまくいかなかったら**: Scoring の描画ずれは `metadata.json` の scoring kind が template 挙動と噛み合っていない signal。 platform ではなく metadata 側を直す。
+
+### Step 4: オペレータフロー (10 分)
+
+- [ ] 主催者として Application Admin Console を開く。
+- [ ] `info` を 1 件、 `warning` を 1 件送る。
+- [ ] Participant portal に 1 polling tick (= 5 秒、 [`docs/operations/notifications.md`](../operations/notifications.md)) 以内に両方表示されることを確認。
+- [ ] ダッシュボード (CloudWatch / scoreboard) が期待どおり更新することを確認。
+
+### Step 5: Teardown (15 分)
+
+- [ ] Deploy した各問題について teardown を発行する。
+- [ ] 各 stack が `DELETE_COMPLETE` に到達し、 deploy trace に `deploy.cfn.delete.succeeded` が出ることを確認。
+- [ ] リハーサルチームアカウントに残存リソース (S3 バケット / ENI / EBS volume) が無いことを確認。 監査手順は [teardown runbook](./teardown.ja.md) を参照。
+
+### Step 6: レポート (5 分)
+
+- [ ] 発見した gap (= 問題不具合 / scoring 遅延 / portal 表記の混乱 / 通知欠落) を dry run レポートに記録する。
+- [ ] 各 gap について「本番前に直す」か「リスクを受容する」かを明示する。
+
+## うまくいかなかったら (全体)
+
+| 症状 | 1st response | エスカレーション |
+|---|---|---|
+| 複数の問題が deploy 失敗 | Dry run が 「本番でも失敗する」 と告げている signal。 ここで止めて [インシデント対応](./incident-response.ja.md) で triage する。 | T-1 までに全失敗問題を解消できなければイベント再スケジュール。 |
+| Scoring kind と portal 描画が噛み合わない | 当該 `metadata.json` を直し、 その問題だけ dry run を再実行。 | T-1 までに直せなければカタログから外す。 |
+| Teardown でリソースが残る | 種別と手動 cleanup 経路を [teardown runbook](./teardown.ja.md) に書き残す。 | 残存リソースがコストを生むなら、 チームアカウントオーナーに即時エスカレーション。 |
+| 通知配信が壊れている | EventBridge bus ARN 配線を [ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) と突き合わせる。 | T-1 までに直らなければ、 通知無しで運用する旨を facilitator に共有。 |
+
+## 関連 runbook / ADR
+
+- 前: [事前チェックリスト](./pre-event-checklist.ja.md) (T-7 ゲート)。
+- 次: [participant onboarding](./participant-onboarding.ja.md) / [live monitoring](./live-monitoring.ja.md)。
+- イベント中: [インシデント対応](./incident-response.ja.md)。
+- イベント後: [Teardown](./teardown.ja.md)。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) / [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) / [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md)。

--- a/docs/runbooks/dry-run.md
+++ b/docs/runbooks/dry-run.md
@@ -1,0 +1,95 @@
+# Dry run
+
+> Japanese: [dry-run.ja.md](./dry-run.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | Operator (the person who will be on-call during the real event) |
+| When to use | Within 7 days before the real event. Hard prerequisite, not optional. |
+| Estimated time | 90 minutes start to finish |
+| Output | A signed-off dry-run report listing every gap found and either fixed or accepted in writing |
+
+The dry run exists because the only failure modes that matter on event day are the ones nobody anticipated. Running through the entire flow once on the same configuration you will ship is the cheapest way to discover them.
+
+> **Do not skip the dry run.** If the schedule does not allow a dry run, reschedule the event. The [pre-event checklist T-7 row](./pre-event-checklist.md#dry-run-scheduled-hard-gate) treats this as a hard gate.
+
+## Scope of the dry run
+
+The dry run must exercise the same path the participants will exercise.
+
+| Layer | What you deploy or invoke | Why it matters |
+|---|---|---|
+| Platform | Lite mode (`make deploy`) or SaaS mode (`make deploy-saas`) for the event environment | Catches IAM / Cognito / DNS issues at the platform layer before the event |
+| Problem catalog | Every problem you plan to deliver at the event, deployed to one rehearsal team | Catches CFn template drift, region restrictions, account quota issues |
+| Participant flow | Log into the participant portal, accept the problem, submit a flag / observe scoring | Catches scoring kind misconfiguration, missing portal slots, broken endpoints |
+| Operator flow | Send `info` and `warning` notifications, observe via [`docs/operations/notifications.md`](../operations/notifications.md) | Catches notification path failures and the ADR-006 polling delay surprises |
+| Teardown | Tear down the rehearsal team's stacks via the participant portal teardown UI | Catches the teardown failure modes that are hardest to recover from after the real event |
+
+If a problem cannot be exercised end-to-end during the dry run, treat the problem as not ready and drop it from the event catalog.
+
+## Step-by-step
+
+### Step 0: pre-flight (10 min)
+
+- [ ] Confirm the dry-run AWS environment matches the production event environment (same region, same Lite vs SaaS choice, same problem catalog pin).
+- [ ] `make harness && make before-commit` green on the branch under test.
+- [ ] Free up a rehearsal team AWS account with `infrastructure/templates/competitor-bootstrap.yaml` already rolled out (or use the organizer-rented account flow).
+
+### Step 1: platform deploy (15 min)
+
+- [ ] Run `make deploy` (Lite) or `make deploy-saas` (SaaS).
+- [ ] Wait for every stack to reach `CREATE_COMPLETE` / `UPDATE_COMPLETE`.
+- [ ] Capture the output URLs (`make lite-portal-url`, `make lite-console-url`, or the SaaS Admin Console URL).
+
+**If it goes wrong:** A failed stack is the most expensive thing to discover on event day. If a stack fails here, debug the root cause and re-run the dry run from Step 0. Do not work around it with manual fixes that the production deploy will not have.
+
+### Step 2: deploy each selected problem (20 min)
+
+- [ ] For each problem you plan to run, file a `DeployRequested` event (Application Admin Console UI is the supported entry point).
+- [ ] Observe the deploy chain trace using [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md). Confirm `deploy.cfn.deploy.succeeded` appears within the expected window.
+- [ ] Verify the resulting stack name, region, and resource list in the rehearsal team's AWS account match what the template intended.
+
+**If it goes wrong:** Capture the failing CFn stack events into the dry-run report. If the failure is region-specific, decide before the real event whether to drop the problem or change the region.
+
+### Step 3: participant portal flow (15 min)
+
+- [ ] Open the participant portal URL and log in with a dummy team account.
+- [ ] Confirm every deployed problem renders the expected dashboard slots.
+- [ ] Submit a flag (for `flag` scoring), wait for the polling tick (uptime / phased-polling scoring), or trigger the attack (`attack-detection` scoring). Confirm the scoreboard reflects the result.
+
+**If it goes wrong:** Mismatched scoring rendering is a signal that the `metadata.json` scoring kind does not match the template behavior. Fix the metadata, not the platform.
+
+### Step 4: operator flow (10 min)
+
+- [ ] Open the Application Admin Console as the organizer.
+- [ ] Send one `info` and one `warning` notification.
+- [ ] Confirm both appear in the participant portal within one polling tick (5 seconds, see [`docs/operations/notifications.md`](../operations/notifications.md)).
+- [ ] Confirm dashboards (CloudWatch, scoreboard) update as expected.
+
+### Step 5: teardown (15 min)
+
+- [ ] Initiate teardown for each deployed problem via the operator UI.
+- [ ] Confirm each stack reaches `DELETE_COMPLETE` and `deploy.cfn.delete.succeeded` appears in the deploy trace.
+- [ ] Confirm no leftover resources (S3 buckets, ENIs, EBS volumes) remain in the rehearsal team's account. See [teardown runbook](./teardown.md) for the audit procedure.
+
+### Step 6: write the report (5 min)
+
+- [ ] Record every gap (broken problem, slow scoring, confusing portal copy, missing notification) in the dry-run report.
+- [ ] Decide for each gap whether to fix it before the event, or accept the risk and explain why.
+
+## If it goes wrong (overall)
+
+| Symptom | First response | Escalation |
+|---|---|---|
+| Multiple problems fail to deploy | The dry run is signaling that the production deploy will too. Stop here and triage with [incident response](./incident-response.md). | Postpone the event if you cannot resolve every failed problem before T-1. |
+| Scoring kind does not match what participants will see | Update the problem `metadata.json` and re-run the dry run for that problem only. | If you cannot fix it before T-1, drop the problem from the event catalog. |
+| Teardown leaves orphaned resources | Document the resource type and the manual cleanup path in the [teardown runbook](./teardown.md). | If the orphaned resources cost money, escalate the cleanup with the team account owner. |
+| Notification delivery is broken | Check the EventBridge bus ARN wiring per [ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html). | If you cannot fix it before T-1, the event must run without notifications; brief the facilitator. |
+
+## Related runbooks and ADRs
+
+- Previous: [pre-event checklist](./pre-event-checklist.md) (T-7 gate).
+- Next: [participant onboarding](./participant-onboarding.md), [live monitoring](./live-monitoring.md).
+- During event: [incident response](./incident-response.md).
+- After event: [teardown](./teardown.md).
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html), [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html), [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md).

--- a/docs/runbooks/incident-response.html
+++ b/docs/runbooks/incident-response.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Incident response</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Incident response</h1>
+<blockquote>
+<p>Japanese: <a href="./incident-response.ja.md">incident-response.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>On-call operator (the person triaging an active incident)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>When <a href="./live-monitoring.md">live monitoring</a> sends you here, or when a participant report cannot be resolved within one minute of observation</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>5 to 30 minutes per incident</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>Either the incident is resolved with a recorded action, or it is escalated with a documented reason</td>
+</tr>
+</tbody></table>
+<p>This runbook covers the four most common incident classes during a hosted event. Each section follows the same shape: <strong>symptoms → 1st response → safe remediation → escalation</strong>. Do not improvise; pick the matching section and follow it.</p>
+<blockquote>
+<p><strong>Before you act:</strong> Record one observation line in the event timeline (see <a href="./live-monitoring.md#recording-the-event-timeline">live monitoring</a>). Every act-without-observe step is how operators make outages worse.</p>
+</blockquote>
+<h2>Section 1: Lambda errors</h2>
+<h3>Symptoms</h3>
+<ul>
+<li>CloudWatch shows a non-zero error rate on the deploy worker, scoring Lambda, or one of the API handlers.</li>
+<li>Operator dashboard shows deployments stuck in <code>IN_PROGRESS</code> or scoring loop frozen.</li>
+<li>Participants report stale scoreboard or &quot;deploy never finishes&quot;.</li>
+</ul>
+<h3>1st response (under 5 minutes)</h3>
+<ol>
+<li>Confirm which Lambda is erroring. Filter CloudWatch by function name.</li>
+<li>Read the most recent error log. Look for stack trace, error class, and タイムスタンプ.</li>
+<li>Classify: is this a transient AWS error (throttling, timeout, networking) or a code-level error (TypeError, deserialization failure)?</li>
+</ol>
+<h3>Safe remediation</h3>
+<table>
+<thead>
+<tr>
+<th>Error class</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Transient AWS error (rate limit, timeout, DNS)</td>
+<td>Wait two minutes. Most resolve themselves under retry. Send <code>info</code> notification if participants notice.</td>
+</tr>
+<tr>
+<td>Cold-start latency only</td>
+<td>No action; latency is not an incident. Continue <a href="./live-monitoring.md">live monitoring</a>.</td>
+</tr>
+<tr>
+<td>Code-level error (TypeError, schema validation)</td>
+<td>Capture log lines into the event timeline. Do not patch code mid-event; redeploying the platform during a live event is forbidden. Note the affected scoring or deploy path and continue.</td>
+</tr>
+<tr>
+<td>Repeated <code>AccessDenied</code> from AssumeRole</td>
+<td>The ExternalId is wrong for that team. Verify the team metadata and re-issue the credentials.</td>
+</tr>
+</tbody></table>
+<h3>Escalation</h3>
+<ul>
+<li>If the error rate is sustained more than 5 errors / minute for 5 minutes, send <code>warning</code> notification and brief the facilitator.</li>
+<li>If the error affects every team, treat as platform-wide incident and consider pausing scoring until resolved.</li>
+</ul>
+<h2>Section 2: DynamoDB throttling</h2>
+<h3>Symptoms (DynamoDB throttling)</h3>
+<ul>
+<li>CloudWatch DynamoDB metric <code>UserErrors</code> or <code>ThrottledRequests</code> is non-zero.</li>
+<li>Participant portal scoreboard is slow or returns sporadic errors.</li>
+<li>Operator dashboard shows lag between event-time and scoreboard time.</li>
+</ul>
+<h3>1st response (under 5 minutes) — DynamoDB throttling</h3>
+<ol>
+<li>Identify the table being throttled (<code>Deployments</code>, <code>Apps</code>, <code>Events</code>, <code>TenantMappingTable</code>, etc.).</li>
+<li>Check the read / write capacity. Every TenkaCloud table is forced to PROVISIONED 1 RCU / 1 WCU by the <a href="../../infrastructure/lib/cdk-aspect"><code>DynamoDbLowCapacity</code></a> aspect for AWS Free Tier safety.</li>
+<li>Decide whether the throttling is caused by participant traffic (legitimate) or by a runaway Lambda (incident).</li>
+</ol>
+<h3>Safe remediation — DynamoDB throttling</h3>
+<table>
+<thead>
+<tr>
+<th>Cause</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Legitimate traffic burst (event spike)</td>
+<td>Send <code>info</code> notification &quot;scoreboard refresh may be delayed&quot; and wait for the burst to subside. Do not raise capacity in the middle of the event unless every Free Tier guard rail decision has been re-discussed.</td>
+</tr>
+<tr>
+<td>Runaway Lambda hot-looping</td>
+<td>Identify and stop the Lambda invocation source. Most often a misconfigured EventBridge rule firing in a loop.</td>
+</tr>
+<tr>
+<td>Operator-induced scan / list</td>
+<td>Stop the scan. Most operator queries should target specific keys.</td>
+</tr>
+</tbody></table>
+<blockquote>
+<p><strong>Do not</strong> flip the table to <code>PAY_PER_REQUEST</code> mid-event. The aspect enforces PROVISIONED 1/1; switching modes requires a CDK change and is forbidden inline.</p>
+</blockquote>
+<h3>Escalation — DynamoDB throttling</h3>
+<ul>
+<li>If throttling cannot be relieved in 10 minutes, pause scoring and send <code>warning</code> notification before participants notice systematic data loss.</li>
+<li>Document the table and the cause in the event timeline for post-event review.</li>
+</ul>
+<h2>Section 3: Cognito sign-in failure</h2>
+<h3>Symptoms (Cognito sign-in failure)</h3>
+<ul>
+<li>Participant reports cannot log in via the participant portal.</li>
+<li>Application Admin Console SSO login fails.</li>
+<li>Operator sees Cognito Hosted UI errors in CloudWatch.</li>
+</ul>
+<h3>1st response (under 5 minutes) — Cognito sign-in failure</h3>
+<ol>
+<li>Confirm the scope: one participant, one team, or all participants.</li>
+<li>For a single participant: ask them to clear cookies and retry. Verify the participant portal URL has no trailing whitespace.</li>
+<li>For a single team: check the team&#39;s metadata is wired. Confirm SSO IdP configuration if federated.</li>
+<li>For all participants: this is a platform-wide incident. Treat as Section 4 or as Lambda errors depending on the failure mode.</li>
+</ol>
+<h3>Safe remediation — Cognito sign-in failure</h3>
+<table>
+<thead>
+<tr>
+<th>Failure mode</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Wrong login key (typo, trailing space)</td>
+<td>Re-send the correct key over the agreed channel from <a href="./participant-onboarding.md">participant onboarding</a>.</td>
+</tr>
+<tr>
+<td>Cognito Hosted UI 5xx</td>
+<td>Wait 60 seconds and retry. Most Cognito Hosted UI errors are transient.</td>
+</tr>
+<tr>
+<td>OAuth callback URL mismatch</td>
+<td>The participant portal URL changed since deploy. Confirm the callback URL in Cognito matches the current CloudFront URL. Re-deploy is the fix; do not patch Cognito by hand.</td>
+</tr>
+<tr>
+<td>SAML IdP rejecting the assertion</td>
+<td>Check the IdP-side log first. See <a href="../operations/application-plane-saml-setup.md"><code>docs/operations/application-plane-saml-setup.md</code></a>.</td>
+</tr>
+<tr>
+<td>Account is locked</td>
+<td>Cognito locks after multiple failed attempts. Wait 15 minutes or unlock via the AWS Console.</td>
+</tr>
+</tbody></table>
+<h3>Escalation — Cognito sign-in failure</h3>
+<ul>
+<li>If multiple teams cannot log in, hold the event and send <code>warning</code> notification before announcing further actions.</li>
+<li>If the callback URL is wrong, this is a deploy-time bug — do not attempt to fix in-flight, document and recover via <a href="./teardown.md">teardown</a>.</li>
+</ul>
+<h2>Section 4: CloudFormation stack ROLLBACK</h2>
+<h3>Symptoms (CFn stack ROLLBACK)</h3>
+<ul>
+<li>One or more team stacks show <code>CREATE_FAILED</code>, <code>ROLLBACK_IN_PROGRESS</code>, or <code>ROLLBACK_COMPLETE</code> in the operator dashboard or the team account.</li>
+<li>Participant reports their endpoint is unreachable.</li>
+<li>Deploy trace shows <code>deploy.cfn.deploy.failed</code>.</li>
+</ul>
+<h3>1st response (under 5 minutes) — CFn stack ROLLBACK</h3>
+<ol>
+<li>Identify the failing stack and the failure reason from CFn stack events.</li>
+<li>Classify the failure:<ul>
+<li><strong>Quota</strong> (account-level limit, e.g., VPC, EIP, Lambda)</li>
+<li><strong>Region restriction</strong> (service not available in the chosen region)</li>
+<li><strong>IAM</strong> (missing permission for the AssumeRole path, often ExternalId-related)</li>
+<li><strong>Template defect</strong> (bug in the problem template — should have been caught in <a href="./dry-run.md">dry run</a>)</li>
+</ul>
+</li>
+</ol>
+<h3>Safe remediation — CFn stack ROLLBACK</h3>
+<table>
+<thead>
+<tr>
+<th>Failure class</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Quota</td>
+<td>Request a quota increase or move the team to a different region if the problem allows. Do not work around quota by manually creating resources.</td>
+</tr>
+<tr>
+<td>Region restriction</td>
+<td>Drop the problem for that team or change the region (only if a single-region change is safe per the problem template).</td>
+</tr>
+<tr>
+<td>IAM</td>
+<td>Verify ExternalId, the competitor-bootstrap.yaml IAM role is rolled out, and the participant viewer role has the right policy. AssumeRole into competitor accounts always requires ExternalId; this is a hard invariant (see <a href="../../CLAUDE.md">CLAUDE.md</a> security section).</td>
+</tr>
+<tr>
+<td>Template defect</td>
+<td>Do not patch in-flight. Drop the problem for the affected teams, send <code>warning</code> notification, and capture for post-event fix.</td>
+</tr>
+</tbody></table>
+<h3>Safe redeploy</h3>
+<p>If you decide to redeploy (single-team only, after the triage in <a href="./live-monitoring.md">live monitoring</a>):</p>
+<ol>
+<li>Initiate teardown of the failed stack first (<code>scripts/delete-battles.sh</code> or the Application Admin Console teardown action). Confirm <code>DELETE_COMPLETE</code> before re-creating.</li>
+<li>Re-issue <code>DeployRequested</code> from the operator UI.</li>
+<li>Watch the deploy trace for the new <code>jobId</code>. Do not declare success until <code>deploy.cfn.deploy.succeeded</code> appears.</li>
+</ol>
+<h3>Escalation — CFn stack ROLLBACK</h3>
+<ul>
+<li>If multiple teams fail simultaneously with the same cause, treat as platform-wide. Pause scoring, send <code>warning</code>, and do not redeploy until you understand the cause.</li>
+<li>If ROLLBACK leaves orphaned resources, document and follow up in <a href="./teardown.md">teardown</a>.</li>
+</ul>
+<h2>Universal post-incident steps</h2>
+<p>After every incident:</p>
+<ol>
+<li>Append the final timeline entries (observed, acted, resolved).</li>
+<li>Send one <code>info</code> notification: &quot;Issue resolved; scoring is current as of HH:MM.&quot;</li>
+<li>File a post-event issue describing the cause, action, and any code-level follow-up.</li>
+<li>If the incident produced orphan resources or unclear scoring state, escalate to <a href="./teardown.md">teardown</a> for handling at event end.</li>
+</ol>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Use together with: <a href="./live-monitoring.md">live monitoring</a> — every incident starts from a live monitoring observation.</li>
+<li>After event: <a href="./teardown.md">teardown</a> — orphan resources from incidents are recovered here.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> (you cannot edit notifications, so wording matters), <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a> (why state converges asynchronously), <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a> (jobId tracing for incidents).</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/incident-response.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/incident-response.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/incident-response.ja.html
+++ b/docs/runbooks/incident-response.ja.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>インシデント対応</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>インシデント対応</h1>
+<blockquote>
+<p>English: <a href="./incident-response.md">incident-response.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>オンコールオペレータ (= 進行中のインシデントを triage する人)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td><a href="./live-monitoring.ja.md">live monitoring</a> からここへ送られたとき、 または参加者報告が 1 分以内に解決できないとき</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>1 件あたり 5 〜 30 分</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>インシデントが解決されアクション記録が残るか、 理由を明文化したうえでエスカレーションするか</td>
+</tr>
+</tbody></table>
+<p>ホスト型イベントで頻出する 4 種のインシデントを取り上げます。 各セクションは <strong>症状 → 1st response → 安全な remediation → エスカレーション</strong> の同型構造です。 即興しないこと、 該当節を選んでなぞること。</p>
+<blockquote>
+<p><strong>動く前に</strong>。 <a href="./live-monitoring.ja.md#%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%82%BF%E3%82%A4%E3%83%A0%E3%83%A9%E3%82%A4%E3%83%B3%E3%81%AE%E8%A8%98%E9%8C%B2">live monitoring の event timeline</a> に観測ラインを 1 行追記する。 観測なしの行動が、 オペレータが outage を悪化させる典型経路。</p>
+</blockquote>
+<h2>セクション 1: Lambda エラー</h2>
+<h3>症状</h3>
+<ul>
+<li>CloudWatch で deploy worker / scoring Lambda / API handler のいずれかにエラー率が出ている。</li>
+<li>オペレータダッシュボードで deployment が <code>IN_PROGRESS</code> のまま、 または scoring loop が止まっている。</li>
+<li>参加者から「scoreboard が古い」「deploy が終わらない」報告。</li>
+</ul>
+<h3>1st response (5 分以内)</h3>
+<ol>
+<li>どの Lambda がエラーかを確定。 CloudWatch を関数名でフィルタ。</li>
+<li>最新エラーログを読む。 stack trace / エラークラス / タイムスタンプを確認。</li>
+<li>分類する: AWS 由来の transient (throttling / timeout / networking) か、 コード由来 (TypeError / デシリアライゼーション失敗) か。</li>
+</ol>
+<h3>安全な remediation</h3>
+<table>
+<thead>
+<tr>
+<th>エラークラス</th>
+<th>アクション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>AWS 由来 transient (rate limit / timeout / DNS)</td>
+<td>2 分待つ。 大半は retry で解消。 参加者が気づいたなら <code>info</code> 通知。</td>
+</tr>
+<tr>
+<td>Cold-start のレイテンシだけ</td>
+<td>何もしない。 レイテンシはインシデントではない。 <a href="./live-monitoring.ja.md">live monitoring</a> を継続。</td>
+</tr>
+<tr>
+<td>コード由来 (TypeError / schema validation)</td>
+<td>ログをタイムラインにキャプチャ。 イベント中のコードパッチは禁止 (= ライブ中のプラットフォーム再 deploy 禁止)。 影響範囲をメモして継続。</td>
+</tr>
+<tr>
+<td>AssumeRole の <code>AccessDenied</code> が反復</td>
+<td>そのチームの ExternalId が誤り。 Tenant metadata を確認し、 認証情報を再発行。</td>
+</tr>
+</tbody></table>
+<h3>エスカレーション</h3>
+<ul>
+<li>5 件/分超のエラーが 5 分続いたら <code>warning</code> 通知を送り、 facilitator に共有。</li>
+<li>全チームに影響していれば plat-wide インシデント。 解決まで scoring 停止を検討。</li>
+</ul>
+<h2>セクション 2: DynamoDB throttling</h2>
+<h3>症状 (DynamoDB throttling)</h3>
+<ul>
+<li>CloudWatch DynamoDB の <code>UserErrors</code> または <code>ThrottledRequests</code> が非ゼロ。</li>
+<li>Participant portal の scoreboard が遅い / 散発的にエラー。</li>
+<li>オペレータダッシュボードで event 時刻と scoreboard 時刻の lag が拡大。</li>
+</ul>
+<h3>1st response (5 分以内) — DynamoDB throttling</h3>
+<ol>
+<li>Throttle されているテーブル (<code>Deployments</code> / <code>Apps</code> / <code>Events</code> / <code>TenantMappingTable</code> 等) を特定。</li>
+<li>Capacity 設定を確認。 TenkaCloud は AWS Free Tier 安全のため <a href="../../infrastructure/lib/cdk-aspect"><code>DynamoDbLowCapacity</code></a> aspect で全テーブルを PROVISIONED 1 RCU / 1 WCU に強制している。</li>
+<li>原因が participant traffic (正当) か runaway Lambda (インシデント) かを切り分け。</li>
+</ol>
+<h3>安全な remediation — DynamoDB throttling</h3>
+<table>
+<thead>
+<tr>
+<th>原因</th>
+<th>アクション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>イベントスパイクによる正当な burst</td>
+<td>「scoreboard 更新が遅れる可能性」と <code>info</code> 通知を送り、 burst が収まるのを待つ。 Free Tier ガードレールに紐づく決定をすべて再議論しない限り、 イベント中に capacity を上げない。</td>
+</tr>
+<tr>
+<td>Runaway Lambda の hot loop</td>
+<td>発火源の Lambda invocation を止める。 EventBridge rule の誤設定でループしているケースが多い。</td>
+</tr>
+<tr>
+<td>オペレータ起因の scan / list</td>
+<td>Scan を止める。 オペレータクエリは特定キー検索に限定する。</td>
+</tr>
+</tbody></table>
+<blockquote>
+<p>テーブルを <code>PAY_PER_REQUEST</code> に切り替えてはいけない。 Aspect が PROVISIONED 1/1 を強制しており、 モード切替には CDK 変更が必要 (= inline 禁止)。</p>
+</blockquote>
+<h3>エスカレーション — DynamoDB throttling</h3>
+<ul>
+<li>10 分で throttle が解消しなければ scoring を一時停止し、 系統的データ欠落の前に <code>warning</code> を送る。</li>
+<li>テーブル名と原因をタイムラインに記録、 事後レビューへ。</li>
+</ul>
+<h2>セクション 3: Cognito sign in 失敗</h2>
+<h3>症状 (Cognito sign in 失敗)</h3>
+<ul>
+<li>参加者から participant portal にログインできない報告。</li>
+<li>Application Admin Console の SSO ログイン失敗。</li>
+<li>CloudWatch に Cognito Hosted UI のエラー。</li>
+</ul>
+<h3>1st response (5 分以内) — Cognito sign in 失敗</h3>
+<ol>
+<li>範囲を確定: 参加者 1 名 / 1 チーム / 全員。</li>
+<li>1 名の場合: Cookie 削除して再試行を依頼。 participant portal URL の末尾空白を確認。</li>
+<li>1 チームの場合: チーム metadata の配線を確認。 SSO IdP 構成も併せて確認。</li>
+<li>全員の場合: プラットフォーム障害。 セクション 4 または Lambda エラーセクションとして扱う。</li>
+</ol>
+<h3>安全な remediation — Cognito sign in 失敗</h3>
+<table>
+<thead>
+<tr>
+<th>失敗モード</th>
+<th>アクション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Login key の typo / 末尾空白</td>
+<td><a href="./participant-onboarding.ja.md">participant onboarding</a> の合意チャネルで正しい key を再送。</td>
+</tr>
+<tr>
+<td>Cognito Hosted UI の 5xx</td>
+<td>60 秒待って再試行。 大半は transient。</td>
+</tr>
+<tr>
+<td>OAuth callback URL の不一致</td>
+<td>Deploy 後に participant portal URL が変わっている。 Cognito callback URL が現行 CloudFront URL と一致するか確認。 修正は再 deploy が正規路。 手動で Cognito を弄らない。</td>
+</tr>
+<tr>
+<td>SAML IdP の assertion 拒否</td>
+<td>IdP 側ログを先に確認。 <a href="../operations/application-plane-saml-setup.md"><code>docs/operations/application-plane-saml-setup.md</code></a> を参照。</td>
+</tr>
+<tr>
+<td>アカウントロック</td>
+<td>Cognito は反復失敗でロックする。 15 分待つか AWS Console から解除。</td>
+</tr>
+</tbody></table>
+<h3>エスカレーション — Cognito sign in 失敗</h3>
+<ul>
+<li>複数チームがログイン不可なら、 イベント進行を保留し <code>warning</code> を送ってから次手を発表。</li>
+<li>Callback URL ミスは deploy 時バグ。 ライブで直さない。 <a href="./teardown.ja.md">Teardown</a> で復旧フェーズへ。</li>
+</ul>
+<h2>セクション 4: CloudFormation スタック ROLLBACK</h2>
+<h3>症状 (CFn スタック ROLLBACK)</h3>
+<ul>
+<li>オペレータダッシュボード / チームアカウントで 1 つ以上のスタックが <code>CREATE_FAILED</code> / <code>ROLLBACK_IN_PROGRESS</code> / <code>ROLLBACK_COMPLETE</code>。</li>
+<li>参加者から endpoint 不通の報告。</li>
+<li>Deploy trace に <code>deploy.cfn.deploy.failed</code>。</li>
+</ul>
+<h3>1st response (5 分以内) — CFn スタック ROLLBACK</h3>
+<ol>
+<li>失敗 stack と CFn event から失敗理由を特定。</li>
+<li>失敗を分類:<ul>
+<li><strong>Quota</strong> (アカウントレベル上限。 VPC / EIP / Lambda 等)</li>
+<li><strong>Region 制約</strong> (該当 region でサービス未提供)</li>
+<li><strong>IAM</strong> (AssumeRole 経路の権限不足。 ExternalId 関連が多い)</li>
+<li><strong>テンプレート不具合</strong> (問題テンプレートのバグ。 本来 <a href="./dry-run.ja.md">Dry run</a> で検出されるべきもの)</li>
+</ul>
+</li>
+</ol>
+<h3>安全な remediation — CFn スタック ROLLBACK</h3>
+<table>
+<thead>
+<tr>
+<th>失敗クラス</th>
+<th>アクション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Quota</td>
+<td>Quota 緩和申請、 または問題が許すなら別 region に変更。 手動でリソースを補充して回避しない。</td>
+</tr>
+<tr>
+<td>Region 制約</td>
+<td>当該チームの問題を落とすか、 region を変更 (= 単一 region 変更が問題テンプレート的に安全な場合のみ)。</td>
+</tr>
+<tr>
+<td>IAM</td>
+<td>ExternalId / <code>competitor-bootstrap.yaml</code> IAM role の展開 / participant viewer role の policy を確認。 チームアカウントへの AssumeRole は ExternalId 必須 = ハード不変 (<a href="../../CLAUDE.md">CLAUDE.md</a> の Security 節)。</td>
+</tr>
+<tr>
+<td>テンプレート不具合</td>
+<td>ライブパッチ禁止。 当該チームの当該問題を落とし、 <code>warning</code> を送り、 事後修正用にキャプチャ。</td>
+</tr>
+</tbody></table>
+<h3>安全な再 deploy</h3>
+<p><a href="./live-monitoring.ja.md">live monitoring</a> の triage を経て、 単独チーム再 deploy と決めた場合に限り、 次の順序で実施する。</p>
+<ol>
+<li>先に失敗スタックの teardown を発行 (<code>scripts/delete-battles.sh</code> または Application Admin Console の teardown action)。 <code>DELETE_COMPLETE</code> を確認してから再作成。</li>
+<li>オペレータ UI から <code>DeployRequested</code> を再発行。</li>
+<li>新しい <code>jobId</code> で deploy trace を観察。 <code>deploy.cfn.deploy.succeeded</code> が出るまで完了宣言しない。</li>
+</ol>
+<h3>エスカレーション — CFn スタック ROLLBACK</h3>
+<ul>
+<li>複数チームが同原因で同時失敗 → プラットフォーム全体扱い。 Scoring 停止 / <code>warning</code> 送信 / 原因理解までは redeploy 禁止。</li>
+<li>ROLLBACK で残存リソースがあれば、 <a href="./teardown.ja.md">Teardown</a> で扱う。</li>
+</ul>
+<h2>インシデント後の共通ステップ</h2>
+<p>各インシデントの解決後、 次を必ず実施する。</p>
+<ol>
+<li>タイムラインに最終エントリを追記 (observed / acted / resolved)。</li>
+<li><code>info</code> を 1 件送信し、「問題は解消した。 scoring は HH:MM 時点で最新」と明示する。</li>
+<li>原因 / アクション / コードレベル follow up を記述した post-event issue を起票。</li>
+<li>Orphan リソース / scoring 状態が不明瞭なら、 <a href="./teardown.ja.md">Teardown</a> に持ち越して処理。</li>
+</ol>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>併用: <a href="./live-monitoring.ja.md">live monitoring</a> — インシデントは常に live monitoring 観測から始まる。</li>
+<li>イベント後: <a href="./teardown.ja.md">Teardown</a> — インシデントが残した orphan リソースはここで復旧。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> (通知は編集不可なので文言が重要) / <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> (状態が非同期に収束する理由) / <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a> (インシデント時の jobId tracing)。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/incident-response.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/incident-response.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/incident-response.ja.md
+++ b/docs/runbooks/incident-response.ja.md
@@ -1,0 +1,155 @@
+# インシデント対応
+
+> English: [incident-response.md](./incident-response.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | オンコールオペレータ (= 進行中のインシデントを triage する人) |
+| 使うタイミング | [live monitoring](./live-monitoring.ja.md) からここへ送られたとき、 または参加者報告が 1 分以内に解決できないとき |
+| 所要時間 | 1 件あたり 5 〜 30 分 |
+| 出力 | インシデントが解決されアクション記録が残るか、 理由を明文化したうえでエスカレーションするか |
+
+ホスト型イベントで頻出する 4 種のインシデントを取り上げます。 各セクションは **症状 → 1st response → 安全な remediation → エスカレーション** の同型構造です。 即興しないこと、 該当節を選んでなぞること。
+
+> **動く前に**。 [live monitoring の event timeline](./live-monitoring.ja.md#%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%82%BF%E3%82%A4%E3%83%A0%E3%83%A9%E3%82%A4%E3%83%B3%E3%81%AE%E8%A8%98%E9%8C%B2) に観測ラインを 1 行追記する。 観測なしの行動が、 オペレータが outage を悪化させる典型経路。
+
+## セクション 1: Lambda エラー
+
+### 症状
+
+- CloudWatch で deploy worker / scoring Lambda / API handler のいずれかにエラー率が出ている。
+- オペレータダッシュボードで deployment が `IN_PROGRESS` のまま、 または scoring loop が止まっている。
+- 参加者から「scoreboard が古い」「deploy が終わらない」報告。
+
+### 1st response (5 分以内)
+
+1. どの Lambda がエラーかを確定。 CloudWatch を関数名でフィルタ。
+2. 最新エラーログを読む。 stack trace / エラークラス / タイムスタンプを確認。
+3. 分類する: AWS 由来の transient (throttling / timeout / networking) か、 コード由来 (TypeError / デシリアライゼーション失敗) か。
+
+### 安全な remediation
+
+| エラークラス | アクション |
+|---|---|
+| AWS 由来 transient (rate limit / timeout / DNS) | 2 分待つ。 大半は retry で解消。 参加者が気づいたなら `info` 通知。 |
+| Cold-start のレイテンシだけ | 何もしない。 レイテンシはインシデントではない。 [live monitoring](./live-monitoring.ja.md) を継続。 |
+| コード由来 (TypeError / schema validation) | ログをタイムラインにキャプチャ。 イベント中のコードパッチは禁止 (= ライブ中のプラットフォーム再 deploy 禁止)。 影響範囲をメモして継続。 |
+| AssumeRole の `AccessDenied` が反復 | そのチームの ExternalId が誤り。 Tenant metadata を確認し、 認証情報を再発行。 |
+
+### エスカレーション
+
+- 5 件/分超のエラーが 5 分続いたら `warning` 通知を送り、 facilitator に共有。
+- 全チームに影響していれば plat-wide インシデント。 解決まで scoring 停止を検討。
+
+## セクション 2: DynamoDB throttling
+
+### 症状 (DynamoDB throttling)
+
+- CloudWatch DynamoDB の `UserErrors` または `ThrottledRequests` が非ゼロ。
+- Participant portal の scoreboard が遅い / 散発的にエラー。
+- オペレータダッシュボードで event 時刻と scoreboard 時刻の lag が拡大。
+
+### 1st response (5 分以内) — DynamoDB throttling
+
+1. Throttle されているテーブル (`Deployments` / `Apps` / `Events` / `TenantMappingTable` 等) を特定。
+2. Capacity 設定を確認。 TenkaCloud は AWS Free Tier 安全のため [`DynamoDbLowCapacity`](../../infrastructure/lib/cdk-aspect) aspect で全テーブルを PROVISIONED 1 RCU / 1 WCU に強制している。
+3. 原因が participant traffic (正当) か runaway Lambda (インシデント) かを切り分け。
+
+### 安全な remediation — DynamoDB throttling
+
+| 原因 | アクション |
+|---|---|
+| イベントスパイクによる正当な burst | 「scoreboard 更新が遅れる可能性」と `info` 通知を送り、 burst が収まるのを待つ。 Free Tier ガードレールに紐づく決定をすべて再議論しない限り、 イベント中に capacity を上げない。 |
+| Runaway Lambda の hot loop | 発火源の Lambda invocation を止める。 EventBridge rule の誤設定でループしているケースが多い。 |
+| オペレータ起因の scan / list | Scan を止める。 オペレータクエリは特定キー検索に限定する。 |
+
+> テーブルを `PAY_PER_REQUEST` に切り替えてはいけない。 Aspect が PROVISIONED 1/1 を強制しており、 モード切替には CDK 変更が必要 (= inline 禁止)。
+
+### エスカレーション — DynamoDB throttling
+
+- 10 分で throttle が解消しなければ scoring を一時停止し、 系統的データ欠落の前に `warning` を送る。
+- テーブル名と原因をタイムラインに記録、 事後レビューへ。
+
+## セクション 3: Cognito sign in 失敗
+
+### 症状 (Cognito sign in 失敗)
+
+- 参加者から participant portal にログインできない報告。
+- Application Admin Console の SSO ログイン失敗。
+- CloudWatch に Cognito Hosted UI のエラー。
+
+### 1st response (5 分以内) — Cognito sign in 失敗
+
+1. 範囲を確定: 参加者 1 名 / 1 チーム / 全員。
+2. 1 名の場合: Cookie 削除して再試行を依頼。 participant portal URL の末尾空白を確認。
+3. 1 チームの場合: チーム metadata の配線を確認。 SSO IdP 構成も併せて確認。
+4. 全員の場合: プラットフォーム障害。 セクション 4 または Lambda エラーセクションとして扱う。
+
+### 安全な remediation — Cognito sign in 失敗
+
+| 失敗モード | アクション |
+|---|---|
+| Login key の typo / 末尾空白 | [participant onboarding](./participant-onboarding.ja.md) の合意チャネルで正しい key を再送。 |
+| Cognito Hosted UI の 5xx | 60 秒待って再試行。 大半は transient。 |
+| OAuth callback URL の不一致 | Deploy 後に participant portal URL が変わっている。 Cognito callback URL が現行 CloudFront URL と一致するか確認。 修正は再 deploy が正規路。 手動で Cognito を弄らない。 |
+| SAML IdP の assertion 拒否 | IdP 側ログを先に確認。 [`docs/operations/application-plane-saml-setup.md`](../operations/application-plane-saml-setup.md) を参照。 |
+| アカウントロック | Cognito は反復失敗でロックする。 15 分待つか AWS Console から解除。 |
+
+### エスカレーション — Cognito sign in 失敗
+
+- 複数チームがログイン不可なら、 イベント進行を保留し `warning` を送ってから次手を発表。
+- Callback URL ミスは deploy 時バグ。 ライブで直さない。 [Teardown](./teardown.ja.md) で復旧フェーズへ。
+
+## セクション 4: CloudFormation スタック ROLLBACK
+
+### 症状 (CFn スタック ROLLBACK)
+
+- オペレータダッシュボード / チームアカウントで 1 つ以上のスタックが `CREATE_FAILED` / `ROLLBACK_IN_PROGRESS` / `ROLLBACK_COMPLETE`。
+- 参加者から endpoint 不通の報告。
+- Deploy trace に `deploy.cfn.deploy.failed`。
+
+### 1st response (5 分以内) — CFn スタック ROLLBACK
+
+1. 失敗 stack と CFn event から失敗理由を特定。
+2. 失敗を分類:
+   - **Quota** (アカウントレベル上限。 VPC / EIP / Lambda 等)
+   - **Region 制約** (該当 region でサービス未提供)
+   - **IAM** (AssumeRole 経路の権限不足。 ExternalId 関連が多い)
+   - **テンプレート不具合** (問題テンプレートのバグ。 本来 [Dry run](./dry-run.ja.md) で検出されるべきもの)
+
+### 安全な remediation — CFn スタック ROLLBACK
+
+| 失敗クラス | アクション |
+|---|---|
+| Quota | Quota 緩和申請、 または問題が許すなら別 region に変更。 手動でリソースを補充して回避しない。 |
+| Region 制約 | 当該チームの問題を落とすか、 region を変更 (= 単一 region 変更が問題テンプレート的に安全な場合のみ)。 |
+| IAM | ExternalId / `competitor-bootstrap.yaml` IAM role の展開 / participant viewer role の policy を確認。 チームアカウントへの AssumeRole は ExternalId 必須 = ハード不変 ([CLAUDE.md](../../CLAUDE.md) の Security 節)。 |
+| テンプレート不具合 | ライブパッチ禁止。 当該チームの当該問題を落とし、 `warning` を送り、 事後修正用にキャプチャ。 |
+
+### 安全な再 deploy
+
+[live monitoring](./live-monitoring.ja.md) の triage を経て、 単独チーム再 deploy と決めた場合に限り、 次の順序で実施する。
+
+1. 先に失敗スタックの teardown を発行 (`scripts/delete-battles.sh` または Application Admin Console の teardown action)。 `DELETE_COMPLETE` を確認してから再作成。
+2. オペレータ UI から `DeployRequested` を再発行。
+3. 新しい `jobId` で deploy trace を観察。 `deploy.cfn.deploy.succeeded` が出るまで完了宣言しない。
+
+### エスカレーション — CFn スタック ROLLBACK
+
+- 複数チームが同原因で同時失敗 → プラットフォーム全体扱い。 Scoring 停止 / `warning` 送信 / 原因理解までは redeploy 禁止。
+- ROLLBACK で残存リソースがあれば、 [Teardown](./teardown.ja.md) で扱う。
+
+## インシデント後の共通ステップ
+
+各インシデントの解決後、 次を必ず実施する。
+
+1. タイムラインに最終エントリを追記 (observed / acted / resolved)。
+2. `info` を 1 件送信し、「問題は解消した。 scoring は HH:MM 時点で最新」と明示する。
+3. 原因 / アクション / コードレベル follow up を記述した post-event issue を起票。
+4. Orphan リソース / scoring 状態が不明瞭なら、 [Teardown](./teardown.ja.md) に持ち越して処理。
+
+## 関連 runbook / ADR
+
+- 併用: [live monitoring](./live-monitoring.ja.md) — インシデントは常に live monitoring 観測から始まる。
+- イベント後: [Teardown](./teardown.ja.md) — インシデントが残した orphan リソースはここで復旧。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) (通知は編集不可なので文言が重要) / [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) (状態が非同期に収束する理由) / [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md) (インシデント時の jobId tracing)。

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,155 @@
+# Incident response
+
+> Japanese: [incident-response.ja.md](./incident-response.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | On-call operator (the person triaging an active incident) |
+| When to use | When [live monitoring](./live-monitoring.md) sends you here, or when a participant report cannot be resolved within one minute of observation |
+| Estimated time | 5 to 30 minutes per incident |
+| Output | Either the incident is resolved with a recorded action, or it is escalated with a documented reason |
+
+This runbook covers the four most common incident classes during a hosted event. Each section follows the same shape: **symptoms → 1st response → safe remediation → escalation**. Do not improvise; pick the matching section and follow it.
+
+> **Before you act:** Record one observation line in the event timeline (see [live monitoring](./live-monitoring.md#recording-the-event-timeline)). Every act-without-observe step is how operators make outages worse.
+
+## Section 1: Lambda errors
+
+### Symptoms
+
+- CloudWatch shows a non-zero error rate on the deploy worker, scoring Lambda, or one of the API handlers.
+- Operator dashboard shows deployments stuck in `IN_PROGRESS` or scoring loop frozen.
+- Participants report stale scoreboard or "deploy never finishes".
+
+### 1st response (under 5 minutes)
+
+1. Confirm which Lambda is erroring. Filter CloudWatch by function name.
+2. Read the most recent error log. Look for stack trace, error class, and タイムスタンプ.
+3. Classify: is this a transient AWS error (throttling, timeout, networking) or a code-level error (TypeError, deserialization failure)?
+
+### Safe remediation
+
+| Error class | Action |
+|---|---|
+| Transient AWS error (rate limit, timeout, DNS) | Wait two minutes. Most resolve themselves under retry. Send `info` notification if participants notice. |
+| Cold-start latency only | No action; latency is not an incident. Continue [live monitoring](./live-monitoring.md). |
+| Code-level error (TypeError, schema validation) | Capture log lines into the event timeline. Do not patch code mid-event; redeploying the platform during a live event is forbidden. Note the affected scoring or deploy path and continue. |
+| Repeated `AccessDenied` from AssumeRole | The ExternalId is wrong for that team. Verify the team metadata and re-issue the credentials. |
+
+### Escalation
+
+- If the error rate is sustained more than 5 errors / minute for 5 minutes, send `warning` notification and brief the facilitator.
+- If the error affects every team, treat as platform-wide incident and consider pausing scoring until resolved.
+
+## Section 2: DynamoDB throttling
+
+### Symptoms (DynamoDB throttling)
+
+- CloudWatch DynamoDB metric `UserErrors` or `ThrottledRequests` is non-zero.
+- Participant portal scoreboard is slow or returns sporadic errors.
+- Operator dashboard shows lag between event-time and scoreboard time.
+
+### 1st response (under 5 minutes) — DynamoDB throttling
+
+1. Identify the table being throttled (`Deployments`, `Apps`, `Events`, `TenantMappingTable`, etc.).
+2. Check the read / write capacity. Every TenkaCloud table is forced to PROVISIONED 1 RCU / 1 WCU by the [`DynamoDbLowCapacity`](../../infrastructure/lib/cdk-aspect) aspect for AWS Free Tier safety.
+3. Decide whether the throttling is caused by participant traffic (legitimate) or by a runaway Lambda (incident).
+
+### Safe remediation — DynamoDB throttling
+
+| Cause | Action |
+|---|---|
+| Legitimate traffic burst (event spike) | Send `info` notification "scoreboard refresh may be delayed" and wait for the burst to subside. Do not raise capacity in the middle of the event unless every Free Tier guard rail decision has been re-discussed. |
+| Runaway Lambda hot-looping | Identify and stop the Lambda invocation source. Most often a misconfigured EventBridge rule firing in a loop. |
+| Operator-induced scan / list | Stop the scan. Most operator queries should target specific keys. |
+
+> **Do not** flip the table to `PAY_PER_REQUEST` mid-event. The aspect enforces PROVISIONED 1/1; switching modes requires a CDK change and is forbidden inline.
+
+### Escalation — DynamoDB throttling
+
+- If throttling cannot be relieved in 10 minutes, pause scoring and send `warning` notification before participants notice systematic data loss.
+- Document the table and the cause in the event timeline for post-event review.
+
+## Section 3: Cognito sign-in failure
+
+### Symptoms (Cognito sign-in failure)
+
+- Participant reports cannot log in via the participant portal.
+- Application Admin Console SSO login fails.
+- Operator sees Cognito Hosted UI errors in CloudWatch.
+
+### 1st response (under 5 minutes) — Cognito sign-in failure
+
+1. Confirm the scope: one participant, one team, or all participants.
+2. For a single participant: ask them to clear cookies and retry. Verify the participant portal URL has no trailing whitespace.
+3. For a single team: check the team's metadata is wired. Confirm SSO IdP configuration if federated.
+4. For all participants: this is a platform-wide incident. Treat as Section 4 or as Lambda errors depending on the failure mode.
+
+### Safe remediation — Cognito sign-in failure
+
+| Failure mode | Action |
+|---|---|
+| Wrong login key (typo, trailing space) | Re-send the correct key over the agreed channel from [participant onboarding](./participant-onboarding.md). |
+| Cognito Hosted UI 5xx | Wait 60 seconds and retry. Most Cognito Hosted UI errors are transient. |
+| OAuth callback URL mismatch | The participant portal URL changed since deploy. Confirm the callback URL in Cognito matches the current CloudFront URL. Re-deploy is the fix; do not patch Cognito by hand. |
+| SAML IdP rejecting the assertion | Check the IdP-side log first. See [`docs/operations/application-plane-saml-setup.md`](../operations/application-plane-saml-setup.md). |
+| Account is locked | Cognito locks after multiple failed attempts. Wait 15 minutes or unlock via the AWS Console. |
+
+### Escalation — Cognito sign-in failure
+
+- If multiple teams cannot log in, hold the event and send `warning` notification before announcing further actions.
+- If the callback URL is wrong, this is a deploy-time bug — do not attempt to fix in-flight, document and recover via [teardown](./teardown.md).
+
+## Section 4: CloudFormation stack ROLLBACK
+
+### Symptoms (CFn stack ROLLBACK)
+
+- One or more team stacks show `CREATE_FAILED`, `ROLLBACK_IN_PROGRESS`, or `ROLLBACK_COMPLETE` in the operator dashboard or the team account.
+- Participant reports their endpoint is unreachable.
+- Deploy trace shows `deploy.cfn.deploy.failed`.
+
+### 1st response (under 5 minutes) — CFn stack ROLLBACK
+
+1. Identify the failing stack and the failure reason from CFn stack events.
+2. Classify the failure:
+   - **Quota** (account-level limit, e.g., VPC, EIP, Lambda)
+   - **Region restriction** (service not available in the chosen region)
+   - **IAM** (missing permission for the AssumeRole path, often ExternalId-related)
+   - **Template defect** (bug in the problem template — should have been caught in [dry run](./dry-run.md))
+
+### Safe remediation — CFn stack ROLLBACK
+
+| Failure class | Action |
+|---|---|
+| Quota | Request a quota increase or move the team to a different region if the problem allows. Do not work around quota by manually creating resources. |
+| Region restriction | Drop the problem for that team or change the region (only if a single-region change is safe per the problem template). |
+| IAM | Verify ExternalId, the competitor-bootstrap.yaml IAM role is rolled out, and the participant viewer role has the right policy. AssumeRole into competitor accounts always requires ExternalId; this is a hard invariant (see [CLAUDE.md](../../CLAUDE.md) security section). |
+| Template defect | Do not patch in-flight. Drop the problem for the affected teams, send `warning` notification, and capture for post-event fix. |
+
+### Safe redeploy
+
+If you decide to redeploy (single-team only, after the triage in [live monitoring](./live-monitoring.md)):
+
+1. Initiate teardown of the failed stack first (`scripts/delete-battles.sh` or the Application Admin Console teardown action). Confirm `DELETE_COMPLETE` before re-creating.
+2. Re-issue `DeployRequested` from the operator UI.
+3. Watch the deploy trace for the new `jobId`. Do not declare success until `deploy.cfn.deploy.succeeded` appears.
+
+### Escalation — CFn stack ROLLBACK
+
+- If multiple teams fail simultaneously with the same cause, treat as platform-wide. Pause scoring, send `warning`, and do not redeploy until you understand the cause.
+- If ROLLBACK leaves orphaned resources, document and follow up in [teardown](./teardown.md).
+
+## Universal post-incident steps
+
+After every incident:
+
+1. Append the final timeline entries (observed, acted, resolved).
+2. Send one `info` notification: "Issue resolved; scoring is current as of HH:MM."
+3. File a post-event issue describing the cause, action, and any code-level follow-up.
+4. If the incident produced orphan resources or unclear scoring state, escalate to [teardown](./teardown.md) for handling at event end.
+
+## Related runbooks and ADRs
+
+- Use together with: [live monitoring](./live-monitoring.md) — every incident starts from a live monitoring observation.
+- After event: [teardown](./teardown.md) — orphan resources from incidents are recovered here.
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html) (you cannot edit notifications, so wording matters), [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) (why state converges asynchronously), [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md) (jobId tracing for incidents).

--- a/docs/runbooks/live-monitoring.html
+++ b/docs/runbooks/live-monitoring.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Live monitoring</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Live monitoring</h1>
+<blockquote>
+<p>Japanese: <a href="./live-monitoring.ja.md">live-monitoring.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>On-call operator (the person who keeps the platform healthy during the event)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Continuously from event start to event end. Pair with <a href="./incident-response.md">incident response</a> at every triage decision.</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>Continuous; expect one focused tab on the scoreboard and one on dashboards</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>An event timeline showing what was observed, what was acted on, and what was deferred to teardown</td>
+</tr>
+</tbody></table>
+<p>The operator&#39;s job during the event is not to fix problems — it is to <strong>observe quickly, classify accurately, and only then act</strong>. Every action taken under pressure on a live platform risks making it worse. This runbook is the structure that keeps the observe-classify-act loop tight.</p>
+<h2>Three tabs to keep open</h2>
+<table>
+<thead>
+<tr>
+<th>Tab</th>
+<th>URL</th>
+<th>What you watch for</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Scoreboard</td>
+<td>Participant portal scoreboard view</td>
+<td>Sudden score drops, teams stuck at zero, anomalous spikes</td>
+</tr>
+<tr>
+<td>Operator dashboard</td>
+<td>Application Admin Console deploy / scoring view</td>
+<td>Stuck deployments, scoring lag, notification delivery</td>
+</tr>
+<tr>
+<td>Deploy trace</td>
+<td>CloudWatch Logs Insights filtered by <code>jobId</code> (see <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a>)</td>
+<td>Per-team deploy failures, CFn rollback events</td>
+</tr>
+</tbody></table>
+<p>If you only have screen real estate for two tabs, drop &quot;operator dashboard&quot; and keep scoreboard + deploy trace. The scoreboard is the participant&#39;s experience; the deploy trace is the platform&#39;s truth.</p>
+<h2>What &quot;healthy&quot; looks like</h2>
+<table>
+<thead>
+<tr>
+<th>Signal</th>
+<th>Healthy state</th>
+<th>Action threshold</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Per-team scoring tick</td>
+<td>Updating every polling interval (uptime: every minute; flag: on submission)</td>
+<td>If a team has not advanced for 10 minutes, suspect a stuck endpoint</td>
+</tr>
+<tr>
+<td>Per-team deploy status</td>
+<td><code>CREATE_COMPLETE</code> for every selected problem</td>
+<td>Any team stuck in <code>CREATE_IN_PROGRESS</code> past 15 minutes is suspicious</td>
+</tr>
+<tr>
+<td>Notification delivery</td>
+<td><code>info</code> and <code>warning</code> reach the portal within the polling tick (currently 5 seconds, see <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>)</td>
+<td>If a sent notification does not appear in 30 seconds, treat as broken</td>
+</tr>
+<tr>
+<td>Lambda error rate</td>
+<td>Near zero</td>
+<td>Any sustained non-zero rate (more than 5 errors / minute) on the deploy worker or scoring Lambda triggers triage</td>
+</tr>
+</tbody></table>
+<h2>Triage decision: redeploy needed vs single-team issue</h2>
+<p>Operators frequently waste time fixing one team&#39;s symptom when the root cause affects every team. Use this decision tree.</p>
+<pre><code>Observation: a team reports their endpoint is down.
+│
+├── Are other teams also seeing it down?
+│   ├── YES → Platform-wide issue. Open [incident response](./incident-response.md).
+│   │         Do NOT redeploy individual stacks until you understand the cause.
+│   │
+│   └── NO  → Single-team issue. Check the team&#39;s deploy trace.
+│             │
+│             ├── Stack in CREATE_FAILED / ROLLBACK_COMPLETE state?
+│             │   → Yes. Single-team redeploy is the right action.
+│             │
+│             ├── Stack in CREATE_COMPLETE but endpoint unreachable?
+│             │   → Yes. Likely a team-induced misconfiguration (they
+│             │     edited the resource). Tell them; do not redeploy
+│             │     blind — that erases their progress.
+│             │
+│             └── Cannot tell?
+│                 → Open [incident response](./incident-response.md).
+│                   Document before acting.
+</code></pre>
+<p>The most common mistake is reflexive redeploy. Redeploying a team&#39;s stack erases their state. If a participant submitted a flag and the scoring already counted it, a redeploy may invalidate the work that produced the flag.</p>
+<h2>Scoreboard watch points</h2>
+<p>Look for shapes, not absolute numbers.</p>
+<table>
+<thead>
+<tr>
+<th>Shape</th>
+<th>Likely interpretation</th>
+<th>First check</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>One team flat at zero</td>
+<td>They cannot log in or their stack failed to deploy</td>
+<td>Confirm their login first (<a href="./participant-onboarding.md">participant onboarding</a>) before assuming a platform fault</td>
+</tr>
+<tr>
+<td>All teams flat for the last 5 minutes</td>
+<td>Scoring loop is stuck</td>
+<td>Check the scoring Lambda invocation count and error rate</td>
+</tr>
+<tr>
+<td>One team&#39;s score drops backward</td>
+<td>Uptime scoring penalty fired — check whether their endpoint went down</td>
+<td>Their endpoint dropped; legitimate scoring behavior</td>
+</tr>
+<tr>
+<td>All teams&#39; scores drop backward simultaneously</td>
+<td>Health check Lambda misfired or AWS region-level disruption</td>
+<td>Open <a href="./incident-response.md">incident response</a> immediately</td>
+</tr>
+</tbody></table>
+<h2>Notification policy during live monitoring</h2>
+<p>Use notifications sparingly. The participant portal poll interval is 5 seconds; over-notifying creates fatigue. See <a href="../architecture/adr-006-notifications.html">ADR-006</a> for the design choices.</p>
+<ul>
+<li>Send <code>info</code> when you change something the participant should know about but they do not need to react. Example: &quot;Scoring resumed after the 14:30 maintenance pause.&quot;</li>
+<li>Send <code>warning</code> only when participants must take action or risk losing time. Example: &quot;Endpoint health check paused for 5 minutes from 15:00.&quot;</li>
+<li>Hard limit of five <code>warning</code> messages per event. If you exceed five, you are using <code>warning</code> for items that should be <code>info</code>.</li>
+</ul>
+<h2>Recording the event timeline</h2>
+<p>For every observation and action, append one line to the event timeline:</p>
+<pre><code>HH:MM | observed | scoreboard shows team-A flat for 8 minutes
+HH:MM | acted    | inspected team-A deploy trace, found CFn ROLLBACK_COMPLETE
+HH:MM | acted    | initiated redeploy via Application Admin Console
+HH:MM | observed | team-A scoring resumed
+</code></pre>
+<p>This timeline is the input to the post-event review and to any incident postmortem.</p>
+<h2>If it goes wrong</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>First response</th>
+<th>Escalation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Scoreboard is frozen for everyone</td>
+<td>Check the scoring Lambda invocation count and error rate first. Send an <code>info</code> notification within 60 seconds.</td>
+<td>Open <a href="./incident-response.md">incident response</a> under &quot;scoring not updating&quot;.</td>
+</tr>
+<tr>
+<td>You cannot tell whether it is the platform or one team</td>
+<td>Default to platform-wide investigation. The cost of investigating a non-issue is much lower than the cost of redeploying a team blindly.</td>
+<td><a href="./incident-response.md">incident response</a>.</td>
+</tr>
+<tr>
+<td>You sent the wrong <code>warning</code> notification</td>
+<td>You cannot edit or delete a notification (see <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>). Send a follow-up <code>info</code> immediately to correct it.</td>
+<td>If the wrong notification caused participants to act, document it in the event timeline and post-event report.</td>
+</tr>
+<tr>
+<td>Participants flood the support channel</td>
+<td>Pin the question routing table from <a href="./participant-onboarding.md">participant onboarding</a>. Triage from oldest to newest.</td>
+<td>If volume exceeds operator capacity, send an <code>info</code> &quot;we are investigating, expect updates every 10 minutes&quot; and keep the cadence.</td>
+</tr>
+<tr>
+<td>You are unsure whether to act</td>
+<td>Do not act. Observe for another minute, ask the facilitator, and only then act.</td>
+<td><a href="./incident-response.md">incident response</a> — every entry has a &quot;1st response&quot; branch that lets you act safely.</td>
+</tr>
+</tbody></table>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Previous: <a href="./pre-event-checklist.md">pre-event checklist</a>, <a href="./dry-run.md">dry run</a>, <a href="./participant-onboarding.md">participant onboarding</a>.</li>
+<li>Use together with: <a href="./incident-response.md">incident response</a> — open the matching incident type when you act.</li>
+<li>After event: <a href="./teardown.md">teardown</a>.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a>, <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a>, <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a>, <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/live-monitoring.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/live-monitoring.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/live-monitoring.ja.html
+++ b/docs/runbooks/live-monitoring.ja.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Live monitoring</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Live monitoring</h1>
+<blockquote>
+<p>English: <a href="./live-monitoring.md">live-monitoring.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>オンコールオペレータ (= イベント中にプラットフォームを健全に保つ人)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>イベント開始から終了まで継続。 各 triage 判断で <a href="./incident-response.ja.md">インシデント対応</a> と必ず併用。</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>継続。 Scoreboard 用とダッシュボード用の 2 タブを常時開く想定</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>「観測したもの」 / 「打ち手」 / 「Teardown に持ち越したもの」 を 1 ライン単位で記録したイベントタイムライン</td>
+</tr>
+</tbody></table>
+<p>イベント中のオペレータの仕事は問題を直すことではなく、 <strong>素早く観測し、 正確に分類し、 そのあとで初めて動く</strong> ことです。 ライブプラットフォームで圧力下のもと打つアクションは、 事態を悪化させるリスクを持ちます。 このループを締めるための構造が本 runbook です。</p>
+<h2>常時開いておく 3 タブ</h2>
+<table>
+<thead>
+<tr>
+<th>タブ</th>
+<th>URL</th>
+<th>何を見るか</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Scoreboard</td>
+<td>Participant portal の scoreboard ビュー</td>
+<td>急なスコア下落 / 0 点のまま動かないチーム / 異常なスパイク</td>
+</tr>
+<tr>
+<td>オペレータダッシュボード</td>
+<td>Application Admin Console の deploy / scoring ビュー</td>
+<td>詰まった deployment / scoring 遅延 / 通知配信</td>
+</tr>
+<tr>
+<td>Deploy trace</td>
+<td><a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a> の手順で <code>jobId</code> で CloudWatch Logs Insights をフィルタ</td>
+<td>チーム別 deploy 失敗 / CFn rollback</td>
+</tr>
+</tbody></table>
+<p>画面占有が 2 枚しか取れないなら、 オペレータダッシュボードを落として scoreboard + deploy trace を残す。 Scoreboard が参加者の体験で、 deploy trace がプラットフォームの真実だからです。</p>
+<h2>「健全」 とは</h2>
+<table>
+<thead>
+<tr>
+<th>シグナル</th>
+<th>健全状態</th>
+<th>行動閾値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>チーム別 scoring tick</td>
+<td>Polling 間隔ごとに更新 (uptime は 1 分ごと / flag は提出時)</td>
+<td>10 分間更新が無いチームがあれば endpoint stuck を疑う</td>
+</tr>
+<tr>
+<td>チーム別 deploy 状態</td>
+<td>選定問題すべてが <code>CREATE_COMPLETE</code></td>
+<td><code>CREATE_IN_PROGRESS</code> のまま 15 分超過するチームは要疑</td>
+</tr>
+<tr>
+<td>通知配信</td>
+<td><code>info</code> / <code>warning</code> が polling tick 以内に portal に出る (= 現状 5 秒、 <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a> を参照)</td>
+<td>30 秒経って出ないなら 「壊れた」 と扱う</td>
+</tr>
+<tr>
+<td>Lambda エラー率</td>
+<td>ほぼゼロ</td>
+<td>Deploy worker / scoring Lambda で持続的に 5 件/分以上が出たら triage 開始</td>
+</tr>
+</tbody></table>
+<h2>Triage 判断: 再 deploy が必要 vs 単独 team 問題</h2>
+<p>オペレータは「1 チームの症状」を直そうとして、 全チームに効く根本原因を見落としがちです。 次の decision tree を使うこと。</p>
+<pre><code>観測: あるチームから endpoint が落ちている と報告
+│
+├── 他チームでも落ちているか?
+│   ├── YES → プラットフォーム全体障害。 [インシデント対応](./incident-response.ja.md) を開く。
+│   │         原因を理解するまで個別 stack を再 deploy しない。
+│   │
+│   └── NO  → 単独チーム。 そのチームの deploy trace を読む。
+│             │
+│             ├── スタックが CREATE_FAILED / ROLLBACK_COMPLETE か?
+│             │   → Yes。 単独チーム再 deploy が妥当。
+│             │
+│             ├── CREATE_COMPLETE だが endpoint 不通か?
+│             │   → Yes。 チームによる構成変更が原因の可能性大。
+│             │     チームに伝えるだけにとどめる。 盲目的 redeploy は
+│             │     チームの進捗を消すので行わない。
+│             │
+│             └── 判断不能か?
+│                 → [インシデント対応](./incident-response.ja.md) を開く。
+│                   動く前に必ず記録する。
+</code></pre>
+<p>頻出ミスは反射的な再 deploy です。 Redeploy はチームの state を消去します。 すでに scoring に flag が反映済みなら、 redeploy がその成果を無効化することがある。</p>
+<h2>Scoreboard の見方</h2>
+<p>絶対値ではなく形を見ます。</p>
+<table>
+<thead>
+<tr>
+<th>形</th>
+<th>解釈</th>
+<th>1st check</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1 チームだけ 0 点で平坦</td>
+<td>そのチームがログイン不可、 または stack 失敗</td>
+<td>プラットフォーム障害と決めつける前に、 ログイン状態を <a href="./participant-onboarding.ja.md">participant onboarding</a> で確認</td>
+</tr>
+<tr>
+<td>全チームが直近 5 分間平坦</td>
+<td>Scoring loop 停止</td>
+<td>Scoring Lambda の invocation count と error rate を確認</td>
+</tr>
+<tr>
+<td>1 チームのスコアだけ後退</td>
+<td>Uptime scoring のペナルティが発火。 endpoint 落ちか確認</td>
+<td>そのチームの endpoint 障害。 仕様どおりの挙動</td>
+</tr>
+<tr>
+<td>全チームのスコアが同時に後退</td>
+<td>Health check Lambda の誤発火か、 AWS region 障害</td>
+<td>即座に <a href="./incident-response.ja.md">インシデント対応</a> へ</td>
+</tr>
+</tbody></table>
+<h2>イベント中の通知ポリシー</h2>
+<p>通知は控えめに。 Participant portal の polling 間隔は 5 秒。 過剰通知は疲弊を生む。 設計選択は <a href="../architecture/adr-006-notifications.html">ADR-006</a> を参照。</p>
+<ul>
+<li>参加者が把握すべきだが行動は不要、 という場合に <code>info</code>。 例:「14:30 から scoring 再開しました」。</li>
+<li>参加者が行動しないと不利益、 という場合のみ <code>warning</code>。 例:「15:00 から 5 分間 health check を停止」。</li>
+<li><code>warning</code> は 1 イベント 5 件まで。 6 件目を打ちたくなったら、 それは <code>info</code> で十分なメッセージ。</li>
+</ul>
+<h2>イベントタイムラインの記録</h2>
+<p>観測も打ち手も、 1 ライン単位でタイムラインに追記します。</p>
+<pre><code>HH:MM | observed | scoreboard で team-A が 8 分間平坦
+HH:MM | acted    | team-A の deploy trace を確認、 CFn ROLLBACK_COMPLETE を発見
+HH:MM | acted    | Application Admin Console から redeploy を発行
+HH:MM | observed | team-A の scoring 再開
+</code></pre>
+<p>このタイムラインが事後レビューとインシデント postmortem の入力になります。</p>
+<h2>うまくいかなかったら</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>1st response</th>
+<th>エスカレーション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>全員の scoreboard が止まる</td>
+<td>まず scoring Lambda の invocation count と error rate を確認。 60 秒以内に <code>info</code> 通知を送る。</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a> の 「scoring 更新が止まる」 を開く。</td>
+</tr>
+<tr>
+<td>プラットフォーム障害か単独チームか判別できない</td>
+<td>デフォルトでプラットフォーム調査に倒す。 「無事の調査コスト」 は 「盲目的 redeploy のコスト」 よりはるかに安い。</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a>。</td>
+</tr>
+<tr>
+<td>誤った <code>warning</code> を送った</td>
+<td>通知は edit / delete できない (<a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>)。 直ちに修正用 <code>info</code> を送る。</td>
+<td>誤通知で参加者が動いてしまった場合は、 タイムラインと事後レポートに必ず記録。</td>
+</tr>
+<tr>
+<td>サポートチャネルが質問で溢れる</td>
+<td><a href="./participant-onboarding.ja.md">participant onboarding</a> のルーティング表を再 pin。 古い順から triage。</td>
+<td>オペレータ容量を超えそうなら 「現在調査中、 10 分ごとに状況更新」 という <code>info</code> を打ち、 cadence を維持。</td>
+</tr>
+<tr>
+<td>動いていいか迷う</td>
+<td>動かない。 もう 1 分観測し、 facilitator に相談してから打つ。</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a> — 各エントリに 「1st response」 ブランチがあるので、 安全に動ける。</td>
+</tr>
+</tbody></table>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>前: <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> / <a href="./dry-run.ja.md">Dry run</a> / <a href="./participant-onboarding.ja.md">participant onboarding</a>。</li>
+<li>併用: <a href="./incident-response.ja.md">インシデント対応</a> — 動くときは必ず対応する incident 種別を開く。</li>
+<li>イベント後: <a href="./teardown.ja.md">Teardown</a>。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> / <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> / <a href="../operations/deploy-trace.md"><code>docs/operations/deploy-trace.md</code></a> / <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/live-monitoring.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/live-monitoring.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/live-monitoring.ja.md
+++ b/docs/runbooks/live-monitoring.ja.md
@@ -1,0 +1,108 @@
+# Live monitoring
+
+> English: [live-monitoring.md](./live-monitoring.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | オンコールオペレータ (= イベント中にプラットフォームを健全に保つ人) |
+| 使うタイミング | イベント開始から終了まで継続。 各 triage 判断で [インシデント対応](./incident-response.ja.md) と必ず併用。 |
+| 所要時間 | 継続。 Scoreboard 用とダッシュボード用の 2 タブを常時開く想定 |
+| 出力 | 「観測したもの」 / 「打ち手」 / 「Teardown に持ち越したもの」 を 1 ライン単位で記録したイベントタイムライン |
+
+イベント中のオペレータの仕事は問題を直すことではなく、 **素早く観測し、 正確に分類し、 そのあとで初めて動く** ことです。 ライブプラットフォームで圧力下のもと打つアクションは、 事態を悪化させるリスクを持ちます。 このループを締めるための構造が本 runbook です。
+
+## 常時開いておく 3 タブ
+
+| タブ | URL | 何を見るか |
+|---|---|---|
+| Scoreboard | Participant portal の scoreboard ビュー | 急なスコア下落 / 0 点のまま動かないチーム / 異常なスパイク |
+| オペレータダッシュボード | Application Admin Console の deploy / scoring ビュー | 詰まった deployment / scoring 遅延 / 通知配信 |
+| Deploy trace | [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md) の手順で `jobId` で CloudWatch Logs Insights をフィルタ | チーム別 deploy 失敗 / CFn rollback |
+
+画面占有が 2 枚しか取れないなら、 オペレータダッシュボードを落として scoreboard + deploy trace を残す。 Scoreboard が参加者の体験で、 deploy trace がプラットフォームの真実だからです。
+
+## 「健全」 とは
+
+| シグナル | 健全状態 | 行動閾値 |
+|---|---|---|
+| チーム別 scoring tick | Polling 間隔ごとに更新 (uptime は 1 分ごと / flag は提出時) | 10 分間更新が無いチームがあれば endpoint stuck を疑う |
+| チーム別 deploy 状態 | 選定問題すべてが `CREATE_COMPLETE` | `CREATE_IN_PROGRESS` のまま 15 分超過するチームは要疑 |
+| 通知配信 | `info` / `warning` が polling tick 以内に portal に出る (= 現状 5 秒、 [`docs/operations/notifications.md`](../operations/notifications.md) を参照) | 30 秒経って出ないなら 「壊れた」 と扱う |
+| Lambda エラー率 | ほぼゼロ | Deploy worker / scoring Lambda で持続的に 5 件/分以上が出たら triage 開始 |
+
+## Triage 判断: 再 deploy が必要 vs 単独 team 問題
+
+オペレータは「1 チームの症状」を直そうとして、 全チームに効く根本原因を見落としがちです。 次の decision tree を使うこと。
+
+```
+観測: あるチームから endpoint が落ちている と報告
+│
+├── 他チームでも落ちているか?
+│   ├── YES → プラットフォーム全体障害。 [インシデント対応](./incident-response.ja.md) を開く。
+│   │         原因を理解するまで個別 stack を再 deploy しない。
+│   │
+│   └── NO  → 単独チーム。 そのチームの deploy trace を読む。
+│             │
+│             ├── スタックが CREATE_FAILED / ROLLBACK_COMPLETE か?
+│             │   → Yes。 単独チーム再 deploy が妥当。
+│             │
+│             ├── CREATE_COMPLETE だが endpoint 不通か?
+│             │   → Yes。 チームによる構成変更が原因の可能性大。
+│             │     チームに伝えるだけにとどめる。 盲目的 redeploy は
+│             │     チームの進捗を消すので行わない。
+│             │
+│             └── 判断不能か?
+│                 → [インシデント対応](./incident-response.ja.md) を開く。
+│                   動く前に必ず記録する。
+```
+
+頻出ミスは反射的な再 deploy です。 Redeploy はチームの state を消去します。 すでに scoring に flag が反映済みなら、 redeploy がその成果を無効化することがある。
+
+## Scoreboard の見方
+
+絶対値ではなく形を見ます。
+
+| 形 | 解釈 | 1st check |
+|---|---|---|
+| 1 チームだけ 0 点で平坦 | そのチームがログイン不可、 または stack 失敗 | プラットフォーム障害と決めつける前に、 ログイン状態を [participant onboarding](./participant-onboarding.ja.md) で確認 |
+| 全チームが直近 5 分間平坦 | Scoring loop 停止 | Scoring Lambda の invocation count と error rate を確認 |
+| 1 チームのスコアだけ後退 | Uptime scoring のペナルティが発火。 endpoint 落ちか確認 | そのチームの endpoint 障害。 仕様どおりの挙動 |
+| 全チームのスコアが同時に後退 | Health check Lambda の誤発火か、 AWS region 障害 | 即座に [インシデント対応](./incident-response.ja.md) へ |
+
+## イベント中の通知ポリシー
+
+通知は控えめに。 Participant portal の polling 間隔は 5 秒。 過剰通知は疲弊を生む。 設計選択は [ADR-006](../architecture/adr-006-notifications.html) を参照。
+
+- 参加者が把握すべきだが行動は不要、 という場合に `info`。 例:「14:30 から scoring 再開しました」。
+- 参加者が行動しないと不利益、 という場合のみ `warning`。 例:「15:00 から 5 分間 health check を停止」。
+- `warning` は 1 イベント 5 件まで。 6 件目を打ちたくなったら、 それは `info` で十分なメッセージ。
+
+## イベントタイムラインの記録
+
+観測も打ち手も、 1 ライン単位でタイムラインに追記します。
+
+```
+HH:MM | observed | scoreboard で team-A が 8 分間平坦
+HH:MM | acted    | team-A の deploy trace を確認、 CFn ROLLBACK_COMPLETE を発見
+HH:MM | acted    | Application Admin Console から redeploy を発行
+HH:MM | observed | team-A の scoring 再開
+```
+
+このタイムラインが事後レビューとインシデント postmortem の入力になります。
+
+## うまくいかなかったら
+
+| 症状 | 1st response | エスカレーション |
+|---|---|---|
+| 全員の scoreboard が止まる | まず scoring Lambda の invocation count と error rate を確認。 60 秒以内に `info` 通知を送る。 | [インシデント対応](./incident-response.ja.md) の 「scoring 更新が止まる」 を開く。 |
+| プラットフォーム障害か単独チームか判別できない | デフォルトでプラットフォーム調査に倒す。 「無事の調査コスト」 は 「盲目的 redeploy のコスト」 よりはるかに安い。 | [インシデント対応](./incident-response.ja.md)。 |
+| 誤った `warning` を送った | 通知は edit / delete できない ([`docs/operations/notifications.md`](../operations/notifications.md))。 直ちに修正用 `info` を送る。 | 誤通知で参加者が動いてしまった場合は、 タイムラインと事後レポートに必ず記録。 |
+| サポートチャネルが質問で溢れる | [participant onboarding](./participant-onboarding.ja.md) のルーティング表を再 pin。 古い順から triage。 | オペレータ容量を超えそうなら 「現在調査中、 10 分ごとに状況更新」 という `info` を打ち、 cadence を維持。 |
+| 動いていいか迷う | 動かない。 もう 1 分観測し、 facilitator に相談してから打つ。 | [インシデント対応](./incident-response.ja.md) — 各エントリに 「1st response」 ブランチがあるので、 安全に動ける。 |
+
+## 関連 runbook / ADR
+
+- 前: [事前チェックリスト](./pre-event-checklist.ja.md) / [Dry run](./dry-run.ja.md) / [participant onboarding](./participant-onboarding.ja.md)。
+- 併用: [インシデント対応](./incident-response.ja.md) — 動くときは必ず対応する incident 種別を開く。
+- イベント後: [Teardown](./teardown.ja.md)。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) / [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) / [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md) / [`docs/operations/notifications.md`](../operations/notifications.md)。

--- a/docs/runbooks/live-monitoring.md
+++ b/docs/runbooks/live-monitoring.md
@@ -1,0 +1,108 @@
+# Live monitoring
+
+> Japanese: [live-monitoring.ja.md](./live-monitoring.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | On-call operator (the person who keeps the platform healthy during the event) |
+| When to use | Continuously from event start to event end. Pair with [incident response](./incident-response.md) at every triage decision. |
+| Estimated time | Continuous; expect one focused tab on the scoreboard and one on dashboards |
+| Output | An event timeline showing what was observed, what was acted on, and what was deferred to teardown |
+
+The operator's job during the event is not to fix problems — it is to **observe quickly, classify accurately, and only then act**. Every action taken under pressure on a live platform risks making it worse. This runbook is the structure that keeps the observe-classify-act loop tight.
+
+## Three tabs to keep open
+
+| Tab | URL | What you watch for |
+|---|---|---|
+| Scoreboard | Participant portal scoreboard view | Sudden score drops, teams stuck at zero, anomalous spikes |
+| Operator dashboard | Application Admin Console deploy / scoring view | Stuck deployments, scoring lag, notification delivery |
+| Deploy trace | CloudWatch Logs Insights filtered by `jobId` (see [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md)) | Per-team deploy failures, CFn rollback events |
+
+If you only have screen real estate for two tabs, drop "operator dashboard" and keep scoreboard + deploy trace. The scoreboard is the participant's experience; the deploy trace is the platform's truth.
+
+## What "healthy" looks like
+
+| Signal | Healthy state | Action threshold |
+|---|---|---|
+| Per-team scoring tick | Updating every polling interval (uptime: every minute; flag: on submission) | If a team has not advanced for 10 minutes, suspect a stuck endpoint |
+| Per-team deploy status | `CREATE_COMPLETE` for every selected problem | Any team stuck in `CREATE_IN_PROGRESS` past 15 minutes is suspicious |
+| Notification delivery | `info` and `warning` reach the portal within the polling tick (currently 5 seconds, see [`docs/operations/notifications.md`](../operations/notifications.md)) | If a sent notification does not appear in 30 seconds, treat as broken |
+| Lambda error rate | Near zero | Any sustained non-zero rate (more than 5 errors / minute) on the deploy worker or scoring Lambda triggers triage |
+
+## Triage decision: redeploy needed vs single-team issue
+
+Operators frequently waste time fixing one team's symptom when the root cause affects every team. Use this decision tree.
+
+```
+Observation: a team reports their endpoint is down.
+│
+├── Are other teams also seeing it down?
+│   ├── YES → Platform-wide issue. Open [incident response](./incident-response.md).
+│   │         Do NOT redeploy individual stacks until you understand the cause.
+│   │
+│   └── NO  → Single-team issue. Check the team's deploy trace.
+│             │
+│             ├── Stack in CREATE_FAILED / ROLLBACK_COMPLETE state?
+│             │   → Yes. Single-team redeploy is the right action.
+│             │
+│             ├── Stack in CREATE_COMPLETE but endpoint unreachable?
+│             │   → Yes. Likely a team-induced misconfiguration (they
+│             │     edited the resource). Tell them; do not redeploy
+│             │     blind — that erases their progress.
+│             │
+│             └── Cannot tell?
+│                 → Open [incident response](./incident-response.md).
+│                   Document before acting.
+```
+
+The most common mistake is reflexive redeploy. Redeploying a team's stack erases their state. If a participant submitted a flag and the scoring already counted it, a redeploy may invalidate the work that produced the flag.
+
+## Scoreboard watch points
+
+Look for shapes, not absolute numbers.
+
+| Shape | Likely interpretation | First check |
+|---|---|---|
+| One team flat at zero | They cannot log in or their stack failed to deploy | Confirm their login first ([participant onboarding](./participant-onboarding.md)) before assuming a platform fault |
+| All teams flat for the last 5 minutes | Scoring loop is stuck | Check the scoring Lambda invocation count and error rate |
+| One team's score drops backward | Uptime scoring penalty fired — check whether their endpoint went down | Their endpoint dropped; legitimate scoring behavior |
+| All teams' scores drop backward simultaneously | Health check Lambda misfired or AWS region-level disruption | Open [incident response](./incident-response.md) immediately |
+
+## Notification policy during live monitoring
+
+Use notifications sparingly. The participant portal poll interval is 5 seconds; over-notifying creates fatigue. See [ADR-006](../architecture/adr-006-notifications.html) for the design choices.
+
+- Send `info` when you change something the participant should know about but they do not need to react. Example: "Scoring resumed after the 14:30 maintenance pause."
+- Send `warning` only when participants must take action or risk losing time. Example: "Endpoint health check paused for 5 minutes from 15:00."
+- Hard limit of five `warning` messages per event. If you exceed five, you are using `warning` for items that should be `info`.
+
+## Recording the event timeline
+
+For every observation and action, append one line to the event timeline:
+
+```
+HH:MM | observed | scoreboard shows team-A flat for 8 minutes
+HH:MM | acted    | inspected team-A deploy trace, found CFn ROLLBACK_COMPLETE
+HH:MM | acted    | initiated redeploy via Application Admin Console
+HH:MM | observed | team-A scoring resumed
+```
+
+This timeline is the input to the post-event review and to any incident postmortem.
+
+## If it goes wrong
+
+| Symptom | First response | Escalation |
+|---|---|---|
+| Scoreboard is frozen for everyone | Check the scoring Lambda invocation count and error rate first. Send an `info` notification within 60 seconds. | Open [incident response](./incident-response.md) under "scoring not updating". |
+| You cannot tell whether it is the platform or one team | Default to platform-wide investigation. The cost of investigating a non-issue is much lower than the cost of redeploying a team blindly. | [incident response](./incident-response.md). |
+| You sent the wrong `warning` notification | You cannot edit or delete a notification (see [`docs/operations/notifications.md`](../operations/notifications.md)). Send a follow-up `info` immediately to correct it. | If the wrong notification caused participants to act, document it in the event timeline and post-event report. |
+| Participants flood the support channel | Pin the question routing table from [participant onboarding](./participant-onboarding.md). Triage from oldest to newest. | If volume exceeds operator capacity, send an `info` "we are investigating, expect updates every 10 minutes" and keep the cadence. |
+| You are unsure whether to act | Do not act. Observe for another minute, ask the facilitator, and only then act. | [incident response](./incident-response.md) — every entry has a "1st response" branch that lets you act safely. |
+
+## Related runbooks and ADRs
+
+- Previous: [pre-event checklist](./pre-event-checklist.md), [dry run](./dry-run.md), [participant onboarding](./participant-onboarding.md).
+- Use together with: [incident response](./incident-response.md) — open the matching incident type when you act.
+- After event: [teardown](./teardown.md).
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html), [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html), [`docs/operations/deploy-trace.md`](../operations/deploy-trace.md), [`docs/operations/notifications.md`](../operations/notifications.md).

--- a/docs/runbooks/participant-onboarding.html
+++ b/docs/runbooks/participant-onboarding.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Participant onboarding</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Participant onboarding</h1>
+<blockquote>
+<p>Japanese: <a href="./participant-onboarding.ja.md">participant-onboarding.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Facilitator (the person who greets participants and runs the kickoff)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Event-day morning, just before the announced start time</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>20 minutes of facilitator preparation; participants spend 5 to 10 minutes during kickoff</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>Every team has logged in, knows where to ask questions, and understands what they will see on the participant portal</td>
+</tr>
+</tbody></table>
+<p>The onboarding step exists because participants who cannot log in or do not know where to ask a question will stall the entire event. The fix is to deliver three artifacts before the event starts: login keys, a one-page kickoff briefing, and a clearly named support channel.</p>
+<h2>Three artifacts to deliver</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Artifact</th>
+<th>Channel</th>
+<th>Owner</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td>Login key (Cognito-only) or SSO link (federated)</td>
+<td>Decided on <a href="./pre-event-checklist.md#authentication-and-access">T-7 of the pre-event checklist</a></td>
+<td>Facilitator</td>
+</tr>
+<tr>
+<td>2</td>
+<td>Kickoff briefing slides (3 to 5 slides)</td>
+<td>Shown on the main screen at kickoff and posted in the support channel</td>
+<td>Facilitator</td>
+</tr>
+<tr>
+<td>3</td>
+<td>Support channel link</td>
+<td>Shared in the kickoff briefing and pinned in any chat tool</td>
+<td>Facilitator</td>
+</tr>
+</tbody></table>
+<h2>Step-by-step</h2>
+<h3>Step 1: distribute login keys or SSO links (10 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Verify the participant portal URL (<code>make lite-portal-url</code> or the SaaS CloudFront URL) renders the login screen.</li>
+<li><input disabled="" type="checkbox"> For each team, send the login key or SSO link through the agreed channel (email, Slack DM, printed card). Include the participant portal URL alongside the key, so participants do not have to hunt for it.</li>
+<li><input disabled="" type="checkbox"> Ask each team to confirm receipt before the kickoff. If a team has not confirmed by T-15 minutes, message them directly.</li>
+</ul>
+<blockquote>
+<p><strong>Reminder:</strong> Login keys are sensitive; never post them in a shared channel. Use 1:1 DMs or per-team email aliases.</p>
+</blockquote>
+<h3>Step 2: prepare the kickoff briefing (5 min)</h3>
+<p>Slide outline (3 to 5 slides):</p>
+<ol>
+<li><strong>Welcome and event identity.</strong> Event name, hosted by, sponsors if any. Reinforce that this is a cloud drill, not just a CTF.</li>
+<li><strong>What participants will see.</strong> Screenshot of the participant portal scoreboard plus the team-view dashboard. Point at where flags / endpoints / scores live.</li>
+<li><strong>How to ask questions.</strong> Link to the support channel and how to escalate. Set the expectation that the operator answers in minutes, not seconds.</li>
+<li><strong>Scoring rules and time window.</strong> Event start, event end, and a one-sentence summary of each problem. Refer participants to the per-problem README for detail.</li>
+<li><strong>Code of conduct and AWS limits.</strong> Reinforce that participants must not touch resources outside the problem template; AWS bills nothing for the platform but per-team CFn stacks have real costs.</li>
+</ol>
+<h3>Step 3: open the kickoff (5 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> At T-5 minutes, post the kickoff briefing to the support channel as a permanent reference.</li>
+<li><input disabled="" type="checkbox"> At T-0, walk through the kickoff briefing live (or send a recorded version).</li>
+<li><input disabled="" type="checkbox"> Confirm at least one participant per team has successfully logged into the participant portal before announcing the official start.</li>
+</ul>
+<h3>Step 4: hand off to live monitoring</h3>
+<p>Once kickoff is done, transition to <a href="./live-monitoring.md">live monitoring</a>. The facilitator may stay engaged on the support channel, but the operator now owns the platform side.</p>
+<h2>Question routing</h2>
+<p>Define who answers what before participants ask.</p>
+<table>
+<thead>
+<tr>
+<th>Question type</th>
+<th>Routing</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>&quot;How do I log in&quot;</td>
+<td>Facilitator (= onboarding artifact issue)</td>
+<td>Wrong login key, wrong URL</td>
+</tr>
+<tr>
+<td>&quot;My endpoint is down&quot;</td>
+<td>On-call operator via <a href="./live-monitoring.md">live monitoring</a></td>
+<td>Stack rolled back; see <a href="./incident-response.md">incident response</a></td>
+</tr>
+<tr>
+<td>&quot;My flag was rejected&quot;</td>
+<td>Problem author or facilitator (= scoring config)</td>
+<td>Flag format mismatch; check the problem README</td>
+</tr>
+<tr>
+<td>&quot;Can I use service X&quot;</td>
+<td>Facilitator (= code of conduct)</td>
+<td>Out-of-scope AWS service request</td>
+</tr>
+<tr>
+<td>&quot;Is the platform broken&quot;</td>
+<td>On-call operator</td>
+<td>Triage with <a href="./incident-response.md">incident response</a></td>
+</tr>
+</tbody></table>
+<p>Post this table in the support channel before kickoff so participants self-route.</p>
+<h2>If it goes wrong</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>First response</th>
+<th>Escalation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>A team never received their login key</td>
+<td>Check the channel, then resend the key 1:1; verify the participant portal URL was included</td>
+<td>If multiple teams missed it, hold the start and review the distribution channel</td>
+</tr>
+<tr>
+<td>Participant logs in but sees an empty portal</td>
+<td>Confirm the team metadata (tenantId, teamSlug) is wired and at least one problem is deployed for that team</td>
+<td>If empty for everyone, treat as a platform incident — go to <a href="./incident-response.md">incident response</a></td>
+</tr>
+<tr>
+<td>Participant asks a question outside the support channel (DM, hallway)</td>
+<td>Politely redirect to the support channel so the answer is logged</td>
+<td>If pattern repeats, re-pin the support channel link</td>
+</tr>
+<tr>
+<td>Facilitator role is unclear during kickoff</td>
+<td>Decide before kickoff: one MC, one operator. Do not multitask the two roles during the event</td>
+<td>If you must, prepare a second facilitator for the next event</td>
+</tr>
+</tbody></table>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Previous: <a href="./pre-event-checklist.md">pre-event checklist</a>, <a href="./dry-run.md">dry run</a>.</li>
+<li>Next: <a href="./live-monitoring.md">live monitoring</a>.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — operator-to-participant notification semantics.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/participant-onboarding.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/participant-onboarding.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/participant-onboarding.ja.html
+++ b/docs/runbooks/participant-onboarding.ja.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Participant onboarding</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Participant onboarding</h1>
+<blockquote>
+<p>English: <a href="./participant-onboarding.md">participant-onboarding.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Facilitator (= 参加者を迎えて kickoff を仕切る人)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>イベント当日朝、 公表開始時刻の直前</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>Facilitator の準備 20 分、 参加者は kickoff 中 5 〜 10 分</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>全チームがログイン完了、 質問導線を理解、 participant portal で何を見るかを理解した状態</td>
+</tr>
+</tbody></table>
+<p>このステップは、「ログインできない / 質問先がわからない」参加者がイベント全体を止めるため必要です。 対応は 3 つのアーティファクト (login key / kickoff ブリーフィング / 明示的なサポートチャネル) を開始前に届けることに集約されます。</p>
+<h2>配布する 3 アーティファクト</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>アーティファクト</th>
+<th>チャネル</th>
+<th>オーナー</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td>Login key (Cognito 単独) または SSO リンク (federated)</td>
+<td><a href="./pre-event-checklist.ja.md#%E8%AA%8D%E8%A8%BC--%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9">事前チェックリスト T-7</a> で決定</td>
+<td>Facilitator</td>
+</tr>
+<tr>
+<td>2</td>
+<td>Kickoff ブリーフィングスライド (3 〜 5 枚)</td>
+<td>Kickoff のメイン画面に投影 / サポートチャネルにも転載</td>
+<td>Facilitator</td>
+</tr>
+<tr>
+<td>3</td>
+<td>サポートチャネルリンク</td>
+<td>Kickoff ブリーフィングで共有し、 チャットツール側に pin</td>
+<td>Facilitator</td>
+</tr>
+</tbody></table>
+<h2>Step-by-step</h2>
+<h3>Step 1: Login key / SSO リンクの配布 (10 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Participant portal URL (<code>make lite-portal-url</code> / SaaS CloudFront URL) がログイン画面を描画することを確認。</li>
+<li><input disabled="" type="checkbox"> 各チームに login key または SSO リンクを合意済みのチャネル (メール / Slack DM / 紙カード) で送付。 参加者が探さなくて済むよう、 必ず participant portal URL を併記する。</li>
+<li><input disabled="" type="checkbox"> Kickoff 前に各チームから受領確認をもらう。 T-15 分時点で未確認のチームには 1:1 で連絡。</li>
+</ul>
+<blockquote>
+<p><strong>念のため</strong>: Login key は機微情報。 共有チャネルに投稿しないこと。 1:1 DM または各チーム用メールエイリアスを使う。</p>
+</blockquote>
+<h3>Step 2: Kickoff ブリーフィングの準備 (5 分)</h3>
+<p>3 〜 5 枚のスライドを次の構成で用意する。</p>
+<ol>
+<li><strong>Welcome / イベント識別</strong>。 イベント名 / 主催 / 協賛。 CTF ではなく「クラウド drill」であることを強調。</li>
+<li><strong>参加者が見る画面</strong>。 Participant portal の scoreboard とチームビュー dashboard のスクリーンショット。 Flag / endpoint / score の位置を指し示す。</li>
+<li><strong>質問の出し方</strong>。 サポートチャネルのリンクとエスカレーション手順。 オペレータの応答は「数分」単位 (= 数秒ではない) と期待値を握る。</li>
+<li><strong>Scoring rule / 時間枠</strong>。 開始時刻 / 終了時刻 / 各問題の 1 文サマリ。 詳細は問題ごとの README にリンク。</li>
+<li><strong>行動規範 / AWS 制約</strong>。 問題テンプレート範囲外のリソースに触らないこと。 プラットフォーム側の AWS 課金は無いが、 チーム別 CFn stack は実コストが乗ることを明示。</li>
+</ol>
+<h3>Step 3: Kickoff の開始 (5 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> T-5 分でブリーフィングをサポートチャネルへ恒久参照として投稿。</li>
+<li><input disabled="" type="checkbox"> T-0 でブリーフィングをライブ (= または事前録画) で通読。</li>
+<li><input disabled="" type="checkbox"> 公表開始時刻前に各チーム少なくとも 1 名が participant portal にログイン済みであることを確認。</li>
+</ul>
+<h3>Step 4: Live monitoring に引継ぎ</h3>
+<p>Kickoff が完了したら、 <a href="./live-monitoring.ja.md">live monitoring</a> に切り替えます。 Facilitator はサポートチャネルに残ってもよいが、 プラットフォーム側はここからオペレータの担当。</p>
+<h2>質問ルーティング</h2>
+<p>参加者が質問する前に、 誰が何に答えるかを決めておきます。</p>
+<table>
+<thead>
+<tr>
+<th>質問種別</th>
+<th>ルーティング</th>
+<th>例</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>「ログインできない」</td>
+<td>Facilitator (= onboarding アーティファクト不備)</td>
+<td>Login key 間違い / URL 間違い</td>
+</tr>
+<tr>
+<td>「endpoint が落ちている」</td>
+<td>オンコールオペレータ (= <a href="./live-monitoring.ja.md">live monitoring</a> 経由)</td>
+<td>スタックが rollback。 <a href="./incident-response.ja.md">インシデント対応</a> を参照</td>
+</tr>
+<tr>
+<td>「Flag が rejected された」</td>
+<td>問題作者または facilitator (= scoring 設定)</td>
+<td>Flag 形式の不一致。 問題 README を確認</td>
+</tr>
+<tr>
+<td>「サービス X を使ってよいか」</td>
+<td>Facilitator (= 行動規範)</td>
+<td>スコープ外 AWS サービスの利用申請</td>
+</tr>
+<tr>
+<td>「プラットフォームが壊れている?」</td>
+<td>オンコールオペレータ</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a> で triage</td>
+</tr>
+</tbody></table>
+<p>この表を kickoff 前にサポートチャネルへ投稿し、 参加者が自己ルーティングできるようにする。</p>
+<h2>うまくいかなかったら</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>1st response</th>
+<th>エスカレーション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>あるチームに login key が届いていない</td>
+<td>チャネルを確認し、 1:1 で再送する。 participant portal URL も同梱されているかを確認。</td>
+<td>複数チームで未受領が発生したら、 開始を保留して配布チャネルを見直す。</td>
+</tr>
+<tr>
+<td>ログインしたが portal が空</td>
+<td>チーム metadata (tenantId / teamSlug) の配線と、 当該チームに最低 1 問が deploy 済みであることを確認。</td>
+<td>全員空ならプラットフォーム障害。 <a href="./incident-response.ja.md">インシデント対応</a> へ。</td>
+</tr>
+<tr>
+<td>参加者がサポートチャネル外 (DM / 廊下) で質問する</td>
+<td>「ログを残すため」 と説明しサポートチャネルへ誘導。</td>
+<td>パターン化したら、 サポートチャネルリンクを再 pin。</td>
+</tr>
+<tr>
+<td>Kickoff 中に facilitator role が曖昧</td>
+<td>Kickoff 前に MC とオペレータを 1 名ずつ確定する。 1 人で兼務しない。</td>
+<td>やむを得ない場合は、 次回イベント用に 2 人目の facilitator を準備。</td>
+</tr>
+</tbody></table>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>前: <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> / <a href="./dry-run.ja.md">Dry run</a>。</li>
+<li>次: <a href="./live-monitoring.ja.md">live monitoring</a>。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — 主催者から参加者への通知セマンティクス。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/participant-onboarding.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/participant-onboarding.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/participant-onboarding.ja.md
+++ b/docs/runbooks/participant-onboarding.ja.md
@@ -1,0 +1,79 @@
+# Participant onboarding
+
+> English: [participant-onboarding.md](./participant-onboarding.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | Facilitator (= 参加者を迎えて kickoff を仕切る人) |
+| 使うタイミング | イベント当日朝、 公表開始時刻の直前 |
+| 所要時間 | Facilitator の準備 20 分、 参加者は kickoff 中 5 〜 10 分 |
+| 出力 | 全チームがログイン完了、 質問導線を理解、 participant portal で何を見るかを理解した状態 |
+
+このステップは、「ログインできない / 質問先がわからない」参加者がイベント全体を止めるため必要です。 対応は 3 つのアーティファクト (login key / kickoff ブリーフィング / 明示的なサポートチャネル) を開始前に届けることに集約されます。
+
+## 配布する 3 アーティファクト
+
+| # | アーティファクト | チャネル | オーナー |
+|---|---|---|---|
+| 1 | Login key (Cognito 単独) または SSO リンク (federated) | [事前チェックリスト T-7](./pre-event-checklist.ja.md#%E8%AA%8D%E8%A8%BC--%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9) で決定 | Facilitator |
+| 2 | Kickoff ブリーフィングスライド (3 〜 5 枚) | Kickoff のメイン画面に投影 / サポートチャネルにも転載 | Facilitator |
+| 3 | サポートチャネルリンク | Kickoff ブリーフィングで共有し、 チャットツール側に pin | Facilitator |
+
+## Step-by-step
+
+### Step 1: Login key / SSO リンクの配布 (10 分)
+
+- [ ] Participant portal URL (`make lite-portal-url` / SaaS CloudFront URL) がログイン画面を描画することを確認。
+- [ ] 各チームに login key または SSO リンクを合意済みのチャネル (メール / Slack DM / 紙カード) で送付。 参加者が探さなくて済むよう、 必ず participant portal URL を併記する。
+- [ ] Kickoff 前に各チームから受領確認をもらう。 T-15 分時点で未確認のチームには 1:1 で連絡。
+
+> **念のため**: Login key は機微情報。 共有チャネルに投稿しないこと。 1:1 DM または各チーム用メールエイリアスを使う。
+
+### Step 2: Kickoff ブリーフィングの準備 (5 分)
+
+3 〜 5 枚のスライドを次の構成で用意する。
+
+1. **Welcome / イベント識別**。 イベント名 / 主催 / 協賛。 CTF ではなく「クラウド drill」であることを強調。
+2. **参加者が見る画面**。 Participant portal の scoreboard とチームビュー dashboard のスクリーンショット。 Flag / endpoint / score の位置を指し示す。
+3. **質問の出し方**。 サポートチャネルのリンクとエスカレーション手順。 オペレータの応答は「数分」単位 (= 数秒ではない) と期待値を握る。
+4. **Scoring rule / 時間枠**。 開始時刻 / 終了時刻 / 各問題の 1 文サマリ。 詳細は問題ごとの README にリンク。
+5. **行動規範 / AWS 制約**。 問題テンプレート範囲外のリソースに触らないこと。 プラットフォーム側の AWS 課金は無いが、 チーム別 CFn stack は実コストが乗ることを明示。
+
+### Step 3: Kickoff の開始 (5 分)
+
+- [ ] T-5 分でブリーフィングをサポートチャネルへ恒久参照として投稿。
+- [ ] T-0 でブリーフィングをライブ (= または事前録画) で通読。
+- [ ] 公表開始時刻前に各チーム少なくとも 1 名が participant portal にログイン済みであることを確認。
+
+### Step 4: Live monitoring に引継ぎ
+
+Kickoff が完了したら、 [live monitoring](./live-monitoring.ja.md) に切り替えます。 Facilitator はサポートチャネルに残ってもよいが、 プラットフォーム側はここからオペレータの担当。
+
+## 質問ルーティング
+
+参加者が質問する前に、 誰が何に答えるかを決めておきます。
+
+| 質問種別 | ルーティング | 例 |
+|---|---|---|
+| 「ログインできない」 | Facilitator (= onboarding アーティファクト不備) | Login key 間違い / URL 間違い |
+| 「endpoint が落ちている」 | オンコールオペレータ (= [live monitoring](./live-monitoring.ja.md) 経由) | スタックが rollback。 [インシデント対応](./incident-response.ja.md) を参照 |
+| 「Flag が rejected された」 | 問題作者または facilitator (= scoring 設定) | Flag 形式の不一致。 問題 README を確認 |
+| 「サービス X を使ってよいか」 | Facilitator (= 行動規範) | スコープ外 AWS サービスの利用申請 |
+| 「プラットフォームが壊れている?」 | オンコールオペレータ | [インシデント対応](./incident-response.ja.md) で triage |
+
+この表を kickoff 前にサポートチャネルへ投稿し、 参加者が自己ルーティングできるようにする。
+
+## うまくいかなかったら
+
+| 症状 | 1st response | エスカレーション |
+|---|---|---|
+| あるチームに login key が届いていない | チャネルを確認し、 1:1 で再送する。 participant portal URL も同梱されているかを確認。 | 複数チームで未受領が発生したら、 開始を保留して配布チャネルを見直す。 |
+| ログインしたが portal が空 | チーム metadata (tenantId / teamSlug) の配線と、 当該チームに最低 1 問が deploy 済みであることを確認。 | 全員空ならプラットフォーム障害。 [インシデント対応](./incident-response.ja.md) へ。 |
+| 参加者がサポートチャネル外 (DM / 廊下) で質問する | 「ログを残すため」 と説明しサポートチャネルへ誘導。 | パターン化したら、 サポートチャネルリンクを再 pin。 |
+| Kickoff 中に facilitator role が曖昧 | Kickoff 前に MC とオペレータを 1 名ずつ確定する。 1 人で兼務しない。 | やむを得ない場合は、 次回イベント用に 2 人目の facilitator を準備。 |
+
+## 関連 runbook / ADR
+
+- 前: [事前チェックリスト](./pre-event-checklist.ja.md) / [Dry run](./dry-run.ja.md)。
+- 次: [live monitoring](./live-monitoring.ja.md)。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) — 主催者から参加者への通知セマンティクス。

--- a/docs/runbooks/participant-onboarding.md
+++ b/docs/runbooks/participant-onboarding.md
@@ -1,0 +1,79 @@
+# Participant onboarding
+
+> Japanese: [participant-onboarding.ja.md](./participant-onboarding.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | Facilitator (the person who greets participants and runs the kickoff) |
+| When to use | Event-day morning, just before the announced start time |
+| Estimated time | 20 minutes of facilitator preparation; participants spend 5 to 10 minutes during kickoff |
+| Output | Every team has logged in, knows where to ask questions, and understands what they will see on the participant portal |
+
+The onboarding step exists because participants who cannot log in or do not know where to ask a question will stall the entire event. The fix is to deliver three artifacts before the event starts: login keys, a one-page kickoff briefing, and a clearly named support channel.
+
+## Three artifacts to deliver
+
+| # | Artifact | Channel | Owner |
+|---|---|---|---|
+| 1 | Login key (Cognito-only) or SSO link (federated) | Decided on [T-7 of the pre-event checklist](./pre-event-checklist.md#authentication-and-access) | Facilitator |
+| 2 | Kickoff briefing slides (3 to 5 slides) | Shown on the main screen at kickoff and posted in the support channel | Facilitator |
+| 3 | Support channel link | Shared in the kickoff briefing and pinned in any chat tool | Facilitator |
+
+## Step-by-step
+
+### Step 1: distribute login keys or SSO links (10 min)
+
+- [ ] Verify the participant portal URL (`make lite-portal-url` or the SaaS CloudFront URL) renders the login screen.
+- [ ] For each team, send the login key or SSO link through the agreed channel (email, Slack DM, printed card). Include the participant portal URL alongside the key, so participants do not have to hunt for it.
+- [ ] Ask each team to confirm receipt before the kickoff. If a team has not confirmed by T-15 minutes, message them directly.
+
+> **Reminder:** Login keys are sensitive; never post them in a shared channel. Use 1:1 DMs or per-team email aliases.
+
+### Step 2: prepare the kickoff briefing (5 min)
+
+Slide outline (3 to 5 slides):
+
+1. **Welcome and event identity.** Event name, hosted by, sponsors if any. Reinforce that this is a cloud drill, not just a CTF.
+2. **What participants will see.** Screenshot of the participant portal scoreboard plus the team-view dashboard. Point at where flags / endpoints / scores live.
+3. **How to ask questions.** Link to the support channel and how to escalate. Set the expectation that the operator answers in minutes, not seconds.
+4. **Scoring rules and time window.** Event start, event end, and a one-sentence summary of each problem. Refer participants to the per-problem README for detail.
+5. **Code of conduct and AWS limits.** Reinforce that participants must not touch resources outside the problem template; AWS bills nothing for the platform but per-team CFn stacks have real costs.
+
+### Step 3: open the kickoff (5 min)
+
+- [ ] At T-5 minutes, post the kickoff briefing to the support channel as a permanent reference.
+- [ ] At T-0, walk through the kickoff briefing live (or send a recorded version).
+- [ ] Confirm at least one participant per team has successfully logged into the participant portal before announcing the official start.
+
+### Step 4: hand off to live monitoring
+
+Once kickoff is done, transition to [live monitoring](./live-monitoring.md). The facilitator may stay engaged on the support channel, but the operator now owns the platform side.
+
+## Question routing
+
+Define who answers what before participants ask.
+
+| Question type | Routing | Example |
+|---|---|---|
+| "How do I log in" | Facilitator (= onboarding artifact issue) | Wrong login key, wrong URL |
+| "My endpoint is down" | On-call operator via [live monitoring](./live-monitoring.md) | Stack rolled back; see [incident response](./incident-response.md) |
+| "My flag was rejected" | Problem author or facilitator (= scoring config) | Flag format mismatch; check the problem README |
+| "Can I use service X" | Facilitator (= code of conduct) | Out-of-scope AWS service request |
+| "Is the platform broken" | On-call operator | Triage with [incident response](./incident-response.md) |
+
+Post this table in the support channel before kickoff so participants self-route.
+
+## If it goes wrong
+
+| Symptom | First response | Escalation |
+|---|---|---|
+| A team never received their login key | Check the channel, then resend the key 1:1; verify the participant portal URL was included | If multiple teams missed it, hold the start and review the distribution channel |
+| Participant logs in but sees an empty portal | Confirm the team metadata (tenantId, teamSlug) is wired and at least one problem is deployed for that team | If empty for everyone, treat as a platform incident — go to [incident response](./incident-response.md) |
+| Participant asks a question outside the support channel (DM, hallway) | Politely redirect to the support channel so the answer is logged | If pattern repeats, re-pin the support channel link |
+| Facilitator role is unclear during kickoff | Decide before kickoff: one MC, one operator. Do not multitask the two roles during the event | If you must, prepare a second facilitator for the next event |
+
+## Related runbooks and ADRs
+
+- Previous: [pre-event checklist](./pre-event-checklist.md), [dry run](./dry-run.md).
+- Next: [live monitoring](./live-monitoring.md).
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html) — operator-to-participant notification semantics.

--- a/docs/runbooks/pre-event-checklist.html
+++ b/docs/runbooks/pre-event-checklist.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Pre-event checklist</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Pre-event checklist</h1>
+<blockquote>
+<p>Japanese: <a href="./pre-event-checklist.ja.md">pre-event-checklist.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Facilitator (the person who owns event delivery end-to-end)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Three staged sessions before the event: T-7 days, T-1 day, T-0 morning</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>30 min per セッション (90 min total across the three sessions)</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>A green checklist that lets you start the event on time</td>
+</tr>
+</tbody></table>
+<p>The checklist is split into three sessions because some items (budget alarm provisioning, IdP wiring) need lead time, while others (URL distribution) only make sense the morning of.</p>
+<blockquote>
+<p><strong>Hard gate:</strong> Before the event runs in production, you must have completed the <a href="./dry-run.md">dry run</a> within the previous 7 days. The T-7 checklist row &quot;Dry run scheduled&quot; enforces this.</p>
+</blockquote>
+<h2>T-7 days: foundations</h2>
+<h3>AWS environment readiness</h3>
+<ul>
+<li><input disabled="" type="checkbox"> AWS account chosen for the event has at least one IAM admin user available to the operator on call.</li>
+<li><input disabled="" type="checkbox"> <code>infrastructure/environments/&lt;env&gt;/.env</code> exists and <code>make env-check-lite</code> (Lite mode) or <code>make env-check</code> (SaaS mode) returns no error.</li>
+<li><input disabled="" type="checkbox"> Billing alarm is configured for the event AWS account with a threshold appropriate for the planned problem catalog (a single Lite-mode event typically stays under the AWS Free Tier 25 RCU/WCU window enforced by the <code>DynamoDbLowCapacity</code> aspect, but per-team CFn stacks add cost).</li>
+<li><input disabled="" type="checkbox"> Source bundle bucket exists (run <code>make prepare-source-bundle</code> once if not).</li>
+</ul>
+<h3>Deploy mode decision</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Choose Lite vs SaaS mode. Default to Lite unless you must run more than one tenant. See <a href="../architecture/OVERVIEW.md"><code>docs/architecture/OVERVIEW.md</code></a> for the comparison.</li>
+<li><input disabled="" type="checkbox"> Document the choice in the event run sheet so on-call operators do not guess at midnight.</li>
+</ul>
+<h3>Problem catalog selection</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Pick 1 to 5 problems from <a href="../../problems/CATALOG.md"><code>problems/CATALOG.md</code></a>. Validate each with <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code>.</li>
+<li><input disabled="" type="checkbox"> Sanity-check the scoring kind mix (one <code>flag</code>, one <code>uptime-multi</code>, etc.). Avoid running 3 simultaneous <code>phased-polling</code> problems on your first event.</li>
+<li><input disabled="" type="checkbox"> Confirm the problem catalog version (<code>problems/</code> submodule SHA) is pinned in the event run sheet.</li>
+</ul>
+<h3>Team and participant list</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Final team list (team name, expected member count, contact email) is collected and reviewed.</li>
+<li><input disabled="" type="checkbox"> Decide whether each team brings their own AWS account or rents one from the organizer. Brought-by-team requires the team to roll out <code>infrastructure/templates/competitor-bootstrap.yaml</code> in advance.</li>
+<li><input disabled="" type="checkbox"> Participant list is captured in the event run sheet.</li>
+</ul>
+<h3>Authentication and access</h3>
+<ul>
+<li><input disabled="" type="checkbox"> If using federated SSO for the Application Admin Console, the IdP wiring is done. See <a href="../operations/application-plane-saml-setup.md"><code>docs/operations/application-plane-saml-setup.md</code></a>.</li>
+<li><input disabled="" type="checkbox"> If using Cognito-only, the participant login key distribution channel (email, Slack DM, printed card) is decided.</li>
+</ul>
+<h3>Communication channels</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Primary participant support channel (Slack workspace, Discord, in-room MC) is provisioned.</li>
+<li><input disabled="" type="checkbox"> Secondary escalation channel (operator phone, on-call rotation) is documented.</li>
+<li><input disabled="" type="checkbox"> Status notification template drafted for <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> <code>info</code> and <code>warning</code> severities (no more than five <code>warning</code> per event — see the ADR for the rationale).</li>
+</ul>
+<h3>Dry run scheduled (hard gate)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <a href="./dry-run.md">Dry run</a> date is fixed and on the calendar within the next 7 days, with a real test of the same problem catalog you will use at the event.</li>
+</ul>
+<h2>T-1 day: final wiring</h2>
+<h3>Deploy verification</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <code>make harness</code> and <code>make before-commit</code> return green on the branch that pins the event-day configuration.</li>
+<li><input disabled="" type="checkbox"> <code>make deploy</code> (Lite) or <code>make deploy-saas</code> (SaaS) has been re-run within the last 24 hours against the event environment; <code>make lite-status</code> or the SaaS install logs show every stack is <code>CREATE_COMPLETE</code> / <code>UPDATE_COMPLETE</code>.</li>
+<li><input disabled="" type="checkbox"> <code>make ops-health</code> returns no warning (no orphan Lambdas, no stuck deployments in DDB).</li>
+</ul>
+<h3>Per-team setup</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Per-team AWS account IDs and the ExternalId for each team are populated in the tenant metadata. Without the ExternalId the AssumeRole into the team account will refuse (this is a hard invariant, not a soft check).</li>
+<li><input disabled="" type="checkbox"> Participant portal URL (<code>make lite-portal-url</code> or the SaaS CloudFront URL) is verified to load and shows the login screen.</li>
+</ul>
+<h3>Notification dry run</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Send one <code>info</code> and one <code>warning</code> notification through the Application Admin Console and confirm the participant portal renders both within one polling tick (currently 5 seconds, see <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a>).</li>
+</ul>
+<h3>Demo data and fallback</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Pre-recorded fallback screenshots / videos exist for each selected problem in case live AWS becomes unstable.</li>
+<li><input disabled="" type="checkbox"> Sample participant login key is verified to work end-to-end.</li>
+</ul>
+<h3>Sign-off</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Facilitator signs off the T-1 checklist in the event run sheet. If a row is red, decide explicitly: fix it tonight or accept the risk in writing.</li>
+</ul>
+<h2>T-0 morning: event-day kickoff</h2>
+<p>Start 60 to 90 minutes before the announced event start.</p>
+<h3>Final platform check</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Re-run <code>make ops-health</code> and confirm zero anomalies.</li>
+<li><input disabled="" type="checkbox"> Confirm the participant portal URL still loads (rare DNS / CloudFront propagation issues catch you here).</li>
+<li><input disabled="" type="checkbox"> Confirm CloudWatch dashboards for the event environment are open and visible to the on-call operator.</li>
+</ul>
+<h3>Participant distribution</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Distribute participant login keys (or SSO links) using the channel decided on T-7. See <a href="./participant-onboarding.md">participant onboarding</a> for the talking points.</li>
+<li><input disabled="" type="checkbox"> Post the kickoff announcement template to the support channel.</li>
+<li><input disabled="" type="checkbox"> Confirm at least one participant per team has successfully logged in before the official start time.</li>
+</ul>
+<h3>Operator handoff</h3>
+<ul>
+<li><input disabled="" type="checkbox"> On-call operator is online and has read <a href="./live-monitoring.md">live monitoring</a> and <a href="./incident-response.md">incident response</a>.</li>
+<li><input disabled="" type="checkbox"> Both pages bookmarked in the operator browser.</li>
+<li><input disabled="" type="checkbox"> Phone is unmuted, escalation channel is open.</li>
+</ul>
+<h3>Go / no-go decision</h3>
+<ul>
+<li><input disabled="" type="checkbox"> If three or more participants cannot log in, hold the start and triage with <a href="./incident-response.md">incident response</a> before announcing the start.</li>
+<li><input disabled="" type="checkbox"> Otherwise announce the start and switch to <a href="./live-monitoring.md">live monitoring</a>.</li>
+</ul>
+<h2>If it goes wrong</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>First response</th>
+<th>Escalation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Dry run was skipped because of time pressure</td>
+<td>Cancel or postpone the event. There is no safe way to recover from a missed dry run in production.</td>
+<td>Inform commercial stakeholders early; better to reschedule than to fail in front of paying participants.</td>
+</tr>
+<tr>
+<td><code>make ops-health</code> reports anomalies at T-1</td>
+<td>Open <a href="./incident-response.md">incident response</a>, classify the anomaly, and fix the root cause; do not run with known anomalies.</td>
+<td>If the anomaly is a stuck deployment, see the &quot;deploy stuck&quot; branch of <a href="./incident-response.md">incident response</a>.</td>
+</tr>
+<tr>
+<td>Participant cannot log in at T-0</td>
+<td>Check the login key, the participant portal URL, and Cognito status; usually the login key was copy-pasted with a trailing space.</td>
+<td>See &quot;participant cannot log in&quot; in <a href="./incident-response.md">incident response</a>.</td>
+</tr>
+<tr>
+<td>AWS budget alarm fired before the event started</td>
+<td>Do not start the event until you understand the cause; a runaway Lambda from a previous dry run is the usual suspect.</td>
+<td>If you cannot identify it within 30 minutes, switch to a clean event environment or reschedule.</td>
+</tr>
+</tbody></table>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Next: <a href="./dry-run.md">dry run</a> — execute it within 7 days of the event.</li>
+<li>During event: <a href="./live-monitoring.md">live monitoring</a>, <a href="./incident-response.md">incident response</a>.</li>
+<li>After event: <a href="./teardown.md">teardown</a>.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a>, <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a>.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/pre-event-checklist.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/pre-event-checklist.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/pre-event-checklist.ja.html
+++ b/docs/runbooks/pre-event-checklist.ja.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>事前チェックリスト</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>事前チェックリスト</h1>
+<blockquote>
+<p>English: <a href="./pre-event-checklist.md">pre-event-checklist.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Facilitator (= イベント運営の end-to-end オーナー)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>T-7 日 / T-1 日 / T-0 朝の 3 セッションで段階的に実施</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>各セッション 30 分 (合計 90 分)</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>イベントを予定どおり開始できる green チェックリスト</td>
+</tr>
+</tbody></table>
+<p>3 セッションに分割する理由は、 予算アラームや IdP 連携にはリードタイムが要るのに対し、 URL 配布は当日朝にしか意味を持たないからです。</p>
+<blockquote>
+<p><strong>ハードゲート</strong>: 本番運用前に <a href="./dry-run.ja.md">Dry run</a> を 7 日以内に必ず完了させてください。 T-7 のチェック「Dry run のスケジュール確保」がこれを担保します。</p>
+</blockquote>
+<h2>T-7 日: 土台</h2>
+<h3>AWS 環境の準備</h3>
+<ul>
+<li><input disabled="" type="checkbox"> イベントに使う AWS アカウントに、 オペレータがオンコール中に呼べる IAM Admin ユーザーが少なくとも 1 名いること。</li>
+<li><input disabled="" type="checkbox"> <code>infrastructure/environments/&lt;env&gt;/.env</code> が存在し、 <code>make env-check-lite</code> (Lite mode) または <code>make env-check</code> (SaaS mode) がエラーを返さないこと。</li>
+<li><input disabled="" type="checkbox"> 想定 problem catalog に応じた閾値の billing alarm をイベント AWS アカウントに設定済み。 Lite mode の単発イベントは <code>DynamoDbLowCapacity</code> aspect が強制する AWS Free Tier 25 RCU/WCU 枠に概ね収まるが、 チーム別 CFn スタックは別途コストが発生する。</li>
+<li><input disabled="" type="checkbox"> Source bundle 用 S3 バケットが存在すること (= 未作成なら <code>make prepare-source-bundle</code> を 1 度実行)。</li>
+</ul>
+<h3>Deploy モードの決定</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Lite と SaaS のどちらで運用するかを決める。 複数テナント運用が必須でなければ Lite をデフォルトとする。 比較は <a href="../architecture/OVERVIEW.md"><code>docs/architecture/OVERVIEW.md</code></a> を参照。</li>
+<li><input disabled="" type="checkbox"> 選択結果を運営シートに明記する。 深夜のオンコールに推測させない。</li>
+</ul>
+<h3>Problem catalog 選定</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <a href="../../problems/CATALOG.md"><code>problems/CATALOG.md</code></a> から 1 〜 5 問を選び、 <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code> で各問題を validate。</li>
+<li><input disabled="" type="checkbox"> Scoring kind の比率を確認する (= <code>flag</code> 1 つ、 <code>uptime-multi</code> 1 つ、 など)。 初回イベントで <code>phased-polling</code> を 3 問同時に走らせない。</li>
+<li><input disabled="" type="checkbox"> Problem catalog のバージョン (= <code>problems/</code> submodule SHA) を運営シートに pin する。</li>
+</ul>
+<h3>チーム / 参加者リスト</h3>
+<ul>
+<li><input disabled="" type="checkbox"> チーム名 / 想定参加人数 / 連絡先メールを含む最終チームリストを収集 / レビュー済み。</li>
+<li><input disabled="" type="checkbox"> 各チームが自前の AWS アカウントを持参するか、 主催者から払い出すかを決める。 持参の場合、 各チームは事前に <code>infrastructure/templates/competitor-bootstrap.yaml</code> を展開しておく必要がある。</li>
+<li><input disabled="" type="checkbox"> 参加者リストを運営シートに記録。</li>
+</ul>
+<h3>認証 / アクセス</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Application Admin Console で federated SSO を使う場合、 IdP 連携が完了済み。 <a href="../operations/application-plane-saml-setup.md"><code>docs/operations/application-plane-saml-setup.md</code></a> を参照。</li>
+<li><input disabled="" type="checkbox"> Cognito 単独運用の場合、 participant login key の配布チャネル (メール / Slack DM / 紙カード) を決定済み。</li>
+</ul>
+<h3>コミュニケーションチャネル</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 参加者サポート用のプライマリチャネル (Slack workspace / Discord / 会場 MC) を整備済み。</li>
+<li><input disabled="" type="checkbox"> エスカレーション用セカンダリチャネル (オペレータ電話 / オンコールローテーション) を文書化済み。</li>
+<li><input disabled="" type="checkbox"> <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> の <code>info</code> / <code>warning</code> 用テンプレートをドラフト済み (= 1 イベント <code>warning</code> 5 件以下、 ADR の rationale を参照)。</li>
+</ul>
+<h3>Dry run の予定確保 (ハードゲート)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <a href="./dry-run.ja.md">Dry run</a> の実施日が直近 7 日以内のカレンダーに入っており、 本番と同じ problem catalog で実施することが確定している。</li>
+</ul>
+<h2>T-1 日: 最終配線</h2>
+<h3>Deploy 検証</h3>
+<ul>
+<li><input disabled="" type="checkbox"> イベント当日構成を pin したブランチで <code>make harness</code> と <code>make before-commit</code> が green。</li>
+<li><input disabled="" type="checkbox"> 直近 24 時間以内に <code>make deploy</code> (Lite) または <code>make deploy-saas</code> (SaaS) を当該環境で再実行済み。 <code>make lite-status</code> または SaaS install ログで全 stack が <code>CREATE_COMPLETE</code> / <code>UPDATE_COMPLETE</code> になっている。</li>
+<li><input disabled="" type="checkbox"> <code>make ops-health</code> で警告ゼロ (= orphan Lambda なし、 DDB に stuck deployment なし)。</li>
+</ul>
+<h3>チーム別セットアップ</h3>
+<ul>
+<li><input disabled="" type="checkbox"> チームごとの AWS Account ID と ExternalId が tenant metadata に登録済み。 ExternalId が無いとチーム AWS アカウントへの AssumeRole は拒否される (= soft check ではなくハード不変)。</li>
+<li><input disabled="" type="checkbox"> Participant portal URL (<code>make lite-portal-url</code> または SaaS CloudFront URL) が実際に開いてログイン画面を表示する。</li>
+</ul>
+<h3>Notification dry run</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Application Admin Console から <code>info</code> を 1 件、 <code>warning</code> を 1 件送り、 participant portal が 1 polling tick 以内 (= 現状 5 秒、 <a href="../operations/notifications.md"><code>docs/operations/notifications.md</code></a> を参照) でレンダリングすることを確認。</li>
+</ul>
+<h3>デモデータ / フォールバック</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 選定した各問題について、 ライブ AWS が不安定になった際の事前録画 / スクリーンショットを準備済み。</li>
+<li><input disabled="" type="checkbox"> サンプル participant login key で end-to-end ログインが成功することを確認済み。</li>
+</ul>
+<h3>Sign off</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Facilitator が T-1 チェックリストに署名。 赤い行があれば、「今夜直す」か「明文化したリスクを受容する」かを必ず決定する。</li>
+</ul>
+<h2>T-0 朝: 当日 kickoff</h2>
+<p>公表開始時刻の 60 〜 90 分前に着手します。</p>
+<h3>最終プラットフォーム確認</h3>
+<ul>
+<li><input disabled="" type="checkbox"> <code>make ops-health</code> を再実行して 0 件異常を確認。</li>
+<li><input disabled="" type="checkbox"> Participant portal URL が依然ロードできる (= 稀な DNS / CloudFront 伝播の見落としをここで拾う)。</li>
+<li><input disabled="" type="checkbox"> 当該環境の CloudWatch ダッシュボードを開き、 オンコールオペレータが視認できる状態にする。</li>
+</ul>
+<h3>参加者への配布</h3>
+<ul>
+<li><input disabled="" type="checkbox"> T-7 で決めたチャネルで participant login key (または SSO リンク) を配布。 トークポイントは <a href="./participant-onboarding.ja.md">participant onboarding</a> を参照。</li>
+<li><input disabled="" type="checkbox"> Kickoff アナウンスのテンプレートをサポートチャネルへ投稿。</li>
+<li><input disabled="" type="checkbox"> 公表開始時刻の前に各チーム少なくとも 1 名がログイン済みであることを確認。</li>
+</ul>
+<h3>オペレータ引継ぎ</h3>
+<ul>
+<li><input disabled="" type="checkbox"> オンコールオペレータがオンラインで、 <a href="./live-monitoring.ja.md">live monitoring</a> と <a href="./incident-response.ja.md">インシデント対応</a> を読了している。</li>
+<li><input disabled="" type="checkbox"> 上記 2 ページをオペレータ用ブラウザにブックマーク済み。</li>
+<li><input disabled="" type="checkbox"> 電話の通知を ON。 エスカレーションチャネルを開いておく。</li>
+</ul>
+<h3>Go / no-go</h3>
+<ul>
+<li><input disabled="" type="checkbox"> 3 チーム以上がログインできない場合、 開始を保留して <a href="./incident-response.ja.md">インシデント対応</a> で triage してから開始を宣言。</li>
+<li><input disabled="" type="checkbox"> 上記でなければ開始を宣言し、 <a href="./live-monitoring.ja.md">live monitoring</a> に移行。</li>
+</ul>
+<h2>うまくいかなかったら</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>1st response</th>
+<th>エスカレーション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Dry run を時間切れでスキップした</td>
+<td>イベント自体を中止または延期する。 本番で dry run 漏れから安全に回復する経路は無い。</td>
+<td>商業ステークホルダーに早期に連絡。 有料参加者の前で失敗するより、 再スケジュールが優先。</td>
+</tr>
+<tr>
+<td>T-1 で <code>make ops-health</code> が異常を返す</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a> を開いて分類し、 根本原因を直す。 既知異常を抱えたまま走らない。</td>
+<td>Stuck deployment であれば <a href="./incident-response.ja.md">インシデント対応</a> の deploy stuck 分岐を参照。</td>
+</tr>
+<tr>
+<td>T-0 で参加者がログインできない</td>
+<td>Login key / participant portal URL / Cognito 状態を確認。 大半は login key の末尾に空白が混入したケース。</td>
+<td><a href="./incident-response.ja.md">インシデント対応</a> の「Cognito sign in failure」を参照。</td>
+</tr>
+<tr>
+<td>イベント開始前に AWS budget alarm が発火</td>
+<td>原因を理解するまで開始しない。 大半は前回 dry run の Lambda が走り続けているケース。</td>
+<td>30 分以内に特定できなければ、 clean なイベント環境に切り替えるか再スケジュール。</td>
+</tr>
+</tbody></table>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>次: <a href="./dry-run.ja.md">Dry run</a> — イベントの 7 日以内に実施。</li>
+<li>イベント中: <a href="./live-monitoring.ja.md">live monitoring</a> / <a href="./incident-response.ja.md">インシデント対応</a>。</li>
+<li>イベント後: <a href="./teardown.ja.md">Teardown</a>。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> / <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a>。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/pre-event-checklist.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/pre-event-checklist.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/pre-event-checklist.ja.md
+++ b/docs/runbooks/pre-event-checklist.ja.md
@@ -1,0 +1,124 @@
+# 事前チェックリスト
+
+> English: [pre-event-checklist.md](./pre-event-checklist.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | Facilitator (= イベント運営の end-to-end オーナー) |
+| 使うタイミング | T-7 日 / T-1 日 / T-0 朝の 3 セッションで段階的に実施 |
+| 所要時間 | 各セッション 30 分 (合計 90 分) |
+| 出力 | イベントを予定どおり開始できる green チェックリスト |
+
+3 セッションに分割する理由は、 予算アラームや IdP 連携にはリードタイムが要るのに対し、 URL 配布は当日朝にしか意味を持たないからです。
+
+> **ハードゲート**: 本番運用前に [Dry run](./dry-run.ja.md) を 7 日以内に必ず完了させてください。 T-7 のチェック「Dry run のスケジュール確保」がこれを担保します。
+
+## T-7 日: 土台
+
+### AWS 環境の準備
+
+- [ ] イベントに使う AWS アカウントに、 オペレータがオンコール中に呼べる IAM Admin ユーザーが少なくとも 1 名いること。
+- [ ] `infrastructure/environments/<env>/.env` が存在し、 `make env-check-lite` (Lite mode) または `make env-check` (SaaS mode) がエラーを返さないこと。
+- [ ] 想定 problem catalog に応じた閾値の billing alarm をイベント AWS アカウントに設定済み。 Lite mode の単発イベントは `DynamoDbLowCapacity` aspect が強制する AWS Free Tier 25 RCU/WCU 枠に概ね収まるが、 チーム別 CFn スタックは別途コストが発生する。
+- [ ] Source bundle 用 S3 バケットが存在すること (= 未作成なら `make prepare-source-bundle` を 1 度実行)。
+
+### Deploy モードの決定
+
+- [ ] Lite と SaaS のどちらで運用するかを決める。 複数テナント運用が必須でなければ Lite をデフォルトとする。 比較は [`docs/architecture/OVERVIEW.md`](../architecture/OVERVIEW.md) を参照。
+- [ ] 選択結果を運営シートに明記する。 深夜のオンコールに推測させない。
+
+### Problem catalog 選定
+
+- [ ] [`problems/CATALOG.md`](../../problems/CATALOG.md) から 1 〜 5 問を選び、 `bun run scripts/tenkacloud-problem.ts validate <id>` で各問題を validate。
+- [ ] Scoring kind の比率を確認する (= `flag` 1 つ、 `uptime-multi` 1 つ、 など)。 初回イベントで `phased-polling` を 3 問同時に走らせない。
+- [ ] Problem catalog のバージョン (= `problems/` submodule SHA) を運営シートに pin する。
+
+### チーム / 参加者リスト
+
+- [ ] チーム名 / 想定参加人数 / 連絡先メールを含む最終チームリストを収集 / レビュー済み。
+- [ ] 各チームが自前の AWS アカウントを持参するか、 主催者から払い出すかを決める。 持参の場合、 各チームは事前に `infrastructure/templates/competitor-bootstrap.yaml` を展開しておく必要がある。
+- [ ] 参加者リストを運営シートに記録。
+
+### 認証 / アクセス
+
+- [ ] Application Admin Console で federated SSO を使う場合、 IdP 連携が完了済み。 [`docs/operations/application-plane-saml-setup.md`](../operations/application-plane-saml-setup.md) を参照。
+- [ ] Cognito 単独運用の場合、 participant login key の配布チャネル (メール / Slack DM / 紙カード) を決定済み。
+
+### コミュニケーションチャネル
+
+- [ ] 参加者サポート用のプライマリチャネル (Slack workspace / Discord / 会場 MC) を整備済み。
+- [ ] エスカレーション用セカンダリチャネル (オペレータ電話 / オンコールローテーション) を文書化済み。
+- [ ] [ADR-006: Notifications](../architecture/adr-006-notifications.html) の `info` / `warning` 用テンプレートをドラフト済み (= 1 イベント `warning` 5 件以下、 ADR の rationale を参照)。
+
+### Dry run の予定確保 (ハードゲート)
+
+- [ ] [Dry run](./dry-run.ja.md) の実施日が直近 7 日以内のカレンダーに入っており、 本番と同じ problem catalog で実施することが確定している。
+
+## T-1 日: 最終配線
+
+### Deploy 検証
+
+- [ ] イベント当日構成を pin したブランチで `make harness` と `make before-commit` が green。
+- [ ] 直近 24 時間以内に `make deploy` (Lite) または `make deploy-saas` (SaaS) を当該環境で再実行済み。 `make lite-status` または SaaS install ログで全 stack が `CREATE_COMPLETE` / `UPDATE_COMPLETE` になっている。
+- [ ] `make ops-health` で警告ゼロ (= orphan Lambda なし、 DDB に stuck deployment なし)。
+
+### チーム別セットアップ
+
+- [ ] チームごとの AWS Account ID と ExternalId が tenant metadata に登録済み。 ExternalId が無いとチーム AWS アカウントへの AssumeRole は拒否される (= soft check ではなくハード不変)。
+- [ ] Participant portal URL (`make lite-portal-url` または SaaS CloudFront URL) が実際に開いてログイン画面を表示する。
+
+### Notification dry run
+
+- [ ] Application Admin Console から `info` を 1 件、 `warning` を 1 件送り、 participant portal が 1 polling tick 以内 (= 現状 5 秒、 [`docs/operations/notifications.md`](../operations/notifications.md) を参照) でレンダリングすることを確認。
+
+### デモデータ / フォールバック
+
+- [ ] 選定した各問題について、 ライブ AWS が不安定になった際の事前録画 / スクリーンショットを準備済み。
+- [ ] サンプル participant login key で end-to-end ログインが成功することを確認済み。
+
+### Sign off
+
+- [ ] Facilitator が T-1 チェックリストに署名。 赤い行があれば、「今夜直す」か「明文化したリスクを受容する」かを必ず決定する。
+
+## T-0 朝: 当日 kickoff
+
+公表開始時刻の 60 〜 90 分前に着手します。
+
+### 最終プラットフォーム確認
+
+- [ ] `make ops-health` を再実行して 0 件異常を確認。
+- [ ] Participant portal URL が依然ロードできる (= 稀な DNS / CloudFront 伝播の見落としをここで拾う)。
+- [ ] 当該環境の CloudWatch ダッシュボードを開き、 オンコールオペレータが視認できる状態にする。
+
+### 参加者への配布
+
+- [ ] T-7 で決めたチャネルで participant login key (または SSO リンク) を配布。 トークポイントは [participant onboarding](./participant-onboarding.ja.md) を参照。
+- [ ] Kickoff アナウンスのテンプレートをサポートチャネルへ投稿。
+- [ ] 公表開始時刻の前に各チーム少なくとも 1 名がログイン済みであることを確認。
+
+### オペレータ引継ぎ
+
+- [ ] オンコールオペレータがオンラインで、 [live monitoring](./live-monitoring.ja.md) と [インシデント対応](./incident-response.ja.md) を読了している。
+- [ ] 上記 2 ページをオペレータ用ブラウザにブックマーク済み。
+- [ ] 電話の通知を ON。 エスカレーションチャネルを開いておく。
+
+### Go / no-go
+
+- [ ] 3 チーム以上がログインできない場合、 開始を保留して [インシデント対応](./incident-response.ja.md) で triage してから開始を宣言。
+- [ ] 上記でなければ開始を宣言し、 [live monitoring](./live-monitoring.ja.md) に移行。
+
+## うまくいかなかったら
+
+| 症状 | 1st response | エスカレーション |
+|---|---|---|
+| Dry run を時間切れでスキップした | イベント自体を中止または延期する。 本番で dry run 漏れから安全に回復する経路は無い。 | 商業ステークホルダーに早期に連絡。 有料参加者の前で失敗するより、 再スケジュールが優先。 |
+| T-1 で `make ops-health` が異常を返す | [インシデント対応](./incident-response.ja.md) を開いて分類し、 根本原因を直す。 既知異常を抱えたまま走らない。 | Stuck deployment であれば [インシデント対応](./incident-response.ja.md) の deploy stuck 分岐を参照。 |
+| T-0 で参加者がログインできない | Login key / participant portal URL / Cognito 状態を確認。 大半は login key の末尾に空白が混入したケース。 | [インシデント対応](./incident-response.ja.md) の「Cognito sign in failure」を参照。 |
+| イベント開始前に AWS budget alarm が発火 | 原因を理解するまで開始しない。 大半は前回 dry run の Lambda が走り続けているケース。 | 30 分以内に特定できなければ、 clean なイベント環境に切り替えるか再スケジュール。 |
+
+## 関連 runbook / ADR
+
+- 次: [Dry run](./dry-run.ja.md) — イベントの 7 日以内に実施。
+- イベント中: [live monitoring](./live-monitoring.ja.md) / [インシデント対応](./incident-response.ja.md)。
+- イベント後: [Teardown](./teardown.ja.md)。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) / [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html)。

--- a/docs/runbooks/pre-event-checklist.md
+++ b/docs/runbooks/pre-event-checklist.md
@@ -1,0 +1,124 @@
+# Pre-event checklist
+
+> Japanese: [pre-event-checklist.ja.md](./pre-event-checklist.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | Facilitator (the person who owns event delivery end-to-end) |
+| When to use | Three staged sessions before the event: T-7 days, T-1 day, T-0 morning |
+| Estimated time | 30 min per セッション (90 min total across the three sessions) |
+| Output | A green checklist that lets you start the event on time |
+
+The checklist is split into three sessions because some items (budget alarm provisioning, IdP wiring) need lead time, while others (URL distribution) only make sense the morning of.
+
+> **Hard gate:** Before the event runs in production, you must have completed the [dry run](./dry-run.md) within the previous 7 days. The T-7 checklist row "Dry run scheduled" enforces this.
+
+## T-7 days: foundations
+
+### AWS environment readiness
+
+- [ ] AWS account chosen for the event has at least one IAM admin user available to the operator on call.
+- [ ] `infrastructure/environments/<env>/.env` exists and `make env-check-lite` (Lite mode) or `make env-check` (SaaS mode) returns no error.
+- [ ] Billing alarm is configured for the event AWS account with a threshold appropriate for the planned problem catalog (a single Lite-mode event typically stays under the AWS Free Tier 25 RCU/WCU window enforced by the `DynamoDbLowCapacity` aspect, but per-team CFn stacks add cost).
+- [ ] Source bundle bucket exists (run `make prepare-source-bundle` once if not).
+
+### Deploy mode decision
+
+- [ ] Choose Lite vs SaaS mode. Default to Lite unless you must run more than one tenant. See [`docs/architecture/OVERVIEW.md`](../architecture/OVERVIEW.md) for the comparison.
+- [ ] Document the choice in the event run sheet so on-call operators do not guess at midnight.
+
+### Problem catalog selection
+
+- [ ] Pick 1 to 5 problems from [`problems/CATALOG.md`](../../problems/CATALOG.md). Validate each with `bun run scripts/tenkacloud-problem.ts validate <id>`.
+- [ ] Sanity-check the scoring kind mix (one `flag`, one `uptime-multi`, etc.). Avoid running 3 simultaneous `phased-polling` problems on your first event.
+- [ ] Confirm the problem catalog version (`problems/` submodule SHA) is pinned in the event run sheet.
+
+### Team and participant list
+
+- [ ] Final team list (team name, expected member count, contact email) is collected and reviewed.
+- [ ] Decide whether each team brings their own AWS account or rents one from the organizer. Brought-by-team requires the team to roll out `infrastructure/templates/competitor-bootstrap.yaml` in advance.
+- [ ] Participant list is captured in the event run sheet.
+
+### Authentication and access
+
+- [ ] If using federated SSO for the Application Admin Console, the IdP wiring is done. See [`docs/operations/application-plane-saml-setup.md`](../operations/application-plane-saml-setup.md).
+- [ ] If using Cognito-only, the participant login key distribution channel (email, Slack DM, printed card) is decided.
+
+### Communication channels
+
+- [ ] Primary participant support channel (Slack workspace, Discord, in-room MC) is provisioned.
+- [ ] Secondary escalation channel (operator phone, on-call rotation) is documented.
+- [ ] Status notification template drafted for [ADR-006: Notifications](../architecture/adr-006-notifications.html) `info` and `warning` severities (no more than five `warning` per event — see the ADR for the rationale).
+
+### Dry run scheduled (hard gate)
+
+- [ ] [Dry run](./dry-run.md) date is fixed and on the calendar within the next 7 days, with a real test of the same problem catalog you will use at the event.
+
+## T-1 day: final wiring
+
+### Deploy verification
+
+- [ ] `make harness` and `make before-commit` return green on the branch that pins the event-day configuration.
+- [ ] `make deploy` (Lite) or `make deploy-saas` (SaaS) has been re-run within the last 24 hours against the event environment; `make lite-status` or the SaaS install logs show every stack is `CREATE_COMPLETE` / `UPDATE_COMPLETE`.
+- [ ] `make ops-health` returns no warning (no orphan Lambdas, no stuck deployments in DDB).
+
+### Per-team setup
+
+- [ ] Per-team AWS account IDs and the ExternalId for each team are populated in the tenant metadata. Without the ExternalId the AssumeRole into the team account will refuse (this is a hard invariant, not a soft check).
+- [ ] Participant portal URL (`make lite-portal-url` or the SaaS CloudFront URL) is verified to load and shows the login screen.
+
+### Notification dry run
+
+- [ ] Send one `info` and one `warning` notification through the Application Admin Console and confirm the participant portal renders both within one polling tick (currently 5 seconds, see [`docs/operations/notifications.md`](../operations/notifications.md)).
+
+### Demo data and fallback
+
+- [ ] Pre-recorded fallback screenshots / videos exist for each selected problem in case live AWS becomes unstable.
+- [ ] Sample participant login key is verified to work end-to-end.
+
+### Sign-off
+
+- [ ] Facilitator signs off the T-1 checklist in the event run sheet. If a row is red, decide explicitly: fix it tonight or accept the risk in writing.
+
+## T-0 morning: event-day kickoff
+
+Start 60 to 90 minutes before the announced event start.
+
+### Final platform check
+
+- [ ] Re-run `make ops-health` and confirm zero anomalies.
+- [ ] Confirm the participant portal URL still loads (rare DNS / CloudFront propagation issues catch you here).
+- [ ] Confirm CloudWatch dashboards for the event environment are open and visible to the on-call operator.
+
+### Participant distribution
+
+- [ ] Distribute participant login keys (or SSO links) using the channel decided on T-7. See [participant onboarding](./participant-onboarding.md) for the talking points.
+- [ ] Post the kickoff announcement template to the support channel.
+- [ ] Confirm at least one participant per team has successfully logged in before the official start time.
+
+### Operator handoff
+
+- [ ] On-call operator is online and has read [live monitoring](./live-monitoring.md) and [incident response](./incident-response.md).
+- [ ] Both pages bookmarked in the operator browser.
+- [ ] Phone is unmuted, escalation channel is open.
+
+### Go / no-go decision
+
+- [ ] If three or more participants cannot log in, hold the start and triage with [incident response](./incident-response.md) before announcing the start.
+- [ ] Otherwise announce the start and switch to [live monitoring](./live-monitoring.md).
+
+## If it goes wrong
+
+| Symptom | First response | Escalation |
+|---|---|---|
+| Dry run was skipped because of time pressure | Cancel or postpone the event. There is no safe way to recover from a missed dry run in production. | Inform commercial stakeholders early; better to reschedule than to fail in front of paying participants. |
+| `make ops-health` reports anomalies at T-1 | Open [incident response](./incident-response.md), classify the anomaly, and fix the root cause; do not run with known anomalies. | If the anomaly is a stuck deployment, see the "deploy stuck" branch of [incident response](./incident-response.md). |
+| Participant cannot log in at T-0 | Check the login key, the participant portal URL, and Cognito status; usually the login key was copy-pasted with a trailing space. | See "participant cannot log in" in [incident response](./incident-response.md). |
+| AWS budget alarm fired before the event started | Do not start the event until you understand the cause; a runaway Lambda from a previous dry run is the usual suspect. | If you cannot identify it within 30 minutes, switch to a clean event environment or reschedule. |
+
+## Related runbooks and ADRs
+
+- Next: [dry run](./dry-run.md) — execute it within 7 days of the event.
+- During event: [live monitoring](./live-monitoring.md), [incident response](./incident-response.md).
+- After event: [teardown](./teardown.md).
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html), [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html).

--- a/docs/runbooks/teardown.html
+++ b/docs/runbooks/teardown.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Teardown</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Teardown</h1>
+<blockquote>
+<p>Japanese: <a href="./teardown.ja.md">teardown.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Operator (the person responsible for closing the event cleanly)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Within 24 hours after the announced event end. Do not let teardown drift; orphan resources keep billing.</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>60 minutes for a typical Lite-mode event; longer if multiple teams have orphaned resources</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>Every event stack is <code>DELETE_COMPLETE</code> or explicitly archived; audit log export is saved; competitor IAM roles are documented as deprovisioned</td>
+</tr>
+</tbody></table>
+<p>The teardown runbook closes the loop opened by <a href="./pre-event-checklist.md">pre-event checklist</a>. It exists because the most expensive failure mode is a leftover Lambda or DDB table billing for a year after the event ended.</p>
+<h2>Three required outputs</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Output</th>
+<th>Why it matters</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td>Every event-scoped CFn stack is <code>DELETE_COMPLETE</code>, or moved to a documented &quot;Force ARCHIVED&quot; state with a written reason</td>
+<td>Cost containment. Orphans cost money.</td>
+</tr>
+<tr>
+<td>2</td>
+<td>Audit log export is captured (CloudTrail / scoring history / notification log)</td>
+<td>SOC2 evidence and post-event review. Audit logs must survive the teardown of the platform itself.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>Each competitor IAM role is confirmed deprovisioned (or scheduled to expire)</td>
+<td>Security. Cross-account trust without an active event is an unnecessary attack surface.</td>
+</tr>
+</tbody></table>
+<h2>Step-by-step</h2>
+<h3>Step 0: confirm the event is really ended (5 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Scoring loop is stopped (operator dashboard shows no active scoring jobs).</li>
+<li><input disabled="" type="checkbox"> No participant is mid-submission. Send one final <code>info</code> notification: &quot;Event closed at HH:MM. Submissions after this time are not scored.&quot;</li>
+<li><input disabled="" type="checkbox"> Wait for any in-flight deploy to complete (<code>make ops-health</code> shows zero IN_PROGRESS jobs) before initiating teardown — tearing down mid-deploy creates orphans.</li>
+</ul>
+<h3>Step 1: collect audit evidence first (10 min)</h3>
+<p>Do this <strong>before</strong> you start destroying things. Once stacks are deleted, some logs become harder to retrieve.</p>
+<ul>
+<li><input disabled="" type="checkbox"> Export CloudTrail events for the event window to S3 (the production AWS environment should already be configured to ship CloudTrail; if not, capture manually). This is the primary SOC2 evidence.</li>
+<li><input disabled="" type="checkbox"> Export the scoring history. The scoring DynamoDB tables retain history until DDB TTL fires; copy the relevant team and event records out of band.</li>
+<li><input disabled="" type="checkbox"> Export the notification log from the Events table. Notifications cannot be edited or deleted (see <a href="../architecture/adr-006-notifications.html">ADR-006</a>), so the table is authoritative.</li>
+<li><input disabled="" type="checkbox"> Save the <a href="./live-monitoring.md">live monitoring</a> event timeline to the same archive folder.</li>
+</ul>
+<h3>Step 2: tear down per-team problem stacks (15 min)</h3>
+<p>For each team and each deployed problem:</p>
+<ul>
+<li><input disabled="" type="checkbox"> Initiate teardown via the Application Admin Console teardown action or <code>make destroy-battles BATTLES=&quot;problems/&lt;category&gt;/&lt;id&gt;&quot; TEAM_SLUG=&lt;slug&gt;</code> for the Lite-mode local path.</li>
+<li><input disabled="" type="checkbox"> Confirm <code>deploy.cfn.delete.succeeded</code> in the deploy trace.</li>
+<li><input disabled="" type="checkbox"> Confirm the stack is <code>DELETE_COMPLETE</code> in the team&#39;s AWS account (cross-account DescribeStack from the operator, or ask the team to confirm).</li>
+</ul>
+<blockquote>
+<p><strong>Force ARCHIVED procedure.</strong> If a team&#39;s stack is stuck in <code>DELETE_FAILED</code> or <code>UPDATE_ROLLBACK_FAILED</code>, follow this manual sequence:</p>
+<ol>
+<li>Inspect the failure: open the CFn stack in the team&#39;s AWS account and read the failed event reasons.</li>
+<li>Manually delete the blocking resources (most often S3 buckets with content, EIPs in use, or ENIs attached to deleted security groups). Document each manual delete in the teardown report.</li>
+<li>Re-run <code>delete-stack</code> from the operator after the blocker is removed.</li>
+<li>If the stack still cannot delete, mark it <code>ARCHIVED</code> in the event run sheet with the date and the resource list left behind. The team account owner is responsible for follow-up. <strong>Never leave it &quot;I will check later&quot; — write it down.</strong></li>
+</ol>
+</blockquote>
+<h3>Step 3: tear down the platform (15 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Lite mode: <code>make destroy</code> (runs <code>bun run scripts/tenkacloud-lite.ts down</code>). Confirm both <code>AppPlaneCore</code> and <code>ProblemDeployBackend</code> reach <code>DELETE_COMPLETE</code>.</li>
+<li><input disabled="" type="checkbox"> SaaS mode: <code>make destroy-saas</code> (runs <code>scripts/cleanup.sh</code>). This script is intentionally idempotent — if a prior attempt left partial state, re-run it.</li>
+<li><input disabled="" type="checkbox"> Confirm the source bundle S3 bucket is empty or scheduled for lifecycle deletion (the bucket itself may persist between events; the bundle inside is what costs).</li>
+</ul>
+<h3>Step 4: deprovision competitor IAM roles (10 min)</h3>
+<p>The <a href="../../infrastructure/templates/competitor-bootstrap.yaml">competitor-bootstrap.yaml</a> IAM Role is rolled out one time in each competitor account. After the event:</p>
+<ul>
+<li><input disabled="" type="checkbox"> For each team account, ask the team to delete the IAM Role stack OR confirm a documented retention window (e.g., &quot;kept until the next event in 4 weeks&quot;).</li>
+<li><input disabled="" type="checkbox"> Record the disposition (deleted, retained-until-DATE) in the event run sheet for SOC2 evidence.</li>
+<li><input disabled="" type="checkbox"> If a team retains the role, confirm the ExternalId is rotated before the next event. Reusing the same ExternalId across separated events weakens the AssumeRole guarantee.</li>
+</ul>
+<h3>Step 5: cost check (5 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Open AWS Cost Explorer for the event AWS account and confirm the cost curve flattens within 24 hours of teardown.</li>
+<li><input disabled="" type="checkbox"> If cost continues to accrue, return to Step 2 — there is an orphan resource somewhere.</li>
+</ul>
+<h3>Step 6: file post-event issues (5 min)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Open one GitHub issue per gap surfaced during the event or teardown (broken problem, slow scoring, manual-delete required during Force ARCHIVED).</li>
+<li><input disabled="" type="checkbox"> Link each issue to the parent commercial-launch epic (#1336) where applicable.</li>
+</ul>
+<h2>If it goes wrong</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>First response</th>
+<th>Escalation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>A stack will not delete (<code>DELETE_FAILED</code>)</td>
+<td>Follow the Force ARCHIVED procedure in Step 2. Do not loop on <code>delete-stack</code> without fixing the blocker.</td>
+<td>If you cannot identify the blocker, escalate to the team account owner with a list of stuck resources.</td>
+</tr>
+<tr>
+<td>Audit log export is incomplete</td>
+<td>Stop teardown until the audit evidence is captured. The platform must outlive the platform itself for SOC2 purposes.</td>
+<td>If CloudTrail was not enabled, file an immediate fix-forward issue; do not silently accept incomplete evidence.</td>
+</tr>
+<tr>
+<td>Cost continues to accrue after teardown</td>
+<td>An orphan resource exists. Walk the AWS Cost Explorer service-by-service to find it.</td>
+<td>If you cannot find it within 60 minutes, escalate with the AWS account owner.</td>
+</tr>
+<tr>
+<td>Team did not delete the competitor IAM role</td>
+<td>Record retention window explicitly and rotate the ExternalId before the next event.</td>
+<td>If the team is unreachable, document the open trust path as a known risk; do not silently leave it.</td>
+</tr>
+<tr>
+<td>Multiple stacks stuck in DELETE_FAILED simultaneously</td>
+<td>Likely a region-wide AWS issue or a missed dependency. Wait 30 minutes, retry; otherwise consult the <a href="./incident-response.md">incident response</a> Section 4 (CFn ROLLBACK) for context.</td>
+<td>Escalate as a platform-wide post-incident; the design assumption in <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> is that state eventually converges — give it time.</td>
+</tr>
+</tbody></table>
+<h2>Closing the loop</h2>
+<ul>
+<li>File a post-event review thread (separate from per-issue follow-ups) describing what worked, what failed, and what to change in the next <a href="./pre-event-checklist.md">pre-event checklist</a> cycle.</li>
+<li>Update this runbook if you discovered a teardown gap not covered here. The runbook is the source of truth for the next operator.</li>
+</ul>
+<h2>Related runbooks and ADRs</h2>
+<ul>
+<li>Previous: <a href="./pre-event-checklist.md">pre-event checklist</a>, <a href="./dry-run.md">dry run</a>, <a href="./participant-onboarding.md">participant onboarding</a>, <a href="./live-monitoring.md">live monitoring</a>, <a href="./incident-response.md">incident response</a>.</li>
+<li>Background: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> (notification log must be captured before teardown), <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a> (state converges asynchronously; wait before forcing).</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/teardown.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/teardown.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/teardown.ja.html
+++ b/docs/runbooks/teardown.ja.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Teardown</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Teardown</h1>
+<blockquote>
+<p>English: <a href="./teardown.md">teardown.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>オペレータ (= イベントを clean に閉じる責任者)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>公表終了時刻から 24 時間以内。 Teardown を先送りしない。 Orphan リソースは課金され続ける。</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>Lite mode の典型イベントで 60 分。 複数チームに orphan があれば延長。</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>全イベントスタックが <code>DELETE_COMPLETE</code> または明示的に archive 済み / 監査ログ export 完了 / 競技者 IAM Role の deprovision 状態を記録</td>
+</tr>
+</tbody></table>
+<p>Teardown runbook は <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> が開いたループを閉じます。 もっとも高くつく失敗は、 イベント終了後 1 年間 Lambda と DDB が課金され続けるパターンです。</p>
+<h2>必須の 3 出力</h2>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>出力</th>
+<th>重要性</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>1</td>
+<td>イベントスコープの CFn スタックがすべて <code>DELETE_COMPLETE</code>、 または書面の理由付きで 「Force ARCHIVED」 状態に移動済み</td>
+<td>コスト制御。 Orphan は課金される。</td>
+</tr>
+<tr>
+<td>2</td>
+<td>監査ログ export を取得済み (CloudTrail / scoring 履歴 / 通知ログ)</td>
+<td>SOC2 evidence と事後レビュー。 監査ログはプラットフォームそのものより長生きさせる必要がある。</td>
+</tr>
+<tr>
+<td>3</td>
+<td>競技者 IAM Role の deprovision (または期限失効) を記録済み</td>
+<td>セキュリティ。 進行中イベントを伴わないクロスアカウント信頼は不要な attack surface。</td>
+</tr>
+</tbody></table>
+<h2>Step-by-step</h2>
+<h3>Step 0: イベントが本当に終わっているか確認 (5 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Scoring loop が停止 (オペレータダッシュボードに active scoring job が無い)。</li>
+<li><input disabled="" type="checkbox"> 参加者が提出途中ではないこと。 最後の <code>info</code> 通知を 1 件:「イベントは HH:MM に終了しました。 以降の提出は scoring されません」。</li>
+<li><input disabled="" type="checkbox"> 進行中の deploy を完了させる (<code>make ops-health</code> で IN_PROGRESS ゼロを確認)。 Deploy 中に teardown を始めると orphan を作る。</li>
+</ul>
+<h3>Step 1: 監査 evidence を先に回収 (10 分)</h3>
+<p>破壊を始める <strong>前</strong> に必ず実施。 スタック削除後はログ取得が難しくなる項目があります。</p>
+<ul>
+<li><input disabled="" type="checkbox"> イベント時間範囲の CloudTrail を S3 に export (本番 AWS 環境は通常 CloudTrail 配信済み。 未設定なら手動キャプチャ)。 SOC2 主 evidence。</li>
+<li><input disabled="" type="checkbox"> Scoring 履歴の export。 Scoring 用 DDB テーブルは TTL 失効まで履歴を保持するが、 関係チーム / イベントレコードを別建てでコピーしておく。</li>
+<li><input disabled="" type="checkbox"> Events テーブルから通知ログを export。 通知は edit / delete 不可 (<a href="../architecture/adr-006-notifications.html">ADR-006</a>) のため、 当該テーブルが authoritative。</li>
+<li><input disabled="" type="checkbox"> <a href="./live-monitoring.ja.md">live monitoring</a> のイベントタイムラインを同じアーカイブフォルダへ保存。</li>
+</ul>
+<h3>Step 2: チーム別問題スタックを teardown (15 分)</h3>
+<p>各チーム × 各 deploy 問題の組について、 次を順に実施する。</p>
+<ul>
+<li><input disabled="" type="checkbox"> Application Admin Console の teardown action、 または Lite mode ローカル経路では <code>make destroy-battles BATTLES=&quot;problems/&lt;category&gt;/&lt;id&gt;&quot; TEAM_SLUG=&lt;slug&gt;</code> で teardown を発行。</li>
+<li><input disabled="" type="checkbox"> Deploy trace に <code>deploy.cfn.delete.succeeded</code> が出ることを確認。</li>
+<li><input disabled="" type="checkbox"> チームの AWS アカウントで stack が <code>DELETE_COMPLETE</code> であることを確認 (= オペレータからのクロスアカウント DescribeStack、 またはチームに確認依頼)。</li>
+</ul>
+<blockquote>
+<p><strong>Force ARCHIVED 手順</strong>。 スタックが <code>DELETE_FAILED</code> / <code>UPDATE_ROLLBACK_FAILED</code> に詰まった場合は、 次の手動シーケンスに従う。</p>
+<ol>
+<li>失敗を解析。 チームの AWS アカウントで CFn スタックを開き、 失敗 event を読む。</li>
+<li>ブロッカーになるリソースを手動削除 (= 内容物のある S3 バケット / 使用中の EIP / 削除済み SG に紐づく ENI が頻出)。 各手動削除を teardown レポートに記録。</li>
+<li>ブロッカー解除後にオペレータから <code>delete-stack</code> を再実行。</li>
+<li>それでも削除できなければ、 運営シートに <code>ARCHIVED</code> と日付 / 残置リソース一覧を明記。 チームアカウントオーナーがフォローアップ責任を負う。 <strong>「後で確認する」 で放置しない</strong>。 文書化する。</li>
+</ol>
+</blockquote>
+<h3>Step 3: プラットフォーム teardown (15 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Lite mode: <code>make destroy</code> (= <code>bun run scripts/tenkacloud-lite.ts down</code>)。 <code>AppPlaneCore</code> と <code>ProblemDeployBackend</code> が <code>DELETE_COMPLETE</code> に到達することを確認。</li>
+<li><input disabled="" type="checkbox"> SaaS mode: <code>make destroy-saas</code> (= <code>scripts/cleanup.sh</code>)。 このスクリプトは意図的に idempotent。 前回失敗の残骸がある場合は再実行。</li>
+<li><input disabled="" type="checkbox"> Source bundle S3 バケットが空、 または lifecycle 削除予約済みであることを確認 (バケット自体はイベント間で残してよい。 中身の bundle が課金対象)。</li>
+</ul>
+<h3>Step 4: 競技者 IAM Role を deprovision (10 分)</h3>
+<p><a href="../../infrastructure/templates/competitor-bootstrap.yaml">competitor-bootstrap.yaml</a> の IAM Role は各競技者アカウントに 1 度展開済み。 イベント後、 次を確認する。</p>
+<ul>
+<li><input disabled="" type="checkbox"> 各チームアカウントについて、 IAM Role スタックの削除を依頼するか、 保管期限を明文化 (例:「4 週間後の次回イベントまで保持」)。</li>
+<li><input disabled="" type="checkbox"> 処置 (deleted / retained-until-DATE) を SOC2 evidence として運営シートに記録。</li>
+<li><input disabled="" type="checkbox"> Role を保管する場合、 次回イベント前に ExternalId をローテーション。 同 ExternalId を分離イベントで再利用すると AssumeRole の保証が弱まる。</li>
+</ul>
+<h3>Step 5: コスト確認 (5 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> イベント AWS アカウントの AWS Cost Explorer を開き、 teardown から 24 時間以内にコスト曲線が flat 化することを確認。</li>
+<li><input disabled="" type="checkbox"> コストが上がり続けるなら Step 2 へ戻る。 どこかに orphan がある。</li>
+</ul>
+<h3>Step 6: 事後 issue 起票 (5 分)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> イベント / teardown 中に表面化した gap (= 不具合問題 / 遅延 scoring / Force ARCHIVED 中の手動削除など) ごとに GitHub issue を 1 件起票。</li>
+<li><input disabled="" type="checkbox"> 該当する場合は親 commercial-launch epic (#1336) にリンク。</li>
+</ul>
+<h2>うまくいかなかったら</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>1st response</th>
+<th>エスカレーション</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>スタックが削除できない (<code>DELETE_FAILED</code>)</td>
+<td>Step 2 の Force ARCHIVED 手順に従う。 ブロッカーを直さずに <code>delete-stack</code> をループしない。</td>
+<td>ブロッカーを特定できなければ、 stuck リソース一覧を添えてチームアカウントオーナーへエスカレーション。</td>
+</tr>
+<tr>
+<td>監査ログ export が不完全</td>
+<td>Evidence 取得が終わるまで teardown を停止。 監査ログはプラットフォームそのものより長生きさせる必要がある。</td>
+<td>CloudTrail 未有効だったなら、 fix-forward issue を即起票。 不完全 evidence を黙認しない。</td>
+</tr>
+<tr>
+<td>Teardown 後もコストが累積</td>
+<td>Orphan リソースが存在。 AWS Cost Explorer をサービス単位で歩いて探す。</td>
+<td>60 分以内に見つからなければ、 AWS アカウントオーナーへエスカレーション。</td>
+</tr>
+<tr>
+<td>チームが競技者 IAM Role を削除しない</td>
+<td>保管期限を明文化し、 次回イベント前に ExternalId をローテ。</td>
+<td>チームに連絡が付かない場合、 「open trust path」 を既知リスクとして文書化。 黙認しない。</td>
+</tr>
+<tr>
+<td>複数スタックが同時に DELETE_FAILED</td>
+<td>Region 規模の AWS 障害か依存抜けの可能性。 30 分待って再試行。 文脈は <a href="./incident-response.ja.md">インシデント対応</a> のセクション 4 (CFn ROLLBACK) を参照。</td>
+<td>プラットフォーム全体の事後インシデントとしてエスカレーション。 <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> は状態が最終的に収束する前提なので、 時間を渡す。</td>
+</tr>
+</tbody></table>
+<h2>ループを閉じる</h2>
+<ul>
+<li>「うまくいったこと / 失敗したこと / 次の <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> サイクルで変えること」をまとめた事後レビュースレッドを起票 (問題別 follow up とは別建て)。</li>
+<li>本 runbook がカバーしていない teardown gap を発見したら、 この runbook 自体を更新する。 Runbook は次のオペレータにとっての正本。</li>
+</ul>
+<h2>関連 runbook / ADR</h2>
+<ul>
+<li>前: <a href="./pre-event-checklist.ja.md">事前チェックリスト</a> / <a href="./dry-run.ja.md">Dry run</a> / <a href="./participant-onboarding.ja.md">participant onboarding</a> / <a href="./live-monitoring.ja.md">live monitoring</a> / <a href="./incident-response.ja.md">インシデント対応</a>。</li>
+<li>背景: <a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> (通知ログは teardown 前に必ずキャプチャ) / <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> (状態は非同期収束。 焦って force しない)。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/teardown.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/teardown.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/teardown.ja.md
+++ b/docs/runbooks/teardown.ja.md
@@ -1,0 +1,96 @@
+# Teardown
+
+> English: [teardown.md](./teardown.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | オペレータ (= イベントを clean に閉じる責任者) |
+| 使うタイミング | 公表終了時刻から 24 時間以内。 Teardown を先送りしない。 Orphan リソースは課金され続ける。 |
+| 所要時間 | Lite mode の典型イベントで 60 分。 複数チームに orphan があれば延長。 |
+| 出力 | 全イベントスタックが `DELETE_COMPLETE` または明示的に archive 済み / 監査ログ export 完了 / 競技者 IAM Role の deprovision 状態を記録 |
+
+Teardown runbook は [事前チェックリスト](./pre-event-checklist.ja.md) が開いたループを閉じます。 もっとも高くつく失敗は、 イベント終了後 1 年間 Lambda と DDB が課金され続けるパターンです。
+
+## 必須の 3 出力
+
+| # | 出力 | 重要性 |
+|---|---|---|
+| 1 | イベントスコープの CFn スタックがすべて `DELETE_COMPLETE`、 または書面の理由付きで 「Force ARCHIVED」 状態に移動済み | コスト制御。 Orphan は課金される。 |
+| 2 | 監査ログ export を取得済み (CloudTrail / scoring 履歴 / 通知ログ) | SOC2 evidence と事後レビュー。 監査ログはプラットフォームそのものより長生きさせる必要がある。 |
+| 3 | 競技者 IAM Role の deprovision (または期限失効) を記録済み | セキュリティ。 進行中イベントを伴わないクロスアカウント信頼は不要な attack surface。 |
+
+## Step-by-step
+
+### Step 0: イベントが本当に終わっているか確認 (5 分)
+
+- [ ] Scoring loop が停止 (オペレータダッシュボードに active scoring job が無い)。
+- [ ] 参加者が提出途中ではないこと。 最後の `info` 通知を 1 件:「イベントは HH:MM に終了しました。 以降の提出は scoring されません」。
+- [ ] 進行中の deploy を完了させる (`make ops-health` で IN_PROGRESS ゼロを確認)。 Deploy 中に teardown を始めると orphan を作る。
+
+### Step 1: 監査 evidence を先に回収 (10 分)
+
+破壊を始める **前** に必ず実施。 スタック削除後はログ取得が難しくなる項目があります。
+
+- [ ] イベント時間範囲の CloudTrail を S3 に export (本番 AWS 環境は通常 CloudTrail 配信済み。 未設定なら手動キャプチャ)。 SOC2 主 evidence。
+- [ ] Scoring 履歴の export。 Scoring 用 DDB テーブルは TTL 失効まで履歴を保持するが、 関係チーム / イベントレコードを別建てでコピーしておく。
+- [ ] Events テーブルから通知ログを export。 通知は edit / delete 不可 ([ADR-006](../architecture/adr-006-notifications.html)) のため、 当該テーブルが authoritative。
+- [ ] [live monitoring](./live-monitoring.ja.md) のイベントタイムラインを同じアーカイブフォルダへ保存。
+
+### Step 2: チーム別問題スタックを teardown (15 分)
+
+各チーム × 各 deploy 問題の組について、 次を順に実施する。
+
+- [ ] Application Admin Console の teardown action、 または Lite mode ローカル経路では `make destroy-battles BATTLES="problems/<category>/<id>" TEAM_SLUG=<slug>` で teardown を発行。
+- [ ] Deploy trace に `deploy.cfn.delete.succeeded` が出ることを確認。
+- [ ] チームの AWS アカウントで stack が `DELETE_COMPLETE` であることを確認 (= オペレータからのクロスアカウント DescribeStack、 またはチームに確認依頼)。
+
+> **Force ARCHIVED 手順**。 スタックが `DELETE_FAILED` / `UPDATE_ROLLBACK_FAILED` に詰まった場合は、 次の手動シーケンスに従う。
+>
+> 1. 失敗を解析。 チームの AWS アカウントで CFn スタックを開き、 失敗 event を読む。
+> 2. ブロッカーになるリソースを手動削除 (= 内容物のある S3 バケット / 使用中の EIP / 削除済み SG に紐づく ENI が頻出)。 各手動削除を teardown レポートに記録。
+> 3. ブロッカー解除後にオペレータから `delete-stack` を再実行。
+> 4. それでも削除できなければ、 運営シートに `ARCHIVED` と日付 / 残置リソース一覧を明記。 チームアカウントオーナーがフォローアップ責任を負う。 **「後で確認する」 で放置しない**。 文書化する。
+
+### Step 3: プラットフォーム teardown (15 分)
+
+- [ ] Lite mode: `make destroy` (= `bun run scripts/tenkacloud-lite.ts down`)。 `AppPlaneCore` と `ProblemDeployBackend` が `DELETE_COMPLETE` に到達することを確認。
+- [ ] SaaS mode: `make destroy-saas` (= `scripts/cleanup.sh`)。 このスクリプトは意図的に idempotent。 前回失敗の残骸がある場合は再実行。
+- [ ] Source bundle S3 バケットが空、 または lifecycle 削除予約済みであることを確認 (バケット自体はイベント間で残してよい。 中身の bundle が課金対象)。
+
+### Step 4: 競技者 IAM Role を deprovision (10 分)
+
+[competitor-bootstrap.yaml](../../infrastructure/templates/competitor-bootstrap.yaml) の IAM Role は各競技者アカウントに 1 度展開済み。 イベント後、 次を確認する。
+
+- [ ] 各チームアカウントについて、 IAM Role スタックの削除を依頼するか、 保管期限を明文化 (例:「4 週間後の次回イベントまで保持」)。
+- [ ] 処置 (deleted / retained-until-DATE) を SOC2 evidence として運営シートに記録。
+- [ ] Role を保管する場合、 次回イベント前に ExternalId をローテーション。 同 ExternalId を分離イベントで再利用すると AssumeRole の保証が弱まる。
+
+### Step 5: コスト確認 (5 分)
+
+- [ ] イベント AWS アカウントの AWS Cost Explorer を開き、 teardown から 24 時間以内にコスト曲線が flat 化することを確認。
+- [ ] コストが上がり続けるなら Step 2 へ戻る。 どこかに orphan がある。
+
+### Step 6: 事後 issue 起票 (5 分)
+
+- [ ] イベント / teardown 中に表面化した gap (= 不具合問題 / 遅延 scoring / Force ARCHIVED 中の手動削除など) ごとに GitHub issue を 1 件起票。
+- [ ] 該当する場合は親 commercial-launch epic (#1336) にリンク。
+
+## うまくいかなかったら
+
+| 症状 | 1st response | エスカレーション |
+|---|---|---|
+| スタックが削除できない (`DELETE_FAILED`) | Step 2 の Force ARCHIVED 手順に従う。 ブロッカーを直さずに `delete-stack` をループしない。 | ブロッカーを特定できなければ、 stuck リソース一覧を添えてチームアカウントオーナーへエスカレーション。 |
+| 監査ログ export が不完全 | Evidence 取得が終わるまで teardown を停止。 監査ログはプラットフォームそのものより長生きさせる必要がある。 | CloudTrail 未有効だったなら、 fix-forward issue を即起票。 不完全 evidence を黙認しない。 |
+| Teardown 後もコストが累積 | Orphan リソースが存在。 AWS Cost Explorer をサービス単位で歩いて探す。 | 60 分以内に見つからなければ、 AWS アカウントオーナーへエスカレーション。 |
+| チームが競技者 IAM Role を削除しない | 保管期限を明文化し、 次回イベント前に ExternalId をローテ。 | チームに連絡が付かない場合、 「open trust path」 を既知リスクとして文書化。 黙認しない。 |
+| 複数スタックが同時に DELETE_FAILED | Region 規模の AWS 障害か依存抜けの可能性。 30 分待って再試行。 文脈は [インシデント対応](./incident-response.ja.md) のセクション 4 (CFn ROLLBACK) を参照。 | プラットフォーム全体の事後インシデントとしてエスカレーション。 [ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) は状態が最終的に収束する前提なので、 時間を渡す。 |
+
+## ループを閉じる
+
+- 「うまくいったこと / 失敗したこと / 次の [事前チェックリスト](./pre-event-checklist.ja.md) サイクルで変えること」をまとめた事後レビュースレッドを起票 (問題別 follow up とは別建て)。
+- 本 runbook がカバーしていない teardown gap を発見したら、 この runbook 自体を更新する。 Runbook は次のオペレータにとっての正本。
+
+## 関連 runbook / ADR
+
+- 前: [事前チェックリスト](./pre-event-checklist.ja.md) / [Dry run](./dry-run.ja.md) / [participant onboarding](./participant-onboarding.ja.md) / [live monitoring](./live-monitoring.ja.md) / [インシデント対応](./incident-response.ja.md)。
+- 背景: [ADR-006: Notifications](../architecture/adr-006-notifications.html) (通知ログは teardown 前に必ずキャプチャ) / [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) (状態は非同期収束。 焦って force しない)。

--- a/docs/runbooks/teardown.md
+++ b/docs/runbooks/teardown.md
@@ -1,0 +1,96 @@
+# Teardown
+
+> Japanese: [teardown.ja.md](./teardown.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | Operator (the person responsible for closing the event cleanly) |
+| When to use | Within 24 hours after the announced event end. Do not let teardown drift; orphan resources keep billing. |
+| Estimated time | 60 minutes for a typical Lite-mode event; longer if multiple teams have orphaned resources |
+| Output | Every event stack is `DELETE_COMPLETE` or explicitly archived; audit log export is saved; competitor IAM roles are documented as deprovisioned |
+
+The teardown runbook closes the loop opened by [pre-event checklist](./pre-event-checklist.md). It exists because the most expensive failure mode is a leftover Lambda or DDB table billing for a year after the event ended.
+
+## Three required outputs
+
+| # | Output | Why it matters |
+|---|---|---|
+| 1 | Every event-scoped CFn stack is `DELETE_COMPLETE`, or moved to a documented "Force ARCHIVED" state with a written reason | Cost containment. Orphans cost money. |
+| 2 | Audit log export is captured (CloudTrail / scoring history / notification log) | SOC2 evidence and post-event review. Audit logs must survive the teardown of the platform itself. |
+| 3 | Each competitor IAM role is confirmed deprovisioned (or scheduled to expire) | Security. Cross-account trust without an active event is an unnecessary attack surface. |
+
+## Step-by-step
+
+### Step 0: confirm the event is really ended (5 min)
+
+- [ ] Scoring loop is stopped (operator dashboard shows no active scoring jobs).
+- [ ] No participant is mid-submission. Send one final `info` notification: "Event closed at HH:MM. Submissions after this time are not scored."
+- [ ] Wait for any in-flight deploy to complete (`make ops-health` shows zero IN_PROGRESS jobs) before initiating teardown — tearing down mid-deploy creates orphans.
+
+### Step 1: collect audit evidence first (10 min)
+
+Do this **before** you start destroying things. Once stacks are deleted, some logs become harder to retrieve.
+
+- [ ] Export CloudTrail events for the event window to S3 (the production AWS environment should already be configured to ship CloudTrail; if not, capture manually). This is the primary SOC2 evidence.
+- [ ] Export the scoring history. The scoring DynamoDB tables retain history until DDB TTL fires; copy the relevant team and event records out of band.
+- [ ] Export the notification log from the Events table. Notifications cannot be edited or deleted (see [ADR-006](../architecture/adr-006-notifications.html)), so the table is authoritative.
+- [ ] Save the [live monitoring](./live-monitoring.md) event timeline to the same archive folder.
+
+### Step 2: tear down per-team problem stacks (15 min)
+
+For each team and each deployed problem:
+
+- [ ] Initiate teardown via the Application Admin Console teardown action or `make destroy-battles BATTLES="problems/<category>/<id>" TEAM_SLUG=<slug>` for the Lite-mode local path.
+- [ ] Confirm `deploy.cfn.delete.succeeded` in the deploy trace.
+- [ ] Confirm the stack is `DELETE_COMPLETE` in the team's AWS account (cross-account DescribeStack from the operator, or ask the team to confirm).
+
+> **Force ARCHIVED procedure.** If a team's stack is stuck in `DELETE_FAILED` or `UPDATE_ROLLBACK_FAILED`, follow this manual sequence:
+>
+> 1. Inspect the failure: open the CFn stack in the team's AWS account and read the failed event reasons.
+> 2. Manually delete the blocking resources (most often S3 buckets with content, EIPs in use, or ENIs attached to deleted security groups). Document each manual delete in the teardown report.
+> 3. Re-run `delete-stack` from the operator after the blocker is removed.
+> 4. If the stack still cannot delete, mark it `ARCHIVED` in the event run sheet with the date and the resource list left behind. The team account owner is responsible for follow-up. **Never leave it "I will check later" — write it down.**
+
+### Step 3: tear down the platform (15 min)
+
+- [ ] Lite mode: `make destroy` (runs `bun run scripts/tenkacloud-lite.ts down`). Confirm both `AppPlaneCore` and `ProblemDeployBackend` reach `DELETE_COMPLETE`.
+- [ ] SaaS mode: `make destroy-saas` (runs `scripts/cleanup.sh`). This script is intentionally idempotent — if a prior attempt left partial state, re-run it.
+- [ ] Confirm the source bundle S3 bucket is empty or scheduled for lifecycle deletion (the bucket itself may persist between events; the bundle inside is what costs).
+
+### Step 4: deprovision competitor IAM roles (10 min)
+
+The [competitor-bootstrap.yaml](../../infrastructure/templates/competitor-bootstrap.yaml) IAM Role is rolled out one time in each competitor account. After the event:
+
+- [ ] For each team account, ask the team to delete the IAM Role stack OR confirm a documented retention window (e.g., "kept until the next event in 4 weeks").
+- [ ] Record the disposition (deleted, retained-until-DATE) in the event run sheet for SOC2 evidence.
+- [ ] If a team retains the role, confirm the ExternalId is rotated before the next event. Reusing the same ExternalId across separated events weakens the AssumeRole guarantee.
+
+### Step 5: cost check (5 min)
+
+- [ ] Open AWS Cost Explorer for the event AWS account and confirm the cost curve flattens within 24 hours of teardown.
+- [ ] If cost continues to accrue, return to Step 2 — there is an orphan resource somewhere.
+
+### Step 6: file post-event issues (5 min)
+
+- [ ] Open one GitHub issue per gap surfaced during the event or teardown (broken problem, slow scoring, manual-delete required during Force ARCHIVED).
+- [ ] Link each issue to the parent commercial-launch epic (#1336) where applicable.
+
+## If it goes wrong
+
+| Symptom | First response | Escalation |
+|---|---|---|
+| A stack will not delete (`DELETE_FAILED`) | Follow the Force ARCHIVED procedure in Step 2. Do not loop on `delete-stack` without fixing the blocker. | If you cannot identify the blocker, escalate to the team account owner with a list of stuck resources. |
+| Audit log export is incomplete | Stop teardown until the audit evidence is captured. The platform must outlive the platform itself for SOC2 purposes. | If CloudTrail was not enabled, file an immediate fix-forward issue; do not silently accept incomplete evidence. |
+| Cost continues to accrue after teardown | An orphan resource exists. Walk the AWS Cost Explorer service-by-service to find it. | If you cannot find it within 60 minutes, escalate with the AWS account owner. |
+| Team did not delete the competitor IAM role | Record retention window explicitly and rotate the ExternalId before the next event. | If the team is unreachable, document the open trust path as a known risk; do not silently leave it. |
+| Multiple stacks stuck in DELETE_FAILED simultaneously | Likely a region-wide AWS issue or a missed dependency. Wait 30 minutes, retry; otherwise consult the [incident response](./incident-response.md) Section 4 (CFn ROLLBACK) for context. | Escalate as a platform-wide post-incident; the design assumption in [ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) is that state eventually converges — give it time. |
+
+## Closing the loop
+
+- File a post-event review thread (separate from per-issue follow-ups) describing what worked, what failed, and what to change in the next [pre-event checklist](./pre-event-checklist.md) cycle.
+- Update this runbook if you discovered a teardown gap not covered here. The runbook is the source of truth for the next operator.
+
+## Related runbooks and ADRs
+
+- Previous: [pre-event checklist](./pre-event-checklist.md), [dry run](./dry-run.md), [participant onboarding](./participant-onboarding.md), [live monitoring](./live-monitoring.md), [incident response](./incident-response.md).
+- Background: [ADR-006: Notifications](../architecture/adr-006-notifications.html) (notification log must be captured before teardown), [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) (state converges asynchronously; wait before forcing).


### PR DESCRIPTION
## Summary

Add `docs/runbooks/` — 6 self-contained operational runbooks that let a facilitator / operator run a small TenkaCloud hosted event end-to-end without relying on maintainer memory.

- `pre-event-checklist.md` — T-7 / T-1 / T-0 staged readiness
- `dry-run.md` — mandatory within 7 days before the event (hard gate)
- `participant-onboarding.md` — login keys + kickoff briefing + support routing
- `live-monitoring.md` — 3-tab observe-classify-act loop + the "redeploy needed vs single-team issue" triage tree
- `incident-response.md` — Lambda errors / DDB throttling / Cognito sign-in failure / CFn ROLLBACK
- `teardown.md` — Force ARCHIVED procedure + audit log export (SOC2) + competitor IAM deprovision

Each runbook lists Audience, When to use, Step-by-step + estimated time, and an "If it goes wrong" branch. Bilingual (`<name>.md` is English primary, `<name>.ja.md` is the Japanese translation) following the existing `docs/demos/` convention. Generated `.html` siblings follow the `docs/build-docs.ts` contract.

Cross-references:

- `pre-event-checklist` → `dry-run` (T-7 hard gate)
- `live-monitoring` → `incident-response` (triage decision point)
- `incident-response` and `teardown` → `live-monitoring` (observation context)
- Each runbook cites [ADR-006: Notifications](../blob/main/docs/architecture/adr-006-notifications.html) and [ADR-014: EventBridge-driven state reconciliation](../blob/main/docs/architecture/adr-014-eventbridge-driven-state-reconciliation.html) where the design semantics matter.

Closes #1351
Relates #1336

## Regression analysis

Docs-only change. No application code, no infrastructure, no schema, no Lambda or CDK delta. No risk of runtime regression. The only failure mode is documentation drift (e.g., if `make ops-health` semantics later change); the harness treats these runbooks the same as the existing `docs/operations/*.md` set and will catch markdown ↔ generated-html mismatches via `make check-docs`.

## Physical impact

- CREATE: `docs/runbooks/` (7 `.md` English sources + 7 `.ja.md` Japanese translations + 14 generated `.html` siblings = 28 new files).
- NO-OP: no Lambda / CFn / DDB / IAM / Cognito / API Gateway changes. No CDK synth diff.

## Test plan

- [x] `make lint` (markdownlint + textlint + biome) green
- [x] `make check-docs` (markdown ↔ html sync) green
- [x] `make harness` (architecture invariants) green
- [x] `make validate-problems` green
- [x] All 6 runbooks (×2 languages) verified to render via `make build-docs`
- [x] Cross-links in both languages verified to resolve to the right `.md` / `.ja.md` peer
- [x] ADR-006 / ADR-014 references resolve to the existing `.html` files