### PR TITLE
fix(login): auto-redirect to Cognito skips intermediate page when no SAML IdP — #1360

### DIFF
--- a/apps/admin-console/src/pages/Login.tsx
+++ b/apps/admin-console/src/pages/Login.tsx
@@ -12,6 +12,11 @@
  *                              fallback として local 経路を提供)
  *         - kind: "redirect" → `beginLogin({ identityProvider })` で IdP に直接 redirect
  *         - kind: "select"   → 候補 IdP の button 列を表示 (= 同一 domain 複数 IdP)
+ *
+ * Issue #1360: SAML 未設定の場合、 中間の 「サインイン」 button は無意味な 1 click を
+ * 増やすだけだったため、 mount 直後に `beginLogin()` を発火させて Cognito Hosted UI に
+ * 直接 redirect する。 SAML 設定済の場合は picker を出すために中間 page が必要なので
+ * 既存 UX を維持する。
  */
 
 import Alert from "@cloudscape-design/components/alert";
@@ -20,7 +25,7 @@ import Button from "@cloudscape-design/components/button";
 import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { distinctProviders, type IdpResolution, resolveIdp } from "../auth/idp-resolution";
 import { ProductLoginShell } from "../components/ProductLoginShell";
@@ -59,7 +64,21 @@ export function LoginPage({ config }: { config: AppConfig }) {
     }
   };
 
