### PR TITLE
fix(lite): V2 Pre-Token trigger so ID token carries TenantAdmin claim — #1358

### DIFF
--- a/infrastructure/lib/app-plane-core/handlers/pre-token-generation/index.ts
+++ b/infrastructure/lib/app-plane-core/handlers/pre-token-generation/index.ts
@@ -1,7 +1,10 @@
-import type { PreTokenGenerationTriggerEvent, PreTokenGenerationTriggerHandler } from "aws-lambda";
+import type {
+  PreTokenGenerationV2TriggerEvent,
+  PreTokenGenerationV2TriggerHandler,
+} from "aws-lambda";
 
 /**
- * Issue #1327: Lite mode Cognito UserPool 用 Pre-Token Generation trigger。
+ * Issue #1327 / #1358: Lite mode Cognito UserPool 用 Pre-Token Generation V2 trigger。
  *
  * ## なぜ必要か
  * Lite mode (= `tenantId="local"` 1 tenant 専用) では SBT pipeline / `provision-tenant.sh`
@@ -11,8 +14,18 @@ import type { PreTokenGenerationTriggerEvent, PreTokenGenerationTriggerHandler }
  * `resolveTenantId(c)` で `custom:tenantId` を読むため、 Lite mode で sign-in した user は
  * SAML IdP / 監査ログ ページが 403 で開けない (= bug #1327 の症状)。
  *
+ * ## V2 trigger を採用する理由 (#1358)
+ * V1 trigger response (`response.claimsOverrideDetails.claimsToAddOrOverride`) は **access token**
+ * 側にしか claim を inject しない。 一方 Application Plane の handler は Cognito JWT
+ * authorizer 経由で **ID token** を読むため (= `requireRole` / `resolveTenantId` が claim を
+ * 取り出す source が ID token)、 V1 形式だと claim が乗らず 403 が解消しない。
+ *
+ * V2 trigger response (`claimsAndScopeOverrideDetails.idTokenGeneration.claimsToAddOrOverride`)
+ * は ID token と access token の双方に inject 可能。 両方に同値を入れることで API Gateway /
+ * Lambda authorizer / SDK 側の token 種類選好に依らず一貫した claim を提供する。
+ *
  * ## 解決
- * Cognito の Pre-Token Generation trigger を Lite mode UserPool に attach し、 id_token /
+ * Cognito の Pre-Token Generation V2 trigger を Lite mode UserPool に attach し、 id_token /
  * access_token 発行のタイミングで `custom:userRole = "TenantAdmin"` + `custom:tenantId = "local"`
  * を必ず claim に上書きする。 Lite mode は 1 tenant 専用 (= ADR-016 Phase 3) なので、
  * 「全 user は暗黙に TenantAdmin」 という運用前提を JWT claim 層で具現化する。
@@ -24,10 +37,10 @@ import type { PreTokenGenerationTriggerEvent, PreTokenGenerationTriggerHandler }
  * 暗黙の TenantAdmin 昇格を引き起こすことは無い。
  *
  * ## なぜ event を mutate するだけで済むか
- * Cognito Pre-Token Generation は handler が `event.response.claimsOverrideDetails.claimsToAddOrOverride`
- * を返すと、 JWT 発行直前にその key / value を claim に注入する (= AWS doc: Customizing user
- * pool workflows with Lambda triggers / Pre token generation Lambda trigger)。 IAM / 外部
- * API call は不要。
+ * Cognito Pre-Token Generation は handler が `event.response.claimsAndScopeOverrideDetails`
+ * を返すと、 JWT 発行直前にその key / value を id_token / access_token の claim に注入する
+ * (= AWS doc: Customizing user pool workflows with Lambda triggers / Pre token generation
+ * Lambda trigger / V2 trigger event)。 IAM / 外部 API call は不要。
  *
  * ## 注意 (= overwrite ではなく override)
  * `claimsToAddOrOverride` は既存 claim を **上書き** する仕様 (= 既存 user attribute に
@@ -37,15 +50,26 @@ import type { PreTokenGenerationTriggerEvent, PreTokenGenerationTriggerHandler }
 export const LITE_TENANT_ADMIN_ROLE = "TenantAdmin" as const;
 export const LITE_TENANT_ID = "local" as const;
 
-export const handler: PreTokenGenerationTriggerHandler = async (
-  event: PreTokenGenerationTriggerEvent,
+export const handler: PreTokenGenerationV2TriggerHandler = async (
+  event: PreTokenGenerationV2TriggerEvent,
 ) => {
+  const claimsToAddOrOverride = {
+    "custom:userRole": LITE_TENANT_ADMIN_ROLE,
+    "custom:tenantId": LITE_TENANT_ID,
+  } as const;
+
   event.response = {
-    claimsOverrideDetails: {
-      claimsToAddOrOverride: {
-        "custom:userRole": LITE_TENANT_ADMIN_ROLE,
-        "custom:tenantId": LITE_TENANT_ID,
+    claimsAndScopeOverrideDetails: {
+      idTokenGeneration: {
+        claimsToAddOrOverride,
       },
+      accessTokenGeneration: {
+        claimsToAddOrOverride,
+      },
+      // group override は使わない (= UserPool group 経路を Lite では使わない)。 ただし
+      // V2 contract 上 `groupOverrideDetails: {}` を明示的に空オブジェクトで返すことで
+      // 「未指定 = 既存 group を尊重」 を意図として固定する。
+      groupOverrideDetails: {},
     },
   };
   return event;

--- a/infrastructure/lib/app-plane-core/lite-admin-claims-lambda.ts
+++ b/infrastructure/lib/app-plane-core/lite-admin-claims-lambda.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
 import type { UserPool } from "aws-cdk-lib/aws-cognito";
-import { UserPoolOperation } from "aws-cdk-lib/aws-cognito";
+import { LambdaVersion, UserPoolOperation } from "aws-cdk-lib/aws-cognito";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -32,10 +32,15 @@ export interface LiteAdminClaimsLambdaProps {
  * 本 Lambda は event を mutate して返すだけ (= 外部 service call 不要)。 IAM 追加権限・
  * env / VPC は不要。 timeout 5s / memory 128MB で十分 (Cognito の sync invoke 上限 5s も満たす)。
  *
- * ## addTrigger の挙動
- * `userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION, fn)` は CFn 上で UserPool の
- * `LambdaConfig.PreTokenGeneration` を本 Lambda の ARN に設定し、 同時に Cognito service
- * principal が本 Lambda を invoke するための resource-based policy も自動追加する。
+ * ## addTrigger の挙動 (= V2 trigger / #1358)
+ * `userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION_CONFIG, fn, LambdaVersion.V2_0)`
+ * は CFn 上で UserPool の `LambdaConfig.PreTokenGenerationConfig` を本 Lambda の ARN +
+ * `LambdaVersion: V2_0` で設定し、 同時に Cognito service principal が本 Lambda を invoke
+ * するための resource-based policy も自動追加する。 V2 trigger を指定することで Cognito 側は
+ * V2 event shape (= `claimsAndScopeOverrideDetails.idTokenGeneration` を読む経路) で
+ * Lambda を呼び出し、 ID token / access token の双方に custom claim を inject 可能になる。
+ * V1 trigger (= `PRE_TOKEN_GENERATION`) は access token のみ override 可能で、 Application Plane
+ * handler が読む ID token に claim が乗らないため使用しない (= #1358 root cause)。
  */
 export class LiteAdminClaimsLambda extends Construct {
   public readonly fn: NodejsFunction;
@@ -64,10 +69,17 @@ export class LiteAdminClaimsLambda extends Construct {
       },
     });
 
