### PR TITLE
fix(events): gate teamLoginKey exposure to mutating roles

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/list.ts
@@ -111,8 +111,10 @@ export async function listEvents(
 /**
  * 指定 eventId の Event 詳細 + Teams 一覧を返す。`tenantId` 不一致は undefined (404 相当)。
  *
- * teams[].teamLoginKey は **詳細経路でのみ露出** (operator が hand-off に使うため)。
- * 一覧経路 (`listEvents`) では teams 自体を返さない。
+ * teams[].teamLoginKey は participant の bearer credential であり、 **明示的に
+ * `opts.includeLoginKeys=true` を渡した呼び出しでのみ露出** する (default-deny)。 #1392: route 側で
+ * mutating role (TenantAdmin / TenantOperator = hand-off 担当) のときだけ true を渡し、 read-only の
+ * TenantViewer には返さない。 一覧経路 (`listEvents`) では teams 自体を返さない。
  *
  * Issue #1038 P1 #7: `opts.withScoreEvents=true` のとき全 team の累計 score event timeline を
  * `scoreEventsByTeam` に含める。 default (= false) は従来挙動を維持 (= 余分な DDB query を
@@ -122,7 +124,7 @@ export async function getEventDetail(
   shared: EventSharedResources,
   tenantId: string,
   eventId: string,
-  opts: { readonly withScoreEvents?: boolean } = {},
+  opts: { readonly withScoreEvents?: boolean; readonly includeLoginKeys?: boolean } = {},
 ): Promise<EventDetail | undefined> {
   // Event Get と Teams Query は依存関係なし → 並列発火でラウンドトリップを 1 回分節約。
   // Event / Teams / Deployments を並列発火。Deployments は競技者が PATCH /portal/me で
@@ -178,7 +180,9 @@ export async function getEventDetail(
       // 競技者が portal で設定した名前 (Deployments 経由) を優先、無ければ
       // TeamsTable.displayName (operator 事前設定があれば)、それも無ければ undefined。
       displayName: displayNameByTeamId.get(teamId) ?? fromTeamsTable,
-      teamLoginKey: typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
+      // #1392: bearer credential。 mutating role 経由 (includeLoginKeys) のときだけ露出する。
+      teamLoginKey:
+        opts.includeLoginKeys && typeof t.teamLoginKey === "string" ? t.teamLoginKey : undefined,
       // #528: team の deploy 先 AWS Account ID。旧 Event は undefined。
       awsAccountId: typeof t.awsAccountId === "string" ? t.awsAccountId : undefined,
     };

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/events.ts
@@ -2,6 +2,7 @@ import type { Hono } from "hono";
 import { StatusCodes } from "http-status-codes";
 import {
   resolveTenantId,
+  resolveUserRole,
   TENANT_ADMIN_ROLE,
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
@@ -74,9 +75,14 @@ export function registerEventRoutes(app: Hono, shared: EventSharedResources): vo
       // Issue #1038 P1 #7: opt-in で全 team の累計 score event timeline を返す。
       // default (= "true" 以外) は scoreEventsByTeam を省き、 既存 caller を素通り。
       const withScoreEvents = c.req.query("withScoreEvents") === "true";
+      // #1392: teamLoginKey (participant bearer) は hand-off 担当の mutating role にのみ返す。
+      // 読取り専用の TenantViewer には露出しない (= getEventDetail は default-deny)。
+      const role = resolveUserRole(c);
+      const includeLoginKeys = role === TENANT_ADMIN_ROLE || role === TENANT_OPERATOR_ROLE;
       try {
         const detail = await getEventDetail(shared, resolveTenantId(c), eventId, {
           withScoreEvents,
+          includeLoginKeys,
         });
         if (!detail) return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
         return c.json(detail, StatusCodes.OK);

--- a/infrastructure/test/problem-deploy/event-list.test.ts
+++ b/infrastructure/test/problem-deploy/event-list.test.ts
@@ -74,7 +74,7 @@ describe("listEvents", () => {
 describe("getEventDetail", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("normal case: should return Event + Teams including teamLoginKey (detail path exposes it)", async () => {
+  it("normal case: should return Event + Teams, exposing teamLoginKey only when includeLoginKeys=true", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({
       Item: {
@@ -101,7 +101,7 @@ describe("getEventDetail", () => {
     // いないので displayTeamName 行は無し。
     ddbSend.mockResolvedValueOnce({ Items: [] });
 
-    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    const out = await getEventDetail(shared, "tenant-acme", "EV1", { includeLoginKeys: true });
     expect(out).toBeDefined();
     expect(out?.eventId).toBe("EV1");
     expect(out?.problems).toHaveLength(1);
@@ -126,6 +126,35 @@ describe("getEventDetail", () => {
     expect(deploymentsQuery).toBeInstanceOf(QueryCommand);
     expect(deploymentsQuery.input.IndexName).toBe("GSI1");
     expect(deploymentsQuery.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-acme");
+  });
+
+  it("#1392: should omit teamLoginKey by default (default-deny for read-only TenantViewer)", async () => {
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: {
+        eventId: "EV1",
+        tenantId: "tenant-acme",
+        name: "イベント A",
+        status: "DRAFT",
+        teamCount: 1,
+        problems: [],
+        createdAt: "2026-05-07T08:00:00.000Z",
+        updatedAt: "2026-05-07T08:00:00.000Z",
+        expiresAt: 9_999_999_999,
+      },
+    });
+    ddbSend.mockResolvedValueOnce({
+      Items: [{ teamId: "T1", internalSlug: "team-alpha", teamLoginKey: "key-1" }],
+    });
+    ddbSend.mockResolvedValueOnce({ Items: [] });
+
+    // includeLoginKeys を渡さない (= default) → bearer credential は露出しない。
+    const out = await getEventDetail(shared, "tenant-acme", "EV1");
+    expect(out?.teams).toHaveLength(1);
+    expect(out?.teams[0]?.teamLoginKey).toBeUndefined();
+    // 他の team メタデータ (internalSlug 等) は引き続き返る。
+    expect(out?.teams[0]?.internalSlug).toBe("team-alpha");
+    expect(JSON.stringify(out)).not.toContain("key-1");
   });
 
   it("should merge displayTeamName set by participants in the portal from Deployments", async () => {

--- a/infrastructure/test/problem-deploy/role-gates.test.ts
+++ b/infrastructure/test/problem-deploy/role-gates.test.ts
@@ -393,9 +393,15 @@ describe("ADR-020 Phase B.1 (#948): event-handler route role gates", () => {
       expect(res.status).toBe(200);
     });
 
-    it("GET /events/:id は pass", async () => {
+    it("GET /events/:id は pass するが teamLoginKey 露出を抑止する (#1392: includeLoginKeys=false)", async () => {
       const res = await eventApp.request(`/events/${ULID}`);
       await expectNotForbidden(res);
+      expect(eventMocks.getEventDetail).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ULID,
+        expect.objectContaining({ includeLoginKeys: false }),
+      );
     });
 
     it("GET /events/:id/disruptions は pass (= disruption catalog 観覧)", async () => {
@@ -467,6 +473,17 @@ describe("ADR-020 Phase B.1 (#948): event-handler route role gates", () => {
         body: "",
       });
       await expectNotForbidden(res);
+    });
+
+    it("#1392: GET /events/:id は teamLoginKey を含めて呼ばれる (hand-off 担当 = includeLoginKeys=true)", async () => {
+      const res = await eventApp.request(`/events/${ULID}`);
+      await expectNotForbidden(res);
+      expect(eventMocks.getEventDetail).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ULID,
+        expect.objectContaining({ includeLoginKeys: true }),
+      );
     });
 
     it("POST /events/:id/disruptions/fire は pass", async () => {


### PR DESCRIPTION
## Summary
[APP] fix from the 2026-05-29 `infrastructure/lib` security review (#1392 item).

`GET /events/:eventId` is gated by the `/events/*` middleware that admits **all** `TENANT_ROLES` — including read-only **TenantViewer** — and `getEventDetail` returned each team's `teamLoginKey` (the participant bearer credential) in the `teams[]` payload. A TenantViewer (intended auditor / read-only) could read every team's login key and then impersonate any competitor team (submit flags, reveal hints, open SSO sessions).

**Fix (default-deny):** `getEventDetail` now exposes `teamLoginKey` only when the caller passes `opts.includeLoginKeys=true`. The route sets it **only** for the mutating hand-off roles (`TenantAdmin` / `TenantOperator`) via `resolveUserRole`; `TenantViewer` receives team metadata (`internalSlug`, `displayName`, `awsAccountId`) without the key. `getEventDetail` has exactly one production caller (`routes/events.ts`), so the default change has no other blast radius.

## Scope note — what this PR deliberately does NOT change
The sibling #1392 item "submit-flag / reveal-hint fail-open on missing `eventId`" is **intentionally left as-is**. Existing tests (`submit-flag.test.ts:346`, `reveal-hint.test.ts:376`) document eventId-less rows as **standalone / non-event-scoped (Challenge self-paced)** scoring, which legitimately has no Battle event window. Failing closed there would break evergreen Challenge scoring. The read-path/write-path asymmetry is by design (read path gates the Battle competition-window view; write path allows standalone scoring). Reclassified on #1392 rather than changed.

## Test plan
- `event-list.test.ts`: the exposure test now calls with `{ includeLoginKeys: true }`; new test asserts `teamLoginKey` is omitted by default (default-deny) while other team metadata remains.
- `role-gates.test.ts`: `GET /events/:id` as **TenantViewer** asserts `getEventDetail` is called with `includeLoginKeys: false`; as **TenantOperator** with `includeLoginKeys: true`.
- `make harness` clean; `make before-commit` green (lint / typecheck / all-workspace tests / validate-problems / template security / cdk synth / dependency audit).

## Regression analysis
- Only the event-detail response shape changes: `teamLoginKey` is now absent for non-mutating callers. The Application Console hand-off flow runs as TenantAdmin/TenantOperator and still receives keys. No other production caller of `getEventDetail` exists.
- `submit-flag` / `reveal-hint` behaviour is unchanged (no diff in those files).
- No data, schema, IAM, or env changes.

## Physical impact
- **CFn:** NO-OP topology. The event-handler Lambda gets a new code asset hash → **UPDATE** (in-place code update, no replacement). `cdk synth` passes.
- **Data:** none.