-  // === SAML 未設定: 旧 flow をそのまま返す ===
+  // Issue #1360: SAML 未設定なら mount 直後に Cognito へ自動 redirect する (= 中間 click
+  // を排除)。 React StrictMode 等の重複 mount で 2 度発火しないよう ref で guard。 error
+  // 発生時は flag を維持し、 user が button で再試行する経路に倒す。 依存に startLogin を
+  // 入れると毎 render で hook 再評価されるため samlEnabled のみに固定し、 重複発火は
+  // autoStartedRef で 1 度に絞り込む。
+  const autoStartedRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above (#1360).
+  useEffect(() => {
+    if (samlEnabled) return;
+    if (autoStartedRef.current) return;
+    autoStartedRef.current = true;
+    void startLogin();
+  }, [samlEnabled]);
+
+  // === SAML 未設定: 自動 redirect 中の spinner / error fallback を表示 ===
   if (!samlEnabled) {
     return (
       <ProductLoginShell

--- a/apps/admin-console/test/pages/login.test.tsx
+++ b/apps/admin-console/test/pages/login.test.tsx
@@ -2,10 +2,14 @@
  * Issue #1329: System Admin Console login redesign regression tests.
  *
  * The page must:
- *   - render TenkaCloud product name + sign-in button (= LP branding, not "Admin Console" alone)
- *   - call beginLogin on button click (= contract preserved across the redesign)
- *   - show signing-in state after click (= no fire-and-forget UX)
+ *   - render TenkaCloud product name (= LP branding, not "Admin Console" alone)
+ *   - call beginLogin (= contract preserved across the redesign)
+ *   - show signing-in state (= no fire-and-forget UX)
  *   - show error fallback when beginLogin throws (= support contact + mailto)
+ *
+ * Issue #1360: when samlIdpDirectory is empty, the page must auto-redirect to Cognito
+ * on mount (= no intermediate "Sign in" click). When SAML is configured, the picker UX
+ * is preserved (= existing #1335 flow).
  */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -64,46 +68,67 @@ describe("admin-console LoginPage (#1329)", () => {
     sessionStorage.clear();
   });
 
-  it("should render the TenkaCloud product name and sign-in button", () => {
+  it("should render the TenkaCloud product name in the heading", () => {
+    // hold beginLogin open so the spinner is visible (auto-redirect hides the button on mount).
+    beginLoginMock.mockImplementation(() => new Promise<void>(() => {}));
     renderLogin();
     expect(
       screen.getByRole("heading", { level: 1, name: /TenkaCloud System Admin Console/ }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "サインイン" })).toBeInTheDocument();
   });
 
-  it("should call beginLogin when the sign-in button is clicked", async () => {
+  it("should auto-call beginLogin on mount when samlIdpDirectory is empty", async () => {
     beginLoginMock.mockResolvedValue(undefined);
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     await waitFor(() => {
       expect(beginLoginMock).toHaveBeenCalledTimes(1);
     });
+    // Auto-redirect path passes no identity_provider (= local sign-in).
+    const callArgs = beginLoginMock.mock.calls[0];
+    expect(callArgs?.[1]).toBeUndefined();
   });
 
-  it("should show the signing-in state after the sign-in button is clicked", async () => {
-    // hold the promise open so the spinner state is observable.
-    let resolveLogin: (() => void) | undefined;
-    beginLoginMock.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveLogin = resolve;
-        }),
-    );
+  it("should NOT auto-call beginLogin when samlIdpDirectory has entries", async () => {
+    beginLoginMock.mockResolvedValue(undefined);
+    renderLogin({ samlIdpDirectory: { "example.com": ["corp-entra"] } });
+    // give the effect a tick to (not) fire.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(beginLoginMock).not.toHaveBeenCalled();
+    // Picker mode shows the email input.
+    expect(screen.getByLabelText(/会社のメールアドレス/)).toBeInTheDocument();
+  });
+
+  it("should show the signing-in state while auto-redirecting", async () => {
+    beginLoginMock.mockImplementation(() => new Promise<void>(() => {}));
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     expect(await screen.findByText(/Cognito にリダイレクト中/)).toBeInTheDocument();
-    resolveLogin?.();
   });
 
-  it("should show the error fallback when beginLogin throws", async () => {
+  it("should show the error fallback when beginLogin throws on auto-redirect", async () => {
     beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     expect(await screen.findByText(/サインインに失敗しました/)).toBeInTheDocument();
     // mailto link presence: support@tenkacloud.cloud
     const mailto = screen.getByRole("link", { name: /support@tenkacloud\.cloud/ });
     expect(mailto).toHaveAttribute("href", "mailto:support@tenkacloud.cloud");
+  });
+
+  it("should not re-fire beginLogin on re-render after error", async () => {
+    beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
+    const { rerender } = renderLogin();
+    await waitFor(() => {
+      expect(beginLoginMock).toHaveBeenCalledTimes(1);
+    });
+    // Force a re-render with the same props. The auto-start guard should hold.
+    rerender(
+      <I18nProvider>
+        <AuthProvider config={baseConfig}>
+          <LoginPage config={baseConfig} />
+        </AuthProvider>
+      </I18nProvider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(beginLoginMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/application-admin-console/src/pages/Login.tsx
+++ b/apps/application-admin-console/src/pages/Login.tsx
@@ -3,13 +3,18 @@
  * branding を適用し、 「Application Admin Console」 + dev jargon の文言を商用 SaaS
  * のログイン画面へ refresh。
  *
+ * Issue #1360: SAML IdP picker を表示する余地が application-admin-console には存在
+ * しない (= tenant の Cognito UserPool は SAML を直接持たない / pooled 共有 UserPool)
+ * ため、 中間 「サインイン」 button は常に冗長な 1 click でしかなかった。 Mount 直後に
+ * `beginLogin()` を発火させて Cognito Hosted UI に直接 redirect する。
+ *
  * 表示状態:
- *   1) idle     : title + subtitle + 「サインイン」 button
- *   2) signing  : Cognito へ redirect 中 spinner
- *   3) error    : beginLogin throw 時の fallback alert + mailto link
+ *   1) signing  : Cognito へ redirect 中 spinner (= 初期状態)
+ *   2) error    : beginLogin throw 時の fallback alert + mailto link
+ *                 (= button を再表示し再 sign-in 試行を許可)
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { ProductLoginShell } from "../components/ProductLoginShell";
 import { useT } from "../i18n";
@@ -17,10 +22,14 @@ import { useT } from "../i18n";
 export function LoginPage() {
   const auth = useAuth();
   const t = useT();
-  const [signingIn, setSigningIn] = useState(false);
+  // mount 直後に auto-redirect を 1 回だけ走らせる guard。 React StrictMode の 2 度
+  // mount / re-render での重複発火を防ぐ。 error 発生時は user 操作で再試行できるよう
+  // この flag は触らず、 button の onSignIn から再度 `signIn` を呼ぶ経路に倒す。
+  const autoStartedRef = useRef(false);
+  const [signingIn, setSigningIn] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
-  const onSignIn = async () => {
+  const signIn = async () => {
     setSigningIn(true);
     setErrorMessage(undefined);
     try {
@@ -36,6 +45,16 @@ export function LoginPage() {
     }
   };
 
+  // SAML 候補なし → mount 即 Cognito へ。 error からの再試行は button で。 signIn を
+  // 依存に入れると毎 render で hook 再評価されるため空 array に固定し、 重複発火は
+  // autoStartedRef で 1 度に絞り込む (Issue #1360)。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above (#1360).
+  useEffect(() => {
+    if (autoStartedRef.current) return;
+    autoStartedRef.current = true;
+    void signIn();
+  }, []);
+
   return (
     <ProductLoginShell
       title={t("login.title")}
@@ -44,7 +63,7 @@ export function LoginPage() {
       signingInLabel={t("login.signing_in")}
       signingIn={signingIn}
       errorMessage={errorMessage}
-      onSignIn={onSignIn}
+      onSignIn={signIn}
     />
   );
 }

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -55,16 +55,29 @@ describe("App", () => {
   });
 
   describe("when accessing /login directly", () => {
-    it("should render LoginPage with a sign-in button", async () => {
+    it("should render LoginPage", async () => {
+      // Issue #1360: SAML 候補が無いので login page は中間 button を出さず Cognito へ
+      // 自動 redirect する。 LoginPage が mount された印として heading を確認する。
       renderApp("/login");
-      expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
+      expect(
+        await screen.findByRole("heading", {
+          level: 1,
+          name: /TenkaCloud Application Admin Console/,
+        }),
+      ).toBeInTheDocument();
     });
   });
 
   describe("when accessing / unauthenticated", () => {
-    it("should redirect to LoginPage and show the sign-in button", async () => {
+    it("should redirect to LoginPage", async () => {
+      // Issue #1360: 同上 — sign-in button は出ず、 LoginPage 自動 redirect で spinner が出る。
       renderApp("/");
-      expect(await screen.findByRole("button", { name: "サインイン" })).toBeInTheDocument();
+      expect(
+        await screen.findByRole("heading", {
+          level: 1,
+          name: /TenkaCloud Application Admin Console/,
+        }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/application-admin-console/test/pages/login.test.tsx
+++ b/apps/application-admin-console/test/pages/login.test.tsx
@@ -2,13 +2,16 @@
  * Issue #1329: Tenant Admin Console login redesign regression tests.
  *
  * The page must:
- *   - render TenkaCloud product name + sign-in button
- *   - call beginLogin on button click
- *   - show signing-in state after click
+ *   - render TenkaCloud product name
+ *   - call beginLogin
+ *   - show signing-in state
  *   - show error fallback when beginLogin throws
+ *
+ * Issue #1360: application-admin-console has no SAML IdP picker, so the page must
+ * auto-redirect to Cognito on mount (= no intermediate "Sign in" click).
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const beginLoginMock = vi.fn();
@@ -57,43 +60,51 @@ describe("application-admin-console LoginPage (#1329)", () => {
     sessionStorage.clear();
   });
 
-  it("should render the TenkaCloud product name and sign-in button", () => {
+  it("should render the TenkaCloud product name in the heading", () => {
+    // hold beginLogin open so the auto-redirect spinner is visible.
+    beginLoginMock.mockImplementation(() => new Promise<void>(() => {}));
     renderLogin();
     expect(
       screen.getByRole("heading", { level: 1, name: /TenkaCloud Application Admin Console/ }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "サインイン" })).toBeInTheDocument();
   });
 
-  it("should call beginLogin when the sign-in button is clicked", async () => {
+  it("should auto-call beginLogin on mount (no intermediate click)", async () => {
     beginLoginMock.mockResolvedValue(undefined);
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     await waitFor(() => {
       expect(beginLoginMock).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("should show the signing-in state after the sign-in button is clicked", async () => {
-    let resolveLogin: (() => void) | undefined;
-    beginLoginMock.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveLogin = resolve;
-        }),
-    );
+  it("should show the signing-in state while auto-redirecting", async () => {
+    beginLoginMock.mockImplementation(() => new Promise<void>(() => {}));
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     expect(await screen.findByText(/Cognito にリダイレクト中/)).toBeInTheDocument();
-    resolveLogin?.();
   });
 
-  it("should show the error fallback when beginLogin throws", async () => {
+  it("should show the error fallback when beginLogin throws on auto-redirect", async () => {
     beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
     renderLogin();
-    fireEvent.click(screen.getByRole("button", { name: "サインイン" }));
     expect(await screen.findByText(/サインインに失敗しました/)).toBeInTheDocument();
     const mailto = screen.getByRole("link", { name: /support@tenkacloud\.cloud/ });
     expect(mailto).toHaveAttribute("href", "mailto:support@tenkacloud.cloud");
+  });
+
+  it("should not re-fire beginLogin on re-render after error", async () => {
+    beginLoginMock.mockRejectedValue(new Error("PKCE generation failed"));
+    const { rerender } = renderLogin();
+    await waitFor(() => {
+      expect(beginLoginMock).toHaveBeenCalledTimes(1);
+    });
+    rerender(
+      <I18nProvider>
+        <AuthProvider config={config}>
+          <LoginPage />
+        </AuthProvider>
+      </I18nProvider>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(beginLoginMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

User feedback: 「SAML との切り替えを意識してるならいいけど一手多い」。 SAML IdP candidate が無い時は intermediate page を skip して直接 Cognito Hosted UI へ。

### Implementation

Both admin-console and application-admin-console Login.tsx now:

\`\`\`tsx
const hasSamlIdp = Object.keys(config.samlIdpDirectory ?? {}).length > 0;
useEffect(() => {
  if (hasSamlIdp || error) return;
  void auth.login();
}, [hasSamlIdp, ...]);
\`\`\`

- SAML IdP 無し → 開いた瞬間に \`beginLogin()\` を呼んで Cognito へ
- SAML IdP 1 件 → idp-resolution の auto-redirect (= 既存)
- SAML IdP 複数 → picker (= 既存)
- Error → fallback message (= 自動再試行しない)

Closes #1360
Relates #1334 (branded login pages base) / #1342 / #1340 (SAML SSO Phases)

## Regression analysis

- SAML IdP がある場合の picker は変化なし
- IdP 無し時のみ auto-redirect で 1 click 削減
- Cognito 側で何かエラーが返ったら user に message + 自動再試行はしない (= 無限 loop 防止)

## Physical impact

- NO-OP for CFn / Lambda / runtime
- SPA UX 修正 (5 files / +140/-53)