-    // UserPool に Pre-Token Generation trigger として bind する。 これにより
-    //   - UserPool.LambdaConfig.PreTokenGeneration が fn ARN を指す
+    // UserPool に Pre-Token Generation V2 trigger として bind する。 これにより
+    //   - UserPool.LambdaConfig.PreTokenGenerationConfig.LambdaArn が fn ARN を指す
+    //   - UserPool.LambdaConfig.PreTokenGenerationConfig.LambdaVersion = "V2_0"
     //   - fn の resource-based policy に Cognito 経由の invoke 権限が自動追加される
-    // が同時に行われる。
-    props.userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION, this.fn);
+    // が同時に行われる。 V2 を指定することで handler は V2 event shape
+    // (= `claimsAndScopeOverrideDetails`) を返し、 ID token / access token の双方に
+    // custom claim が乗る (= #1358 fix の根幹)。
+    props.userPool.addTrigger(
+      UserPoolOperation.PRE_TOKEN_GENERATION_CONFIG,
+      this.fn,
+      LambdaVersion.V2_0,
+    );
   }
 }

--- a/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
+++ b/infrastructure/test/app-plane-core/build-app-plane-core.test.ts
@@ -93,11 +93,13 @@ describe("buildAppPlaneCore", () => {
     const userPool = Object.values(userPools)[0];
     const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
       ?.LambdaConfig;
-    // LambdaConfig 自体が無いか、 PreTokenGeneration key が無い (= SaaS mode regression なし)。
+    // LambdaConfig 自体が無いか、 PreTokenGeneration / PreTokenGenerationConfig key が無い
+    // (= SaaS mode regression なし)。 V1 / V2 どちらの key も未設定であることを確認する。
     expect(lambdaConfig?.PreTokenGeneration).toBeUndefined();
+    expect(lambdaConfig?.PreTokenGenerationConfig).toBeUndefined();
   });
 
