### PR TITLE
feat(lite): 30-min first-run experience — #1345

### DIFF
--- a/.claude/harness/baselines/tech-debt-assertion-roulette.json
+++ b/.claude/harness/baselines/tech-debt-assertion-roulette.json
@@ -489,25 +489,25 @@
     {
       "ruleId": "assertion-roulette",
       "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
-      "line": 85,
+      "line": 94,
       "match": "ge-6-expects"
     },
     {
       "ruleId": "assertion-roulette",
       "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
-      "line": 108,
+      "line": 117,
       "match": "ge-6-expects"
     },
     {
       "ruleId": "assertion-roulette",
       "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
-      "line": 189,
+      "line": 316,
       "match": "ge-6-expects"
     },
     {
       "ruleId": "assertion-roulette",
       "filePath": "infrastructure/test/scripts/tenkacloud-lite.test.ts",
-      "line": 293,
+      "line": 420,
       "match": "ge-6-expects"
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export JSII_DEPRECATED := quiet
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
         check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-cli-access \
-        env-check env-check-lite synth check-synth diff bootstrap \
+        env-check env-check-lite env-init env-init-test synth check-synth diff bootstrap \
         deploy deploy-saas deploy-control-plane deploy-bootstrap destroy destroy-saas \
         deploy-battles destroy-battles \
         lite-up lite-down lite-status lite-portal-url lite-console-url \
@@ -142,8 +142,9 @@ env-check:
 env-check-lite:
 	@[ -f "$(ENV_FILE)" ] || { \
 		echo "ERROR: $(ENV_FILE) が存在しません。"; \
+		echo "       make env-init  で対話 wizard から生成できます (Issue #1345)、 または"; \
 		echo "       cp infrastructure/environments/$(ENV)/.env.example infrastructure/environments/$(ENV)/.env"; \
-		echo "       してから AWS_ACCOUNT_ID / TENANT_ADMIN_EMAIL を埋めてください。"; \
+		echo "       して AWS_ACCOUNT_ID / TENANT_ADMIN_EMAIL を埋めてください。"; \
 		exit 1; \
 	}
 	@if [ -z "$${TENANT_ADMIN_EMAIL}" ] && [ -z "$${SYSTEM_ADMIN_EMAIL}" ]; then \
@@ -151,6 +152,17 @@ env-check-lite:
 		echo "       SYSTEM_ADMIN_EMAIL でも代用可能ですが、 Lite mode では TENANT_ADMIN_EMAIL を推奨します"; \
 		exit 1; \
 	fi
+
+# Issue #1345: Lite mode の first-run UX。 .env.example を読んで対話的に必須 3 vars
+# (TENANT_ADMIN_EMAIL / AWS_REGION / CDK_PARAM_DEPLOY_EXTERNAL_ID) を埋め、
+# infrastructure/environments/$(ENV)/.env を生成する。 既存 .env があれば skip。
+env-init:
+	@ENV=$(ENV) bun run scripts/env-init.ts
+
+# Issue #1345: env-init.ts の shell-level integration test。 vitest 側 (= 純粋 logic)
+# とは別に、 bun spawn → file I/O 経路が壊れていないかを確認する smoke。
+env-init-test:
+	@bash scripts/test-env-init.sh
 
 synth:                build           ; $(CDK) synth
 diff:                 build           ; $(CDK) diff --all

--- a/docs/lite-mode-prereqs.html
+++ b/docs/lite-mode-prereqs.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Lite mode prerequisites</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Lite mode prerequisites</h1>
+<blockquote>
+<p>30-minute first-run checklist for <code>make deploy</code> (Lite mode). Read this before
+opening a fresh AWS account or copying <code>.env.example</code>. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/1345">#1345</a>.</p>
+</blockquote>
+<p>Lite mode (= <code>make deploy</code>, the new default since #955) is the fastest path to a
+running TenkaCloud event: one organizer, one AWS account, two CFn stacks
+(AppPlaneCore + ProblemDeployBackend). This page lists everything you need
+<strong>before</strong> that first <code>make deploy</code> so the deploy never trips on environment
+preconditions.</p>
+<p>If you prefer Japanese, jump to <a href="#%E6%97%A5%E6%9C%AC%E8%AA%9E%E7%89%88">日本語版</a>.</p>
+<hr>
+<h2>1. AWS account assumptions</h2>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Lite mode policy</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Account type</td>
+<td>A regular AWS account is fine. <strong>Free Tier accounts are explicitly supported</strong> — DynamoDB is provisioned 1 RCU / 1 WCU per table (CDK Aspect <code>DynamoDbLowCapacity</code>) so the platform fits inside the 25 RCU/WCU Free Tier budget.</td>
+</tr>
+<tr>
+<td>Cost expectation</td>
+<td>Idle: cents/day (DDB provisioned + S3 + CloudFront). Active event: dominated by competitor-account problem stacks (your account only hosts the platform). You are responsible for AWS charges.</td>
+</tr>
+<tr>
+<td>Region</td>
+<td><code>ap-northeast-1</code> (Tokyo) is the recommended default. Other commercial regions also work; GovCloud / China regions are out of scope.</td>
+</tr>
+<tr>
+<td>Account isolation</td>
+<td>Lite mode deploys into the AWS account that the local AWS CLI is currently authenticated to. Competitor accounts are <strong>separate</strong> and are accessed via cross-account <code>AssumeRole</code> + <code>ExternalId</code>.</td>
+</tr>
+</tbody></table>
+<h2>2. Required IAM permissions</h2>
+<p>The IAM principal that runs <code>make deploy</code> needs:</p>
+<ul>
+<li><strong>CDK bootstrap</strong> (one-time, per account+region): the AWS managed policy
+<code>AdministratorAccess</code> is sufficient. <code>make bootstrap</code> invokes <code>cdk bootstrap</code>
+which provisions <code>CDKToolkit</code> IAM roles.</li>
+<li><strong>CDK deploy</strong> (every run): permissions to create / update / delete the AWS
+services used by the two Lite stacks. The minimum required service set:<ul>
+<li><code>iam:*Role</code>, <code>iam:*Policy</code>, <code>iam:PassRole</code> (CDK creates execution roles)</li>
+<li><code>lambda:*Function</code>, <code>lambda:*Layer</code>, <code>lambda:*Permission</code></li>
+<li><code>apigateway:*</code> (HTTP APIs)</li>
+<li><code>cognito-idp:*UserPool*</code>, <code>cognito-idp:*UserPoolClient*</code>, <code>cognito-idp:*UserPoolDomain*</code></li>
+<li><code>dynamodb:CreateTable</code>, <code>dynamodb:UpdateTable</code>, <code>dynamodb:DeleteTable</code>, <code>dynamodb:DescribeTable</code></li>
+<li><code>s3:*Bucket*</code>, <code>s3:PutObject</code>, <code>s3:GetObject</code>, <code>s3:DeleteObject</code></li>
+<li><code>cloudfront:*Distribution*</code>, <code>cloudfront:*OriginAccessIdentity*</code></li>
+<li><code>codebuild:*Project*</code> (the deploy worker builds CFn artifacts)</li>
+<li><code>events:*Rule*</code>, <code>events:*Bus*</code> (EventBridge for DeployRequested / DeployCompleted)</li>
+<li><code>states:*StateMachine*</code> (Step Functions orchestrator)</li>
+<li><code>ssm:GetParameter</code>, <code>ssm:PutParameter</code> (runtime config)</li>
+<li><code>cloudformation:*</code> (CDK uses CFn underneath)</li>
+<li><code>logs:*LogGroup*</code> (CloudWatch Logs)</li>
+</ul>
+</li>
+<li><strong>Tenant Admin invite</strong> (post-deploy step, runs via <code>cognito-idp admin-create-user</code>):<ul>
+<li><code>cognito-idp:DescribeUserPoolDomain</code></li>
+<li><code>cognito-idp:AdminGetUser</code></li>
+<li><code>cognito-idp:AdminCreateUser</code></li>
+</ul>
+</li>
+</ul>
+<p>For day-1 onboarding, attaching <code>AdministratorAccess</code> to the deployer principal
+is the simplest path. Tighten to the list above for production-style operation.</p>
+<h2>3. Local tools</h2>
+<table>
+<thead>
+<tr>
+<th>Tool</th>
+<th>Required version</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Bun</td>
+<td>1.3.11+</td>
+<td>Package manager / runner (<code>make install</code>, <code>bun run</code>).</td>
+</tr>
+<tr>
+<td>AWS CLI v2</td>
+<td>2.13+</td>
+<td><code>aws sts get-caller-identity</code>, Cognito user invite, CFn outputs.</td>
+</tr>
+<tr>
+<td>Node.js</td>
+<td>Bundled by Bun — not required separately.</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Git</td>
+<td>Any modern version</td>
+<td>Submodule fetch (<code>git submodule update --init --recursive problems</code>).</td>
+</tr>
+</tbody></table>
+<h2>4. The first-run flow</h2>
+<pre><code class="language-bash">git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+make env-init               # interactive wizard for .env (Issue #1345)
+make deploy                 # ~10 minutes for the 2 stacks
+make lite-console-url       # prints Application Admin Console URL
+make lite-portal-url        # prints Participant Portal URL
+</code></pre>
+<p><code>make env-init</code> will prompt for three values:</p>
+<ul>
+<li><code>TENANT_ADMIN_EMAIL</code> — inbox that receives the Cognito invitation email.</li>
+<li><code>AWS_REGION</code> — defaults to <code>ap-northeast-1</code>.</li>
+<li><code>CDK_PARAM_DEPLOY_EXTERNAL_ID</code> — opaque string used as the <code>ExternalId</code> when
+the platform AssumeRoles into competitor accounts. Any 2+ character value
+works; treat it as a shared secret with competitors.</li>
+</ul>
+<p>If <code>.env</code> already exists, <code>env-init</code> skips so it stays idempotent. Delete the
+file by hand if you want to regenerate.</p>
+<h2>5. Common failure modes and the recovery path</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>Likely cause</th>
+<th>Recovery</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>cdk deploy</code> fails with <code>is not authorized to perform</code></td>
+<td>IAM principal missing the permissions above</td>
+<td>Attach <code>AdministratorAccess</code> for day 1, then trim.</td>
+</tr>
+<tr>
+<td><code>cdk deploy</code> fails with <code>has not been bootstrapped</code></td>
+<td>First-time CDK in this account+region</td>
+<td><code>make bootstrap</code></td>
+</tr>
+<tr>
+<td><code>cdk deploy</code> fails with <code>Token has expired</code></td>
+<td>AWS SSO セッション expired</td>
+<td><code>aws sso login</code> (or re-export creds), then re-run.</td>
+</tr>
+<tr>
+<td><code>make destroy</code> shows <code>does not exist</code> on one stack</td>
+<td>Partial deploy, one stack rolled back / missing</td>
+<td>Safe to ignore. The other stack will still be cleaned up.</td>
+</tr>
+<tr>
+<td>Tenant Admin email never arrives</td>
+<td>Wrong inbox / SES sandbox / Cognito email queue</td>
+<td><code>aws cognito-idp admin-resend-invitation</code> or recreate via <code>make deploy</code> (idempotent).</td>
+</tr>
+<tr>
+<td><code>Application Admin Console</code> shows a blank page</td>
+<td>CloudFront cache</td>
+<td>Wait 2–5 min after deploy, then hard reload.</td>
+</tr>
+<tr>
+<td>Region mismatch between <code>.env</code> and local AWS CLI</td>
+<td><code>.env</code> says <code>ap-northeast-1</code> but CLI セッション is <code>us-east-1</code></td>
+<td>Set <code>AWS_REGION</code> in both, or <code>export AWS_REGION=...</code> in shell.</td>
+</tr>
+</tbody></table>
+<p>If anything goes wrong, the safe rollback is always:</p>
+<pre><code class="language-bash">make destroy        # answers y to the confirmation prompt
+make deploy
+</code></pre>
+<p>The two Lite stacks have <code>RemovalPolicy=DESTROY</code> and the destroy is idempotent
+from any partial state.</p>
+<h2>6. What to do after <code>make deploy</code> succeeds</h2>
+<p>The <code>make deploy</code> exit banner prints the next steps. In short:</p>
+<ol>
+<li>Sign in to the Application Admin Console using the temp password from the
+Cognito invite email.</li>
+<li>Create an event called <code>Demo</code> (any name works).</li>
+<li>From the Problems tab, deploy <code>hello-world</code> to your local team.</li>
+<li>Open the Participant Portal URL and watch the flag submission flow.</li>
+</ol>
+<p>For deeper context, see:</p>
+<ul>
+<li><a href="../README.md">README.md</a> — overall Quickstart and problem catalog.</li>
+<li><a href="./architecture/OVERVIEW.md"><code>docs/architecture/OVERVIEW.md</code></a> — the 4 planes.</li>
+<li><a href="../infrastructure/templates/README.md"><code>infrastructure/templates/README.md</code></a> — competitor-side IAM setup.</li>
+</ul>
+<hr>
+<h2>日本語版</h2>
+<p><code>make deploy</code> (Lite mode) を初めて叩く前に確認すべき前提条件まとめ。 30 分以内の
+first-run 体験 (= <a href="https://github.com/susumutomita/TenkaCloud/issues/1345">Issue #1345</a>) を実現するための checklist。</p>
+<h3>1. AWS アカウント前提</h3>
+<table>
+<thead>
+<tr>
+<th>項目</th>
+<th>Lite mode の方針</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>アカウント種別</td>
+<td>通常の AWS アカウントで OK。 <strong>Free Tier アカウントは明示サポート対象</strong> (CDK Aspect <code>DynamoDbLowCapacity</code> が DDB を 1 RCU / 1 WCU に強制するため、 25 RCU/WCU Free Tier 枠に収まる)。</td>
+</tr>
+<tr>
+<td>想定コスト</td>
+<td>待機中: 1 日数セント (DDB provisioned + S3 + CloudFront)。 イベント中: 競技者アカウント側の問題 stack が支配的 (プラットフォーム本体は組織者アカウントのみ)。 AWS 課金は user 責任。</td>
+</tr>
+<tr>
+<td>リージョン</td>
+<td><code>ap-northeast-1</code> (東京) が推奨。 他の商用 region でも動作。 GovCloud / China region は対象外。</td>
+</tr>
+<tr>
+<td>アカウント境界</td>
+<td>Lite mode は手元の AWS CLI が認証している account に deploy される。 競技者アカウントは <strong>別アカウント</strong> で、 cross-account <code>AssumeRole</code> + <code>ExternalId</code> でアクセスする。</td>
+</tr>
+</tbody></table>
+<h3>2. 必要 IAM 権限</h3>
+<p><code>make deploy</code> を叩く principal が必要とする権限は次のとおりです。</p>
+<ul>
+<li><strong>CDK bootstrap</strong> (account+region 単位で 1 回): <code>AdministratorAccess</code> で十分。 <code>make bootstrap</code> が <code>cdk bootstrap</code> を呼んで <code>CDKToolkit</code> の IAM role を作る。</li>
+<li><strong>CDK deploy</strong> (毎回): Lite 2 stack で使う AWS サービスの create / update / delete 権限。 最小サービスセットは英語版を参照。</li>
+<li><strong>Tenant Admin 招待</strong> (deploy 後 <code>cognito-idp admin-create-user</code> で実行):<ul>
+<li><code>cognito-idp:DescribeUserPoolDomain</code></li>
+<li><code>cognito-idp:AdminGetUser</code></li>
+<li><code>cognito-idp:AdminCreateUser</code></li>
+</ul>
+</li>
+</ul>
+<p>初日は <code>AdministratorAccess</code> を deployer に付与するのが最短。 本番運用に近づく段階で
+英語版のリストにまで絞り込む。</p>
+<h3>3. ローカルツール</h3>
+<table>
+<thead>
+<tr>
+<th>ツール</th>
+<th>必要バージョン</th>
+<th>用途</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Bun</td>
+<td>1.3.11+</td>
+<td>パッケージマネージャ / runner</td>
+</tr>
+<tr>
+<td>AWS CLI v2</td>
+<td>2.13+</td>
+<td><code>sts get-caller-identity</code> / Cognito 招待 / CFn outputs</td>
+</tr>
+<tr>
+<td>Git</td>
+<td>任意の modern 版</td>
+<td>Submodule fetch</td>
+</tr>
+</tbody></table>
+<h3>4. 初回フロー</h3>
+<pre><code class="language-bash">git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+make env-init               # .env 対話 wizard (Issue #1345)
+make deploy                 # 約 10 分で 2 stack 立ち上げ
+make lite-console-url       # Application Admin Console URL を表示
+make lite-portal-url        # Participant Portal URL を表示
+</code></pre>
+<p><code>make env-init</code> は次の 3 つの値を対話で聞きます。</p>
+<ul>
+<li><code>TENANT_ADMIN_EMAIL</code> — Cognito 招待メールの宛先。</li>
+<li><code>AWS_REGION</code> — default は <code>ap-northeast-1</code>。</li>
+<li><code>CDK_PARAM_DEPLOY_EXTERNAL_ID</code> — 競技者アカウントへの AssumeRole で使う ExternalId。 任意の 2 文字以上の文字列。</li>
+</ul>
+<p><code>.env</code> が既にあれば skip (idempotent)。 再生成したいときは手動で削除する。</p>
+<h3>5. よくある失敗パターンと回避</h3>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>原因の可能性</th>
+<th>対処</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>cdk deploy</code> が <code>is not authorized to perform</code> で失敗</td>
+<td>IAM 権限不足</td>
+<td>初日は <code>AdministratorAccess</code> を付与、 本番化で絞る。</td>
+</tr>
+<tr>
+<td><code>cdk deploy</code> が <code>has not been bootstrapped</code> で失敗</td>
+<td>この account+region で CDK 初回</td>
+<td><code>make bootstrap</code></td>
+</tr>
+<tr>
+<td><code>cdk deploy</code> が <code>Token has expired</code> で失敗</td>
+<td>AWS SSO セッション切れ</td>
+<td><code>aws sso login</code> / credential 再取得</td>
+</tr>
+<tr>
+<td><code>make destroy</code> で「stack does not exist」</td>
+<td>中途半端な deploy で片方の stack が rollback</td>
+<td>無視可。 もう片方は削除される。</td>
+</tr>
+<tr>
+<td>Tenant Admin にメールが届かない</td>
+<td>inbox 違い / SES sandbox / Cognito キュー</td>
+<td><code>aws cognito-idp admin-resend-invitation</code> で再送、 または <code>make deploy</code> 再実行 (idempotent)。</td>
+</tr>
+<tr>
+<td>Console が空白</td>
+<td>CloudFront cache</td>
+<td>deploy 後 2-5 分待ってハードリロード。</td>
+</tr>
+<tr>
+<td><code>.env</code> の region と CLI region が一致しない</td>
+<td>別 region で deploy されている</td>
+<td><code>AWS_REGION</code> を両方で揃える、 または shell で <code>export AWS_REGION=...</code>。</td>
+</tr>
+</tbody></table>
+<p>失敗時の safe な復旧は常に次の手順で行います。</p>
+<pre><code class="language-bash">make destroy        # y/N 確認に y で答える
+make deploy
+</code></pre>
+<p>Lite 2 stack は <code>RemovalPolicy=DESTROY</code>、 partial state からでも idempotent に teardown できる。</p>
+<h3>6. <code>make deploy</code> 成功後の next step</h3>
+<p>deploy 完了時に terminal に出る banner が一次情報になります。要約は次のとおりです。</p>
+<ol>
+<li>Cognito 招待メールの一時パスワードで Application Admin Console にサインイン。</li>
+<li>「Demo」という名前で event を作成。</li>
+<li>Problems タブから <code>hello-world</code> を deploy。</li>
+<li>Participant Portal の URL を team に共有 (login key は event 作成時に発行)。</li>
+</ol>
+<p>詳細は <a href="../README.md">README.md</a> の Quickstart 章、 アーキ全体像は
+<a href="./architecture/OVERVIEW.md"><code>docs/architecture/OVERVIEW.md</code></a> を参照。</p>
+
+<div class="doc-source">Source: <code>docs/lite-mode-prereqs.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/lite-mode-prereqs.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/lite-mode-prereqs.md
+++ b/docs/lite-mode-prereqs.md
@@ -1,0 +1,214 @@
+# Lite mode prerequisites
+
+> 30-minute first-run checklist for `make deploy` (Lite mode). Read this before
+> opening a fresh AWS account or copying `.env.example`. Issue [#1345](https://github.com/susumutomita/TenkaCloud/issues/1345).
+
+Lite mode (= `make deploy`, the new default since #955) is the fastest path to a
+running TenkaCloud event: one organizer, one AWS account, two CFn stacks
+(AppPlaneCore + ProblemDeployBackend). This page lists everything you need
+**before** that first `make deploy` so the deploy never trips on environment
+preconditions.
+
+If you prefer Japanese, jump to [日本語版](#日本語版).
+
+---
+
+## 1. AWS account assumptions
+
+| Topic | Lite mode policy |
+| --- | --- |
+| Account type | A regular AWS account is fine. **Free Tier accounts are explicitly supported** — DynamoDB is provisioned 1 RCU / 1 WCU per table (CDK Aspect `DynamoDbLowCapacity`) so the platform fits inside the 25 RCU/WCU Free Tier budget. |
+| Cost expectation | Idle: cents/day (DDB provisioned + S3 + CloudFront). Active event: dominated by competitor-account problem stacks (your account only hosts the platform). You are responsible for AWS charges. |
+| Region | `ap-northeast-1` (Tokyo) is the recommended default. Other commercial regions also work; GovCloud / China regions are out of scope. |
+| Account isolation | Lite mode deploys into the AWS account that the local AWS CLI is currently authenticated to. Competitor accounts are **separate** and are accessed via cross-account `AssumeRole` + `ExternalId`. |
+
+## 2. Required IAM permissions
+
+The IAM principal that runs `make deploy` needs:
+
+- **CDK bootstrap** (one-time, per account+region): the AWS managed policy
+  `AdministratorAccess` is sufficient. `make bootstrap` invokes `cdk bootstrap`
+  which provisions `CDKToolkit` IAM roles.
+- **CDK deploy** (every run): permissions to create / update / delete the AWS
+  services used by the two Lite stacks. The minimum required service set:
+  - `iam:*Role`, `iam:*Policy`, `iam:PassRole` (CDK creates execution roles)
+  - `lambda:*Function`, `lambda:*Layer`, `lambda:*Permission`
+  - `apigateway:*` (HTTP APIs)
+  - `cognito-idp:*UserPool*`, `cognito-idp:*UserPoolClient*`, `cognito-idp:*UserPoolDomain*`
+  - `dynamodb:CreateTable`, `dynamodb:UpdateTable`, `dynamodb:DeleteTable`, `dynamodb:DescribeTable`
+  - `s3:*Bucket*`, `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`
+  - `cloudfront:*Distribution*`, `cloudfront:*OriginAccessIdentity*`
+  - `codebuild:*Project*` (the deploy worker builds CFn artifacts)
+  - `events:*Rule*`, `events:*Bus*` (EventBridge for DeployRequested / DeployCompleted)
+  - `states:*StateMachine*` (Step Functions orchestrator)
+  - `ssm:GetParameter`, `ssm:PutParameter` (runtime config)
+  - `cloudformation:*` (CDK uses CFn underneath)
+  - `logs:*LogGroup*` (CloudWatch Logs)
+- **Tenant Admin invite** (post-deploy step, runs via `cognito-idp admin-create-user`):
+  - `cognito-idp:DescribeUserPoolDomain`
+  - `cognito-idp:AdminGetUser`
+  - `cognito-idp:AdminCreateUser`
+
+For day-1 onboarding, attaching `AdministratorAccess` to the deployer principal
+is the simplest path. Tighten to the list above for production-style operation.
+
+## 3. Local tools
+
+| Tool | Required version | Why |
+| --- | --- | --- |
+| Bun | 1.3.11+ | Package manager / runner (`make install`, `bun run`). |
+| AWS CLI v2 | 2.13+ | `aws sts get-caller-identity`, Cognito user invite, CFn outputs. |
+| Node.js | Bundled by Bun — not required separately. | — |
+| Git | Any modern version | Submodule fetch (`git submodule update --init --recursive problems`). |
+
+## 4. The first-run flow
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+make env-init               # interactive wizard for .env (Issue #1345)
+make deploy                 # ~10 minutes for the 2 stacks
+make lite-console-url       # prints Application Admin Console URL
+make lite-portal-url        # prints Participant Portal URL
+```
+
+`make env-init` will prompt for three values:
+
+- `TENANT_ADMIN_EMAIL` — inbox that receives the Cognito invitation email.
+- `AWS_REGION` — defaults to `ap-northeast-1`.
+- `CDK_PARAM_DEPLOY_EXTERNAL_ID` — opaque string used as the `ExternalId` when
+  the platform AssumeRoles into competitor accounts. Any 2+ character value
+  works; treat it as a shared secret with competitors.
+
+If `.env` already exists, `env-init` skips so it stays idempotent. Delete the
+file by hand if you want to regenerate.
+
+## 5. Common failure modes and the recovery path
+
+| Symptom | Likely cause | Recovery |
+| --- | --- | --- |
+| `cdk deploy` fails with `is not authorized to perform` | IAM principal missing the permissions above | Attach `AdministratorAccess` for day 1, then trim. |
+| `cdk deploy` fails with `has not been bootstrapped` | First-time CDK in this account+region | `make bootstrap` |
+| `cdk deploy` fails with `Token has expired` | AWS SSO セッション expired | `aws sso login` (or re-export creds), then re-run. |
+| `make destroy` shows `does not exist` on one stack | Partial deploy, one stack rolled back / missing | Safe to ignore. The other stack will still be cleaned up. |
+| Tenant Admin email never arrives | Wrong inbox / SES sandbox / Cognito email queue | `aws cognito-idp admin-resend-invitation` or recreate via `make deploy` (idempotent). |
+| `Application Admin Console` shows a blank page | CloudFront cache | Wait 2–5 min after deploy, then hard reload. |
+| Region mismatch between `.env` and local AWS CLI | `.env` says `ap-northeast-1` but CLI セッション is `us-east-1` | Set `AWS_REGION` in both, or `export AWS_REGION=...` in shell. |
+
+If anything goes wrong, the safe rollback is always:
+
+```bash
+make destroy        # answers y to the confirmation prompt
+make deploy
+```
+
+The two Lite stacks have `RemovalPolicy=DESTROY` and the destroy is idempotent
+from any partial state.
+
+## 6. What to do after `make deploy` succeeds
+
+The `make deploy` exit banner prints the next steps. In short:
+
+1. Sign in to the Application Admin Console using the temp password from the
+   Cognito invite email.
+2. Create an event called `Demo` (any name works).
+3. From the Problems tab, deploy `hello-world` to your local team.
+4. Open the Participant Portal URL and watch the flag submission flow.
+
+For deeper context, see:
+
+- [README.md](../README.md) — overall Quickstart and problem catalog.
+- [`docs/architecture/OVERVIEW.md`](./architecture/OVERVIEW.md) — the 4 planes.
+- [`infrastructure/templates/README.md`](../infrastructure/templates/README.md) — competitor-side IAM setup.
+
+---
+
+## 日本語版
+
+`make deploy` (Lite mode) を初めて叩く前に確認すべき前提条件まとめ。 30 分以内の
+first-run 体験 (= [Issue #1345](https://github.com/susumutomita/TenkaCloud/issues/1345)) を実現するための checklist。
+
+### 1. AWS アカウント前提
+
+| 項目 | Lite mode の方針 |
+| --- | --- |
+| アカウント種別 | 通常の AWS アカウントで OK。 **Free Tier アカウントは明示サポート対象** (CDK Aspect `DynamoDbLowCapacity` が DDB を 1 RCU / 1 WCU に強制するため、 25 RCU/WCU Free Tier 枠に収まる)。 |
+| 想定コスト | 待機中: 1 日数セント (DDB provisioned + S3 + CloudFront)。 イベント中: 競技者アカウント側の問題 stack が支配的 (プラットフォーム本体は組織者アカウントのみ)。 AWS 課金は user 責任。 |
+| リージョン | `ap-northeast-1` (東京) が推奨。 他の商用 region でも動作。 GovCloud / China region は対象外。 |
+| アカウント境界 | Lite mode は手元の AWS CLI が認証している account に deploy される。 競技者アカウントは **別アカウント** で、 cross-account `AssumeRole` + `ExternalId` でアクセスする。 |
+
+### 2. 必要 IAM 権限
+
+`make deploy` を叩く principal が必要とする権限は次のとおりです。
+
+- **CDK bootstrap** (account+region 単位で 1 回): `AdministratorAccess` で十分。 `make bootstrap` が `cdk bootstrap` を呼んで `CDKToolkit` の IAM role を作る。
+- **CDK deploy** (毎回): Lite 2 stack で使う AWS サービスの create / update / delete 権限。 最小サービスセットは英語版を参照。
+- **Tenant Admin 招待** (deploy 後 `cognito-idp admin-create-user` で実行):
+  - `cognito-idp:DescribeUserPoolDomain`
+  - `cognito-idp:AdminGetUser`
+  - `cognito-idp:AdminCreateUser`
+
+初日は `AdministratorAccess` を deployer に付与するのが最短。 本番運用に近づく段階で
+英語版のリストにまで絞り込む。
+
+### 3. ローカルツール
+
+| ツール | 必要バージョン | 用途 |
+| --- | --- | --- |
+| Bun | 1.3.11+ | パッケージマネージャ / runner |
+| AWS CLI v2 | 2.13+ | `sts get-caller-identity` / Cognito 招待 / CFn outputs |
+| Git | 任意の modern 版 | Submodule fetch |
+
+### 4. 初回フロー
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+make install
+make env-init               # .env 対話 wizard (Issue #1345)
+make deploy                 # 約 10 分で 2 stack 立ち上げ
+make lite-console-url       # Application Admin Console URL を表示
+make lite-portal-url        # Participant Portal URL を表示
+```
+
+`make env-init` は次の 3 つの値を対話で聞きます。
+
+- `TENANT_ADMIN_EMAIL` — Cognito 招待メールの宛先。
+- `AWS_REGION` — default は `ap-northeast-1`。
+- `CDK_PARAM_DEPLOY_EXTERNAL_ID` — 競技者アカウントへの AssumeRole で使う ExternalId。 任意の 2 文字以上の文字列。
+
+`.env` が既にあれば skip (idempotent)。 再生成したいときは手動で削除する。
+
+### 5. よくある失敗パターンと回避
+
+| 症状 | 原因の可能性 | 対処 |
+| --- | --- | --- |
+| `cdk deploy` が `is not authorized to perform` で失敗 | IAM 権限不足 | 初日は `AdministratorAccess` を付与、 本番化で絞る。 |
+| `cdk deploy` が `has not been bootstrapped` で失敗 | この account+region で CDK 初回 | `make bootstrap` |
+| `cdk deploy` が `Token has expired` で失敗 | AWS SSO セッション切れ | `aws sso login` / credential 再取得 |
+| `make destroy` で「stack does not exist」 | 中途半端な deploy で片方の stack が rollback | 無視可。 もう片方は削除される。 |
+| Tenant Admin にメールが届かない | inbox 違い / SES sandbox / Cognito キュー | `aws cognito-idp admin-resend-invitation` で再送、 または `make deploy` 再実行 (idempotent)。 |
+| Console が空白 | CloudFront cache | deploy 後 2-5 分待ってハードリロード。 |
+| `.env` の region と CLI region が一致しない | 別 region で deploy されている | `AWS_REGION` を両方で揃える、 または shell で `export AWS_REGION=...`。 |
+
+失敗時の safe な復旧は常に次の手順で行います。
+
+```bash
+make destroy        # y/N 確認に y で答える
+make deploy
+```
+
+Lite 2 stack は `RemovalPolicy=DESTROY`、 partial state からでも idempotent に teardown できる。
+
+### 6. `make deploy` 成功後の next step
+
+deploy 完了時に terminal に出る banner が一次情報になります。要約は次のとおりです。
+
+1. Cognito 招待メールの一時パスワードで Application Admin Console にサインイン。
+2. 「Demo」という名前で event を作成。
+3. Problems タブから `hello-world` を deploy。
+4. Participant Portal の URL を team に共有 (login key は event 作成時に発行)。
+
+詳細は [README.md](../README.md) の Quickstart 章、 アーキ全体像は
+[`docs/architecture/OVERVIEW.md`](./architecture/OVERVIEW.md) を参照。

--- a/infrastructure/test/scripts/env-init.test.ts
+++ b/infrastructure/test/scripts/env-init.test.ts
@@ -1,0 +1,229 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  generateEnvContent,
+  PROMPTS,
+  parseExampleKeys,
+  runEnvInit,
+} from "../../../scripts/env-init";
+
+/**
+ * Issue #1345: `make env-init` の .env 生成 wizard の挙動 pin。
+ *
+ * runEnvInit は prompt I/O を injectable にしてあるので、 file system 上は
+ * 一時 dir で再現し、 stdin / stdout を通さずに deterministic に観測する。
+ */
+
+describe("scripts/env-init (#1345 Lite mode first-run wizard)", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tenkacloud-env-init-"));
+    mkdirSync(join(workDir, "infrastructure", "environments", "development"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function seedExample(content: string): string {
+    const examplePath = join(
+      workDir,
+      "infrastructure",
+      "environments",
+      "development",
+      ".env.example",
+    );
+    writeFileSync(examplePath, content, "utf8");
+    return examplePath;
+  }
+
+  it("parseExampleKeys should ignore comments and blank lines", () => {
+    const parsed = parseExampleKeys(
+      [
+        "# this is a comment",
+        "",
+        "FOO=bar",
+        "BAZ=qux # inline comment kept verbatim",
+        "  # leading-whitespace comment",
+        "TRIMMED  =  value-with-spaces  ",
+      ].join("\n"),
+    );
+    expect(parsed.FOO).toBe("bar");
+    expect(parsed.BAZ).toBe("qux # inline comment kept verbatim");
+    expect(parsed.TRIMMED).toBe("value-with-spaces");
+    expect(parsed).not.toHaveProperty("# this is a comment");
+  });
+
+  it("generateEnvContent should override only declared keys and preserve comments verbatim", () => {
+    const example = ["# header", "FOO=default-foo", "# section", "BAR=default-bar", ""].join("\n");
+    const result = generateEnvContent(example, { FOO: "from-wizard" });
+    expect(result).toContain("# header");
+    expect(result).toContain("# section");
+    expect(result).toContain("FOO=from-wizard");
+    expect(result).toContain("BAR=default-bar"); // untouched
+  });
+
+  it("generateEnvContent should append unknown override keys to the end (future-proof)", () => {
+    const example = "FOO=default-foo\n";
+    const result = generateEnvContent(example, { FOO: "v1", NEW_KEY: "v2" });
+    expect(result).toContain("FOO=v1");
+    expect(result).toContain("NEW_KEY=v2");
+    expect(result).toContain("# === Added by `make env-init` ===");
+  });
+
+  it("PROMPTS should ask for the three task-required keys (TENANT_ADMIN_EMAIL / AWS_REGION / CDK_PARAM_DEPLOY_EXTERNAL_ID)", () => {
+    const keys = PROMPTS.map((p) => p.key);
+    expect(keys).toContain("TENANT_ADMIN_EMAIL");
+    expect(keys).toContain("AWS_REGION");
+    expect(keys).toContain("CDK_PARAM_DEPLOY_EXTERNAL_ID");
+  });
+
+  it("PROMPTS validate should reject malformed email / region / external id", () => {
+    const email = PROMPTS.find((p) => p.key === "TENANT_ADMIN_EMAIL");
+    expect(email?.validate?.("noatsymbol")).toBeDefined();
+    expect(email?.validate?.("ok@example.com")).toBeUndefined();
+
+    const region = PROMPTS.find((p) => p.key === "AWS_REGION");
+    expect(region?.validate?.("tokyo")).toBeDefined();
+    expect(region?.validate?.("ap-northeast-1")).toBeUndefined();
+
+    const externalId = PROMPTS.find((p) => p.key === "CDK_PARAM_DEPLOY_EXTERNAL_ID");
+    expect(externalId?.validate?.("a")).toBeDefined();
+    expect(externalId?.validate?.("tenkacloud-lite-default")).toBeUndefined();
+  });
+
+  it("runEnvInit should skip when .env already exists (idempotent)", async () => {
+    seedExample("FOO=bar\n");
+    const envPath = join(workDir, "infrastructure", "environments", "development", ".env");
+    writeFileSync(envPath, "# pre-existing", "utf8");
+
+    const out: string[] = [];
+    const result = await runEnvInit({
+      env: "development",
+      repoRoot: workDir,
+      ask: async () => "should-not-be-asked",
+      print: (line) => out.push(line),
+    });
+    expect(result.status).toBe("exists");
+    expect(result.path).toBe(envPath);
+    // 既存 file は触らない (= 上書きしない)。
+    expect(readFileSync(envPath, "utf8")).toBe("# pre-existing");
+    expect(out.join("\n")).toContain("既に存在します");
+  });
+
+  it("runEnvInit should write a .env file using wizard answers", async () => {
+    seedExample(
+      [
+        "# TenkaCloud .env example",
+        "TENANT_ADMIN_EMAIL=admin@example.com",
+        "SYSTEM_ADMIN_EMAIL=admin@example.com",
+        "AWS_REGION=ap-northeast-1",
+        "CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default",
+        "# end",
+      ].join("\n"),
+    );
+
+    const answers = new Map<string, string>([
+      ["TENANT_ADMIN_EMAIL", "user@org.example"],
+      ["AWS_REGION", "us-east-1"],
+      ["CDK_PARAM_DEPLOY_EXTERNAL_ID", "my-external-id"],
+    ]);
+
+    const result = await runEnvInit({
+      env: "development",
+      repoRoot: workDir,
+      ask: async (question) => {
+        for (const [key, value] of answers.entries()) {
+          if (question.startsWith(key)) return value;
+        }
+        return "";
+      },
+      print: () => undefined,
+    });
+
+    expect(result.status).toBe("created");
+    const content = readFileSync(result.path, "utf8");
+    expect(content).toContain("TENANT_ADMIN_EMAIL=user@org.example");
+    expect(content).toContain("SYSTEM_ADMIN_EMAIL=user@org.example"); // derived
+    expect(content).toContain("AWS_REGION=us-east-1");
+    expect(content).toContain("CDK_PARAM_DEPLOY_EXTERNAL_ID=my-external-id");
+    expect(content).toContain("# TenkaCloud .env example"); // comments preserved
+  });
+
+  it("runEnvInit should use default values in nonInteractive mode (CI / pipe)", async () => {
+    seedExample(
+      [
+        "TENANT_ADMIN_EMAIL=admin@example.com",
+        "SYSTEM_ADMIN_EMAIL=admin@example.com",
+        "AWS_REGION=ap-northeast-1",
+        "CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default",
+      ].join("\n"),
+    );
+
+    let askCalls = 0;
+    const result = await runEnvInit({
+      env: "development",
+      repoRoot: workDir,
+      ask: async () => {
+        askCalls++;
+        return "";
+      },
+      print: () => undefined,
+      nonInteractive: true,
+    });
+    expect(askCalls).toBe(0);
+    expect(result.status).toBe("created");
+    const content = readFileSync(result.path, "utf8");
+    expect(content).toContain("TENANT_ADMIN_EMAIL=admin@example.com");
+    expect(content).toContain("AWS_REGION=ap-northeast-1");
+    expect(content).toContain("CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default");
+  });
+
+  it("runEnvInit should re-prompt up to 3 times on validate failure", async () => {
+    seedExample(
+      [
+        "TENANT_ADMIN_EMAIL=admin@example.com",
+        "AWS_REGION=ap-northeast-1",
+        "CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default",
+      ].join("\n"),
+    );
+
+    const asked: Array<{ q: string; n: number }> = [];
+    let emailAttempt = 0;
+    const result = await runEnvInit({
+      env: "development",
+      repoRoot: workDir,
+      ask: async (question) => {
+        if (question.startsWith("TENANT_ADMIN_EMAIL")) {
+          emailAttempt++;
+          asked.push({ q: "TENANT_ADMIN_EMAIL", n: emailAttempt });
+          // 1 回目は invalid を返す → re-prompt されることを観測。
+          if (emailAttempt === 1) return "no-at-symbol";
+          return "ok@example.com";
+        }
+        return "";
+      },
+      print: () => undefined,
+    });
+    expect(emailAttempt).toBeGreaterThanOrEqual(2);
+    expect(result.status).toBe("created");
+    const content = readFileSync(result.path, "utf8");
+    expect(content).toContain("TENANT_ADMIN_EMAIL=ok@example.com");
+  });
+
+  it("runEnvInit should throw when .env.example is missing", async () => {
+    const envDir = join(workDir, "infrastructure", "environments", "development");
+    expect(existsSync(join(envDir, ".env.example"))).toBe(false);
+    await expect(
+      runEnvInit({
+        env: "development",
+        repoRoot: workDir,
+        ask: async () => "",
+        print: () => undefined,
+      }),
+    ).rejects.toThrow(/\.env\.example/);
+  });
+});

--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -22,15 +22,18 @@ interface SpawnCall {
 function buildIO(opts: {
   readonly inheritExitCode?: number;
   readonly capture?: (cmd: string, args: readonly string[]) => SpawnCaptureResult;
+  readonly confirmAnswer?: boolean;
 }): {
   readonly io: CliIO;
   readonly stdout: string[];
   readonly stderr: string[];
   readonly calls: SpawnCall[];
+  readonly confirms: string[];
 } {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const calls: SpawnCall[] = [];
+  const confirms: string[] = [];
   const io: CliIO = {
     stdout: (text) => {
       stdout.push(text);
@@ -46,8 +49,14 @@ function buildIO(opts: {
       calls.push({ cmd, args: [...args], mode: "capture" });
       return opts.capture ? opts.capture(cmd, [...args]) : { code: 0, stdout: "", stderr: "" };
     },
+    confirm: async (q) => {
+      confirms.push(q);
+      // unit test default: confirm pass-through (= 既存 down テストの flow を維持)。
+      // confirmAnswer を明示指定したケースだけ override。
+      return opts.confirmAnswer ?? true;
+    },
   };
-  return { io, stdout, stderr, calls };
+  return { io, stdout, stderr, calls, confirms };
 }
 
 function tenantAdminUpCapture(opts: {
@@ -138,7 +147,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     // 1st spawn (= prepare-source-bundle.sh) で失敗させ、 2nd (= cdk deploy) は呼ばれないことを確認
     let firstCall = true;
     const calls: Array<{ cmd: string; args: readonly string[] }> = [];
-    const io = {
+    const io: CliIO = {
       stdout: () => undefined,
       stderr: () => undefined,
       spawnInherit: async (cmd: string, args: readonly string[]) => {
@@ -150,6 +159,7 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
         return 0;
       },
       spawnCapture: async () => ({ code: 0, stdout: "", stderr: "" }),
+      confirm: async () => true,
     };
     const code = await main(["up"], io);
     expect(code).toBe(1);
@@ -165,6 +175,83 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(calls.filter((c) => c.cmd === "aws")).toHaveLength(0);
   });
 
+  // Issue #1345: deploy 失敗時は「次のステップ」 を stderr に出して user の次の動作を導く。
+  it("up should print a failure guide to stderr when prepare-source-bundle.sh fails (#1345)", async () => {
+    let firstCall = true;
+    const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+    const stderrChunks: string[] = [];
+    const io: CliIO = {
+      stdout: () => undefined,
+      stderr: (text) => stderrChunks.push(text),
+      spawnInherit: async (cmd, args) => {
+        calls.push({ cmd, args });
+        if (firstCall) {
+          firstCall = false;
+          return 1;
+        }
+        return 0;
+      },
+      spawnCapture: async () => ({ code: 0, stdout: "", stderr: "" }),
+      confirm: async () => true,
+    };
+    const code = await main(["up"], io);
+    expect(code).toBe(1);
+    const stderr = stderrChunks.join("");
+    expect(stderr).toContain("次のステップ");
+    expect(stderr).toContain("make destroy");
+    expect(stderr).toContain("再実行");
+  });
+
+  // Issue #1345: deploy 成功時は post-deploy guide を stdout に出して 30-min 体験を完結させる。
+  // 3 つの観測 (banner / URLs / next-steps + progress 表記) に it を分割して assertion roulette を避ける。
+  describe("up post-deploy guide (#1345)", () => {
+    function buildPostDeployIO(): ReturnType<typeof buildIO> {
+      return buildIO({
+        inheritExitCode: 0,
+        capture: (_cmd, args) => {
+          if (args.join(" ").includes("ApplicationAdminConsoleUrl")) {
+            return { code: 0, stdout: "https://console.example.cloudfront.net\n", stderr: "" };
+          }
+          if (args.join(" ").includes("ParticipantPortalApiUrl")) {
+            return { code: 0, stdout: "https://portal.example.cloudfront.net\n", stderr: "" };
+          }
+          if (args.includes("describe-user-pool-domain")) {
+            return { code: 0, stdout: "ap-northeast-1_AbCdEf\n", stderr: "" };
+          }
+          return { code: 0, stdout: "", stderr: "" };
+        },
+      });
+    }
+
+    it("up should print a success banner and resolved access URLs", async () => {
+      const { io, stdout } = buildPostDeployIO();
+      const code = await main(["up"], io);
+      expect(code).toBe(0);
+      const out = stdout.join("");
+      expect(out).toContain("Lite mode deploy complete");
+      expect(out).toContain("https://console.example.cloudfront.net");
+      expect(out).toContain("https://portal.example.cloudfront.net");
+    });
+
+    it("up should print next-steps + teardown guidance after deploy", async () => {
+      const { io, stdout } = buildPostDeployIO();
+      await main(["up"], io);
+      const out = stdout.join("");
+      expect(out).toContain("Next steps");
+      expect(out).toContain("hello-world");
+      expect(out).toContain("Teardown");
+    });
+
+    it("up should number each phase as [i/3] progress markers", async () => {
+      const { io, stdout } = buildPostDeployIO();
+      await main(["up"], io);
+      const out = stdout.join("");
+      expect(out).toContain("[1/3]");
+      expect(out).toContain("[2/3]");
+      expect(out).toContain("[3/3]");
+    });
+  });
+
   it("down should destroy the app stack first and then the problem-deploy stack", async () => {
     const { io, calls } = buildIO({ inheritExitCode: 0 });
     const code = await main(["down"], io);
@@ -177,6 +264,46 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     for (const call of destroyCalls) {
       expect(call.args).toContain("--force");
     }
+  });
+
+  // Issue #1345: destroy 前に y/N 確認 prompt を入れる。 first-run user が誤爆して
+  // DB データを消すのを防ぐ。 `--yes` で bypass 可能。
+  it("down should ask for confirmation before destroying (#1345)", async () => {
+    const { io, calls, confirms } = buildIO({
+      inheritExitCode: 0,
+      confirmAnswer: true,
+    });
+    const code = await main(["down"], io);
+    expect(code).toBe(0);
+    expect(confirms).toHaveLength(1);
+    expect(confirms[0]).toContain("続行しますか");
+    const destroyCalls = calls.filter((c) => c.args.includes("destroy"));
+    expect(destroyCalls).toHaveLength(2);
+  });
+
+  it("down should abort without calling destroy when user answers N (#1345)", async () => {
+    const { io, calls, stdout, confirms } = buildIO({
+      inheritExitCode: 0,
+      confirmAnswer: false,
+    });
+    const code = await main(["down"], io);
+    expect(code).toBe(0);
+    expect(confirms).toHaveLength(1);
+    const destroyCalls = calls.filter((c) => c.args.includes("destroy"));
+    expect(destroyCalls).toHaveLength(0);
+    expect(stdout.join("")).toContain("aborted");
+  });
+
+  it("down --yes should bypass the confirmation prompt (#1345)", async () => {
+    const { io, calls, confirms } = buildIO({
+      inheritExitCode: 0,
+      confirmAnswer: false,
+    });
+    const code = await main(["down", "--yes"], io);
+    expect(code).toBe(0);
+    expect(confirms).toHaveLength(0);
+    const destroyCalls = calls.filter((c) => c.args.includes("destroy"));
+    expect(destroyCalls).toHaveLength(2);
   });
 
   it("down should return the same exit code without calling the second destroy when the first one fails", async () => {

--- a/scripts/env-init.ts
+++ b/scripts/env-init.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env bun
+/**
+ * Issue #1345: `make env-init` の .env 生成 wizard。
+ *
+ * Lite mode の first-run UX 改善 (= 30-min onboarding target) の一環として、
+ * `cp .env.example .env` → エディタで手編集 → 値が空 / placeholder の状態で
+ * `make deploy` を叩いて失敗する pitfall を潰す。
+ *
+ * 設計判断:
+ *   - 既存 `.env` があれば skip (idempotent)。 上書きしたいときは手動で削除させる
+ *     (= destructive を黙ってやらない)。
+ *   - .env.example を text parse して `KEY=value` 行を取り出し、 必須キーだけ prompt。
+ *     SCHEMA を別 file 化しない (= source of truth は .env.example 1 つ)。
+ *   - prompt は stdin / stdout で行う標準的な readline。 process がパイプされている
+ *     場合 (= 非 TTY) はデフォルト値で書き出し (= CI / dev container でも壊れない)。
+ *   - 値検証は最小限。 email は @ を含む、 region は ap-northeast-1 形式、
+ *     ExternalId は 2 chars 以上。 厳しくしすぎて user を tabber に追い込まない。
+ *
+ * テスト容易性:
+ *   - generateEnvContent / parseExampleKeys を pure 関数で export。
+ *   - prompt は injectable (= shell test では non-TTY パスを通る)。
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline/promises";
+
+export const DEFAULT_ENV = "development";
+
+export interface EnvInitOptions {
+  readonly env: string;
+  readonly repoRoot: string;
+  readonly ask: (question: string, fallback: string) => Promise<string>;
+  readonly print: (line: string) => void;
+  readonly nonInteractive?: boolean;
+}
+
+export interface EnvKeyPrompt {
+  readonly key: string;
+  readonly label: string;
+  readonly defaultValue: string;
+  readonly required: boolean;
+  readonly validate?: (value: string) => string | undefined;
+}
+
+/**
+ * Issue #1345 task spec: 「必須 vars (SYSTEM_ADMIN_EMAIL / CDK_PARAM_DEPLOY_EXTERNAL_ID
+ * / AWS_REGION) を prompt」。 Lite mode の実情に合わせて TENANT_ADMIN_EMAIL を主、
+ * SYSTEM_ADMIN_EMAIL も書き出すが prompt は 1 回で済ます (= fallback 互換、
+ * scripts/tenkacloud-lite.ts cmdUp の env 解決と同じ規約)。
+ */
+export const PROMPTS: readonly EnvKeyPrompt[] = [
+  {
+    key: "TENANT_ADMIN_EMAIL",
+    label:
+      "Application Admin Console 初期ユーザー宛先 (= Lite mode の Tenant Admin、 SaaS mode の System Admin)",
+    defaultValue: "admin@example.com",
+    required: true,
+    validate: (v) => (v.includes("@") ? undefined : "email アドレス形式にしてください (= xxx@yyy)"),
+  },
+  {
+    key: "AWS_REGION",
+    label: "AWS リージョン (推奨: ap-northeast-1)",
+    defaultValue: "ap-northeast-1",
+    required: true,
+    validate: (v) =>
+      /^[a-z]{2}-[a-z]+-\d$/.test(v)
+        ? undefined
+        : "AWS region 形式にしてください (= ap-northeast-1 等)",
+  },
+  {
+    key: "CDK_PARAM_DEPLOY_EXTERNAL_ID",
+    label:
+      "ExternalId (= competitor AWS account への AssumeRole で confused-deputy 攻撃を防ぐ secret、 任意の文字列)",
+    defaultValue: "tenkacloud-lite-default",
+    required: true,
+    validate: (v) => (v.length >= 2 ? undefined : "2 文字以上にしてください"),
+  },
+];
+
+/**
+ * .env.example を text parse して `KEY=value` の行から KEY = value の対応を取り出す。
+ * comment / blank 行は無視。 multi-line value (= shell の quoted heredoc 等) は未対応
+ * (= .env.example の形式ではそもそも使っていない)。
+ */
+export function parseExampleKeys(exampleContent: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of exampleContent.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const equalsIdx = line.indexOf("=");
+    if (equalsIdx <= 0) continue;
+    const key = line.slice(0, equalsIdx).trim();
+    const value = line.slice(equalsIdx + 1).trim();
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * `.env` の中身を生成する。 prompt 結果 + .env.example の comment 構造を保つため、
+ * example をベースに必須キーだけ override する。 まったく新しい key を入れない
+ * (= example をそのまま compatible に保つ)。
+ */
+export function generateEnvContent(
+  exampleContent: string,
+  overrides: Readonly<Record<string, string>>,
+): string {
+  const lines = exampleContent.split("\n");
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const rawLine of lines) {
+    const line = rawLine;
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      result.push(line);
+      continue;
+    }
+    const equalsIdx = trimmed.indexOf("=");
+    if (equalsIdx <= 0) {
+      result.push(line);
+      continue;
+    }
+    const key = trimmed.slice(0, equalsIdx).trim();
+    if (Object.hasOwn(overrides, key)) {
+      result.push(`${key}=${overrides[key]}`);
+      seen.add(key);
+    } else {
+      result.push(line);
+    }
+  }
+  // override に存在するが example に無いキーは末尾に追記 (= future-proof)。
+  const extras = Object.entries(overrides).filter(([k]) => !seen.has(k));
+  if (extras.length > 0) {
+    result.push("");
+    result.push("# === Added by `make env-init` ===");
+    for (const [k, v] of extras) {
+      result.push(`${k}=${v}`);
+    }
+  }
+  return result.join("\n");
+}
+
+/**
+ * 1 つの prompt について、 最大 3 回まで再入力を許し validate を通った値を返す。
+ * 非対話モードでは validate を skip して default を採用 (= 設計バグの場合 deploy
+ * 時に再度 fail する)。
+ */
+async function resolvePromptValue(prompt: EnvKeyPrompt, opts: EnvInitOptions): Promise<string> {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const raw = opts.nonInteractive
+      ? prompt.defaultValue
+      : await opts.ask(`${prompt.key} (${prompt.label})`, prompt.defaultValue);
+    const trimmed = raw.trim();
+    const candidate = trimmed.length > 0 ? trimmed : prompt.defaultValue;
+    const error = prompt.validate?.(candidate);
+    if (!error) return candidate;
+    opts.print(`  ✗ ${error}`);
+    if (opts.nonInteractive) return candidate;
+  }
+  // 3 回 invalid なら最後の試行結果ではなく default を採用 (deterministic fallback)。
+  return prompt.defaultValue;
+}
+
+function printIntro(opts: EnvInitOptions, envPath: string, examplePath: string): void {
+  opts.print("=== TenkaCloud Lite mode .env wizard ===");
+  opts.print("");
+  opts.print(`生成先: ${envPath}`);
+  opts.print(`参照元: ${examplePath}`);
+  opts.print("");
+  opts.print("必須の 3 項目を入力してください (Enter で default 採用):");
+  opts.print("");
+}
+
+function printOutro(opts: EnvInitOptions, envPath: string): void {
+  opts.print("");
+  opts.print(`✓ .env を生成しました: ${envPath}`);
+  opts.print("");
+  opts.print("Next steps:");
+  opts.print("  1. make deploy       — Lite mode deploy (= ~10 min)");
+  opts.print("  2. make lite-console-url   — Application Admin Console URL を表示");
+  opts.print("  3. make lite-portal-url    — Participant Portal URL を表示");
+  opts.print("");
+  opts.print("詳細: docs/lite-mode-prereqs.md");
+}
+
+/**
+ * `.env` を生成する main flow。 副作用は file 書き込みだけで、 prompt I/O は
+ * injectable (= unit test で deterministic 答えを返せる)。
+ */
+export async function runEnvInit(opts: EnvInitOptions): Promise<{
+  readonly status: "created" | "exists";
+  readonly path: string;
+}> {
+  const envDir = join(opts.repoRoot, "infrastructure", "environments", opts.env);
+  const envPath = join(envDir, ".env");
+  const examplePath = join(envDir, ".env.example");
+
+  if (existsSync(envPath)) {
+    opts.print(`✓ ${envPath} は既に存在します (skip)`);
+    opts.print("  上書きしたい場合は手動で削除してから再実行してください。");
+    return { status: "exists", path: envPath };
+  }
+
+  if (!existsSync(examplePath)) {
+    throw new Error(`.env.example が見つかりません: ${examplePath}`);
+  }
+
+  const exampleContent = readFileSync(examplePath, "utf8");
+  printIntro(opts, envPath, examplePath);
+
+  const overrides: Record<string, string> = {};
+  for (const prompt of PROMPTS) {
+    overrides[prompt.key] = await resolvePromptValue(prompt, opts);
+  }
+
+  // SaaS mode との env 共用を考えて SYSTEM_ADMIN_EMAIL も TENANT_ADMIN_EMAIL から
+  // 派生させる (= 同 inbox で SystemAdmin invite も受けたい運用が多い)。
+  const tenantAdminEmail = overrides.TENANT_ADMIN_EMAIL;
+  if (tenantAdminEmail) {
+    overrides.SYSTEM_ADMIN_EMAIL = tenantAdminEmail;
+  }
+
+  const content = generateEnvContent(exampleContent, overrides);
+  mkdirSync(dirname(envPath), { recursive: true });
+  writeFileSync(envPath, content, "utf8");
+
+  printOutro(opts, envPath);
+  return { status: "created", path: envPath };
+}
+
+async function defaultMain(): Promise<number> {
+  const env = process.env.ENV ?? DEFAULT_ENV;
+  const repoRoot = process.cwd();
+  const isTty = process.stdin.isTTY && process.stdout.isTTY;
+
+  if (!isTty) {
+    // 非 TTY (= CI / pipe) では default 値で 1 発生成。 user 確認を強要しない。
+    try {
+      await runEnvInit({
+        env,
+        repoRoot,
+        ask: async (_q, fallback) => fallback,
+        print: (line) => process.stdout.write(`${line}\n`),
+        nonInteractive: true,
+      });
+      return 0;
+    } catch (err) {
+      process.stderr.write(`env-init failed: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    await runEnvInit({
+      env,
+      repoRoot,
+      ask: async (question, fallback) => {
+        const answer = await rl.question(`  ${question}\n  [default: ${fallback}] > `);
+        return answer;
+      },
+      print: (line) => process.stdout.write(`${line}\n`),
+    });
+    return 0;
+  } catch (err) {
+    process.stderr.write(`env-init failed: ${(err as Error).message}\n`);
+    return 1;
+  } finally {
+    rl.close();
+  }
+}
+
+if (import.meta.main) {
+  const exitCode = await defaultMain();
+  process.exit(exitCode);
+}

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -59,6 +59,12 @@ export interface CliIO {
   readonly stderr: (text: string) => void;
   readonly spawnInherit: (cmd: string, args: readonly string[]) => Promise<number>;
   readonly spawnCapture: (cmd: string, args: readonly string[]) => Promise<SpawnCaptureResult>;
+  /**
+   * Issue #1345: destroy 前の y/N 確認 prompt。 非 TTY (= CI / pipe) では false を返す
+   * default を採用 (= make destroy --yes で bypass する経路を用意する)。 unit test では
+   * scripted answer を返す stub に差し替える。
+   */
+  readonly confirm: (question: string) => Promise<boolean>;
 }
 
 interface CommandSpec {
@@ -140,19 +146,20 @@ async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
     );
   }
 
-  // ProblemDeployBackendStack 内の DeployCodeBuildProject が `<bucket>/source.zip` を参照
-  // するため、 cdk deploy 前に source bundle を upload する。 SaaS install.sh と同じ shared
-  // shell (prepare-source-bundle.sh) を呼ぶ (= bash 1 source of truth、 SBT 制約下で host /
-  // CodeBuild 双方が読める形を維持)。 OO refactor (= TypeScript SourceBundle class 化) は
-  // 別 follow-up issue で扱う。
-  io.stdout("[lite] preparing source bundle (= bucket + source.zip)...\n");
+  // Issue #1345: 30-min first-run UX — 各 phase を「[i/N] ...」 で示す。
+  const totalSteps = 3;
+  io.stdout(`\n[lite] [1/${totalSteps}] preparing source bundle (= S3 bucket + source.zip)...\n`);
   const prepCode = await io.spawnInherit("bash", ["scripts/prepare-source-bundle.sh"]);
   if (prepCode !== 0) {
     io.stderr(`[lite] prepare-source-bundle.sh failed with exit code ${prepCode}\n`);
+    printFailureGuide(io, "source bundle 準備");
     return prepCode;
   }
 
-  io.stdout("[lite] deploying 2 stacks (= AppPlane + ProblemDeploy)...\n");
+  io.stdout(`\n[lite] [2/${totalSteps}] deploying 2 stacks (= AppPlane + ProblemDeploy)...\n`);
+  io.stdout(
+    "[lite]       初回 deploy は ~10 分かかります (= AWS の制約)。 cdk の出力を直接表示します。\n",
+  );
   const code = await io.spawnInherit(CDK_BIN, [
     ...CDK_OPTS,
     "deploy",
@@ -163,23 +170,20 @@ async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
   ]);
   if (code !== 0) {
     io.stderr(`[lite] cdk deploy failed with exit code ${code}\n`);
+    printFailureGuide(io, "CFn stack deploy");
     return code;
   }
-  io.stdout("\n[lite] deploy complete. URLs:\n");
-  await readOutput(
-    LITE_STACK_NAMES.app,
-    "ApplicationAdminConsoleUrl",
-    "  Application Admin Console: ",
-    io,
-  );
-  await readOutput(
+
+  io.stdout(`\n[lite] [3/${totalSteps}] resolving access URLs + creating Tenant Admin...\n`);
+  const consoleUrl = await readStackOutput(LITE_STACK_NAMES.app, "ApplicationAdminConsoleUrl", io);
+  const portalUrl = await readStackOutput(
     LITE_STACK_NAMES.problemDeploy,
     "ParticipantPortalApiUrl",
-    "  Participant Portal:        ",
     io,
   );
 
   // Tenant Admin user を Cognito に作る (= 初回 sign-in のため)。
+  let tenantAdminCreated = false;
   if (tenantAdminEmail) {
     const created = await ensureTenantAdminUser(tenantAdminEmail, io);
     if (created !== 0) {
@@ -189,9 +193,95 @@ async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
           "[lite]   aws cognito-idp list-user-pools --max-results 60\n" +
           "[lite]   aws cognito-idp admin-create-user --user-pool-id <id> --username <email> --user-attributes Name=email,Value=<email> Name=email_verified,Value=True --desired-delivery-mediums EMAIL\n",
       );
+    } else {
+      tenantAdminCreated = true;
     }
   }
+
+  printPostDeployGuide(io, {
+    consoleUrl,
+    portalUrl,
+    tenantAdminEmail,
+    tenantAdminCreated,
+  });
   return 0;
+}
+
+/**
+ * Issue #1345: deploy 失敗時に user が次に取るべき action を出す。 AWS / CDK の
+ * エラーメッセージは「token expired / permission denied / stack rolled back」 と
+ * 多様で、 ありがちなのは「ログを見る → teardown → 再実行」 の 3 step ループに
+ * 収まる。
+ */
+function printFailureGuide(io: CliIO, phase: string): void {
+  io.stderr(
+    [
+      "",
+      `[lite] ✗ ${phase} で失敗しました。`,
+      "[lite] 次のステップ:",
+      "[lite]   1. 直前のログ (= 上に表示された CDK / AWS CLI の出力) でエラー原因を確認",
+      "[lite]   2. make destroy           — 中途半端な stack を tear down (idempotent)",
+      "[lite]   3. このコマンドを再実行   — make deploy",
+      "[lite] よくある原因と対処:",
+      "[lite]   - credentials expired       → aws sso login / 新しい session を取得",
+      "[lite]   - role 不足                  → docs/lite-mode-prereqs.md を参照",
+      "[lite]   - bootstrap 未実行           → make bootstrap",
+      "[lite]   - region 不一致 (.env と現環境) → AWS_REGION を .env と一致させる",
+      "",
+    ].join("\n"),
+  );
+}
+
+interface PostDeployGuideInput {
+  readonly consoleUrl?: string | undefined;
+  readonly portalUrl?: string | undefined;
+  readonly tenantAdminEmail: string;
+  readonly tenantAdminCreated: boolean;
+}
+
+/**
+ * Issue #1345: deploy 完了直後に「次にやること」 を 1 画面で見せる post-deploy guide。
+ * 「Application Admin Console を開いて hello-world を deploy → Participant Portal で
+ * 確認」 までの最短経路を文字で示す。 URL が読めなかった場合 (= IAM 不足 / output 名
+ * 変更) でも guidance だけは出す。
+ */
+function printPostDeployGuide(io: CliIO, input: PostDeployGuideInput): void {
+  const lines: string[] = [
+    "",
+    "================================================================",
+    "✓ Lite mode deploy complete",
+    "================================================================",
+    "",
+    "Access URLs:",
+    `  - Application Admin Console: ${input.consoleUrl ?? "(unknown — make lite-console-url)"}`,
+    `  - Participant Portal:        ${input.portalUrl ?? "(unknown — make lite-portal-url)"}`,
+    "",
+  ];
+  if (input.tenantAdminEmail) {
+    lines.push(
+      input.tenantAdminCreated
+        ? `Tenant Admin invite を ${input.tenantAdminEmail} に送信しました (Cognito email)。`
+        : `Tenant Admin (${input.tenantAdminEmail}) は既存または作成に失敗。 上のログを参照。`,
+    );
+    lines.push("");
+  }
+  lines.push(
+    "Next steps:",
+    "  1. メールの一時パスワードで Application Admin Console にサインイン",
+    "  2. Event タブで 「Demo」 という名前の event を作成",
+    "  3. Problems タブから hello-world を deploy",
+    "  4. Participant Portal URL を team に共有 (login key は event 作成時に発行)",
+    "",
+    "Teardown:",
+    "  make destroy     — 全 stack を削除 (DDB / S3 含む、 確認 prompt あり)",
+    "",
+    "Docs:",
+    "  - docs/lite-mode-prereqs.md  — 前提条件 + 必要 IAM permission",
+    "  - README.md (Quickstart)     — 30-min first-run の全体像",
+    "================================================================",
+    "",
+  );
+  io.stdout(lines.join("\n"));
 }
 
 /**
@@ -271,7 +361,24 @@ async function ensureTenantAdminUser(email: string, io: CliIO): Promise<number> 
   return 0;
 }
 
-async function cmdDown(_args: readonly string[], io: CliIO): Promise<number> {
+async function cmdDown(args: readonly string[], io: CliIO): Promise<number> {
+  // Issue #1345: destroy は idempotent でも DB データ消去を伴うので、 first-run user の
+  // 誤爆を避けるため確認 prompt を入れる。 `--yes` / `-y` で skip 可能 (= CI / cleanup
+  // script から呼ぶときは bypass)。
+  const skipConfirm =
+    args.includes("--yes") || args.includes("-y") || process.env.TENKACLOUD_LITE_DOWN_YES === "1";
+  if (!skipConfirm) {
+    const confirmed = await io.confirm(
+      "[lite] make destroy は Lite mode の **全 stack** (= AppPlane + ProblemDeploy) を削除します。\n" +
+        "[lite] DynamoDB の Deployments / Apps / DDB データ、 S3 bucket の portal asset / source bundle、\n" +
+        "[lite] Cognito UserPool (= Tenant Admin user 含む) も RemovalPolicy=DESTROY で消えます。\n" +
+        "[lite] 続行しますか? (y/N): ",
+    );
+    if (!confirmed) {
+      io.stdout("[lite] aborted (no resources were modified).\n");
+      return 0;
+    }
+  }
   io.stdout("[lite] destroying 2 stacks...\n");
   // app stack を先に destroy (= cross-stack 参照 (DeployApi Lambda 等) の依存方向に合わせる)。
   const code1 = await io.spawnInherit(CDK_BIN, [
@@ -371,6 +478,27 @@ export function defaultIO(): CliIO {
         proc.on("close", (code) => resolveFn({ code: code ?? 0, stdout, stderr }));
         proc.on("error", () => resolveFn({ code: 127, stdout, stderr }));
       }),
+    confirm: async (question) => {
+      // 非 TTY (= CI / pipe) では false を返して safety net とする。
+      // bypass したい場合は呼び出し側で --yes / TENKACLOUD_LITE_DOWN_YES=1 を渡す。
+      if (!process.stdin.isTTY) return false;
+      process.stdout.write(question);
+      // node:readline/promises に依存せず stdin から 1 chunk を待つ単純実装。
+      return await new Promise<boolean>((resolveFn) => {
+        let buf = "";
+        const onData = (chunk: Buffer | string) => {
+          buf += chunk.toString();
+          if (buf.includes("\n")) {
+            process.stdin.removeListener("data", onData);
+            process.stdin.pause();
+            const answer = buf.trim().toLowerCase();
+            resolveFn(answer === "y" || answer === "yes");
+          }
+        };
+        process.stdin.resume();
+        process.stdin.on("data", onData);
+      });
+    },
   };
 }
 

--- a/scripts/test-env-init.sh
+++ b/scripts/test-env-init.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Issue #1345: shell-level integration test for `scripts/env-init.ts`.
+#
+# vitest 側 (= infrastructure/test/scripts/env-init.test.ts) で純粋 logic は
+# pin している。 本 shell test は CLI entry (= `bun run scripts/env-init.ts`) を
+# 一時 work dir で叩き、
+#   1. 非対話 (= 非 TTY) 経路で .env が生成される
+#   2. 既存 .env がある場合は skip + 上書きしない (idempotent)
+#   3. .env.example 不在で exit 1 + stderr に message
+# を観測する。
+#
+# 失敗時は exit 1 + 失敗 case 名を echo。 まとめて Makefile から呼ばれることを想定。
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# bun が PATH に無いと早期 fail (= CI runner 設定漏れの可能性)。
+if ! command -v bun >/dev/null 2>&1; then
+  echo "ERROR: bun が PATH に見つかりません" >&2
+  exit 1
+fi
+
+# 一時 work dir を作って .env.example を seed → runEnvInit を call。
+WORKDIR="$(mktemp -d -t tenkacloud-env-init.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+ENV_DIR="$WORKDIR/infrastructure/environments/development"
+mkdir -p "$ENV_DIR"
+cat >"$ENV_DIR/.env.example" <<'EOF'
+# Seed example for shell-level test.
+TENANT_ADMIN_EMAIL=admin@example.com
+SYSTEM_ADMIN_EMAIL=admin@example.com
+AWS_REGION=ap-northeast-1
+CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default
+EOF
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Case 1: 非対話 (= stdin closed) で `.env` が default 値で生成される。
+( cd "$WORKDIR" && bun run "$REPO_ROOT/scripts/env-init.ts" </dev/null >/tmp/env-init-case1.out 2>&1 ) \
+  || { cat /tmp/env-init-case1.out; fail "case1: env-init exited non-zero in non-interactive mode"; }
+[ -f "$ENV_DIR/.env" ] || fail "case1: .env was not created"
+grep -q "^TENANT_ADMIN_EMAIL=admin@example.com$" "$ENV_DIR/.env" || fail "case1: TENANT_ADMIN_EMAIL missing"
+grep -q "^AWS_REGION=ap-northeast-1$" "$ENV_DIR/.env" || fail "case1: AWS_REGION missing"
+grep -q "^CDK_PARAM_DEPLOY_EXTERNAL_ID=tenkacloud-lite-default$" "$ENV_DIR/.env" \
+  || fail "case1: CDK_PARAM_DEPLOY_EXTERNAL_ID missing"
+echo "OK case1: non-interactive default generation"
+
+# Case 2: 2 度目の起動は skip (idempotent) で既存 .env を上書きしない。
+echo "MARKER=preserved" >>"$ENV_DIR/.env"
+( cd "$WORKDIR" && bun run "$REPO_ROOT/scripts/env-init.ts" </dev/null >/tmp/env-init-case2.out 2>&1 ) \
+  || { cat /tmp/env-init-case2.out; fail "case2: env-init exited non-zero on re-run"; }
+grep -q "MARKER=preserved" "$ENV_DIR/.env" || fail "case2: existing .env was overwritten"
+grep -q "既に存在します" /tmp/env-init-case2.out || fail "case2: skip message not printed"
+echo "OK case2: idempotent skip on re-run"
+
+# Case 3: .env.example を消すと exit 1 + stderr に message。
+rm "$ENV_DIR/.env"
+rm "$ENV_DIR/.env.example"
+set +e
+( cd "$WORKDIR" && bun run "$REPO_ROOT/scripts/env-init.ts" </dev/null >/tmp/env-init-case3.out 2>&1 )
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "case3: env-init should fail when .env.example is missing (got exit 0)"
+grep -q "\.env\.example" /tmp/env-init-case3.out || fail "case3: stderr should mention .env.example"
+echo "OK case3: missing .env.example -> exit 1"
+
+echo "All env-init shell tests passed."


### PR DESCRIPTION
## Summary

Implements the Lite mode 30-minute first-run UX from Issue #1345 (parent: #1336). Five concrete improvements close the gap between `git clone` and a working event:

- **`make env-init`** — interactive wizard that prompts for `TENANT_ADMIN_EMAIL` / `AWS_REGION` / `CDK_PARAM_DEPLOY_EXTERNAL_ID`, generates `.env` from `.env.example`, skips when one already exists (idempotent).
- **`docs/lite-mode-prereqs.md`** (English + Japanese in one file) — required IAM permissions, Free-Tier statement, region recommendation, and a 7-row troubleshooting table.
- **`make deploy` progress markers** — each phase prints `[i/3]` and on failure stderr shows a 3-step recovery guide (check logs / `make destroy` / re-run) plus common-cause hints (expired creds / missing bootstrap / region mismatch).
- **Post-deploy guide** — `cmdUp` ends with a banner showing the resolved Console / Portal URLs and a 4-step next-action list (sign-in → create Demo event → deploy hello-world → share Portal URL).
- **`make destroy` confirmation prompt** — explicit `y/N` before tearing down DDB / S3 / Cognito; `--yes` / `TENKACLOUD_LITE_DOWN_YES=1` bypass for CI / `cleanup.sh`.

Closes #1345
Relates #1336

## Regression analysis

- Existing `make deploy` is unchanged when `.env` is already populated. `env-init` is opt-in via the new Makefile target; nothing implicit.
- `cmdUp` post-deploy output adds banner lines but the URL-resolution code path (`readStackOutput`) is unchanged.
- `cmdDown` now gates destroy on a confirmation prompt. Non-TTY callers (CI / scripted `make destroy`) must pass `--yes` or `TENKACLOUD_LITE_DOWN_YES=1`; the default `CliIO.confirm` returns `false` on non-TTY as a safety net.
- Existing tenkacloud-lite tests pass after injecting `confirm: async () => true` into the shared `buildIO` helper.
- Tech-debt assertion-roulette baseline shifts by ~10 lines on `tenkacloud-lite.test.ts` (new tests pushed existing entries down); updated surgically (only the 4 affected entries, no fresh additions).
- No CDK / SBT / IAM / template changes — `make synth` is byte-identical on every stack.

## Physical impact

- **NO-OP** on CFn: no CDK stacks edited, no IAM / Lambda / DDB changes.
- **CREATE**: `docs/lite-mode-prereqs.md` (+ generated `.html` via `make build-docs`) — docs only.
- **CREATE**: `scripts/env-init.ts` + `scripts/test-env-init.sh` — local CLI only.
- **UPDATE**: `Makefile` — adds `env-init` / `env-init-test` targets, hints `make env-init` in the `env-check-lite` error message.
- **UPDATE**: `scripts/tenkacloud-lite.ts` — `cmdUp` progress + post-deploy guide, `cmdDown` confirm prompt; both behind a new `CliIO.confirm` seam so unit tests stay deterministic.
- **UPDATE**: `infrastructure/test/scripts/tenkacloud-lite.test.ts` — 5 new test cases (failure guide / post-deploy banner / next-steps / progress markers / confirm prompt / abort / `--yes` bypass).
- **UPDATE**: `.claude/harness/baselines/tech-debt-assertion-roulette.json` — 4 line-number shifts for pre-existing baselined `tenkacloud-lite.test.ts` entries.

## Test plan

- [x] `bun vitest run test/scripts/env-init.test.ts` — 10 cases (parse / generate / wizard / idempotent / nonInteractive / 3-attempt validate re-prompt / missing example).
- [x] `bun vitest run test/scripts/tenkacloud-lite.test.ts` — 23 cases (incl. 5 new: failure-guide, post-deploy banner / next-steps / progress, confirm prompt, abort, `--yes` bypass).
- [x] `bash scripts/test-env-init.sh` (= `make env-init-test`) — shell-level integration (non-interactive default / idempotent / missing-example fail).
- [x] `make harness` — 0 findings.
- [x] `CDK_PARAM_SYSTEM_ADMIN_EMAIL=placeholder@example.com make before-commit` — lint / typecheck / test / docs / validate-problems / check-synth all pass (same env requirement as on `main`).
- [ ] Manual: `make env-init` in fresh worktree → run wizard interactively → confirm `.env` matches expected.
- [ ] Manual: `make destroy` against a real Lite stack → confirm y/N prompt fires + `--yes` bypasses.

[USER-REVIEW]: Makefile target additions and `scripts/tenkacloud-lite.ts` changes are agent-owned per AGENTS.md role split (no CDK / IAM / SBT changes). The `docs/lite-mode-prereqs.md` IAM permission list reflects the current Lite stacks — if the platform adds new services later, that list will need a follow-up update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)