### PR TITLE
feat(observability): structured logging + metrics + dashboard hint — #1352

### DIFF
--- a/docs/operations/observability.html
+++ b/docs/operations/observability.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Observability and failure diagnosis</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Observability and failure diagnosis</h1>
+<blockquote>
+<p>Issue: <a href="https://github.com/susumutomita/TenkaCloud/issues/1352">#1352</a> (parent: <a href="https://github.com/susumutomita/TenkaCloud/issues/1336">#1336</a>)
+Audience: on-call operator running a paid TenkaCloud event
+Sibling docs: <a href="./deploy-trace.md"><code>deploy-trace.md</code></a> (= per-job triage), <code>docs/runbooks/incident-response.md</code> (= remediation playbook, tracked under #1351)</p>
+</blockquote>
+<p>This page is the operator-facing reference for <strong>what to watch during the event</strong> and <strong>where to look first when something fails</strong>. It pins the structured-log shape, the CloudWatch metric catalog, the saved Insights queries, and a short failure-diagnosis runbook.</p>
+<h2>1. Structured log shape</h2>
+<p>Every operator-visible event from the Lambda layer emits a single JSON line via the helper at <code>infrastructure/lib/problem-deploy/handlers/shared/structured-log.ts</code>. The shape is <strong>pinned by unit tests</strong> (<code>infrastructure/test/problem-deploy/structured-log.test.ts</code>):</p>
+<pre><code class="language-json">{
+  &quot;level&quot;: &quot;info | warn | error&quot;,
+  &quot;ts&quot;: &quot;2026-05-26T12:34:56.000Z&quot;,
+  &quot;component&quot;: &quot;problem-deploy&quot;,
+  &quot;eventName&quot;: &quot;&lt;domain&gt;.&lt;resource&gt;.&lt;verb&gt;&quot;,
+  &quot;action&quot;: &quot;create_deployment&quot;,
+  &quot;status&quot;: &quot;started | succeeded | failed | timeout | skipped&quot;,
+  &quot;tenantId&quot;: &quot;tenant-1&quot;,
+  &quot;teamId&quot;: &quot;team-A&quot;,
+  &quot;problemId&quot;: &quot;hello-world&quot;,
+  &quot;durationMs&quot;: 1234,
+  &quot;errorCode&quot;: &quot;AccessDeniedError&quot;
+}
+</code></pre>
+<h3>Naming conventions</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Convention</th>
+<th>Example</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>eventName</code></td>
+<td><code>&lt;domain&gt;.&lt;resource&gt;.&lt;verb&gt;</code> (dot-separated, prefix-greppable)</td>
+<td><code>deploy.stack.create</code> / <code>scoring.flag.submit</code> / <code>participant.portal.login</code></td>
+</tr>
+<tr>
+<td><code>action</code></td>
+<td>snake_case verb that maps to operator runbook entry</td>
+<td><code>create_deployment</code>, <code>submit_flag</code>, <code>assume_competitor_role</code></td>
+</tr>
+<tr>
+<td><code>status</code></td>
+<td>One of the 5 enum values (= filterable in alarms)</td>
+<td><code>failed</code> triggers paged response, <code>timeout</code> triggers wait + retry</td>
+</tr>
+<tr>
+<td><code>errorCode</code></td>
+<td>Stable short identifier (= Error class name when from SDK)</td>
+<td><code>AccessDenied</code>, <code>ValidationError</code>, <code>ThrottlingException</code></td>
+</tr>
+<tr>
+<td><code>errorMessage</code></td>
+<td>Clamped to 240 chars to cap CloudWatch ingest cost</td>
+<td>(free-form, redaction-safe)</td>
+</tr>
+</tbody></table>
+<h3>Secret redaction (= same allowlist as #1297 audit log)</h3>
+<p>The helper uses an <strong>allowlist-only</strong> filter (<code>FIELD_ALLOWLIST</code> in <code>structured-log.ts</code>). Caller-supplied keys outside that set — including secret-shaped names like <code>password</code> / <code>accessKey</code> / <code>externalId</code> / <code>presignedUrl</code> / <code>cookie</code> / <code>authorization</code> / <code>samlMetadata</code> / <code>idToken</code> / <code>accessToken</code> / <code>refreshToken</code> / <code>clientSecret</code> — are <strong>silently dropped</strong>. Non-primitive values (nested object / array / Date / function) are also dropped, mirroring <code>redactForAudit</code> shallow semantics so a future contributor cannot accidentally widen the leak surface.</p>
+<h2>2. CloudWatch metric catalog</h2>
+<p>Emitted from Lambda code via <code>infrastructure/lib/problem-deploy/handlers/shared/operator-metrics.ts</code>. Namespace is <code>TenkaCloud/{env}</code> (= <code>TenkaCloud/Lite</code> for Lite mode, <code>TenkaCloud/production</code> for hosted production). Empty <code>TENKACLOUD_METRIC_ENV</code> env value downgrades emission to no-op so old stacks without the env wired still deploy cleanly.</p>
+<table>
+<thead>
+<tr>
+<th>Metric</th>
+<th>Unit</th>
+<th>Dimensions</th>
+<th>Operator use</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>deploy.duration_ms</code></td>
+<td>Milliseconds</td>
+<td>TenantId, ProblemId, Outcome, Environment</td>
+<td>Watch p95 latency per problem; alert if &gt; 8 min</td>
+</tr>
+<tr>
+<td><code>deploy.outcome</code></td>
+<td>Count</td>
+<td>TenantId, ProblemId, Outcome, Environment</td>
+<td>Outcome ∈ {success, failed, timeout}. Alarm: <code>SUM(failed) / SUM(success+failed+timeout) &gt; 10%</code> over 15 min</td>
+</tr>
+<tr>
+<td><code>scoring.flag_submission_rate</code></td>
+<td>Count</td>
+<td>TenantId, ProblemId, Environment</td>
+<td>Flat 0 over event window = silent scoring death</td>
+</tr>
+<tr>
+<td><code>scoring.disruption_detection_rate</code></td>
+<td>Count</td>
+<td>TenantId, ProblemId, DisruptionId, Environment</td>
+<td>Spike per <code>DisruptionId</code> correlates with deliberate competitor attack vs flaky probe</td>
+</tr>
+</tbody></table>
+<h3>Suggested CloudWatch alarms</h3>
+<ul>
+<li><strong>Deploy failure rate &gt; 10%</strong> — <code>(SUM deploy.outcome WHERE Outcome=failed) / (SUM deploy.outcome)</code> over 15 min, threshold 0.1. Indicates competitor account misconfig or platform regression.</li>
+<li><strong>Event API 5xx rate &gt; 1%</strong> — Standard API Gateway <code>5XXError</code> / <code>Count</code> on the EventApi stage, over 5 min. Indicates handler crash or DDB throttle.</li>
+<li><strong>Scoring silent</strong> — <code>SUM scoring.flag_submission_rate</code> over 10 min &lt; 1 during an active event window. Indicates the scoring Lambda stopped reading the event stream.</li>
+</ul>
+<h2>3. CloudWatch Logs Insights — saved queries</h2>
+<p>Drop these into the Logs Insights saved-queries panel of the AWS account hosting the platform.</p>
+<h3>Query 1: Deploy slow path (= jobs that took &gt; 5 minutes)</h3>
+<pre><code class="language-text">fields @timestamp, tenantId, teamId, problemId, durationMs, status, errorCode
+| filter eventName like /^deploy\./ and status in [&quot;succeeded&quot;, &quot;failed&quot;, &quot;timeout&quot;]
+| filter durationMs &gt; 300000
+| sort durationMs desc
+| limit 50
+</code></pre>
+<p>Sort by <code>durationMs desc</code> to find which problem template is the slowest under real load. Pair with the <code>deploy.duration_ms</code> metric chart for cohort comparison.</p>
+<h3>Query 2: Participant 4xx (= portal calls failing on the client side)</h3>
+<pre><code class="language-text">fields @timestamp, tenantId, teamId, problemId, eventName, action, status, errorCode, errorMessage
+| filter eventName like /^participant\./
+| filter status = &quot;failed&quot;
+| sort @timestamp desc
+| limit 100
+</code></pre>
+<p>Reveals which team / which portal action is rejecting. Common <code>errorCode</code> values point straight at the runbook section below: <code>Unauthorized</code> -&gt; Cognito setup, <code>NotFound</code> -&gt; problem teardown raced, <code>ValidationError</code> -&gt; portal version drift.</p>
+<h3>Query 3: Failed CFn stack (= competitor-account-side rollback)</h3>
+<pre><code class="language-text">fields @timestamp, tenantId, teamId, problemId, stackStatus, errorCode, errorMessage
+| filter eventName = &quot;deploy.stack.create&quot; or eventName = &quot;deploy.stack.describe&quot;
+| filter status = &quot;failed&quot; or stackStatus like /ROLLBACK/ or stackStatus like /FAILED/
+| sort @timestamp desc
+| limit 50
+</code></pre>
+<p>Cross-reference with <code>deploy-trace.md</code> Query B (= shell-side <code>deploy.cfn.deploy.failed</code>) to pin whether the rollback originated in CFn itself or in our Lambda gating.</p>
+<h3>Common log groups to attach</h3>
+<ul>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-DeployApiFunction*</code></li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-EventApiFunction*</code></li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-DeployWorkerFunction*</code></li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-GenericScoringFunction*</code></li>
+<li><code>/aws/lambda/&lt;problem-deploy stack&gt;-ParticipantApiFunction*</code></li>
+</ul>
+<h2>4. Failure diagnosis runbook</h2>
+<p>The three event-day failure modes that overlap with this issue (full step-by-step playbook lives under the runbooks directory tracked by #1351):</p>
+<h3>4.1. DeployRequested event disappeared (= &quot;I clicked deploy and nothing happened&quot;)</h3>
+<ol>
+<li><strong>EventBridge bus</strong> — Open the <code>default</code> (or <code>tenkacloud-*</code> custom) bus in the CloudWatch metrics console; check the <code>MatchedEvents</code> metric for the rule routing to the Deploy Worker. Zero matches = rule disabled or filter pattern mismatch.</li>
+<li><strong>DLQ</strong> — Check the <code>ProblemDeployDeadLetterQueue</code> SQS metric <code>ApproximateNumberOfMessagesVisible</code>. Non-zero means the worker rejected the event; pull one message to inspect the failure reason.</li>
+<li><strong>Worker Lambda logs</strong> — Run <strong>Query 3</strong> above; if the worker never received the event, the failure is upstream (= EventBridge rule). If it received and failed, the failure is downstream (= AssumeRole or CFn).</li>
+</ol>
+<h3>4.2. DDB throttle (= sudden slowness across all admin actions)</h3>
+<ol>
+<li><strong>Provisioned capacity</strong> — Open the table in DDB console; check <code>ReadThrottleEvents</code> / <code>WriteThrottleEvents</code>. Any non-zero count means traffic exceeded 1 RCU / 1 WCU (= <code>DynamoDbLowCapacity</code> Aspect, per AGENTS.md).</li>
+<li><strong>Scan pattern</strong> — Run query: <code>filter eventName like /^deploy\./ | stats count() by action</code>. A <code>list_*</code> action spiking out of proportion = O(N) scan replacing a Query. Fix is to add a GSI or to switch to PK-scoped Query.</li>
+<li><strong>Mitigation</strong> — Burst capacity can carry short spikes. If the pattern is persistent (= the same scan every poll cycle), open an issue and add a covering GSI. <strong>Do not switch the table to on-demand</strong> — that violates the Free Tier budget.</li>
+</ol>
+<h3>4.3. Cognito sign-in failure (= participant cannot log in)</h3>
+<ol>
+<li><strong>User pool client</strong> — Confirm the client ID in <code>runtime-config.json</code> matches the deployed pool (= mismatch is the #1 cause after a redeploy).</li>
+<li><strong>Hosted UI domain</strong> — Try the hosted UI URL directly in a private window. A 404 means the domain is not provisioned for this stage / region.</li>
+<li><strong>Callback URL</strong> — Open the user pool app client -&gt; &quot;Hosted UI&quot; tab. The <code>Callback URL</code> list must contain the <strong>exact</strong> participant portal origin (CloudFront URL or <code>localhost:5175</code> for dev). Off-by-one slash = redirect_mismatch error.</li>
+<li><strong>Logs</strong> — Run <strong>Query 2</strong> above with <code>filter errorCode = &quot;Unauthorized&quot;</code> to see if the Lambda authorizer is rejecting the JWT (= different failure from Cognito sign-in itself).</li>
+</ol>
+<h2>5. Local dev parity</h2>
+<p>The same helper runs in <code>make dev</code>. Open the Lambda Local Runtime console (= <code>bun run dev</code> in <code>infrastructure/</code>) and the same JSON lines appear on stdout. CloudWatch is not the gate during development; the gate is the test (<code>bun run test test/problem-deploy/structured-log.test.ts</code>) which pins the wire shape so the operator query never drifts from the producer.</p>
+<h2>6. Related ADRs and issues</h2>
+<ul>
+<li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a> — why this issue uses polling-friendly logs and metrics rather than SSE</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/768">Issue #768</a> — <code>trace-log.ts</code> (= per-job triage helper, sibling of this one)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/1297">Issue #1297</a> — audit log redaction allowlist (same pattern as <code>redactFields</code> here)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/1310">Issue #1310</a> — Lambda env 3KB harness budget (= this issue stays under it; helpers are pure code with 1 optional env)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/1336">Issue #1336</a> — parent commercial-event launch readiness epic</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/operations/observability.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/operations/observability.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,141 @@
+# Observability and failure diagnosis
+
+> Issue: [#1352](https://github.com/susumutomita/TenkaCloud/issues/1352) (parent: [#1336](https://github.com/susumutomita/TenkaCloud/issues/1336))
+> Audience: on-call operator running a paid TenkaCloud event
+> Sibling docs: [`deploy-trace.md`](./deploy-trace.md) (= per-job triage), `docs/runbooks/incident-response.md` (= remediation playbook, tracked under #1351)
+
+This page is the operator-facing reference for **what to watch during the event** and **where to look first when something fails**. It pins the structured-log shape, the CloudWatch metric catalog, the saved Insights queries, and a short failure-diagnosis runbook.
+
+## 1. Structured log shape
+
+Every operator-visible event from the Lambda layer emits a single JSON line via the helper at `infrastructure/lib/problem-deploy/handlers/shared/structured-log.ts`. The shape is **pinned by unit tests** (`infrastructure/test/problem-deploy/structured-log.test.ts`):
+
+```json
+{
+  "level": "info | warn | error",
+  "ts": "2026-05-26T12:34:56.000Z",
+  "component": "problem-deploy",
+  "eventName": "<domain>.<resource>.<verb>",
+  "action": "create_deployment",
+  "status": "started | succeeded | failed | timeout | skipped",
+  "tenantId": "tenant-1",
+  "teamId": "team-A",
+  "problemId": "hello-world",
+  "durationMs": 1234,
+  "errorCode": "AccessDeniedError"
+}
+```
+
+### Naming conventions
+
+| Field | Convention | Example |
+| --- | --- | --- |
+| `eventName` | `<domain>.<resource>.<verb>` (dot-separated, prefix-greppable) | `deploy.stack.create` / `scoring.flag.submit` / `participant.portal.login` |
+| `action` | snake_case verb that maps to operator runbook entry | `create_deployment`, `submit_flag`, `assume_competitor_role` |
+| `status` | One of the 5 enum values (= filterable in alarms) | `failed` triggers paged response, `timeout` triggers wait + retry |
+| `errorCode` | Stable short identifier (= Error class name when from SDK) | `AccessDenied`, `ValidationError`, `ThrottlingException` |
+| `errorMessage` | Clamped to 240 chars to cap CloudWatch ingest cost | (free-form, redaction-safe) |
+
+### Secret redaction (= same allowlist as #1297 audit log)
+
+The helper uses an **allowlist-only** filter (`FIELD_ALLOWLIST` in `structured-log.ts`). Caller-supplied keys outside that set — including secret-shaped names like `password` / `accessKey` / `externalId` / `presignedUrl` / `cookie` / `authorization` / `samlMetadata` / `idToken` / `accessToken` / `refreshToken` / `clientSecret` — are **silently dropped**. Non-primitive values (nested object / array / Date / function) are also dropped, mirroring `redactForAudit` shallow semantics so a future contributor cannot accidentally widen the leak surface.
+
+## 2. CloudWatch metric catalog
+
+Emitted from Lambda code via `infrastructure/lib/problem-deploy/handlers/shared/operator-metrics.ts`. Namespace is `TenkaCloud/{env}` (= `TenkaCloud/Lite` for Lite mode, `TenkaCloud/production` for hosted production). Empty `TENKACLOUD_METRIC_ENV` env value downgrades emission to no-op so old stacks without the env wired still deploy cleanly.
+
+| Metric | Unit | Dimensions | Operator use |
+| --- | --- | --- | --- |
+| `deploy.duration_ms` | Milliseconds | TenantId, ProblemId, Outcome, Environment | Watch p95 latency per problem; alert if > 8 min |
+| `deploy.outcome` | Count | TenantId, ProblemId, Outcome, Environment | Outcome ∈ {success, failed, timeout}. Alarm: `SUM(failed) / SUM(success+failed+timeout) > 10%` over 15 min |
+| `scoring.flag_submission_rate` | Count | TenantId, ProblemId, Environment | Flat 0 over event window = silent scoring death |
+| `scoring.disruption_detection_rate` | Count | TenantId, ProblemId, DisruptionId, Environment | Spike per `DisruptionId` correlates with deliberate competitor attack vs flaky probe |
+
+### Suggested CloudWatch alarms
+
+- **Deploy failure rate > 10%** — `(SUM deploy.outcome WHERE Outcome=failed) / (SUM deploy.outcome)` over 15 min, threshold 0.1. Indicates competitor account misconfig or platform regression.
+- **Event API 5xx rate > 1%** — Standard API Gateway `5XXError` / `Count` on the EventApi stage, over 5 min. Indicates handler crash or DDB throttle.
+- **Scoring silent** — `SUM scoring.flag_submission_rate` over 10 min < 1 during an active event window. Indicates the scoring Lambda stopped reading the event stream.
+
+## 3. CloudWatch Logs Insights — saved queries
+
+Drop these into the Logs Insights saved-queries panel of the AWS account hosting the platform.
+
+### Query 1: Deploy slow path (= jobs that took > 5 minutes)
+
+```text
+fields @timestamp, tenantId, teamId, problemId, durationMs, status, errorCode
+| filter eventName like /^deploy\./ and status in ["succeeded", "failed", "timeout"]
+| filter durationMs > 300000
+| sort durationMs desc
+| limit 50
+```
+
+Sort by `durationMs desc` to find which problem template is the slowest under real load. Pair with the `deploy.duration_ms` metric chart for cohort comparison.
+
+### Query 2: Participant 4xx (= portal calls failing on the client side)
+
+```text
+fields @timestamp, tenantId, teamId, problemId, eventName, action, status, errorCode, errorMessage
+| filter eventName like /^participant\./
+| filter status = "failed"
+| sort @timestamp desc
+| limit 100
+```
+
+Reveals which team / which portal action is rejecting. Common `errorCode` values point straight at the runbook section below: `Unauthorized` -> Cognito setup, `NotFound` -> problem teardown raced, `ValidationError` -> portal version drift.
+
+### Query 3: Failed CFn stack (= competitor-account-side rollback)
+
+```text
+fields @timestamp, tenantId, teamId, problemId, stackStatus, errorCode, errorMessage
+| filter eventName = "deploy.stack.create" or eventName = "deploy.stack.describe"
+| filter status = "failed" or stackStatus like /ROLLBACK/ or stackStatus like /FAILED/
+| sort @timestamp desc
+| limit 50
+```
+
+Cross-reference with `deploy-trace.md` Query B (= shell-side `deploy.cfn.deploy.failed`) to pin whether the rollback originated in CFn itself or in our Lambda gating.
+
+### Common log groups to attach
+
+- `/aws/lambda/<problem-deploy stack>-DeployApiFunction*`
+- `/aws/lambda/<problem-deploy stack>-EventApiFunction*`
+- `/aws/lambda/<problem-deploy stack>-DeployWorkerFunction*`
+- `/aws/lambda/<problem-deploy stack>-GenericScoringFunction*`
+- `/aws/lambda/<problem-deploy stack>-ParticipantApiFunction*`
+
+## 4. Failure diagnosis runbook
+
+The three event-day failure modes that overlap with this issue (full step-by-step playbook lives under the runbooks directory tracked by #1351):
+
+### 4.1. DeployRequested event disappeared (= "I clicked deploy and nothing happened")
+
+1. **EventBridge bus** — Open the `default` (or `tenkacloud-*` custom) bus in the CloudWatch metrics console; check the `MatchedEvents` metric for the rule routing to the Deploy Worker. Zero matches = rule disabled or filter pattern mismatch.
+2. **DLQ** — Check the `ProblemDeployDeadLetterQueue` SQS metric `ApproximateNumberOfMessagesVisible`. Non-zero means the worker rejected the event; pull one message to inspect the failure reason.
+3. **Worker Lambda logs** — Run **Query 3** above; if the worker never received the event, the failure is upstream (= EventBridge rule). If it received and failed, the failure is downstream (= AssumeRole or CFn).
+
+### 4.2. DDB throttle (= sudden slowness across all admin actions)
+
+1. **Provisioned capacity** — Open the table in DDB console; check `ReadThrottleEvents` / `WriteThrottleEvents`. Any non-zero count means traffic exceeded 1 RCU / 1 WCU (= `DynamoDbLowCapacity` Aspect, per AGENTS.md).
+2. **Scan pattern** — Run query: `filter eventName like /^deploy\./ | stats count() by action`. A `list_*` action spiking out of proportion = O(N) scan replacing a Query. Fix is to add a GSI or to switch to PK-scoped Query.
+3. **Mitigation** — Burst capacity can carry short spikes. If the pattern is persistent (= the same scan every poll cycle), open an issue and add a covering GSI. **Do not switch the table to on-demand** — that violates the Free Tier budget.
+
+### 4.3. Cognito sign-in failure (= participant cannot log in)
+
+1. **User pool client** — Confirm the client ID in `runtime-config.json` matches the deployed pool (= mismatch is the #1 cause after a redeploy).
+2. **Hosted UI domain** — Try the hosted UI URL directly in a private window. A 404 means the domain is not provisioned for this stage / region.
+3. **Callback URL** — Open the user pool app client -> "Hosted UI" tab. The `Callback URL` list must contain the **exact** participant portal origin (CloudFront URL or `localhost:5175` for dev). Off-by-one slash = redirect_mismatch error.
+4. **Logs** — Run **Query 2** above with `filter errorCode = "Unauthorized"` to see if the Lambda authorizer is rejecting the JWT (= different failure from Cognito sign-in itself).
+
+## 5. Local dev parity
+
+The same helper runs in `make dev`. Open the Lambda Local Runtime console (= `bun run dev` in `infrastructure/`) and the same JSON lines appear on stdout. CloudWatch is not the gate during development; the gate is the test (`bun run test test/problem-deploy/structured-log.test.ts`) which pins the wire shape so the operator query never drifts from the producer.
+
+## 6. Related ADRs and issues
+
+- [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) — why this issue uses polling-friendly logs and metrics rather than SSE
+- [Issue #768](https://github.com/susumutomita/TenkaCloud/issues/768) — `trace-log.ts` (= per-job triage helper, sibling of this one)
+- [Issue #1297](https://github.com/susumutomita/TenkaCloud/issues/1297) — audit log redaction allowlist (same pattern as `redactFields` here)
+- [Issue #1310](https://github.com/susumutomita/TenkaCloud/issues/1310) — Lambda env 3KB harness budget (= this issue stays under it; helpers are pure code with 1 optional env)
+- [Issue #1336](https://github.com/susumutomita/TenkaCloud/issues/1336) — parent commercial-event launch readiness epic

--- a/infrastructure/lib/problem-deploy/handlers/shared/operator-metrics.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/operator-metrics.ts
@@ -1,0 +1,238 @@
+import {
+  CloudWatchClient,
+  type CloudWatchClientConfig,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+/**
+ * Issue #1352 (parent #1336): CloudWatch metric emission helper for
+ * operator-facing dashboards / alarms.
+ *
+ * Why a new helper instead of reusing `external-id-audit-handler/repository.ts`:
+ *
+ *   `external-id-audit` already publishes `TenkaCloud/CompetitorAccounts` with
+ *   the `RotationAge` metric. Reusing that adapter would tangle two unrelated
+ *   metric namespaces in one repository module. This helper is namespaced
+ *   `TenkaCloud/{env}` (= `TenkaCloud/development` / `TenkaCloud/production`
+ *   / `TenkaCloud/Lite` for Lite mode) and is callable from any handler that
+ *   crosses the operator dashboard surface (deploy / scoring / participant).
+ *
+ *   Adapter shape matches `external-id-audit-handler/repository.ts` (= same
+ *   `Pick<CloudWatchClient, "send">` injectable + module-scope cached client)
+ *   so the harness rule `handler-no-direct-sdk-import` keeps holding.
+ *
+ * Metric catalog (= the four the operator dashboard subscribes to):
+ *
+ *   `deploy.duration_ms` — per problem deploy wall-clock from
+ *      `startDeployment` to terminal status (= success / failed / timeout).
+ *      Unit: Milliseconds. Dimensions: TenantId / ProblemId / Outcome.
+ *
+ *   `deploy.outcome` — counter (= Value: 1) for every terminal deploy.
+ *      Unit: Count. Dimensions: TenantId / ProblemId / Outcome.
+ *      Outcome ∈ {success, failed, timeout}. Operator alarm: SUM(failed) /
+ *      SUM(success+failed+timeout) > 10% over 15 min.
+ *
+ *   `scoring.flag_submission_rate` — counter for flag submissions seen by
+ *      the scoring loop. Unit: Count. Dimensions: TenantId / ProblemId.
+ *      Operator dashboard: SUM(Period=1m) — flat at 0 over event window
+ *      means scoring is silently dead.
+ *
+ *   `scoring.disruption_detection_rate` — counter for disruption checks
+ *      that detected an outage. Unit: Count. Dimensions: TenantId /
+ *      ProblemId / DisruptionId. Operator dashboard: stacked SUM by
+ *      DisruptionId — spike correlates with deliberate competitor attack
+ *      vs flaky probe.
+ *
+ *   All 4 share the same `Environment` dimension so a single dashboard
+ *   filters by env (= development vs production vs Lite).
+ *
+ * env footprint: 1 env var added (`TENKACLOUD_METRIC_ENV`). Empty / unset
+ * downgrades to no-op (= same shape as `audit-log.ts` env guard), so old
+ * stacks without the env wired still deploy cleanly. The harness #1310
+ * Lambda env 3KB rule is therefore not affected — the only added bytes are
+ * the env name itself (= 23 bytes) and the env value (= length of "Lite" /
+ * "development" / "production", ≤ 11 bytes).
+ *
+ * fail-safe: PutMetricData failure does **not** propagate. Metric loss is
+ * accepted (= operator dashboard goes blank, alarm goes into Insufficient
+ * Data) over breaking the business operation.
+ */
+
+const METRIC_NAMESPACE_PREFIX = "TenkaCloud";
+
+export type DeployOutcome = "success" | "failed" | "timeout";
+
+export interface MetricClient {
+  send: CloudWatchClient["send"];
+}
+
+export interface OperatorMetricsContext {
+  /**
+   * env discriminator (= `development` / `production` / `Lite`). Resolved
+   * from `TENKACLOUD_METRIC_ENV`, falling back to `DEPLOY_ENVIRONMENT`,
+   * then `"development"`. Used as both the namespace suffix (=
+   * `TenkaCloud/Lite`) and the `Environment` dimension on every metric.
+   */
+  readonly environment: string;
+  readonly client: MetricClient;
+}
+
+let cachedClient: CloudWatchClient | undefined;
+
+function resolveEnvironment(): string {
+  const explicit = process.env.TENKACLOUD_METRIC_ENV ?? "";
+  if (explicit.length > 0) return explicit;
+  const fallback = process.env.DEPLOY_ENVIRONMENT ?? "";
+  if (fallback.length > 0) return fallback;
+  return "development";
+}
+
+/**
+ * Module-scope production client. Lambda warm invokes reuse the same socket
+ * pool. Tests inject their own via the `client` option to keep the
+ * adapter pure (= same pattern as `external-id-audit-handler/repository.ts`).
+ */
+export function getOperatorMetricsContext(): OperatorMetricsContext | undefined {
+  // 明示 env が無いケースは `TENKACLOUD_METRIC_ENV` の値しか手がかりが無い。
+  // 旧 stack (= env 未配線) では `TENKACLOUD_METRIC_ENV` が空文字 → metric emission
+  // を no-op に落とす。 `audit-log.ts` の getEnv と同じ fail-safe デザイン。
+  const explicit = process.env.TENKACLOUD_METRIC_ENV ?? "";
+  if (explicit.length === 0) return undefined;
+  if (!cachedClient) {
+    cachedClient = new CloudWatchClient({} satisfies CloudWatchClientConfig);
+  }
+  return {
+    environment: resolveEnvironment(),
+    client: cachedClient,
+  };
+}
+
+function buildNamespace(environment: string): string {
+  return `${METRIC_NAMESPACE_PREFIX}/${environment}`;
+}
+
+interface BaseDimensions {
+  readonly tenantId: string;
+  readonly problemId: string;
+}
+
+async function publish(
+  ctx: OperatorMetricsContext,
+  metricName: string,
+  value: number,
+  unit: "Milliseconds" | "Count",
+  dimensions: readonly { Name: string; Value: string }[],
+  timestamp: Date,
+): Promise<void> {
+  try {
+    await ctx.client.send(
+      new PutMetricDataCommand({
+        Namespace: buildNamespace(ctx.environment),
+        MetricData: [
+          {
+            MetricName: metricName,
+            Value: value,
+            Unit: unit,
+            Timestamp: timestamp,
+            Dimensions: [...dimensions, { Name: "Environment", Value: ctx.environment }],
+          },
+        ],
+      }),
+    );
+  } catch (err) {
+    // metric 欠落は primary 業務 logic より重要度が低い。 throw しない。
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[operator-metrics] PutMetricData failed", { metricName, message });
+  }
+}
+
+export interface DeployOutcomeArgs extends BaseDimensions {
+  readonly outcome: DeployOutcome;
+  readonly durationMs: number;
+  readonly timestamp?: Date;
+}
+
+/**
+ * Emit `deploy.duration_ms` (Milliseconds) and `deploy.outcome` (Count=1)
+ * together. Operator dashboard pairs them to read latency × outcome ratio.
+ */
+export async function emitDeployOutcome(
+  ctx: OperatorMetricsContext | undefined,
+  args: DeployOutcomeArgs,
+): Promise<void> {
+  if (!ctx) return;
+  const timestamp = args.timestamp ?? new Date();
+  const dimensions = [
+    { Name: "TenantId", Value: args.tenantId },
+    { Name: "ProblemId", Value: args.problemId },
+    { Name: "Outcome", Value: args.outcome },
+  ];
+  await publish(ctx, "deploy.duration_ms", args.durationMs, "Milliseconds", dimensions, timestamp);
+  await publish(ctx, "deploy.outcome", 1, "Count", dimensions, timestamp);
+}
+
+export interface FlagSubmissionArgs extends BaseDimensions {
+  readonly count?: number;
+  readonly timestamp?: Date;
+}
+
+/**
+ * Emit `scoring.flag_submission_rate` (Count). One call per submission, or
+ * batch with `count` if the scoring loop aggregates. Operator dashboard
+ * sums by problem to spot silent scoring death (= flat 0 over event window).
+ */
+export async function emitFlagSubmission(
+  ctx: OperatorMetricsContext | undefined,
+  args: FlagSubmissionArgs,
+): Promise<void> {
+  if (!ctx) return;
+  const timestamp = args.timestamp ?? new Date();
+  await publish(
+    ctx,
+    "scoring.flag_submission_rate",
+    args.count ?? 1,
+    "Count",
+    [
+      { Name: "TenantId", Value: args.tenantId },
+      { Name: "ProblemId", Value: args.problemId },
+    ],
+    timestamp,
+  );
+}
+
+export interface DisruptionDetectionArgs extends BaseDimensions {
+  readonly disruptionId: string;
+  readonly count?: number;
+  readonly timestamp?: Date;
+}
+
+/**
+ * Emit `scoring.disruption_detection_rate` (Count). One call per disruption
+ * detection (= probe found target down). Dimensions include `DisruptionId`
+ * so operator can stack-chart by category to spot deliberate vs flaky.
+ */
+export async function emitDisruptionDetection(
+  ctx: OperatorMetricsContext | undefined,
+  args: DisruptionDetectionArgs,
+): Promise<void> {
+  if (!ctx) return;
+  const timestamp = args.timestamp ?? new Date();
+  await publish(
+    ctx,
+    "scoring.disruption_detection_rate",
+    args.count ?? 1,
+    "Count",
+    [
+      { Name: "TenantId", Value: args.tenantId },
+      { Name: "ProblemId", Value: args.problemId },
+      { Name: "DisruptionId", Value: args.disruptionId },
+    ],
+    timestamp,
+  );
+}
+
+/** Exported for unit tests. */
+export const __test__ = {
+  buildNamespace,
+  resolveEnvironment,
+};

--- a/infrastructure/lib/problem-deploy/handlers/shared/structured-log.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/structured-log.ts
@@ -1,0 +1,260 @@
+/**
+ * Issue #1352 (parent #1336): Structured operator-facing logging helper for
+ * commercial event operations.
+ *
+ * Why a second helper alongside `trace-log.ts`:
+ *
+ *   `trace-log.ts` (Issue #768) is geared toward end-to-end **deploy chain
+ *   triage** (`event = "deploy.<phase>.<outcome>"`, `jobId` propagation,
+ *   shell + Lambda mirrors). Its shape is optimised for "follow one job
+ *   through 6 hops".
+ *
+ *   This helper is geared toward **event-operator diagnosis** while the event
+ *   is running. The on-call operator does not know a `jobId` yet — they know
+ *   "tenant X / team Y / problem Z reported a failure". The pinned shape is
+ *   `{ level, ts, eventName, tenantId?, teamId?, problemId?, action, status,
+ *   durationMs?, errorCode? }` so CloudWatch Logs Insights `filter tenantId =
+ *   "..." and status = "failed"` answers the operator's question in one
+ *   query.
+ *
+ *   The two helpers coexist intentionally — they are different lenses on the
+ *   same logs. `trace-log` traces a request; `structured-log` summarises an
+ *   operator-visible outcome.
+ *
+ * Secret redaction (= same allowlist pattern as Issue #1297 audit redact):
+ *
+ *   Operators paste error messages into incident channels. Raw error strings
+ *   may contain ARNs, X-Forwarded-For IPs, presigned URL query params,
+ *   ExternalId values, or JWT fragments. `redactFields` keeps only the
+ *   allowlisted keys + primitive values, mirroring `redactForAudit` shallow
+ *   semantics so a future contributor cannot accidentally widen the leak
+ *   surface by adding nested objects.
+ *
+ *   Specifically NEVER log (= dropped silently even if caller passes them):
+ *     - `password`, `secret`, `token`, `accessKey`, `externalId`,
+ *       `presignedUrl`, `cookie`, `authorization`, `samlMetadata`,
+ *       `idToken`, `accessToken`, `refreshToken`, `clientSecret`
+ *     - any nested object / array / function / Date
+ *
+ *   `errorCode` is whitelisted as a string-typed primitive. `errorMessage`
+ *   is whitelisted but length-clamped (= 240 chars) so a multi-KB AWS SDK
+ *   stack trace does not blow up CloudWatch ingestion cost.
+ *
+ * env footprint: 0 bytes (pure code helper, no env variables added). The
+ * #1310 Lambda env 3KB harness rule is therefore not affected.
+ */
+
+/** Length cap for `errorMessage` after redaction. AWS SDK errors can carry KB-scale stack traces. */
+const ERROR_MESSAGE_MAX_LEN = 240;
+
+/**
+ * Allowlist of structured-log field names. Any caller-supplied key outside
+ * this set is silently dropped. Mirrors the shallow-only / fail-closed
+ * semantics of `redactForAudit` so secret keys cannot sneak in by
+ * caller-side typos (= `externalID` vs `externalId`).
+ *
+ * Adding a field: confirm it is **not** secret / PII (= never an ExternalId,
+ * password, JWT body, presigned URL query string, IP address, or email).
+ * Operator-facing identifiers (tenantId / teamId / problemId / jobId) are OK;
+ * AWS-side identifiers that are safe to log (region / awsAccountId — same
+ * tenancy boundary as DDB row) are OK; numbers / status enums are OK.
+ */
+const FIELD_ALLOWLIST: ReadonlySet<string> = new Set([
+  // correlation identifiers
+  "tenantId",
+  "teamId",
+  "problemId",
+  "eventId",
+  "deploymentId",
+  "jobId",
+  "correlationId",
+  "requestId",
+  "region",
+  "awsAccountId",
+  // operator-visible context
+  "action",
+  "status",
+  "outcome",
+  "phase",
+  "lastKnownStep",
+  "participantImpact",
+  // numeric / timing
+  "durationMs",
+  "ageSeconds",
+  "attempt",
+  "maxAttempts",
+  // error-shape (clamped / primitive only)
+  "errorCode",
+  "errorMessage",
+  "errorClass",
+  "stackStatus",
+  // operator hint
+  "suggestedAction",
+  "detailType",
+]);
+
+/**
+ * Status enum the operator dashboard / alarm filters on. `failed` is the
+ * gateway to runbook entries — anything that should page the on-call must
+ * land here.
+ */
+export type LogStatus = "started" | "succeeded" | "failed" | "timeout" | "skipped";
+export type LogLevel = "info" | "warn" | "error";
+
+/**
+ * Strict typed surface of an operator-facing log entry. Keys outside this
+ * surface are redacted away. Required: `eventName`, `action`, `status`.
+ *
+ * `eventName` convention: `<domain>.<resource>.<verb>` — for example
+ * `deploy.stack.create`, `scoring.flag.submit`, `participant.portal.login`.
+ * Operators grep by domain prefix in CloudWatch Logs Insights.
+ */
+export interface OperatorLogFields {
+  readonly eventName: string;
+  readonly action: string;
+  readonly status: LogStatus;
+  readonly tenantId?: string;
+  readonly teamId?: string;
+  readonly problemId?: string;
+  readonly eventId?: string;
+  readonly deploymentId?: string;
+  readonly jobId?: string;
+  readonly correlationId?: string;
+  readonly requestId?: string;
+  readonly region?: string;
+  readonly awsAccountId?: string;
+  readonly phase?: string;
+  readonly lastKnownStep?: string;
+  readonly participantImpact?: "none" | "degraded" | "blocked";
+  readonly durationMs?: number;
+  readonly ageSeconds?: number;
+  readonly attempt?: number;
+  readonly maxAttempts?: number;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+  readonly errorClass?: string;
+  readonly stackStatus?: string;
+  readonly suggestedAction?: string;
+  readonly detailType?: string;
+  readonly outcome?: string;
+}
+
+export type RedactedLogFields = Readonly<Record<string, string | number | boolean | null>>;
+
+/**
+ * Coerce + filter caller-supplied fields against the allowlist. Drops:
+ *   - keys outside `FIELD_ALLOWLIST`
+ *   - non-primitive values (nested object / array / Date / function / undefined)
+ *
+ * `errorMessage` is length-clamped to `ERROR_MESSAGE_MAX_LEN` so a multi-KB
+ * AWS SDK error message does not balloon CloudWatch Logs cost.
+ */
+export function redactFields(fields: OperatorLogFields): RedactedLogFields {
+  const out: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (!FIELD_ALLOWLIST.has(key)) continue;
+    if (value === null) {
+      out[key] = null;
+      continue;
+    }
+    if (typeof value === "string") {
+      out[key] = key === "errorMessage" ? clampErrorMessage(value) : value;
+      continue;
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      out[key] = value;
+    }
+    // object / array / undefined / function — drop silently (= fail-closed).
+  }
+  return out;
+}
+
+function clampErrorMessage(value: string): string {
+  if (value.length <= ERROR_MESSAGE_MAX_LEN) return value;
+  return `${value.slice(0, ERROR_MESSAGE_MAX_LEN - 3)}...`;
+}
+
+interface EmitOptions {
+  readonly writer?: (line: string) => void;
+  readonly now?: () => Date;
+}
+
+function levelToWriter(level: LogLevel): (line: string) => void {
+  if (level === "error") return (line: string) => console.error(line);
+  if (level === "warn") return (line: string) => console.warn(line);
+  return (line: string) => console.log(line);
+}
+
+/**
+ * Emit one structured operator-facing log line.
+ *
+ *   - `level` controls the CloudWatch console color + which `console.*` channel
+ *     the line lands in (= `error` / `warn` / `log`).
+ *   - `ts` is ISO-8601 (UTC). CloudWatch Logs preserves it verbatim, so
+ *     Insights `sort @timestamp asc` lines up with operator wall-clock.
+ *   - `component` is pinned to `problem-deploy` for cross-Lambda grep parity
+ *     with `trace-log.ts`. Same Logs Insights query works for both helpers.
+ *
+ * Returns the rendered JSON string so unit tests can pin the wire shape
+ * without spying on `console`. Production caller passes nothing (= writer
+ * defaults to `console.<level>`).
+ */
+export function emitOperatorLog(
+  level: LogLevel,
+  fields: OperatorLogFields,
+  options: EmitOptions = {},
+): string {
+  const ts = (options.now ?? (() => new Date()))().toISOString();
+  const redacted = redactFields(fields);
+  const payload = {
+    level,
+    ts,
+    component: "problem-deploy",
+    eventName: fields.eventName,
+    ...redacted,
+  };
+  const line = JSON.stringify(payload);
+  const writer = options.writer ?? levelToWriter(level);
+  writer(line);
+  return line;
+}
+
+/** Convenience: info-level emission. */
+export function logOperator(fields: OperatorLogFields, options: EmitOptions = {}): string {
+  return emitOperatorLog("info", fields, options);
+}
+
+/** Convenience: warn-level emission (= soft-degraded but operator should notice). */
+export function warnOperator(fields: OperatorLogFields, options: EmitOptions = {}): string {
+  return emitOperatorLog("warn", fields, options);
+}
+
+/** Convenience: error-level emission (= operator must act, paged status). */
+export function errorOperator(fields: OperatorLogFields, options: EmitOptions = {}): string {
+  return emitOperatorLog("error", fields, options);
+}
+
+/**
+ * Build an `errorCode` short string from an Error subclass. Pins a stable
+ * code (= class name) the operator runbook can index on, distinct from the
+ * free-form `errorMessage`. Falls back to `"UnknownError"` when err is not
+ * an Error instance (e.g. caller `throw "string"`).
+ */
+export function classifyError(err: unknown): { errorCode: string; errorMessage: string } {
+  if (err instanceof Error) {
+    return {
+      errorCode: err.name || "Error",
+      errorMessage: err.message,
+    };
+  }
+  return {
+    errorCode: "UnknownError",
+    errorMessage: typeof err === "string" ? err : "non-Error thrown",
+  };
+}
+
+/** Re-exported for unit tests (= internal constants intentionally kept private from prod). */
+export const __test__ = {
+  ERROR_MESSAGE_MAX_LEN,
+  FIELD_ALLOWLIST,
+};

--- a/infrastructure/test/problem-deploy/operator-metrics.test.ts
+++ b/infrastructure/test/problem-deploy/operator-metrics.test.ts
@@ -1,0 +1,145 @@
+import type { PutMetricDataCommand } from "@aws-sdk/client-cloudwatch";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __test__,
+  emitDeployOutcome,
+  emitDisruptionDetection,
+  emitFlagSubmission,
+  getOperatorMetricsContext,
+} from "../../lib/problem-deploy/handlers/shared/operator-metrics";
+
+describe("operator-metrics helper (Issue #1352)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.TENKACLOUD_METRIC_ENV = "Lite";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  describe("namespace + environment resolution", () => {
+    it("should build TenkaCloud/{env} namespace", () => {
+      expect(__test__.buildNamespace("Lite")).toBe("TenkaCloud/Lite");
+      expect(__test__.buildNamespace("development")).toBe("TenkaCloud/development");
+      expect(__test__.buildNamespace("production")).toBe("TenkaCloud/production");
+    });
+
+    it("should prefer TENKACLOUD_METRIC_ENV over DEPLOY_ENVIRONMENT", () => {
+      process.env.TENKACLOUD_METRIC_ENV = "Lite";
+      process.env.DEPLOY_ENVIRONMENT = "production";
+      expect(__test__.resolveEnvironment()).toBe("Lite");
+    });
+
+    it("should fall back to DEPLOY_ENVIRONMENT then 'development'", () => {
+      process.env.TENKACLOUD_METRIC_ENV = "";
+      process.env.DEPLOY_ENVIRONMENT = "staging";
+      expect(__test__.resolveEnvironment()).toBe("staging");
+      process.env.DEPLOY_ENVIRONMENT = "";
+      expect(__test__.resolveEnvironment()).toBe("development");
+    });
+
+    it("should return undefined context (= no-op) when TENKACLOUD_METRIC_ENV is empty (= old stacks)", () => {
+      process.env.TENKACLOUD_METRIC_ENV = "";
+      expect(getOperatorMetricsContext()).toBeUndefined();
+    });
+  });
+
+  describe("emitDeployOutcome", () => {
+    it("should publish deploy.duration_ms (Milliseconds) and deploy.outcome (Count=1) with TenantId/ProblemId/Outcome/Environment dimensions", async () => {
+      const send = vi.fn().mockResolvedValue({});
+      await emitDeployOutcome(
+        { environment: "Lite", client: { send: send as never } },
+        {
+          tenantId: "tenant-1",
+          problemId: "hello-world",
+          outcome: "success",
+          durationMs: 12_345,
+          timestamp: new Date("2026-05-26T00:00:00Z"),
+        },
+      );
+      expect(send).toHaveBeenCalledTimes(2);
+      const cmds = send.mock.calls.map((c) => c[0] as PutMetricDataCommand);
+      const durationCmd = cmds.find(
+        (c) => c.input.MetricData?.[0]?.MetricName === "deploy.duration_ms",
+      );
+      const outcomeCmd = cmds.find((c) => c.input.MetricData?.[0]?.MetricName === "deploy.outcome");
+      expect(durationCmd?.input.Namespace).toBe("TenkaCloud/Lite");
+      expect(durationCmd?.input.MetricData?.[0]?.Value).toBe(12_345);
+      expect(durationCmd?.input.MetricData?.[0]?.Unit).toBe("Milliseconds");
+      expect(outcomeCmd?.input.MetricData?.[0]?.Value).toBe(1);
+      expect(outcomeCmd?.input.MetricData?.[0]?.Unit).toBe("Count");
+      const dimsNames = (outcomeCmd?.input.MetricData?.[0]?.Dimensions ?? []).map((d) => d.Name);
+      expect(dimsNames).toEqual(
+        expect.arrayContaining(["TenantId", "ProblemId", "Outcome", "Environment"]),
+      );
+    });
+
+    it("should no-op when context is undefined", async () => {
+      // not throwing is the contract — old stacks pass undefined ctx
+      await expect(
+        emitDeployOutcome(undefined, {
+          tenantId: "tenant-1",
+          problemId: "hello-world",
+          outcome: "failed",
+          durationMs: 1,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should swallow PutMetricData failures (metric loss < primary op failure)", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const send = vi.fn().mockRejectedValue(new Error("throttled"));
+      await expect(
+        emitDeployOutcome(
+          { environment: "Lite", client: { send: send as never } },
+          { tenantId: "t", problemId: "p", outcome: "success", durationMs: 1 },
+        ),
+      ).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("emitFlagSubmission", () => {
+    it("should publish scoring.flag_submission_rate (Count) with TenantId/ProblemId dimensions", async () => {
+      const send = vi.fn().mockResolvedValue({});
+      await emitFlagSubmission(
+        { environment: "production", client: { send: send as never } },
+        { tenantId: "tenant-1", problemId: "ctf-1", count: 3 },
+      );
+      const cmd = send.mock.calls[0]?.[0] as PutMetricDataCommand;
+      expect(cmd.input.Namespace).toBe("TenkaCloud/production");
+      expect(cmd.input.MetricData?.[0]?.MetricName).toBe("scoring.flag_submission_rate");
+      expect(cmd.input.MetricData?.[0]?.Value).toBe(3);
+      expect(cmd.input.MetricData?.[0]?.Unit).toBe("Count");
+    });
+
+    it("should default count to 1 when omitted (= single submission)", async () => {
+      const send = vi.fn().mockResolvedValue({});
+      await emitFlagSubmission(
+        { environment: "Lite", client: { send: send as never } },
+        { tenantId: "t", problemId: "p" },
+      );
+      const cmd = send.mock.calls[0]?.[0] as PutMetricDataCommand;
+      expect(cmd.input.MetricData?.[0]?.Value).toBe(1);
+    });
+  });
+
+  describe("emitDisruptionDetection", () => {
+    it("should publish scoring.disruption_detection_rate with TenantId/ProblemId/DisruptionId dimensions", async () => {
+      const send = vi.fn().mockResolvedValue({});
+      await emitDisruptionDetection(
+        { environment: "Lite", client: { send: send as never } },
+        { tenantId: "tenant-1", problemId: "uptime-1", disruptionId: "kill-leader" },
+      );
+      const cmd = send.mock.calls[0]?.[0] as PutMetricDataCommand;
+      expect(cmd.input.MetricData?.[0]?.MetricName).toBe("scoring.disruption_detection_rate");
+      const dimsNames = (cmd.input.MetricData?.[0]?.Dimensions ?? []).map((d) => d.Name);
+      expect(dimsNames).toEqual(
+        expect.arrayContaining(["TenantId", "ProblemId", "DisruptionId", "Environment"]),
+      );
+    });
+  });
+});

--- a/infrastructure/test/problem-deploy/structured-log.test.ts
+++ b/infrastructure/test/problem-deploy/structured-log.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __test__,
+  classifyError,
+  emitOperatorLog,
+  errorOperator,
+  logOperator,
+  redactFields,
+  warnOperator,
+} from "../../lib/problem-deploy/handlers/shared/structured-log";
+
+describe("structured-log helper (Issue #1352)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("wire shape pin", () => {
+    it("should emit a single JSON line with the canonical operator schema", () => {
+      const fixedNow = new Date("2026-05-26T12:34:56.000Z");
+      emitOperatorLog(
+        "info",
+        {
+          eventName: "deploy.stack.create",
+          action: "create_deployment",
+          status: "succeeded",
+          tenantId: "tenant-1",
+          teamId: "team-A",
+          problemId: "hello-world",
+          durationMs: 1234,
+        },
+        { writer: (line) => console.log(line), now: () => fixedNow },
+      );
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const raw = logSpy.mock.calls[0]?.[0] as string;
+      const payload = JSON.parse(raw);
+      expect(payload).toMatchObject({
+        level: "info",
+        ts: "2026-05-26T12:34:56.000Z",
+        component: "problem-deploy",
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "succeeded",
+        tenantId: "tenant-1",
+        teamId: "team-A",
+        problemId: "hello-world",
+        durationMs: 1234,
+      });
+    });
+
+    it("should pin eventName / action / status / level / ts / component as required fields on every line", () => {
+      logOperator({
+        eventName: "scoring.flag.submit",
+        action: "submit_flag",
+        status: "succeeded",
+      });
+      const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+      expect(payload.eventName).toBe("scoring.flag.submit");
+      expect(payload.action).toBe("submit_flag");
+      expect(payload.status).toBe("succeeded");
+      expect(payload.level).toBe("info");
+      expect(payload.component).toBe("problem-deploy");
+      expect(typeof payload.ts).toBe("string");
+      expect(() => new Date(payload.ts).toISOString()).not.toThrow();
+    });
+
+    it("warnOperator should route to console.warn at level=warn", () => {
+      warnOperator({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "skipped",
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(warnSpy.mock.calls[0]?.[0] as string);
+      expect(payload.level).toBe("warn");
+    });
+
+    it("errorOperator should route to console.error at level=error", () => {
+      errorOperator({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "failed",
+        errorCode: "AccessDenied",
+      });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+      expect(payload.level).toBe("error");
+      expect(payload.errorCode).toBe("AccessDenied");
+    });
+  });
+
+  describe("secret redaction (allowlist-only)", () => {
+    it("should drop unknown keys (= fail-closed, matches #1297 audit redact)", () => {
+      const out = redactFields({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "succeeded",
+        // @ts-expect-error — caller-side typo we want to silently drop
+        password: "hunter2",
+        // @ts-expect-error — secret-shaped key
+        externalId: "ext-secret-xxx",
+        // @ts-expect-error — secret-shaped key
+        accessKey: "AKIA...",
+        // @ts-expect-error — secret-shaped key
+        cookie: "session=abc",
+      });
+      expect(out).not.toHaveProperty("password");
+      expect(out).not.toHaveProperty("externalId");
+      expect(out).not.toHaveProperty("accessKey");
+      expect(out).not.toHaveProperty("cookie");
+    });
+
+    it("should drop non-primitive values (= object / array / Date / function)", () => {
+      const out = redactFields({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "succeeded",
+        // @ts-expect-error — nested object would leak full shape into CloudWatch
+        tenantId: { id: "tenant-1" },
+        // @ts-expect-error — array smuggling
+        problemId: ["a", "b"],
+      });
+      expect(out).not.toHaveProperty("tenantId");
+      expect(out).not.toHaveProperty("problemId");
+    });
+
+    it("should keep string / number / boolean / null values for allowlisted keys", () => {
+      const out = redactFields({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "succeeded",
+        tenantId: "tenant-1",
+        durationMs: 1234,
+        problemId: "hello-world",
+      });
+      expect(out.tenantId).toBe("tenant-1");
+      expect(out.durationMs).toBe(1234);
+      expect(out.problemId).toBe("hello-world");
+    });
+
+    it("should clamp errorMessage to 240 chars to prevent multi-KB SDK stack traces blowing up CloudWatch", () => {
+      const longMsg = "x".repeat(500);
+      const out = redactFields({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "failed",
+        errorMessage: longMsg,
+      });
+      expect(typeof out.errorMessage).toBe("string");
+      expect((out.errorMessage as string).length).toBeLessThanOrEqual(
+        __test__.ERROR_MESSAGE_MAX_LEN,
+      );
+      expect((out.errorMessage as string).endsWith("...")).toBe(true);
+    });
+
+    it("should not clamp errorMessage shorter than the cap", () => {
+      const out = redactFields({
+        eventName: "deploy.stack.create",
+        action: "create_deployment",
+        status: "failed",
+        errorMessage: "AccessDenied: assume role failed",
+      });
+      expect(out.errorMessage).toBe("AccessDenied: assume role failed");
+    });
+
+    it("should reject every secret-shaped key (negative whitelist self-check)", () => {
+      const secretKeys = [
+        "password",
+        "secret",
+        "token",
+        "accessKey",
+        "externalId",
+        "presignedUrl",
+        "cookie",
+        "authorization",
+        "samlMetadata",
+        "idToken",
+        "accessToken",
+        "refreshToken",
+        "clientSecret",
+      ];
+      for (const key of secretKeys) {
+        expect(__test__.FIELD_ALLOWLIST.has(key)).toBe(false);
+      }
+    });
+  });
+
+  describe("classifyError", () => {
+    it("should extract name + message from an Error instance", () => {
+      const { errorCode, errorMessage } = classifyError(
+        Object.assign(new Error("assume role denied"), { name: "AccessDeniedError" }),
+      );
+      expect(errorCode).toBe("AccessDeniedError");
+      expect(errorMessage).toBe("assume role denied");
+    });
+
+    it("should fall back to UnknownError for non-Error throws", () => {
+      const { errorCode, errorMessage } = classifyError("oops");
+      expect(errorCode).toBe("UnknownError");
+      expect(errorMessage).toBe("oops");
+    });
+  });
+
+  it("should be JSON.parse-safe even with quotes / newlines in field values", () => {
+    logOperator({
+      eventName: "deploy.stack.create",
+      action: "create_deployment",
+      status: "failed",
+      errorMessage: 'broken "quoted"\nmulti-line',
+    });
+    const raw = logSpy.mock.calls[0]?.[0] as string;
+    expect(() => JSON.parse(raw)).not.toThrow();
+    const payload = JSON.parse(raw);
+    expect(payload.errorMessage).toBe('broken "quoted"\nmulti-line');
+  });
+});


### PR DESCRIPTION
## Summary

- New `structured-log.ts` helper: pinned-shape JSON log with allowlist-only secret redaction (= same pattern as #1297 audit redact). Operators query CloudWatch Logs Insights by `tenantId` + `status = "failed"` to surface event-day failures in one step.
- New `operator-metrics.ts` helper: CloudWatch `PutMetricData` adapter publishing `deploy.duration_ms`, `deploy.outcome`, `scoring.flag_submission_rate`, `scoring.disruption_detection_rate` into `TenkaCloud/{env}` namespace. Empty `TENKACLOUD_METRIC_ENV` downgrades emission to no-op so old stacks keep deploying.
- New `docs/operations/observability.md` (+ generated `.html`): operator dashboard hint, suggested alarms, 3 saved CloudWatch Insights queries (slow deploy / participant 4xx / failed CFn stack), and a failure-diagnosis runbook covering DeployRequested disappearance / DDB throttle / Cognito sign-in failure.
- 23 unit tests pin the wire shape (level / ts / eventName / action / status / tenantId / teamId / problemId / durationMs / errorCode), redaction (negative list: password / accessKey / externalId / cookie / token / etc), and PutMetricData dimensions.

Closes #1352
Relates #1336

## Log structure (= what operators search on)

```json
{
  "level": "info | warn | error",
  "ts": "2026-05-26T12:34:56.000Z",
  "component": "problem-deploy",
  "eventName": "deploy.stack.create",
  "action": "create_deployment",
  "status": "succeeded | failed | timeout | started | skipped",
  "tenantId": "tenant-1",
  "teamId": "team-A",
  "problemId": "hello-world",
  "durationMs": 1234,
  "errorCode": "AccessDeniedError"
}
```

## Metric catalog

| Metric | Unit | Dimensions |
| --- | --- | --- |
| `deploy.duration_ms` | Milliseconds | TenantId, ProblemId, Outcome, Environment |
| `deploy.outcome` | Count | TenantId, ProblemId, Outcome, Environment |
| `scoring.flag_submission_rate` | Count | TenantId, ProblemId, Environment |
| `scoring.disruption_detection_rate` | Count | TenantId, ProblemId, DisruptionId, Environment |

Namespace: `TenkaCloud/Lite` for Lite mode, `TenkaCloud/development` / `TenkaCloud/production` for SaaS mode.

## Sample Insights queries

```text
fields @timestamp, tenantId, teamId, problemId, durationMs, status, errorCode
| filter eventName like /^deploy\./ and status in ["succeeded", "failed", "timeout"]
| filter durationMs > 300000
| sort durationMs desc
| limit 50
```

(2 more queries in `docs/operations/observability.md`)

## Regression analysis

- Helpers are new files, opt-in for callers. No existing handler is rewired, so production deploy paths are unchanged at the runtime layer.
- `operator-metrics` no-ops when `TENKACLOUD_METRIC_ENV` is empty (= old stacks). PutMetricData failures are swallowed so a CloudWatch outage cannot block business logic.
- `structured-log` is pure-code (zero env footprint). The allowlist filter fails closed — adding a secret-typed field has no behavioural change until the allowlist is widened, which requires PR review.
- `handler-no-direct-sdk-import` harness rule holds: AWS SDK imported only from non-index helper modules.

## Physical impact

- CREATE: 6 files (2 lib helpers + 2 tests + 1 doc + 1 generated `.html`)
- No CDK / IaC changes. No CFn diff. No deploy required.
- env footprint delta: +0 bytes for callers who do not opt in; +<= 35 bytes (env key + value) for callers who set `TENKACLOUD_METRIC_ENV`. Well under the #1310 Lambda env 3KB harness budget.
- DDB / DynamoDB Aspect 1/1 invariant: unchanged (no new tables).
- The follow-up wiring PR (= calling `logOperator` / `emitDeployOutcome` from deploy / scoring / participant handlers) ships separately, paired with the corresponding handler-side tests, so this PR remains a focused primitive landing.

## Test plan

- [x] `make harness` clean (0 invariant violations)
- [x] `make before-commit` green (lint / textlint / biome / typecheck / 1630+ tests / validate-problems / check-docs / synth)
- [x] 23 new unit tests pass (`infrastructure/test/problem-deploy/structured-log.test.ts` + `operator-metrics.test.ts`)
- [ ] Reviewer to confirm metric dimensions match the planned CloudWatch dashboard (see Metric catalog above)
- [ ] Reviewer to confirm allowlist field set covers the operator runbook surface without leaking secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)