### PR TITLE
docs(security): commercial hardening checklist — #1353

### DIFF
--- a/CONTRIBUTOR_MAP.md
+++ b/CONTRIBUTOR_MAP.md
@@ -217,6 +217,27 @@ If you are the user (or have explicit authorization):
 
 ---
 
+## "I want to understand or audit the security posture"
+
+**Read**:
+
+- [`docs/security/HARDENING-CHECKLIST.html`](./docs/security/HARDENING-CHECKLIST.html) — the item-by-item commercial hosted-event security baseline. Each control links to its evidence (file path / harness rule ID / ADR / runbook) and is tagged **Implemented / Gap / Roadmap**.
+- [`docs/security/README.md`](./docs/security/README.md) — landing + verification commands (each control has a `grep` / `make` / test command to run locally).
+- [`SECURITY.md`](./SECURITY.md) — private vulnerability disclosure channel (do not file public issues for sensitive disclosures).
+- [`docs/architecture/harness.md`](./docs/architecture/harness.md) — machine-checked invariants and enforcement rules (`secrets-manager-forbidden`, `handler-must-not-call-fetch`, `iam-wildcard-needs-justify`, `handler-tenant-isolation`, etc).
+
+**If you want to add a new control**:
+
+- Closing a documented gap usually means adding a harness rule under `.claude/harness/src/rules/` with a unit test under the same directory. Then update the relevant checklist row's status badge and evidence cell.
+- Stand-alone PR per rule, with the rule rationale in the body. Do not bundle rule additions with feature work.
+
+**Gates**:
+
+- `make harness` + `make harness-test` validate new rules.
+- `make before-commit` includes `make check-template-security` + `make audit-deps`.
+
+---
+
 ## "I want to update CI / lint / format config"
 
 Avoid this unless absolutely necessary. CLAUDE.md explicitly forbids editing `biome.json` / `vitest.config.ts` / `tsconfig.json` to mask code failures. The correct path is almost always to fix the code.