-  it("should attach a Pre-Token Generation Lambda when liteAdminClaimsInjection is true (#1327)", () => {
+  it("should attach a Pre-Token Generation V2 Lambda when liteAdminClaimsInjection is true (#1327 / #1358)", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack", {
       env: { account: "123456789012", region: "ap-northeast-1" },
@@ -122,14 +124,27 @@ describe("buildAppPlaneCore", () => {
       },
     });
     const template = Template.fromStack(stack);
+    // #1358: V2 trigger を採用すると Cognito UserPool は LambdaConfig.PreTokenGenerationConfig
+    // (= LambdaArn + LambdaVersion: V2_0) として設定される。 V1 trigger の旧 key
+    // (PreTokenGeneration) が混入していないことも併せて確認する。
     template.hasResourceProperties(
       "AWS::Cognito::UserPool",
       Match.objectLike({
         LambdaConfig: Match.objectLike({
-          PreTokenGeneration: Match.anyValue(),
+          PreTokenGenerationConfig: Match.objectLike({
+            LambdaArn: Match.anyValue(),
+            LambdaVersion: "V2_0",
+          }),
         }),
       }),
     );
+    const userPools = template.findResources("AWS::Cognito::UserPool");
+    const userPool = Object.values(userPools)[0];
+    const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
+      ?.LambdaConfig;
+    // V1 key (= PreTokenGeneration) は使わない (= #1358 root cause: V1 は access token のみ
+    // override 可能で ID token に claim が乗らないため Application Plane handler が 403 を返す)。
+    expect(lambdaConfig?.PreTokenGeneration).toBeUndefined();
   });
 
   it("the returned applicationAdminConsoleUrl should equal hosting.distributionUrl", () => {

--- a/infrastructure/test/app-plane-core/handlers/pre-token-generation.test.ts
+++ b/infrastructure/test/app-plane-core/handlers/pre-token-generation.test.ts
@@ -1,4 +1,4 @@
-import type { PreTokenGenerationTriggerEvent } from "aws-lambda";
+import type { PreTokenGenerationV2TriggerEvent } from "aws-lambda";
 import { describe, expect, it } from "vitest";
 import {
   handler,
@@ -7,19 +7,20 @@ import {
 } from "../../../lib/app-plane-core/handlers/pre-token-generation/index.js";
 
 /**
- * Issue #1327: Pre-Token Generation handler の契約 pin。
+ * Issue #1327 / #1358: Pre-Token Generation V2 handler の契約 pin。
  *
- * Cognito の trigger 仕様 (= 同期 / event mutate 経由で JWT claim を上書き) を
- * input → output で固定する。 SaaS mode handler の `requireRole(c, [TENANT_ADMIN_ROLE])` +
- * `resolveTenantId(c)` が成立するために必要な 2 claim (`custom:userRole` / `custom:tenantId`)
- * が必ず注入されることを保証する。
+ * Cognito の V2 trigger 仕様 (= 同期 / event mutate 経由で id_token / access_token の
+ * 両方に claim を上書き) を input → output で固定する。 SaaS mode handler の
+ * `requireRole(c, [TENANT_ADMIN_ROLE])` + `resolveTenantId(c)` が成立するために必要な 2 claim
+ * (`custom:userRole` / `custom:tenantId`) が **id_token と access_token の双方** に必ず
+ * 注入されることを保証する (#1358 の regression を pin)。
  */
 
 function buildEvent(
-  overrides?: Partial<PreTokenGenerationTriggerEvent>,
-): PreTokenGenerationTriggerEvent {
+  overrides?: Partial<PreTokenGenerationV2TriggerEvent>,
+): PreTokenGenerationV2TriggerEvent {
   return {
-    version: "1",
+    version: "2",
     triggerSource: "TokenGeneration_HostedAuth",
     region: "ap-northeast-1",
     userPoolId: "ap-northeast-1_AAA",
@@ -36,24 +37,39 @@ function buildEvent(
         iamRolesToOverride: [],
         preferredRole: undefined,
       },
+      scopes: ["openid", "email"],
     },
     response: {
-      claimsOverrideDetails: null,
+      claimsAndScopeOverrideDetails: {},
     },
     ...overrides,
-  } as PreTokenGenerationTriggerEvent;
+  } as PreTokenGenerationV2TriggerEvent;
 }
 
-describe("Pre-Token Generation handler (#1327)", () => {
-  it("should inject custom:userRole=TenantAdmin and custom:tenantId=local into JWT claims", async () => {
+describe("Pre-Token Generation V2 handler (#1327 / #1358)", () => {
+  it("should inject custom:userRole=TenantAdmin and custom:tenantId=local into the ID token (#1358 root cause)", async () => {
     const event = buildEvent();
     const result = await handler(event, {} as never, () => undefined);
     expect(result).toBeDefined();
-    const claims =
-      (result as PreTokenGenerationTriggerEvent).response.claimsOverrideDetails
-        ?.claimsToAddOrOverride ?? {};
-    expect(claims["custom:userRole"]).toBe("TenantAdmin");
-    expect(claims["custom:tenantId"]).toBe("local");
+    const idClaims =
+      (result as PreTokenGenerationV2TriggerEvent).response.claimsAndScopeOverrideDetails
+        ?.idTokenGeneration?.claimsToAddOrOverride ?? {};
+    expect(idClaims["custom:userRole"]).toBe("TenantAdmin");
+    expect(idClaims["custom:tenantId"]).toBe("local");
+  });
+
+  it("should also inject claims into the access token so API Gateway / Lambda authorizers see them regardless of token type", async () => {
+    const event = buildEvent();
+    const result = (await handler(
+      event,
+      {} as never,
+      () => undefined,
+    )) as PreTokenGenerationV2TriggerEvent;
+    const accessClaims =
+      result.response.claimsAndScopeOverrideDetails?.accessTokenGeneration?.claimsToAddOrOverride ??
+      {};
+    expect(accessClaims["custom:userRole"]).toBe("TenantAdmin");
+    expect(accessClaims["custom:tenantId"]).toBe("local");
   });
 
   it("should preserve the input event shape (Cognito trigger contract: handler returns the mutated event)", async () => {
@@ -62,7 +78,7 @@ describe("Pre-Token Generation handler (#1327)", () => {
       event,
       {} as never,
       () => undefined,
-    )) as PreTokenGenerationTriggerEvent;
+    )) as PreTokenGenerationV2TriggerEvent;
     // Cognito requires the handler to return the event (sync invoke). Confirm identity is preserved.
     expect(result.userPoolId).toBe(event.userPoolId);
     expect(result.userName).toBe(event.userName);
@@ -79,10 +95,32 @@ describe("Pre-Token Generation handler (#1327)", () => {
       event,
       {} as never,
       () => undefined,
-    )) as PreTokenGenerationTriggerEvent;
-    const claims = result.response.claimsOverrideDetails?.claimsToAddOrOverride ?? {};
-    expect(claims["custom:userRole"]).toBe("TenantAdmin");
-    expect(claims["custom:tenantId"]).toBe("local");
+    )) as PreTokenGenerationV2TriggerEvent;
+    const idClaims =
+      result.response.claimsAndScopeOverrideDetails?.idTokenGeneration?.claimsToAddOrOverride ?? {};
+    const accessClaims =
+      result.response.claimsAndScopeOverrideDetails?.accessTokenGeneration?.claimsToAddOrOverride ??
+      {};
+    expect(idClaims["custom:userRole"]).toBe("TenantAdmin");
+    expect(idClaims["custom:tenantId"]).toBe("local");
+    expect(accessClaims["custom:userRole"]).toBe("TenantAdmin");
+    expect(accessClaims["custom:tenantId"]).toBe("local");
+  });
+
+  it("should emit groupOverrideDetails as an empty object so existing UserPool groups are preserved", async () => {
+    // V2 contract: `groupOverrideDetails: {}` を明示的に空オブジェクトで返すことで
+    // 「未指定 = 既存 group を尊重」 が意図であることを pin する。 Lite mode は UserPool
+    // group 経路を使わないため、 ここで意図せず group を override しない保証になる。
+    const event = buildEvent();
+    const result = (await handler(
+      event,
+      {} as never,
+      () => undefined,
+    )) as PreTokenGenerationV2TriggerEvent;
+    const groupOverride = result.response.claimsAndScopeOverrideDetails?.groupOverrideDetails;
+    expect(groupOverride).toBeDefined();
+    // 空オブジェクトであることを確認 (= groupsToOverride / iamRolesToOverride / preferredRole 未指定)。
+    expect(Object.keys(groupOverride ?? {}).length).toBe(0);
   });
 
   it("should export constants matching the Application Plane handler expectations", () => {

--- a/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
+++ b/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
@@ -195,19 +195,31 @@ describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
     );
   });
 
-  // Issue #1327: Lite mode user に `custom:userRole=TenantAdmin` + `custom:tenantId=local` を
-  // JWT 発行時に注入する Pre-Token Generation Lambda が UserPool に attach されていることを pin。
+  // Issue #1327 / #1358: Lite mode user に `custom:userRole=TenantAdmin` + `custom:tenantId=local` を
+  // JWT 発行時に注入する Pre-Token Generation V2 Lambda が UserPool に attach されていることを pin。
+  // V2 trigger (= PreTokenGenerationConfig + LambdaVersion: V2_0) を使うことで ID token と access token
+  // の双方に claim が乗り、 Application Plane handler の `requireRole` が成立する (#1358 fix の根幹)。
 
-  it("should attach a Pre-Token Generation Lambda trigger on the Lite UserPool (#1327)", () => {
+  it("should attach a Pre-Token Generation V2 Lambda trigger on the Lite UserPool (#1327 / #1358)", () => {
     const template = synth();
     template.hasResourceProperties(
       "AWS::Cognito::UserPool",
       Match.objectLike({
         LambdaConfig: Match.objectLike({
-          PreTokenGeneration: Match.anyValue(),
+          PreTokenGenerationConfig: Match.objectLike({
+            LambdaArn: Match.anyValue(),
+            LambdaVersion: "V2_0",
+          }),
         }),
       }),
     );
+    // V1 key (PreTokenGeneration) が混入していないこと (= #1358 regression guard、 V1 だと
+    // ID token に claim が乗らないため使ってはならない)。
+    const userPools = template.findResources("AWS::Cognito::UserPool");
+    const userPool = Object.values(userPools)[0];
+    const lambdaConfig = (userPool?.Properties as { LambdaConfig?: Record<string, unknown> })
+      ?.LambdaConfig;
+    expect(lambdaConfig?.PreTokenGeneration).toBeUndefined();
   });
 
   it("should bundle a LiteAdminClaims Lambda Function for the Pre-Token Generation trigger (#1327)", () => {


### PR DESCRIPTION
## Summary

- Switch the Lite mode Cognito Pre-Token Generation Lambda from V1 to V2 trigger so `custom:userRole=TenantAdmin` + `custom:tenantId=local` are injected into **both** the ID token and the access token. The Application Plane handler reads the ID token via Cognito JWT authorizer, so the V1-only `claimsOverrideDetails.claimsToAddOrOverride` (= access-token-only override) wasn't reaching `requireRole(c, [TENANT_ADMIN_ROLE])` and produced 403 on Identity Providers / Audit Log pages.
- CDK switches to `userPool.addTrigger(UserPoolOperation.PRE_TOKEN_GENERATION_CONFIG, fn, LambdaVersion.V2_0)`, surfacing in CFn as `LambdaConfig.PreTokenGenerationConfig.{LambdaArn, LambdaVersion: "V2_0"}`. Test pins both the V2 key and a regression guard for the old V1 key.
- SaaS mode is untouched: the trigger only attaches when `liteAdminClaimsInjection: true` (= TenkaCloudLiteStack only). Control Plane is not affected because Lite mode does not stand up `ControlPlaneStack`.

Closes #1358
Relates #1327

## Regression analysis

- **SaaS mode**: `buildAppPlaneCore` regression test (= `liteAdminClaimsInjection` unset) asserts both `PreTokenGeneration` and `PreTokenGenerationConfig` keys are absent on the UserPool. No CFn diff for SaaS tenants.
- **Lite mode existing users**: V2 trigger response semantics are backward-compatible at the Cognito API level — claim names / values are unchanged, only the delivery path expands (id_token now also carries the claims). Existing tokens stay valid until expiry, then next sign-in receives the corrected claim shape.
- **Cognito API**: V2 trigger was GA since 2023; aws-cdk-lib >= 2.150.0 supports it natively (we're on ^2.256.1).
- **Control Plane**: Not relevant to Lite mode — `bin/tenkacloud-lite.ts` does not instantiate `ControlPlaneStack`, so no SystemAdmin Pre-Token Lambda is required.

## Physical impact

- **`AWS::Cognito::UserPool` (TenkaCloudLiteStack)** — UPDATE. `LambdaConfig.PreTokenGeneration` removed, `LambdaConfig.PreTokenGenerationConfig` added with `LambdaVersion: V2_0`.
- **`AWS::Lambda::Function` (LiteAdminClaims)** — UPDATE. Handler source replaced (V1 → V2 response shape). Bundling artifact hash changes; alias stays the same.
- **`AWS::Lambda::Permission` (Cognito invoke)** — NO-OP. CDK re-emits the same resource-based policy; principal / SourceArn unchanged.
- **SaaS / pooled / silo TenantTemplate stacks** — NO-OP. `liteAdminClaimsInjection` is undefined there, so neither LambdaConfig key is set.
- **CloudFormation rollback** — Safe. V2 trigger setup is idempotent; rolling back to V1 redeploys the previous Lambda code and clears `PreTokenGenerationConfig`.

## Test plan

- [x] `make harness` — 0 errors (only an info-level reminder to run `make synth`, satisfied by `make before-commit`).
- [x] `make before-commit` — lint / typecheck / build / synth / 5 workspace test suites (1609 infrastructure + 124 admin-console + 349 application-admin-console + 217 participant-portal + 61 trust-bridge + 30 auth-client + 25 saml-utils + 67 cli + 25 saml-utils-pkg = ~2569 tests) all green.
- [x] Handler unit test pins V2 shape on **both** `idTokenGeneration.claimsToAddOrOverride` and `accessTokenGeneration.claimsToAddOrOverride`.
- [x] CDK template test pins `LambdaConfig.PreTokenGenerationConfig.{LambdaArn, LambdaVersion: "V2_0"}` on both `buildAppPlaneCore` (with `liteAdminClaimsInjection: true`) and `TenkaCloudLiteStack`.
- [x] CDK regression guard: SaaS path (= `liteAdminClaimsInjection` unset) emits neither V1 nor V2 key.
- [ ] Manual: `make deploy` → sign-in flow → DevTools `aws-amplify` ID token decode shows `custom:userRole=TenantAdmin` and `custom:tenantId=local` → Identity Providers + Audit Log pages return 200 (= acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)