### PR TITLE
test(infrastructure): clean cfn refs temp dir

### DIFF
--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   collectGetAttResources,
   collectRefs,
@@ -54,6 +54,9 @@ describe("check-template-cfn-refs detection patterns (= 期待挙動 doc)", () =
   const tmpProblem = join(tmpDir, "problems/challenges/test-problem");
   beforeEach(() => {
     mkdirSync(tmpProblem, { recursive: true });
+  });
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
   });
   afterEach(() => {
     try {


### PR DESCRIPTION
## Summary
- Clean up the `tc-cfn-refs-test-*` temp root created by `check-template-cfn-refs.test.ts`.
- Keep the existing per-test `tmpProblem` cleanup, and add suite-level cleanup for the parent directory.

## Test plan
- `bun run --filter @TenkaCloud/infrastructure test test/scripts/check-template-cfn-refs.test.ts`
- `make harness`
- `SYSTEM_ADMIN_EMAIL=admin@example.com AWS_ACCOUNT_ID=123456789012 AWS_REGION=ap-northeast-1 make before-commit`

## Regression analysis
The leak came from `mkdtempSync(join(tmpdir(), "tc-cfn-refs-test-"))` being evaluated at suite scope while only the nested `tmpProblem` path was removed after each test. This change removes the parent temp root after the suite, so repeated test or hook runs no longer accumulate those directories.

## Physical impact
No deployed infrastructure or runtime behavior changes. The only physical effect is local test cleanup of a temporary directory under `$TMPDIR`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup procedures for temporary files and directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->