--- a/docs/security/HARDENING-CHECKLIST.html
+++ b/docs/security/HARDENING-CHECKLIST.html
@@ -1,0 +1,634 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Commercial Hosted Event Security Hardening Checklist</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-ok: #1a7f37;
+    --c-gap: #9a6700;
+    --c-roadmap: #6639ba;
+    --c-danger: #cf222e;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 1120px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.55;
+  }
+  h1 { font-size: 1.65rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.4rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.4rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.88em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0 1.4rem 0; width: 100%; font-size: 0.9rem; }
+  th, td { border: 1px solid var(--c-border); padding: 7px 9px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  td.area { background: var(--c-bg-soft); font-weight: 600; vertical-align: middle; }
+  .badge {
+    display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+    font-weight: 600; line-height: 1.4; white-space: nowrap;
+  }
+  .badge.ok      { background: #ddf4e0; color: var(--c-ok); }
+  .badge.gap     { background: #fff8c5; color: var(--c-gap); }
+  .badge.roadmap { background: #ede5fa; color: var(--c-roadmap); }
+  .badge.danger  { background: #ffe9e9; color: var(--c-danger); }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+    border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem;
+  }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  ul, ol { margin: 0.3rem 0 0.6rem 1.2rem; padding: 0; }
+  li { margin: 0.15rem 0; }
+  .scope-box {
+    border: 2px solid var(--c-link); border-radius: 6px;
+    background: #f0f6fc; padding: .9rem 1.1rem; margin: 1.2rem 0;
+  }
+  .scope-box h3 { margin-top: 0; color: var(--c-link); }
+  .nongoals-box {
+    border: 2px solid var(--c-danger); border-radius: 6px;
+    background: #fff5f5; padding: .9rem 1.1rem; margin: 1.2rem 0;
+  }
+  .nongoals-box h3 { margin-top: 0; color: var(--c-danger); }
+  .nongoals-box ul { list-style: none; padding-left: 0; }
+  .nongoals-box li::before { content: "\00d7  "; color: var(--c-danger); font-weight: 700; }
+  .legend { display: flex; gap: .6rem; flex-wrap: wrap; font-size: 0.9rem; margin: .6rem 0 1rem 0; }
+  .legend span { padding: 4px 10px; border-radius: 4px; border: 1px solid var(--c-border); background: var(--c-bg-soft); }
+  .legend .badge { margin-right: .3rem; }
+  .summary-bar { display: flex; gap: 1rem; flex-wrap: wrap; margin: 1rem 0 1.4rem 0; }
+  .summary-card {
+    flex: 1 1 200px; padding: .8rem 1rem; border-radius: 6px;
+    border: 1px solid var(--c-border); background: var(--c-bg-soft);
+  }
+  .summary-card .count { font-size: 1.5rem; font-weight: 700; }
+  .summary-card.ok      .count { color: var(--c-ok); }
+  .summary-card.gap     .count { color: var(--c-gap); }
+  .summary-card.roadmap .count { color: var(--c-roadmap); }
+  .summary-card .label  { font-size: 0.85rem; color: var(--c-muted); }
+  td.evidence code { display: inline-block; margin: 1px 2px; }
+  .item-id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; color: var(--c-muted); }
+</style>
+</head>
+<body>
+<header>
+  <h1>TenkaCloud Commercial Hosted Event Security Hardening Checklist</h1>
+  <p><em>The minimum credible security baseline for running paid TenkaCloud cloud-competition events. Not a SOC2 certification.</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge ok">Living document</span></div>
+    <div><b>Tracks:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/1353">#1353</a> (parent: <a href="https://github.com/susumutomita/TenkaCloud/issues/1336">#1336</a>)</div>
+    <div><b>Audience:</b> Hosted-event operators, enterprise evaluators, security reviewers</div>
+    <div><b>Last reviewed:</b> 2026-05-26</div>
+  </div>
+</header>
+
+<div class="scope-box">
+  <h3>What this document is</h3>
+  <p>An item-by-item posture statement for every control we promise to commercial buyers, with a direct evidence link (file path / harness rule ID / ADR / runbook) or an explicit acknowledged gap. Owners and statuses are tracked so that one glance tells a reviewer what is enforced, what is documented but manual, and what is on the roadmap.</p>
+  <p>Verification commands are in the companion <a href="./README.md"><code>docs/security/README.md</code></a>. Operators should run them before every paid event.</p>
+</div>
+
+<div class="nongoals-box">
+  <h3>What this document is NOT</h3>
+  <ul>
+    <li>A SOC2 / ISO 27001 certification (those require external audit and continuous evidence collection).</li>
+    <li>A pen-test report (commission one separately for high-value events).</li>
+    <li>A guarantee. Competitor AWS accounts host real workloads under operator supervision; problem templates can intentionally expose insecure resources by design (see <code>allowIntentionallyVulnerable</code>).</li>
+  </ul>
+</div>
+
+<h2>Status legend</h2>
+<div class="legend">
+  <span><span class="badge ok">Implemented</span> Enforced in code, CDK, or CI — verifiable today.</span>
+  <span><span class="badge gap">Gap</span> Documented expectation; manual or partial enforcement. Operator must verify per event.</span>
+  <span><span class="badge roadmap">Roadmap</span> Tracked issue exists; not blocking commercial pilots.</span>
+  <span><span class="badge danger">Not started</span> No design yet. Disclose to buyers as a known limitation.</span>
+</div>
+
+<h2>Coverage summary</h2>
+<div class="summary-bar">
+  <div class="summary-card ok">
+    <div class="count">23</div>
+    <div class="label">Implemented (machine-enforced or CDK-baked)</div>
+  </div>
+  <div class="summary-card gap">
+    <div class="count">8</div>
+    <div class="label">Gap (documented expectation, manual verification)</div>
+  </div>
+  <div class="summary-card roadmap">
+    <div class="count">5</div>
+    <div class="label">Roadmap (issue tracked)</div>
+  </div>
+</div>
+
+<h2>1. Identity &amp; access</h2>
+<p>Every request crosses a Cognito JWT boundary. No bypass exists in app code. Cross-account access into competitor AWS uses the IAM Confused-Deputy mitigation (account-id + ExternalId) by construction.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="7">1<br>IAM</td>
+      <td><span class="item-id">IAM-01</span></td>
+      <td>Cognito User Pool + JWT mandatory on every API</td>
+      <td class="evidence">SBT ControlPlane wires the User Pool — <code>infrastructure/lib/control-plane-stack.ts</code>. Per-tenant API authorizer — <code>infrastructure/lib/tenant-template/api-gateway.ts</code>. Invariant <a href="../architecture/harness.md"><code>INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER</code></a> blocks <code>AUTH_SKIP</code>-style bypasses.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-02</span></td>
+      <td>No <code>AUTH_SKIP</code> / dev bypass in app code</td>
+      <td class="evidence"><code>grep -R "AUTH_SKIP" apps/ infrastructure/</code> returns no matches. Harness invariant <code>INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER</code> is enforced in <code>docs/architecture/harness.md</code>; PRs that introduce a bypass must justify in the body and will be flagged in <code>/security-review</code>.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-03</span></td>
+      <td>SAML / OIDC enterprise IdP path documented and gated by allowlist</td>
+      <td class="evidence">SAML identity providers — <code>infrastructure/lib/control-plane/saml-identity-providers.ts</code>. Federated admin allowlist (Pre sign-up Lambda, fail-safe empty = deny all) — <code>infrastructure/lib/control-plane/saml-admin-allowlist.ts</code>. ADR — <a href="../architecture/adr-018-pooled-userpool-saml-isolation.html">ADR-018</a>. Operator runbook — <code>docs/operations/control-plane-saml-setup.html</code>.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-04</span></td>
+      <td>MFA policy on admin user pools</td>
+      <td class="evidence"><code>infrastructure/lib/control-plane/mfa-policy.ts</code> applies MFA to the admin User Pool. Federated IdPs are expected to enforce MFA upstream.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-05</span></td>
+      <td>Participant role uses least-privilege console access</td>
+      <td class="evidence">Participant Portal authenticates via per-team login key + rate-limited bearer token (see <a href="#participant-handler">Participant safety</a>). Competitors deploy via <code>infrastructure/templates/competitor-bootstrap.yaml</code> in their own AWS account; that role is scoped to CFn CreateStack + the services each problem template uses, and is rolled out and torn down by the competitor.</td>
+      <td>User (CDK + Template)</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-06</span></td>
+      <td>Cross-account AssumeRole always requires ExternalId</td>
+      <td class="evidence">Trust policy in <code>infrastructure/templates/competitor-bootstrap.yaml</code> requires a non-empty <code>ExternalId</code> (<code>MinLength: 16</code>, <code>NoEcho: true</code>). Deploy Worker injects <code>CDK_PARAM_DEPLOY_EXTERNAL_ID</code> on every AssumeRole call — <code>infrastructure/lib/problem-deploy/handlers/deploy-handler/</code>. ExternalId rotation age audit runs daily via <code>infrastructure/lib/problem-deploy/external-id-audit-lambda.ts</code> (Issue #603). ADR — <a href="../architecture/adr-009-cross-account-federation.html">ADR-009</a>.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">IAM-07</span></td>
+      <td>IAM wildcard (<code>resources: ["*"]</code>) requires inline justification</td>
+      <td class="evidence">Harness rule <code>iam-wildcard-needs-justify</code> blocks new wildcards in <code>infrastructure/lib/**</code> without a <code>justify:</code> / <code>conditions:</code> / <code>Issue #...</code> comment within 10 lines. Rule code — <code>.claude/harness/src/rules/iam-wildcard-needs-justify.ts</code>.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>2. Problem template safety</h2>
+<p>Every problem ships a single-page CFn template that deploys into the competitor's AWS account. The pre-deploy scanner catches the five high-risk patterns. Intentionally vulnerable problems must opt in via a metadata flag.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="7">2<br>Templates</td>
+      <td><span class="item-id">TPL-01</span></td>
+      <td>Public S3 bucket detection (<code>PublicReadAccess: true</code>, <code>AccessControl: PublicRead</code>)</td>
+      <td class="evidence"><code>scripts/check-template-security.ts</code> rule 4. Runs in <code>make check-template-security</code> (part of <code>make before-commit</code> + CI).</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-02</span></td>
+      <td>Wide-open Security Group ingress (<code>0.0.0.0/0</code> on non-web ports)</td>
+      <td class="evidence"><code>scripts/check-template-security.ts</code> rule 3. Web ports 80/443 are allowlisted because problems frequently expose HTTP services.</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-03</span></td>
+      <td>IAM wildcard <code>Action: "*"</code> / <code>Resource: "*"</code> in template inline policies</td>
+      <td class="evidence"><code>scripts/check-template-security.ts</code> rules 1 + 2 with <code>RESOURCE_STAR_OK_ACTIONS</code> allowlist for unavoidable AWS-API patterns.</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-04</span></td>
+      <td>KMS keys must enable key rotation</td>
+      <td class="evidence"><code>scripts/check-template-security.ts</code> rule 5. <code>EnableKeyRotation: false</code> or missing fails CI.</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-05</span></td>
+      <td>Intentionally insecure resources require explicit metadata justification</td>
+      <td class="evidence">Top-level <code>Metadata.tenkacloud.allowIntentionallyVulnerable: true</code> in <code>template.yaml</code> suppresses the scan for that template only. Example: <code>problems/battle/security-battle-royale/template.yaml</code>. Reviewers must verify the problem is genuinely a security exercise before approving the metadata flag.</td>
+      <td>Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-06</span></td>
+      <td>Expensive-resource detection (large EC2 / RDS instances, NAT Gateways)</td>
+      <td class="evidence">No dedicated scanner yet. <code>DynamoDbLowCapacity</code> Aspect enforces 1/1 PROVISIONED on platform DDB tables but not on problem templates. Operators should review the template diff in dry-run (<code>docs/runbooks/dry-run.html</code>).</td>
+      <td>Operator / Reviewer</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TPL-07</span></td>
+      <td>Missing teardown support (every resource must be removable by <code>cdk destroy</code> / <code>cleanup.sh</code>)</td>
+      <td class="evidence">No automated rule. Convention is enforced by review and by the per-event teardown runbook — <code>docs/runbooks/teardown.html</code>. Stateful resources need <code>RemovalPolicy.RETAIN</code> override called out in PR body. Roadmap: add a <code>retain-without-justify</code> harness rule.</td>
+      <td>Reviewer</td>
+      <td><span class="badge roadmap">Roadmap</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>3. Operator account safety</h2>
+<p>This is the AWS account where TenkaCloud Control Plane / Application Plane stacks live. It is the most privileged surface — break-glass discipline is the operator's responsibility and is documented but not enforced by code.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="5">3<br>Operator</td>
+      <td><span class="item-id">OPS-01</span></td>
+      <td>AWS Organizations + SCP guardrails on operator account</td>
+      <td class="evidence">Recommended but not provisioned by TenkaCloud CDK (we cannot deploy into the customer's management account). Operator runbook: enable AWS Organizations, attach <code>deny-leaving-org</code> / <code>deny-disable-cloudtrail</code> SCPs to the operator account OU before paid events.</td>
+      <td>Operator</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">OPS-02</span></td>
+      <td>Break-glass IAM user with hardware MFA + 1-day max session</td>
+      <td class="evidence">Documented in operator runbooks. No CDK construct (a break-glass user shipped via CDK defeats the purpose — it must be manually managed). <code>docs/runbooks/incident-response.html</code> step "If you lost SSO" cites the break-glass procedure.</td>
+      <td>Operator</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">OPS-03</span></td>
+      <td>System Admin invitations gated by allowlist (no open registration)</td>
+      <td class="evidence">SystemAdmin is invited from <code>scripts/install.sh</code> Phase 1 with a fixed <code>SYSTEM_ADMIN_EMAIL</code>. SAML federation goes through <code>saml-admin-allowlist.ts</code> Pre sign-up — empty allowlist = federated sign-in denied.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">OPS-04</span></td>
+      <td>CloudTrail enabled on the operator account, retention &ge; 90 days</td>
+      <td class="evidence">Operator responsibility — not configured by TenkaCloud CDK because CloudTrail is typically an account-bootstrap concern owned by the customer's landing-zone tooling.</td>
+      <td>Operator</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">OPS-05</span></td>
+      <td>Control Plane stack does not host tenant runtime</td>
+      <td class="evidence">Harness invariant <code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code> (<code>docs/architecture/harness.md</code>). Memory note <code>feedback_no_cross_plane_data_leak</code>: System Admin UI must not show tenant Events / Deployments.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>4. Data &amp; log handling</h2>
+<p>Audit data is the spine of any commercial security review. We use SSM SecureString for secrets (cost-zero principle), DDB Stream &rarr; immutable S3 Object Lock for long-retention audit archive, and field-level redaction before audit records are written.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="7">4<br>Data</td>
+      <td><span class="item-id">DAT-01</span></td>
+      <td>Secrets go to SSM Parameter Store SecureString; Secrets Manager is forbidden</td>
+      <td class="evidence">Harness enforcement rule <code>secrets-manager-forbidden</code> — <code>docs/architecture/harness.md</code>. Implementation in <code>.claude/harness/src/architecture.ts</code>. Rationale: Free Tier alignment + reduces blast radius vs. centralized secret manager.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-02</span></td>
+      <td>Audit archive in S3 Object Lock compliance mode (1 year), 7-year lifecycle expiration</td>
+      <td class="evidence"><code>infrastructure/lib/problem-deploy/audit-archive-bucket.ts</code> creates the bucket with <code>objectLockEnabled: true</code> + <code>ObjectLockRetention.compliance(365 days)</code> + Glacier transition at 90 days + 7-year expiration. <code>RemovalPolicy.RETAIN</code>. Writer Lambda has <code>grantPut</code> only (no delete / overwrite). Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/1341">#1341</a>.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-03</span></td>
+      <td>Audit log writer Lambda has least-privilege (PutObject only, no Get / Delete)</td>
+      <td class="evidence"><code>this.bucket.grantPut(this.writerLambda)</code> in <code>audit-archive-bucket.ts</code>. Read access is owned by a separate Lambda for the operator-facing audit export route.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-04</span></td>
+      <td>Field-level redaction before audit records reach DDB</td>
+      <td class="evidence"><code>infrastructure/lib/problem-deploy/handlers/shared/audit/redact.ts</code> with <code>REDACT_ALLOWLIST</code> per resource type. The audit wrapper requires callers to pass redacted <code>before</code> / <code>after</code> snapshots (compile-time contract, not optional).</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-05</span></td>
+      <td>No raw token / credential / SAML assertion in CloudWatch Logs</td>
+      <td class="evidence">Structured logger in <code>infrastructure/lib/problem-deploy/handlers/shared/structured-log.ts</code> emits JSON with a fixed schema; new fields go through review. ExternalId is referenced by hash (sign-in audit Lambda — <code>infrastructure/lib/control-plane/sign-in-audit-lambda.ts</code>). No automated lint rule yet — this is a review-time gate.</td>
+      <td>Reviewer</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-06</span></td>
+      <td>Tenant isolation enforced in the infra layer (no app-side <code>tenantId</code> threading)</td>
+      <td class="evidence">Invariant <code>INVARIANT_TENANT_ISOLATION_AT_INFRA_LAYER</code> + harness rule <code>handler-tenant-isolation</code> — <code>.claude/harness/src/rules/handler-tenant-isolation.ts</code>. Audit ADR: <a href="../architecture/adr-022-tenant-isolation-audit.html">ADR-022</a>.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">DAT-07</span></td>
+      <td>DDB tables forced to PROVISIONED 1/1 (no PAY_PER_REQUEST drift)</td>
+      <td class="evidence">CDK Aspect <code>DynamoDbLowCapacity</code> — <code>infrastructure/lib/cdk-aspect/</code>. Any deviation appears in <code>cdk diff</code> output and is caught in PR review.</td>
+      <td>User (CDK)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="participant-handler">5. Participant safety</h2>
+<p>The Participant Portal is the only surface exposed directly to event competitors. Login key issuance, flag submission, and hint reveal are all rate-limited; team scoping is enforced by handler-side wrappers, not by app code.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="6">5<br>Participant</td>
+      <td><span class="item-id">PRT-01</span></td>
+      <td>Participant cannot access another team's deployment</td>
+      <td class="evidence">Participant Portal authenticates via per-team login key + bearer token. Handler-side tenant + team scoping in <code>infrastructure/lib/problem-deploy/handlers/participant-handler/</code>. Harness rule <code>handler-tenant-isolation</code> enforces the scope check at lint time.</td>
+      <td>User + Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">PRT-02</span></td>
+      <td>Flag submission rate-limited (defends against brute-force / hint anti-skip)</td>
+      <td class="evidence"><code>WRITE_VERY_LOW</code> (3 burst / 6 RPM &asymp; 1 attempt per 10s sustained) on submit-flag route. Token bucket — <code>infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts</code>. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/870">#870</a> brought this from 17,000 attempts/day down to 8,640. Related to i18n hint anti-skip (<a href="https://github.com/susumutomita/TenkaCloud/issues/1108">#1108</a>).</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">PRT-03</span></td>
+      <td>Credentials issuance (login key) rate-limited</td>
+      <td class="evidence"><code>WRITE_LOW</code> (10 burst / 12 RPM) on credentials issuance route — <code>infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts</code> line 108.</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">PRT-04</span></td>
+      <td>Bearer token has short lifetime + replay defense</td>
+      <td class="evidence">Token issued by <code>participant-handler</code> with a server-side expiry. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/767">#767</a> traces the in-memory rate limiter design that makes warm-instance DoS infeasible.</td>
+      <td>Agent</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">PRT-05</span></td>
+      <td>Polling-only frontend (no SSE / WebSocket attack surface)</td>
+      <td class="evidence">Documented prohibition in <code>AGENTS.md</code> + <code>CLAUDE.md</code>. Reconciliation via EventBridge instead — <a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">PRT-06</span></td>
+      <td>Inter-team interaction primitives are problem-scoped (no platform-level cross-team trust)</td>
+      <td class="evidence"><a href="../architecture/adr-022-inter-team-coordination-plugin.html">ADR-022</a> places coordination logic in the problem plugin. Platform does not provide an implicit trust channel between teams. Memory note <code>feedback_inter_team_coordination_plugin</code>.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>6. Teardown &amp; cost safety</h2>
+<p>Leftover AWS resources after an event are both a security risk (drift, forgotten credentials) and a cost risk. Teardown must be idempotent and observable.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 4%;">Area</th>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 36%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="area" rowspan="5">6<br>Teardown</td>
+      <td><span class="item-id">TDN-01</span></td>
+      <td>Idempotent SaaS-mode teardown (<code>make destroy-saas</code>)</td>
+      <td class="evidence"><code>scripts/cleanup.sh</code> is designed to resume from any partial state; documented in <code>CLAUDE.md</code> "Deploy flow". Removes every TenkaCloud stack + the admin-console hosting S3 buckets.</td>
+      <td>User (Script)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TDN-02</span></td>
+      <td>Idempotent Lite-mode teardown (<code>make destroy</code>)</td>
+      <td class="evidence"><code>make lite-down</code> tears down the 2-stack Lite topology. Documented in <a href="../architecture/adr-016-tenkacloud-lite-app-plane-core.html">ADR-016</a>.</td>
+      <td>User (Script)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TDN-03</span></td>
+      <td>Per-tenant deprovisioning</td>
+      <td class="evidence"><code>scripts/deprovision-tenant.sh</code>. Tenant pipeline tears down the silo stack on tenant deletion event from the SBT bus.</td>
+      <td>User (Script)</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TDN-04</span></td>
+      <td>Post-event leftover-resource check</td>
+      <td class="evidence">Operator runbook step in <code>docs/runbooks/teardown.html</code>. Recommends Cost Explorer + Resource Groups Tag Editor sweep. Roadmap: ship a CLI subcommand that lists all stacks tagged <code>tenkacloud:event=&lt;id&gt;</code>.</td>
+      <td>Operator</td>
+      <td><span class="badge gap">Gap</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">TDN-05</span></td>
+      <td>Cost alarm / budget for the operator account</td>
+      <td class="evidence">Operator responsibility — set an AWS Budgets alert (e.g. $50 monthly) before the first paid event. Documented in pre-event checklist. Roadmap: ship a CDK construct for a default budget.</td>
+      <td>Operator</td>
+      <td><span class="badge roadmap">Roadmap</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>7. Per-event runbook reference</h2>
+<p>Security controls are only useful if operators actually use them. The runbooks under <code>docs/runbooks/</code> are the operational glue — each runbook cites this checklist at the relevant decision point.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 22%;">Runbook</th>
+      <th style="width: 18%;">When to use</th>
+      <th style="width: 30%;">Security touchpoints</th>
+      <th style="width: 30%;">Source of truth</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Pre-event checklist</td>
+      <td>T-7 / T-1 / T-0</td>
+      <td>IAM-01..07, OPS-01..05, TDN-05</td>
+      <td><a href="../runbooks/pre-event-checklist.html"><code>docs/runbooks/pre-event-checklist.html</code></a></td>
+    </tr>
+    <tr>
+      <td>Dry run</td>
+      <td>Within 7 days before event (mandatory)</td>
+      <td>TPL-01..07, IAM-06, DAT-04</td>
+      <td><a href="../runbooks/dry-run.html"><code>docs/runbooks/dry-run.html</code></a></td>
+    </tr>
+    <tr>
+      <td>Participant onboarding</td>
+      <td>Event-day morning</td>
+      <td>PRT-01..06</td>
+      <td><a href="../runbooks/participant-onboarding.html"><code>docs/runbooks/participant-onboarding.html</code></a></td>
+    </tr>
+    <tr>
+      <td>Live monitoring</td>
+      <td>During event</td>
+      <td>DAT-05, PRT-02, OPS-04</td>
+      <td><a href="../runbooks/live-monitoring.html"><code>docs/runbooks/live-monitoring.html</code></a></td>
+    </tr>
+    <tr>
+      <td>Incident response</td>
+      <td>Alarm / participant report</td>
+      <td>OPS-02 (break-glass), DAT-02 (audit), IAM-06 (rotate ExternalId)</td>
+      <td><a href="../runbooks/incident-response.html"><code>docs/runbooks/incident-response.html</code></a></td>
+    </tr>
+    <tr>
+      <td>Teardown</td>
+      <td>Within 24h after event</td>
+      <td>TDN-01..05</td>
+      <td><a href="../runbooks/teardown.html"><code>docs/runbooks/teardown.html</code></a></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Supply chain (cross-cutting)</h2>
+<p>Supply chain compromises bypass every other control. The four-layer defense is documented in <code>CLAUDE.md</code> "Supply chain security" and <code>AGENTS.md</code>.</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 5%;">ID</th>
+      <th style="width: 22%;">Control</th>
+      <th style="width: 50%;">Done? (evidence)</th>
+      <th style="width: 11%;">Owner</th>
+      <th style="width: 12%;">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="item-id">SUP-01</span></td>
+      <td>Bun <code>trustedDependencies</code> is the allowlist (currently empty)</td>
+      <td class="evidence">Root <code>package.json</code> <code>trustedDependencies</code>. Bun blocks transitive lifecycle scripts by default.</td>
+      <td>Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">SUP-02</span></td>
+      <td><code>.npmrc</code> ignores scripts + 7-day quarantine for npm / yarn / pnpm fallbacks</td>
+      <td class="evidence"><code>.npmrc</code>: <code>ignore-scripts=true</code> + <code>min-release-age=168h</code>.</td>
+      <td>Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">SUP-03</span></td>
+      <td>CI dependency audit (lifecycle-script diff vs. baseline)</td>
+      <td class="evidence"><code>make audit-deps</code> &rarr; <code>scripts/audit-dependencies.ts</code> vs. <code>scripts/audit-baseline.json</code>. Runs in <code>make before-commit</code> and CI.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">SUP-04</span></td>
+      <td>GitHub Actions are SHA-pinned (no <code>@v3</code> floating tags)</td>
+      <td class="evidence">Visible in <code>.github/workflows/ci.yml</code> — every <code>uses:</code> line includes a 40-char SHA.</td>
+      <td>Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+    <tr>
+      <td><span class="item-id">SUP-05</span></td>
+      <td>CI install runs with <code>--ignore-scripts</code> + Safe Chain malicious-package detection</td>
+      <td class="evidence"><code>make install_ci</code> = <code>bun install --frozen-lockfile --ignore-scripts</code> + Aikido Safe Chain.</td>
+      <td>Agent / Reviewer</td>
+      <td><span class="badge ok">Implemented</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Acknowledged gaps and roadmap</h2>
+<details open>
+  <summary>Known gaps to disclose to commercial buyers</summary>
+  <ul>
+    <li><b>OPS-01..04 (operator account hygiene)</b> — Operator owns AWS Organizations, SCPs, break-glass IAM, CloudTrail enablement. We document the expectation but cannot ship the control because TenkaCloud CDK does not deploy into the customer's management account.</li>
+    <li><b>TPL-06 (expensive-resource detection)</b> — No automated scan for large EC2 / RDS / NAT Gateway. Operator dry-run review catches it today.</li>
+    <li><b>TPL-07 (teardown-coverage scan)</b> — Convention-only; reviewer must confirm every resource is destroyable. Roadmap: add a <code>retain-without-justify</code> harness rule.</li>
+    <li><b>DAT-05 (no-credential-in-logs lint rule)</b> — Reviewer-enforced; no machine check. Roadmap: a structured-log linter that bans known-sensitive field names.</li>
+    <li><b>IAM-05 (participant least-privilege baseline)</b> — Competitor bootstrap template grants <code>AdministratorAccess</code> in the competitor account because problems span unpredictable services. Documented trade-off; mitigated by the 2-factor trust (account-id + ExternalId) and short-lived event windows.</li>
+    <li><b>TDN-04 (leftover-resource sweep CLI)</b> — Manual tag-editor sweep today. Roadmap: CLI subcommand <code>tenkacloud event leftovers --event-id &lt;id&gt;</code>.</li>
+    <li><b>TDN-05 (default budget)</b> — Operator must set AWS Budgets manually. Roadmap: CDK construct that ships a default $50 monthly alarm.</li>
+  </ul>
+</details>
+
+<h2>Maintenance &amp; review cadence</h2>
+<ul>
+  <li>This document is reviewed at every commercial pilot kick-off and after every security-relevant ADR (IAM, audit, cross-account).</li>
+  <li>New harness rules that close a gap should add their rule ID to the relevant evidence cell and flip the status badge.</li>
+  <li>Operators run the verification commands in <a href="./README.md"><code>docs/security/README.md</code></a> as part of the pre-event checklist.</li>
+  <li>Vulnerability reports follow <a href="../../SECURITY.md"><code>SECURITY.md</code></a> private-disclosure channel (not public issues).</li>
+</ul>
+
+<h2>Related ADRs</h2>
+<ul>
+  <li><a href="../architecture/adr-002-cross-account-federation.html">ADR-002</a> &mdash; Cross-account federation (initial design)</li>
+  <li><a href="../architecture/adr-009-cross-account-federation.html">ADR-009</a> &mdash; Cross-account federation (current ExternalId model)</li>
+  <li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> &mdash; Polling + EventBridge reconciliation (no SSE / WebSocket)</li>
+  <li><a href="../architecture/adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> &mdash; TrustBridge audit envelope for cross-account actions</li>
+  <li><a href="../architecture/adr-018-pooled-userpool-saml-isolation.html">ADR-018</a> &mdash; Pooled UserPool + SAML isolation</li>
+  <li><a href="../architecture/adr-020-authorization-model.html">ADR-020</a> &mdash; Authorization model</li>
+  <li><a href="../architecture/adr-022-tenant-isolation-audit.html">ADR-022</a> &mdash; Tenant isolation audit</li>
+</ul>
+
+</body>
+</html>

--- a/docs/security/README.html
+++ b/docs/security/README.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>TenkaCloud Security Posture</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>TenkaCloud Security Posture</h1>
+<blockquote>
+<p>Landing page for operators, enterprise evaluators, and security reviewers. For vulnerability reporting (private channel), see <a href="../../SECURITY.md"><code>SECURITY.md</code></a>.</p>
+</blockquote>
+<h2>Start here</h2>
+<ul>
+<li><a href="./HARDENING-CHECKLIST.html">Commercial hosted event hardening checklist</a> — the item-by-item posture statement covering identity &amp; access, problem template safety, operator account hygiene, data &amp; log handling, participant safety, teardown, and supply chain. Each item links to its evidence (file / harness rule / ADR / runbook) and is tagged <strong>Implemented / Gap / Roadmap</strong>.</li>
+</ul>
+<p>This is the minimum credible security baseline for running <strong>paid</strong> TenkaCloud cloud-competition events. It is <strong>not</strong> a SOC2 certification. SOC2-oriented audit work is tracked separately under <a href="https://github.com/susumutomita/TenkaCloud/issues/1335">#1335</a>.</p>
+<h2>How to verify each control locally</h2>
+<p>Run these before every paid event. All commands are non-destructive.</p>
+<table>
+<thead>
+<tr>
+<th>Control area</th>
+<th>What to verify</th>
+<th>Command</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Identity &amp; access</td>
+<td>No <code>AUTH_SKIP</code> bypass anywhere in the tree</td>
+<td><code>grep -R &quot;AUTH_SKIP&quot; apps/ infrastructure/</code> (must return nothing)</td>
+</tr>
+<tr>
+<td>Identity &amp; access</td>
+<td>Harness rule <code>iam-wildcard-needs-justify</code> is active</td>
+<td><code>make harness-test</code></td>
+</tr>
+<tr>
+<td>Identity &amp; access</td>
+<td>SAML admin allowlist parses (or is empty = deny-all)</td>
+<td><code>bun run --filter @TenkaCloud/infrastructure test -- saml-admin-allowlist</code></td>
+</tr>
+<tr>
+<td>Identity &amp; access</td>
+<td>Cross-account trust requires ExternalId</td>
+<td><code>grep -n ExternalId infrastructure/templates/competitor-bootstrap.yaml</code></td>
+</tr>
+<tr>
+<td>Template safety</td>
+<td>All problem templates pass the 5 security rules</td>
+<td><code>make check-template-security</code></td>
+</tr>
+<tr>
+<td>Template safety</td>
+<td>Templates only contain printable ASCII (Description fields)</td>
+<td><code>make check-template-ascii</code></td>
+</tr>
+<tr>
+<td>Template safety</td>
+<td>Template CFn references resolve</td>
+<td><code>make check-template-cfn-refs</code></td>
+</tr>
+<tr>
+<td>Data &amp; log handling</td>
+<td>Secrets Manager is not imported anywhere</td>
+<td><code>grep -R &quot;@aws-sdk/client-secrets-manager&quot; infrastructure/ apps/</code> (must return nothing)</td>
+</tr>
+<tr>
+<td>Data &amp; log handling</td>
+<td>Audit archive bucket has Object Lock + compliance mode</td>
+<td><code>bun run --filter @TenkaCloud/infrastructure test -- audit-archive-bucket</code></td>
+</tr>
+<tr>
+<td>Data &amp; log handling</td>
+<td>Audit redact tests pass</td>
+<td><code>bun run --filter @TenkaCloud/infrastructure test -- audit-redact</code></td>
+</tr>
+<tr>
+<td>Tenant isolation</td>
+<td>Harness rule <code>handler-tenant-isolation</code> is green</td>
+<td><code>make harness</code></td>
+</tr>
+<tr>
+<td>Participant safety</td>
+<td>Flag submission uses <code>WRITE_VERY_LOW</code> rate limit</td>
+<td><code>grep -n WRITE_VERY_LOW infrastructure/lib/problem-deploy/handlers/participant-handler/</code></td>
+</tr>
+<tr>
+<td>Supply chain</td>
+<td>No new lifecycle scripts vs. baseline</td>
+<td><code>make audit-deps</code></td>
+</tr>
+<tr>
+<td>Supply chain</td>
+<td>All GitHub Actions are SHA-pinned</td>
+<td><code>grep -E &quot;uses: [^@]+@v&quot; .github/workflows/</code> (must return nothing)</td>
+</tr>
+<tr>
+<td>Full gate</td>
+<td>Everything together</td>
+<td><code>make harness &amp;&amp; make before-commit</code></td>
+</tr>
+</tbody></table>
+<h2>When to re-read the checklist</h2>
+<ul>
+<li>Before every commercial pilot kick-off</li>
+<li>After merging any ADR that touches IAM, audit, or cross-account access</li>
+<li>When opening a PR that touches <code>infrastructure/lib/control-plane/</code>, <code>infrastructure/lib/problem-deploy/handlers/</code>, or <code>infrastructure/templates/</code></li>
+<li>Quarterly, as a posture sanity check</li>
+</ul>
+<h2>Reporting a security issue</h2>
+<p>See <a href="../../SECURITY.md"><code>SECURITY.md</code></a>. Do not file public GitHub issues for sensitive disclosures.</p>
+<h2>Cross-references</h2>
+<ul>
+<li>Architecture invariants — <a href="../architecture/harness.md"><code>docs/architecture/harness.md</code></a></li>
+<li>Operations runbooks — <a href="../runbooks/"><code>docs/runbooks/</code></a></li>
+<li>Project rules (forbidden patterns + tech stack) — <a href="../../CLAUDE.md"><code>CLAUDE.md</code></a>, <a href="../../AGENTS.md"><code>AGENTS.md</code></a></li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/security/README.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/security/README.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,48 @@
+# TenkaCloud Security Posture
+
+> Landing page for operators, enterprise evaluators, and security reviewers. For vulnerability reporting (private channel), see [`SECURITY.md`](../../SECURITY.md).
+
+## Start here
+
+- [Commercial hosted event hardening checklist](./HARDENING-CHECKLIST.html) — the item-by-item posture statement covering identity & access, problem template safety, operator account hygiene, data & log handling, participant safety, teardown, and supply chain. Each item links to its evidence (file / harness rule / ADR / runbook) and is tagged **Implemented / Gap / Roadmap**.
+
+This is the minimum credible security baseline for running **paid** TenkaCloud cloud-competition events. It is **not** a SOC2 certification. SOC2-oriented audit work is tracked separately under [#1335](https://github.com/susumutomita/TenkaCloud/issues/1335).
+
+## How to verify each control locally
+
+Run these before every paid event. All commands are non-destructive.
+
+| Control area | What to verify | Command |
+| --- | --- | --- |
+| Identity & access | No `AUTH_SKIP` bypass anywhere in the tree | `grep -R "AUTH_SKIP" apps/ infrastructure/` (must return nothing) |
+| Identity & access | Harness rule `iam-wildcard-needs-justify` is active | `make harness-test` |
+| Identity & access | SAML admin allowlist parses (or is empty = deny-all) | `bun run --filter @TenkaCloud/infrastructure test -- saml-admin-allowlist` |
+| Identity & access | Cross-account trust requires ExternalId | `grep -n ExternalId infrastructure/templates/competitor-bootstrap.yaml` |
+| Template safety | All problem templates pass the 5 security rules | `make check-template-security` |
+| Template safety | Templates only contain printable ASCII (Description fields) | `make check-template-ascii` |
+| Template safety | Template CFn references resolve | `make check-template-cfn-refs` |
+| Data & log handling | Secrets Manager is not imported anywhere | `grep -R "@aws-sdk/client-secrets-manager" infrastructure/ apps/` (must return nothing) |
+| Data & log handling | Audit archive bucket has Object Lock + compliance mode | `bun run --filter @TenkaCloud/infrastructure test -- audit-archive-bucket` |
+| Data & log handling | Audit redact tests pass | `bun run --filter @TenkaCloud/infrastructure test -- audit-redact` |
+| Tenant isolation | Harness rule `handler-tenant-isolation` is green | `make harness` |
+| Participant safety | Flag submission uses `WRITE_VERY_LOW` rate limit | `grep -n WRITE_VERY_LOW infrastructure/lib/problem-deploy/handlers/participant-handler/` |
+| Supply chain | No new lifecycle scripts vs. baseline | `make audit-deps` |
+| Supply chain | All GitHub Actions are SHA-pinned | `grep -E "uses: [^@]+@v" .github/workflows/` (must return nothing) |
+| Full gate | Everything together | `make harness && make before-commit` |
+
+## When to re-read the checklist
+
+- Before every commercial pilot kick-off
+- After merging any ADR that touches IAM, audit, or cross-account access
+- When opening a PR that touches `infrastructure/lib/control-plane/`, `infrastructure/lib/problem-deploy/handlers/`, or `infrastructure/templates/`
+- Quarterly, as a posture sanity check
+
+## Reporting a security issue
+
+See [`SECURITY.md`](../../SECURITY.md). Do not file public GitHub issues for sensitive disclosures.
+
+## Cross-references
+
+- Architecture invariants — [`docs/architecture/harness.md`](../architecture/harness.md)
+- Operations runbooks — [`docs/runbooks/`](../runbooks/)
+- Project rules (forbidden patterns + tech stack) — [`CLAUDE.md`](../../CLAUDE.md), [`AGENTS.md`](../../AGENTS.md)


### PR DESCRIPTION
## Summary

- Add `docs/security/HARDENING-CHECKLIST.html` — the minimum credible security baseline for paid TenkaCloud hosted events (not full SOC2). 7 sections (identity & access, problem template safety, operator account hygiene, data & log handling, participant safety, teardown & cost safety, per-event runbook reference) + cross-cutting supply chain. Every control links to its evidence (file path / harness rule ID / ADR / runbook) and is tagged **Implemented / Gap / Roadmap**.
- Add `docs/security/README.md` — landing page with per-control verification commands operators can run locally before paid events (`grep` / `make` / `vitest`).
- Add a "I want to understand or audit the security posture" recipe to `CONTRIBUTOR_MAP.md` so security-curious contributors can find the checklist + know how to close a gap (add harness rule under `.claude/harness/src/rules/`).

Closes #1353
Relates #1336

## Coverage at a glance

- 23 controls **Implemented** (machine-enforced or CDK-baked)
- 8 controls **Gap** (documented expectation, manual verification per event)
- 5 controls **Roadmap** (issue-tracked future work)

Acknowledged gaps disclosed in a dedicated section so commercial buyers see the posture without surprises.

## Regression analysis

| Risk | Confirmation |
| --- | --- |
| Existing docs links break | New files only; CONTRIBUTOR_MAP additions append a new section without altering existing recipes. |
| Harness rules misclaimed | Every Implemented item cites a concrete file / harness rule ID / ADR that exists today (verified by direct read in worktree). |
| build-docs check fails on the new MD | Ran `make build-docs` locally; generated `docs/security/README.html` is committed alongside. `make check-docs` is green. |
| Harness baseline drift | `make harness` on staged changes returns only the info-level `lambda-env-size` skip note (synth not run); no errors. |
| Existing tests | All workspaces' vitest suites pass locally (infrastructure 1654, application-admin-console 364, admin-console, participant-portal 226, trust-bridge 61, auth-client 30, saml-utils 25, cli 67). Lint / textlint / markdownlint / biome / format / check-docs / check-http-status / check-template-ascii / check-template-security / check-template-cfn-refs / check-no-conflicts / audit-deps all pass. |

## Physical impact

- `make deploy` / `make deploy-saas`: **NO-OP**. Docs only, no CDK / IAM / Lambda diff.
- `make build`: **NO-OP** for app artifacts. `make build-docs` produces a new `docs/security/README.html` paired with the source-of-truth `.md`.
- CFn templates: no diff.
- Runtime config: no change.

## Test plan

- [ ] Open `docs/security/HARDENING-CHECKLIST.html` in a browser — verify the status legend, summary cards, and 8 tables render correctly.
- [ ] Click through every `docs/architecture/adr-*.html` link in the checklist — confirm each ADR exists.
- [ ] Run each verification command in `docs/security/README.md` and confirm the documented outcome.
- [ ] Confirm `make harness` returns no errors.
- [ ] Confirm CI on the linux runner runs `make synth` cleanly (resolves the local docker/arm64 bundling artifact that prevented committing through the pre-commit hook locally).