### PR TITLE
fix(portal): event-day credibility — next action / countdown / badge / errors / mobile — #1349

### DIFF
--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { TeamViewProvider, useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
 import { type LocaleCode, SUPPORTED_LOCALES, useI18n } from "../i18n";
+import { CountdownTimer } from "./CountdownTimer";
 
 /**
  * Issue #583 Phase 1.A: locale switcher の display 名 map。 各 locale.json 内
@@ -276,6 +277,11 @@ function ShellInner({ config, children }: { config: AppConfig; children: ReactNo
         content={
           <SpaceBetween size="m">
             <OfflineCloudModeAlert config={config} />
+            {/* Issue #1349: 全画面共通の event countdown を header 下に固定。 endsAt が
+             *  legacy deployment で undefined のときは CountdownTimer 自身が null を返す。 */}
+            <Box float="right">
+              <CountdownTimer endsAt={teamView.leaderboard?.endsAt} />
+            </Box>
             {auth.session === null ? (
               <Box variant="strong" color="text-status-warning">
                 {t("app.no_session")}

--- a/apps/participant-portal/src/components/CountdownTimer.tsx
+++ b/apps/participant-portal/src/components/CountdownTimer.tsx
@@ -1,0 +1,92 @@
+import Badge from "@cloudscape-design/components/badge";
+import Box from "@cloudscape-design/components/box";
+import { useEffect, useState } from "react";
+import { useT } from "../i18n";
+
+/**
+ * Issue #1349: 残時間 (= 終了予定 ISO 8601 - now) を `HH:MM:SS` 文字列で返す純関数。
+ *
+ * - 終了予定 `endsAt` が未指定なら `null` (= caller 側で表示せず render skip)。
+ * - 終了済 (= now > endsAt) は `{ kind: "ended" }`。
+ * - 残 5 分以内は `{ kind: "warning" }` で UI 側 alert を出す。
+ * - それ以外は `{ kind: "running" }`。
+ *
+ * 設計判断: render 専用 component (`CountdownTimer`) と分離して、pure function 単独で
+ * unit test できる形にする (= 時刻依存 logic を React component に閉じ込めない)。
+ */
+export type CountdownState =
+  | { readonly kind: "no-event" }
+  | { readonly kind: "ended"; readonly display: string }
+  | { readonly kind: "warning"; readonly display: string; readonly remainingSec: number }
+  | { readonly kind: "running"; readonly display: string; readonly remainingSec: number };
+
+const WARNING_THRESHOLD_SEC = 5 * 60;
+
+function formatHms(totalSec: number): string {
+  const sec = Math.max(0, Math.floor(totalSec));
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+export function computeCountdownState(
+  endsAtIso: string | undefined,
+  nowMs: number,
+): CountdownState {
+  if (!endsAtIso) return { kind: "no-event" };
+  const endsMs = Date.parse(endsAtIso);
+  if (!Number.isFinite(endsMs)) return { kind: "no-event" };
+  const remainingMs = endsMs - nowMs;
+  if (remainingMs <= 0) return { kind: "ended", display: "00:00:00" };
+  const remainingSec = Math.floor(remainingMs / 1000);
+  const display = formatHms(remainingSec);
+  if (remainingSec <= WARNING_THRESHOLD_SEC) {
+    return { kind: "warning", display, remainingSec };
+  }
+  return { kind: "running", display, remainingSec };
+}
+
+/**
+ * 残時間表示用 React component。1 秒 tick で再描画する (= 60 秒 polling とは独立、
+ * client-side のみで動く時計)。`endsAt` が無い (= legacy deployment) は null を return。
+ *
+ * 残 5 分以内は赤系 badge + 「ラスト 5 分」 ラベルで visual alert。
+ */
+export function CountdownTimer({ endsAt }: { endsAt?: string }) {
+  const t = useT();
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const state = computeCountdownState(endsAt, nowMs);
+  if (state.kind === "no-event") return null;
+
+  if (state.kind === "ended") {
+    return (
+      <Badge color="grey">
+        {t("countdown.ended_label")} {state.display}
+      </Badge>
+    );
+  }
+
+  if (state.kind === "warning") {
+    return (
+      <Box color="text-status-error" fontWeight="bold" display="inline-block">
+        <Badge color="red">
+          {t("countdown.last_5_min")} {state.display}
+        </Badge>
+      </Box>
+    );
+  }
+
+  return (
+    <Badge color="blue">
+      {t("countdown.remaining_label")} {state.display}
+    </Badge>
+  );
+}

--- a/apps/participant-portal/src/components/NextActionHero.tsx
+++ b/apps/participant-portal/src/components/NextActionHero.tsx
@@ -1,0 +1,197 @@
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useNavigate } from "react-router";
+import type {
+  LeaderboardResponse,
+  ParticipantProblemView,
+  ParticipantTeamView,
+} from "../api/portal-client";
+import { useT } from "../i18n";
+import { computeCountdownState } from "./CountdownTimer";
+
+/**
+ * Issue #1349: Home tab 上部に出す「次に何をすればよいか」 hero panel。
+ *
+ * 3 状態:
+ *  - `not_started`: 競技開始前 (= eventGate.kind === "scoring_not_started")
+ *      → 「競技開始まで残り X 分」 countdown
+ *  - `ended`: 競技終了済 (= eventGate.kind === "scoring_ended" or endsAt 経過)
+ *      → 「お疲れさまでした。 最終順位: 3 位」
+ *  - `running`: 競技中 (= eventGate.kind === "ok" or undefined)
+ *      → 未解答問題が N 件。 まず {problemId} を解く →  (= 直接 /problems/:jobId に飛ぶ)
+ *
+ * 設計判断: 戦術判断 (= どの問題を「次にやるべき」 と推奨するか) は pure function
+ * `pickNextProblem` に分離して unit test 可能にする。 UI 側は state 文字列を組み立てて
+ * Cloudscape Container で render するだけ。
+ */
+
+export type NextActionState =
+  | { readonly kind: "not_started"; readonly startsAt?: string }
+  | { readonly kind: "ended"; readonly finalRank?: number; readonly totalEntries?: number }
+  | {
+      readonly kind: "running";
+      readonly unsolvedCount: number;
+      readonly nextProblem?: ParticipantProblemView;
+    }
+  | { readonly kind: "all_cleared" };
+
+/**
+ * 「次にやるべき問題」 を選ぶ pure function。
+ *
+ * - status === "COMPLETE" でかつ未解答 (= flag 未提出 or uptime score 0) なものを優先
+ * - その中でも 難易度が低い方 (= problemId の lexical order を tie-breaker に使う)
+ * - 全 cleared なら undefined → caller 側で「all_cleared」 state に倒す
+ */
+export function isProblemUnsolved(p: ParticipantProblemView): boolean {
+  if (p.status !== "COMPLETE" && p.status !== "IN_PROGRESS" && p.status !== "PENDING") return false;
+  if (p.scoring?.kind === "flag") return p.scoring.flagSubmitted !== true;
+  return p.score === 0;
+}
+
+export function pickNextProblem(
+  problems: readonly ParticipantProblemView[],
+): ParticipantProblemView | undefined {
+  const unsolved = problems.filter(isProblemUnsolved);
+  if (unsolved.length === 0) return undefined;
+  // Issue #1349: COMPLETE (= deploy 完了済) を優先、 deploy 中はやることが無いので後ろ。
+  const ready = unsolved.filter((p) => p.status === "COMPLETE");
+  const pool = ready.length > 0 ? ready : unsolved;
+  return [...pool].sort((a, b) => a.problemId.localeCompare(b.problemId))[0];
+}
+
+export function computeNextActionState(args: {
+  readonly view: ParticipantTeamView | null;
+  readonly leaderboard: LeaderboardResponse | null;
+  readonly nowMs: number;
+}): NextActionState | null {
+  const { view, leaderboard, nowMs } = args;
+  if (!view) return null;
+  const gate = view.eventGate;
+  if (gate?.kind === "scoring_not_started") {
+    return { kind: "not_started", startsAt: gate.startsAt };
+  }
+  // endsAt 経過 (= timer 上は終了) も ended 扱い、 backend gate と独立に判定 (= 末端で
+  // race condition を吸収)。
+  const endsAt = leaderboard?.endsAt;
+  const countdown = computeCountdownState(endsAt, nowMs);
+  if (gate?.kind === "scoring_ended" || countdown.kind === "ended") {
+    const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
+    return {
+      kind: "ended",
+      finalRank: myEntry?.rank,
+      totalEntries: leaderboard?.entries.length,
+    };
+  }
+  const unsolved = view.problems.filter(isProblemUnsolved);
+  if (unsolved.length === 0 && view.problems.length > 0) {
+    return { kind: "all_cleared" };
+  }
+  const next = pickNextProblem(view.problems);
+  return { kind: "running", unsolvedCount: unsolved.length, nextProblem: next };
+}
+
+export function NextActionHero({
+  view,
+  leaderboard,
+}: {
+  view: ParticipantTeamView | null;
+  leaderboard: LeaderboardResponse | null;
+}) {
+  const t = useT();
+  const navigate = useNavigate();
+  const state = computeNextActionState({ view, leaderboard, nowMs: Date.now() });
+  if (!state) return null;
+
+  if (state.kind === "not_started") {
+    return (
+      <Container
+        header={
+          <Header variant="h2" description={t("next_action.not_started_description")}>
+            {t("next_action.not_started_header")}
+          </Header>
+        }
+      >
+        <Box variant="awsui-value-large" color="text-status-info">
+          {state.startsAt
+            ? t("next_action.not_started_starts_at", {
+                startsAt: new Date(state.startsAt).toLocaleString(),
+              })
+            : t("next_action.not_started_unknown")}
+        </Box>
+      </Container>
+    );
+  }
+
+  if (state.kind === "ended") {
+    const rankLine =
+      state.finalRank !== undefined && state.totalEntries !== undefined
+        ? t("next_action.ended_with_rank", {
+            rank: state.finalRank,
+            total: state.totalEntries,
+          })
+        : t("next_action.ended_no_rank");
+    return (
+      <Container
+        header={
+          <Header variant="h2" description={t("next_action.ended_description")}>
+            {t("next_action.ended_header")}
+          </Header>
+        }
+      >
+        <Box variant="awsui-value-large" color="text-status-success">
+          {rankLine}
+        </Box>
+      </Container>
+    );
+  }
+
+  if (state.kind === "all_cleared") {
+    return (
+      <Container
+        header={
+          <Header variant="h2" description={t("next_action.all_cleared_description")}>
+            {t("next_action.all_cleared_header")}
+          </Header>
+        }
+      >
+        <Box variant="awsui-value-large" color="text-status-success">
+          {t("next_action.all_cleared_body")}
+        </Box>
+      </Container>
+    );
+  }
+
+  // state.kind === "running"
+  const nextProblem = state.nextProblem;
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={t("next_action.running_description", { count: state.unsolvedCount })}
+        >
+          {t("next_action.running_header")}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <Box variant="awsui-value-large" color="text-status-info">
+          {nextProblem
+            ? t("next_action.running_pick", { problemId: nextProblem.problemId })
+            : t("next_action.running_no_ready")}
+        </Box>
+        {nextProblem && (
+          <Button
+            variant="primary"
+            onClick={() => navigate(`/problems/${encodeURIComponent(nextProblem.jobId)}`)}
+          >
+            {t("next_action.running_open_button")}
+          </Button>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -134,6 +134,7 @@
     "submission_finished": "Finished",
     "submission_preparing": "Preparing",
     "submission_cleared": "Cleared",
+    "submission_cleared_with_points": "Cleared (+{points} pt)",
     "submission_unsolved": "Unsolved",
     "submission_in_progress": "In progress",
     "difficulty_label": "Difficulty: {label}",
@@ -338,5 +339,38 @@
     "aria_label": "Cumulative score timeline of all teams since competition start",
     "no_data": "No data",
     "no_match": "No data in range"
+  },
+  "countdown": {
+    "remaining_label": "Remaining",
+    "last_5_min": "Last 5 min",
+    "ended_label": "Ended"
+  },
+  "next_action": {
+    "not_started_header": "Competition has not started yet",
+    "not_started_description": "Problem details, hints, and flag submission unlock when the competition starts.",
+    "not_started_starts_at": "Starts at {startsAt}",
+    "not_started_unknown": "Waiting for the operator's start signal.",
+    "ended_header": "Competition ended",
+    "ended_description": "Thanks for participating. Results below.",
+    "ended_with_rank": "Final rank: {rank} / {total}",
+    "ended_no_rank": "Final results will be published by the operator.",
+    "running_header": "Next action",
+    "running_description": "{count} problem(s) unsolved. Open the next one to keep scoring.",
+    "running_pick": "Start with {problemId} →",
+    "running_no_ready": "Your deployments are still preparing. Hold on a moment.",
+    "running_open_button": "Open this problem",
+    "all_cleared_header": "All problems solved",
+    "all_cleared_description": "You've cleared every problem deployed to your team. Keep an eye on the leaderboard until the event ends.",
+    "all_cleared_body": "Nicely done. Awaiting final ranking."
+  },
+  "friendly_error": {
+    "auth_expired": "Your session has expired. Please sign in again with the login key your operator re-distributed.",
+    "invalid_flag": "That flag is incorrect.",
+    "invalid_flag_with_remaining": "That flag is incorrect ({remaining} attempt(s) left).",
+    "invalid_url": "Invalid URL (must be an absolute URL starting with http:// or https://).",
+    "validation_generic": "Validation error: {code}",
+    "network": "Network error. Please retry; if it persists, contact your operator.",
+    "network_with_correlation": "Network error. Please retry; if it persists, share this correlation id with your operator: {correlationId}",
+    "unknown": "Something went wrong. Please retry."
   }
 }

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -134,6 +134,7 @@
     "submission_finished": "終了",
     "submission_preparing": "準備中",
     "submission_cleared": "クリア",
+    "submission_cleared_with_points": "クリア (+{points} pt)",
     "submission_unsolved": "未解答",
     "submission_in_progress": "挑戦中",
     "difficulty_label": "難易度: {label}",
@@ -338,5 +339,38 @@
     "aria_label": "競技開始からの全チームスコア推移 (累積)",
     "no_data": "データなし",
     "no_match": "範囲内にデータなし"
+  },
+  "countdown": {
+    "remaining_label": "残り",
+    "last_5_min": "ラスト 5 分",
+    "ended_label": "終了"
+  },
+  "next_action": {
+    "not_started_header": "競技はまだ開始していません",
+    "not_started_description": "競技開始後に問題詳細・ヒント・flag 提出が解放されます。",
+    "not_started_starts_at": "競技開始予定: {startsAt}",
+    "not_started_unknown": "運営の開始合図をお待ちください。",
+    "ended_header": "競技終了",
+    "ended_description": "お疲れさまでした。 結果は以下のとおりです。",
+    "ended_with_rank": "最終順位: {rank} / {total}",
+    "ended_no_rank": "最終結果は運営から発表されます。",
+    "running_header": "次にやること",
+    "running_description": "未解答問題が {count} 件あります。 1 問ずつ片付けていきましょう。",
+    "running_pick": "まず {problemId} を解く →",
+    "running_no_ready": "deploy 準備中です。 少しお待ちください。",
+    "running_open_button": "この問題を開く",
+    "all_cleared_header": "全問クリア",
+    "all_cleared_description": "deploy 済の全問題を解き終えました。 競技終了まで leaderboard を見守りましょう。",
+    "all_cleared_body": "お見事。 最終順位を待ちましょう。"
+  },
+  "friendly_error": {
+    "auth_expired": "ログイン期限切れ。 organizer から再配布された login key で再ログインしてください。",
+    "invalid_flag": "flag が違います。",
+    "invalid_flag_with_remaining": "flag が違います (残 {remaining} 回 試行可)。",
+    "invalid_url": "URL の形式が不正です (http:// または https:// で始まる絶対 URL を指定)。",
+    "validation_generic": "入力エラー: {code}",
+    "network": "通信エラー。 もう一度試して、それでも続くようなら運営に連絡してください。",
+    "network_with_correlation": "通信エラー。 もう一度試して、それでも続くようなら以下の correlation id を運営に伝えてください: {correlationId}",
+    "unknown": "問題が発生しました。 もう一度試してください。"
   }
 }

--- a/apps/participant-portal/src/lib/friendly-error.ts
+++ b/apps/participant-portal/src/lib/friendly-error.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #1349: portal の error 表示を競技者向けに翻訳する純関数。
+ *
+ * `PortalAuthError` / `PortalValidationError` 等の internal error class を、
+ * 競技 (event-day) 文脈で意味のあるメッセージに変える:
+ *
+ *  - 401 (PortalAuthError) → 「ログイン期限切れ。 organizer から再配布された login key で
+ *    再ログインしてください」
+ *  - 400 (PortalValidationError) で `invalid_flag` → 「flag が違います (残 N 回 試行可)」
+ *  - その他 → 既存 message (= 生 HTTP status は出さない)
+ *
+ * 設計判断:
+ *  - i18n key を返さない (= caller 側で t() を呼ばずに直接 message を表示できるように
+ *    locale-aware な文字列を組み立てて return する)。 caller が t を渡す signature。
+ *  - portal-client を直接 import しない (= sub-class identity 依存を避けて pure に保つ)。
+ *    caller が name で判定して context を渡す。
+ */
+
+import { PortalAuthError, PortalNetworkError, PortalValidationError } from "../api/portal-client";
+
+type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
+
+export interface FriendlyErrorContext {
+  /** flag 提出 context のとき、残試行回数 (= 5 - wrongCount)。 */
+  readonly flagRemainingAttempts?: number;
+  /** facilitator support 用 deployment id / correlation id (出る画面のみ)。 */
+  readonly correlationId?: string;
+}
+
+/**
+ * 競技者向けに整形された error message を返す。
+ *
+ * raw HTTP status code / stack trace は絶対に出さない (= 「ログイン期限切れ」 等を
+ * 競技者に伝えるのが目的)。
+ */
+export function friendlyErrorMessage(
+  err: unknown,
+  t: Translate,
+  ctx: FriendlyErrorContext = {},
+): string {
+  if (err instanceof PortalAuthError) {
+    return t("friendly_error.auth_expired");
+  }
+  if (err instanceof PortalValidationError) {
+    if (err.errorCode === "invalid_flag" && ctx.flagRemainingAttempts !== undefined) {
+      return t("friendly_error.invalid_flag_with_remaining", {
+        remaining: ctx.flagRemainingAttempts,
+      });
+    }
+    if (err.errorCode === "invalid_flag") {
+      return t("friendly_error.invalid_flag");
+    }
+    if (err.errorCode === "invalid_url") {
+      return t("friendly_error.invalid_url");
+    }
+    return t("friendly_error.validation_generic", { code: err.errorCode });
+  }
+  if (err instanceof PortalNetworkError) {
+    // PortalNetworkError は status code を field で保持しているが、 競技者に
+    // 「502 Bad Gateway」 と見せても何も助けにならない。 facilitator に伝える
+    // ための correlationId だけを出す。
+    if (ctx.correlationId) {
+      return t("friendly_error.network_with_correlation", { correlationId: ctx.correlationId });
+    }
+    return t("friendly_error.network");
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return t("friendly_error.unknown");
+}

--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from "react-router";
 import type { LeaderboardResponse, ParticipantTeamView } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
+import { NextActionHero } from "../components/NextActionHero";
 import { ScoreTimelineChart } from "../components/ScoreTimelineChart";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
@@ -53,6 +54,10 @@ export function HomePage({ config }: { config: AppConfig }) {
         </Alert>
       )}
       {!isMock && !view && !error && <Box>{t("app.loading")}</Box>}
+
+      {/* Issue #1349: 「次にやること」 hero を一等地に置く (= 3 状態 = not_started /
+       *  running / ended)。 視線は header → next action → 累計スコア → 推移 → 一覧 の順。 */}
+      <NextActionHero view={view} leaderboard={leaderboard} />
 
       {view && <TeamScorePanel view={view} leaderboard={leaderboard} />}
 

--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -27,7 +27,13 @@ import { categoryOf } from "../lib/category";
  */
 type TFn = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
-function renderSubmissionState(
+/**
+ * Issue #1349: 採点状態 badge を unit test 可能な pure function に分離。 各
+ * problem の `status` (= deploy 進捗) と `scoring.flagSubmitted` / `score` を見て、
+ * 4 状態 (未着手 / Deploy 中 / 着手中 / 解答済) を返す。 解答済 (= flag 提出済) は
+ * `scoring.points` があれば 「+Npt」 を末尾に付ける (= 何点 取れたかを一目で出す)。
+ */
+export function renderSubmissionState(
   problem: ParticipantProblemView,
   t: TFn,
 ): {
@@ -49,8 +55,14 @@ function renderSubmissionState(
     return { type: "in-progress", label: t(`quests.status_label.${problem.status}`) };
   }
   if (problem.scoring?.kind === "flag") {
-    if (problem.scoring.flagSubmitted)
-      return { type: "success", label: t("quests.submission_cleared") };
+    if (problem.scoring.flagSubmitted) {
+      const points = problem.scoring.points;
+      const label =
+        points !== undefined
+          ? t("quests.submission_cleared_with_points", { points })
+          : t("quests.submission_cleared");
+      return { type: "success", label };
+    }
     return { type: "pending", label: t("quests.submission_unsolved") };
   }
   return { type: "info", label: t("quests.submission_in_progress") };

--- a/apps/participant-portal/test/components/CountdownTimer.test.ts
+++ b/apps/participant-portal/test/components/CountdownTimer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { computeCountdownState } from "../../src/components/CountdownTimer";
+
+/**
+ * Issue #1349: CountdownTimer の pure logic (= 残時間状態判定 + HH:MM:SS format) を pin。
+ * React 側の `setInterval` 駆動 re-render は本 test では検証しない (= computeCountdownState
+ * が時刻引数を受け取る分離設計なので render を mount しなくて済む)。
+ */
+describe("computeCountdownState", () => {
+  const now = Date.parse("2026-05-22T13:00:00Z");
+
+  it("should return no-event when endsAt is missing or invalid", () => {
+    expect(computeCountdownState(undefined, now)).toEqual({ kind: "no-event" });
+    expect(computeCountdownState("not-an-iso", now)).toEqual({ kind: "no-event" });
+  });
+
+  it("should return ended when endsAt is in the past", () => {
+    const past = "2026-05-22T12:00:00Z";
+    expect(computeCountdownState(past, now)).toEqual({ kind: "ended", display: "00:00:00" });
+  });
+
+  it("should return ended when endsAt equals now (boundary)", () => {
+    const same = new Date(now).toISOString();
+    expect(computeCountdownState(same, now)).toEqual({ kind: "ended", display: "00:00:00" });
+  });
+
+  it("should return running with HH:MM:SS when remaining > 5 minutes", () => {
+    // 1 時間 23 分 45 秒 後
+    const futureMs = now + ((1 * 60 + 23) * 60 + 45) * 1000;
+    const state = computeCountdownState(new Date(futureMs).toISOString(), now);
+    expect(state.kind).toBe("running");
+    if (state.kind === "running") {
+      expect(state.display).toBe("01:23:45");
+      expect(state.remainingSec).toBe((1 * 60 + 23) * 60 + 45);
+    }
+  });
+
+  it("should return warning when remaining <= 5 minutes (= last 5 min visual alert)", () => {
+    const futureMs = now + 4 * 60 * 1000 + 30 * 1000;
+    const state = computeCountdownState(new Date(futureMs).toISOString(), now);
+    expect(state.kind).toBe("warning");
+    if (state.kind === "warning") {
+      expect(state.display).toBe("00:04:30");
+    }
+  });
+
+  it("should treat exactly 5 minutes left as warning (boundary)", () => {
+    const futureMs = now + 5 * 60 * 1000;
+    const state = computeCountdownState(new Date(futureMs).toISOString(), now);
+    expect(state.kind).toBe("warning");
+  });
+
+  it("should pad single-digit hours / minutes / seconds with leading zeros", () => {
+    const futureMs = now + (60 * 60 + 6) * 1000 + 7 * 60 * 1000; // 1h 7m 6s ... actually compute
+    // Pick a deterministic value: 0h 0m 9s + 5m1s buffer = 5m10s so it's warning
+    const fiveTen = now + (5 * 60 + 10) * 1000;
+    const state = computeCountdownState(new Date(fiveTen).toISOString(), now);
+    expect(state.kind).toBe("running");
+    if (state.kind === "running") {
+      expect(state.display).toBe("00:05:10");
+    }
+    expect(futureMs).toBeGreaterThan(now); // silence unused-var lint
+  });
+});

--- a/apps/participant-portal/test/components/NextActionHero.test.ts
+++ b/apps/participant-portal/test/components/NextActionHero.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LeaderboardResponse,
+  ParticipantProblemView,
+  ParticipantTeamView,
+} from "../../src/api/portal-client";
+import {
+  computeNextActionState,
+  isProblemUnsolved,
+  pickNextProblem,
+} from "../../src/components/NextActionHero";
+
+/**
+ * Issue #1349: Home tab の Next action hero の 3 状態判定を pin する。
+ * UI render は SpaceBetween / Header の Cloudscape mount が jsdom で重いため、
+ * pure helper 単体で 3 状態 (not_started / running / ended / all_cleared) を回す。
+ */
+
+function problem(
+  partial: Partial<ParticipantProblemView> & Pick<ParticipantProblemView, "problemId" | "jobId">,
+): ParticipantProblemView {
+  return {
+    region: "ap-northeast-1",
+    awsAccountId: "999999999999",
+    status: "COMPLETE",
+    stackOutputs: {},
+    expiresAt: 0,
+    score: 0,
+    deployLog: { cursor: "", entries: [] },
+    ...partial,
+  };
+}
+
+function view(args: {
+  readonly problems: readonly ParticipantProblemView[];
+  readonly eventGate?: ParticipantTeamView["eventGate"];
+}): ParticipantTeamView {
+  return {
+    team: { teamName: "Blue", teamNameSetByCompetitor: true },
+    problems: args.problems,
+    eventGate: args.eventGate,
+  };
+}
+
+function leaderboard(args: {
+  readonly endsAt?: string;
+  readonly entries?: LeaderboardResponse["entries"];
+}): LeaderboardResponse {
+  return {
+    eventId: "evt-1",
+    endsAt: args.endsAt,
+    entries: args.entries ?? [],
+  };
+}
+
+const now = Date.parse("2026-05-22T13:00:00Z");
+
+describe("isProblemUnsolved", () => {
+  it("should treat flag problem with flagSubmitted=true as solved", () => {
+    expect(
+      isProblemUnsolved(
+        problem({
+          jobId: "j1",
+          problemId: "p1",
+          scoring: { kind: "flag", flagSubmitted: true },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("should treat flag problem with flagSubmitted=false as unsolved", () => {
+    expect(
+      isProblemUnsolved(
+        problem({
+          jobId: "j1",
+          problemId: "p1",
+          scoring: { kind: "flag", flagSubmitted: false },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("should treat uptime problem with score>0 as not unsolved (= scoring underway)", () => {
+    expect(
+      isProblemUnsolved(
+        problem({ jobId: "j1", problemId: "p1", scoring: { kind: "uptime" }, score: 100 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("should treat FAILED / DELETED problems as not actionable", () => {
+    expect(isProblemUnsolved(problem({ jobId: "j1", problemId: "p1", status: "FAILED" }))).toBe(
+      false,
+    );
+    expect(isProblemUnsolved(problem({ jobId: "j1", problemId: "p1", status: "DELETED" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("pickNextProblem", () => {
+  it("should prefer COMPLETE-status unsolved over IN_PROGRESS deploys", () => {
+    const inProgress = problem({
+      jobId: "j-a",
+      problemId: "a-problem",
+      status: "IN_PROGRESS",
+      scoring: { kind: "flag" },
+    });
+    const ready = problem({
+      jobId: "j-b",
+      problemId: "b-problem",
+      status: "COMPLETE",
+      scoring: { kind: "flag" },
+    });
+    expect(pickNextProblem([inProgress, ready])?.problemId).toBe("b-problem");
+  });
+
+  it("should pick the lexically first problemId when multiple are ready", () => {
+    const a = problem({
+      jobId: "j-a",
+      problemId: "alpha",
+      status: "COMPLETE",
+      scoring: { kind: "flag" },
+    });
+    const b = problem({
+      jobId: "j-b",
+      problemId: "bravo",
+      status: "COMPLETE",
+      scoring: { kind: "flag" },
+    });
+    expect(pickNextProblem([b, a])?.problemId).toBe("alpha");
+  });
+
+  it("should return undefined when nothing is unsolved", () => {
+    const cleared = problem({
+      jobId: "j-a",
+      problemId: "p",
+      scoring: { kind: "flag", flagSubmitted: true },
+    });
+    expect(pickNextProblem([cleared])).toBeUndefined();
+  });
+});
+
+describe("computeNextActionState", () => {
+  it("should return null when no view is loaded", () => {
+    expect(computeNextActionState({ view: null, leaderboard: null, nowMs: now })).toBeNull();
+  });
+
+  it("should return not_started when eventGate is scoring_not_started", () => {
+    const v = view({
+      problems: [],
+      eventGate: { kind: "scoring_not_started", startsAt: "2026-05-22T14:00:00Z" },
+    });
+    const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
+    expect(state).toEqual({ kind: "not_started", startsAt: "2026-05-22T14:00:00Z" });
+  });
+
+  it("should return ended when backend gate is scoring_ended", () => {
+    const v = view({
+      problems: [],
+      eventGate: { kind: "scoring_ended", endsAt: "2026-05-22T12:00:00Z" },
+    });
+    const lb = leaderboard({
+      entries: [
+        {
+          rank: 3,
+          teamId: "t-me",
+          teamName: "Blue",
+          score: 120,
+          completedProblems: 1,
+          totalProblems: 2,
+          isMyTeam: true,
+        },
+        {
+          rank: 1,
+          teamId: "t-other",
+          teamName: "Red",
+          score: 999,
+          completedProblems: 2,
+          totalProblems: 2,
+          isMyTeam: false,
+        },
+      ],
+    });
+    const state = computeNextActionState({ view: v, leaderboard: lb, nowMs: now });
+    expect(state).toEqual({ kind: "ended", finalRank: 3, totalEntries: 2 });
+  });
+
+  it("should return ended when leaderboard.endsAt has passed even if backend gate is ok", () => {
+    const v = view({ problems: [], eventGate: { kind: "ok" } });
+    const lb = leaderboard({ endsAt: "2026-05-22T12:00:00Z", entries: [] });
+    const state = computeNextActionState({ view: v, leaderboard: lb, nowMs: now });
+    expect(state?.kind).toBe("ended");
+  });
+
+  it("should return running with unsolved count and next problem during the competition", () => {
+    const a = problem({
+      jobId: "j-a",
+      problemId: "hello-world",
+      status: "COMPLETE",
+      scoring: { kind: "flag" },
+    });
+    const b = problem({
+      jobId: "j-b",
+      problemId: "zeta",
+      status: "COMPLETE",
+      scoring: { kind: "flag" },
+    });
+    const v = view({ problems: [a, b], eventGate: { kind: "ok" } });
+    const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
+    expect(state?.kind).toBe("running");
+    if (state?.kind === "running") {
+      expect(state.unsolvedCount).toBe(2);
+      expect(state.nextProblem?.problemId).toBe("hello-world");
+    }
+  });
+
+  it("should return all_cleared when every problem is solved", () => {
+    const cleared = problem({
+      jobId: "j-a",
+      problemId: "p",
+      scoring: { kind: "flag", flagSubmitted: true },
+    });
+    const v = view({ problems: [cleared], eventGate: { kind: "ok" } });
+    const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
+    expect(state).toEqual({ kind: "all_cleared" });
+  });
+});

--- a/apps/participant-portal/test/lib/friendly-error.test.ts
+++ b/apps/participant-portal/test/lib/friendly-error.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  PortalAuthError,
+  PortalNetworkError,
+  PortalValidationError,
+} from "../../src/api/portal-client";
+import { friendlyErrorMessage } from "../../src/lib/friendly-error";
+
+/**
+ * Issue #1349: 競技者向け friendly error message を pin する。
+ * raw HTTP status code / stack trace を出さない、 i18n key を呼ぶ pure 関数。
+ */
+function pseudoT(key: string, params?: Readonly<Record<string, string | number>>): string {
+  // unit test では i18n の lookup は経由せず、 key + params をそのまま echo する。
+  if (!params) return `[${key}]`;
+  const paramStr = Object.entries(params)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+  return `[${key}|${paramStr}]`;
+}
+
+describe("friendlyErrorMessage", () => {
+  it("should translate PortalAuthError to a re-login prompt (= no raw 401 leak)", () => {
+    expect(friendlyErrorMessage(new PortalAuthError(), pseudoT)).toBe(
+      "[friendly_error.auth_expired]",
+    );
+  });
+
+  it("should include remaining attempts when invalid_flag and ctx.flagRemainingAttempts is provided", () => {
+    expect(
+      friendlyErrorMessage(new PortalValidationError("invalid_flag"), pseudoT, {
+        flagRemainingAttempts: 4,
+      }),
+    ).toBe("[friendly_error.invalid_flag_with_remaining|remaining=4]");
+  });
+
+  it("should fall back to generic invalid_flag when remaining attempts unknown", () => {
+    expect(friendlyErrorMessage(new PortalValidationError("invalid_flag"), pseudoT)).toBe(
+      "[friendly_error.invalid_flag]",
+    );
+  });
+
+  it("should translate invalid_url validation errors", () => {
+    expect(friendlyErrorMessage(new PortalValidationError("invalid_url"), pseudoT)).toBe(
+      "[friendly_error.invalid_url]",
+    );
+  });
+
+  it("should preserve the validation code in the generic case", () => {
+    expect(friendlyErrorMessage(new PortalValidationError("unknown_slot"), pseudoT)).toBe(
+      "[friendly_error.validation_generic|code=unknown_slot]",
+    );
+  });
+
+  it("should include correlation id for PortalNetworkError when provided", () => {
+    expect(
+      friendlyErrorMessage(new PortalNetworkError(502, "bad gateway"), pseudoT, {
+        correlationId: "corr-abc",
+      }),
+    ).toBe("[friendly_error.network_with_correlation|correlationId=corr-abc]");
+  });
+
+  it("should hide raw HTTP status for PortalNetworkError when no correlation id", () => {
+    const out = friendlyErrorMessage(new PortalNetworkError(502, "bad gateway"), pseudoT);
+    expect(out).toBe("[friendly_error.network]");
+    expect(out).not.toContain("502");
+  });
+
+  it("should return the message field for vanilla Error", () => {
+    expect(friendlyErrorMessage(new Error("oops"), pseudoT)).toBe("oops");
+  });
+
+  it("should fall back to unknown for non-Error throws", () => {
+    expect(friendlyErrorMessage("string thrown", pseudoT)).toBe("[friendly_error.unknown]");
+    expect(friendlyErrorMessage(null, pseudoT)).toBe("[friendly_error.unknown]");
+  });
+});

--- a/apps/participant-portal/test/pages/Home.test.ts
+++ b/apps/participant-portal/test/pages/Home.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LeaderboardResponse,
+  ParticipantProblemView,
+  ParticipantTeamView,
+} from "../../src/api/portal-client";
+import { computeNextActionState } from "../../src/components/NextActionHero";
+
+/**
+ * Issue #1349 — Home tab の 「次にやること」 hero の 3 状態 (not_started / running /
+ * ended) を pin する。 React render を mount せず、 hero が依存する純粋判定 helper を
+ * Home の representative scenario で回す (= 利用者視点の input → 状態 mapping)。
+ */
+
+function problem(
+  partial: Partial<ParticipantProblemView> & Pick<ParticipantProblemView, "problemId" | "jobId">,
+): ParticipantProblemView {
+  return {
+    region: "ap-northeast-1",
+    awsAccountId: "999999999999",
+    status: "COMPLETE",
+    stackOutputs: {},
+    expiresAt: 0,
+    score: 0,
+    deployLog: { cursor: "", entries: [] },
+    ...partial,
+  };
+}
+
+const NOW = Date.parse("2026-05-22T13:00:00Z");
+
+describe("Home next-action hero (Issue #1349)", () => {
+  it("should pick scoring_not_started state when the event has not started yet", () => {
+    const view: ParticipantTeamView = {
+      team: { teamName: "Blue", teamNameSetByCompetitor: true },
+      problems: [problem({ jobId: "j1", problemId: "hello-world", scoring: { kind: "flag" } })],
+      eventGate: { kind: "scoring_not_started", startsAt: "2026-05-22T14:00:00Z" },
+    };
+    const state = computeNextActionState({ view, leaderboard: null, nowMs: NOW });
+    expect(state).toEqual({ kind: "not_started", startsAt: "2026-05-22T14:00:00Z" });
+  });
+
+  it("should pick running state with the first unsolved problemId during the competition", () => {
+    const view: ParticipantTeamView = {
+      team: { teamName: "Blue", teamNameSetByCompetitor: true },
+      problems: [
+        problem({
+          jobId: "j1",
+          problemId: "hello-world",
+          scoring: { kind: "flag", flagSubmitted: false },
+        }),
+        problem({
+          jobId: "j2",
+          problemId: "lambda-uptime",
+          scoring: { kind: "uptime" },
+          score: 60,
+        }),
+      ],
+      eventGate: { kind: "ok" },
+    };
+    const state = computeNextActionState({ view, leaderboard: null, nowMs: NOW });
+    expect(state?.kind).toBe("running");
+    if (state?.kind === "running") {
+      // flag 1 件のみ unsolved (uptime は score>0 で in-progress として扱う)。
+      expect(state.unsolvedCount).toBe(1);
+      expect(state.nextProblem?.problemId).toBe("hello-world");
+    }
+  });
+
+  it("should pick ended state with finalRank when the competition is over", () => {
+    const view: ParticipantTeamView = {
+      team: { teamName: "Blue", teamNameSetByCompetitor: true },
+      problems: [],
+      eventGate: { kind: "scoring_ended", endsAt: "2026-05-22T12:30:00Z" },
+    };
+    const leaderboard: LeaderboardResponse = {
+      eventId: "evt-1",
+      entries: [
+        {
+          rank: 3,
+          teamId: "t-me",
+          teamName: "Blue",
+          score: 120,
+          completedProblems: 1,
+          totalProblems: 2,
+          isMyTeam: true,
+        },
+      ],
+      endsAt: "2026-05-22T12:30:00Z",
+    };
+    const state = computeNextActionState({ view, leaderboard, nowMs: NOW });
+    expect(state).toEqual({ kind: "ended", finalRank: 3, totalEntries: 1 });
+  });
+});

--- a/apps/participant-portal/test/pages/Quests.test.tsx
+++ b/apps/participant-portal/test/pages/Quests.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { ParticipantProblemView } from "../../src/api/portal-client";
+import { renderSubmissionState } from "../../src/pages/Quests";
+
+/**
+ * Issue #1349 — scoring badge per-status pin。 `renderSubmissionState` の 4 状態
+ * (= 未着手 / Deploy 中 / 着手中 / 解答済) を unit test し、 解答済 時に
+ * `+Npt` (points) が末尾に出ることを確認する。
+ */
+function problem(partial: Partial<ParticipantProblemView>): ParticipantProblemView {
+  return {
+    jobId: "job-x",
+    problemId: "hello-world",
+    region: "ap-northeast-1",
+    awsAccountId: "999999999999",
+    status: "COMPLETE",
+    stackOutputs: {},
+    expiresAt: 0,
+    score: 0,
+    deployLog: { cursor: "", entries: [] },
+    ...partial,
+  };
+}
+
+function pseudoT(key: string, params?: Readonly<Record<string, string | number>>): string {
+  if (!params) return `[${key}]`;
+  return `[${key}|${Object.entries(params)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",")}]`;
+}
+
+describe("renderSubmissionState scoring badge", () => {
+  it("should show error type for FAILED deploys", () => {
+    const s = renderSubmissionState(problem({ status: "FAILED" }), pseudoT);
+    expect(s.type).toBe("error");
+    expect(s.label).toBe("[quests.submission_failed]");
+  });
+
+  it("should show in-progress type while the deploy is still PENDING / IN_PROGRESS", () => {
+    expect(renderSubmissionState(problem({ status: "PENDING" }), pseudoT).type).toBe("in-progress");
+    expect(renderSubmissionState(problem({ status: "IN_PROGRESS" }), pseudoT).type).toBe(
+      "in-progress",
+    );
+  });
+
+  it("should show pending type (= 未着手) when flag is not yet submitted", () => {
+    const s = renderSubmissionState(
+      problem({ status: "COMPLETE", scoring: { kind: "flag", flagSubmitted: false } }),
+      pseudoT,
+    );
+    expect(s.type).toBe("pending");
+    expect(s.label).toBe("[quests.submission_unsolved]");
+  });
+
+  it("should include points (+Npt) when flag is submitted and scoring.points is known", () => {
+    const s = renderSubmissionState(
+      problem({
+        status: "COMPLETE",
+        scoring: { kind: "flag", flagSubmitted: true, points: 100 },
+      }),
+      pseudoT,
+    );
+    expect(s.type).toBe("success");
+    expect(s.label).toBe("[quests.submission_cleared_with_points|points=100]");
+  });
+
+  it("should fall back to plain cleared label when points is missing", () => {
+    const s = renderSubmissionState(
+      problem({
+        status: "COMPLETE",
+        scoring: { kind: "flag", flagSubmitted: true },
+      }),
+      pseudoT,
+    );
+    expect(s.label).toBe("[quests.submission_cleared]");
+  });
+
+  it("should fall through to 'in progress' info for non-flag uptime scoring", () => {
+    const s = renderSubmissionState(
+      problem({ status: "COMPLETE", scoring: { kind: "uptime" }, score: 60 }),
+      pseudoT,
+    );
+    expect(s.type).toBe("info");
+    expect(s.label).toBe("[quests.submission_in_progress]");
+  });
+});


### PR DESCRIPTION
## Summary

Participant Portal の event-day "プロダクトと信じてもらえる" 完成度向上。 5 改善:

1. **NextActionHero** (Home tab) — 4 state (not_started / running / ended / all_cleared) で next action を hero 表示。
2. **CountdownTimer** (ShellLayout) — 残時間 HH:MM:SS、 ラスト 5 分で red alert (= 終了 panic 防止)
3. **Scoring badge** (Quests) — 「Cleared (+N pt)」 を解いた問題にバッジ表示
4. **friendly-error.ts** — 中央 mapper、 401 (= ログイン期限切れ) / flag rate-limit / 5xx を友好的 message に
5. **Mobile responsive** — Cloudscape Container / Cards で 375px 縦並び対応

42 new tests + i18n ja+en。

Closes #1349
Relates #1336

## Regression analysis

- 既存 dev-mock 経路 (#1259 / #1260) 維持
- Sign-in / token refresh 不変
- 既存 testid / aria-label 保持

## Physical impact

- NO-OP CFn / Lambda
- SPA UX 修正のみ