### PR TITLE
fix(control-plane): exact provider boundary in SAML admin allowlist

### DIFF
--- a/infrastructure/lib/control-plane/saml-admin-allowlist.ts
+++ b/infrastructure/lib/control-plane/saml-admin-allowlist.ts
@@ -28,11 +28,11 @@ import type { Construct } from "constructs";
  *       を経由しない。 Control Plane では SAML identity を手動 link しないこと。
  */
 
-// provider 束縛は federated username `{provider}_{subject}` の prefix 一致で判定するため、
-// ある provider 名が別 provider 名の `_` 区切り prefix になっていると誤マッチしうる
-// (例: `corp` と `corp_evil`)。 provider 登録は operator (env-driven) なので攻撃者には到達
-// 不能だが、 命名は `_` 区切り prefix 衝突を避け `-` 区切りを推奨する。
-const PROVIDER_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{2,31}$/;
+// provider 束縛は federated username `{provider}_{subject}` を最初の `_` で分割し、 provider 部を
+// 完全一致で判定する (PRE_SIGNUP_HANDLER 参照)。 provider 名自体に `_` を許すと `{provider}_{subject}`
+// の境界が曖昧になり、 ある provider が別 provider の prefix に化けて誤マッチしうる
+// (例: `corp` と `corp_evil`)。 これを根本から塞ぐため provider 名は `_` を **禁止** し `-` 区切りのみ許可する。
+const PROVIDER_RE = /^[A-Za-z0-9][A-Za-z0-9-]{2,31}$/;
 // ざっくり email 形 (local@domain.tld、 空白・@・/ を含まない)。 厳密 RFC ではないが
 // `@` だけ・空 part 等の明らかな誤りを fail-loud で弾く。 突き合わせは完全一致。
 const EMAIL_RE = /^[^@\s/]+@[^@\s/]+\.[^@\s/]+$/;
@@ -97,10 +97,11 @@ export function parseAdminAllowlist(
 
 // Pre sign-up Lambda 本体 (inline, 依存なし)。 federated (外部 IdP) 初回 sign-in 時のみ
 // 発火し、 allowlist の `provider/email` を強制する: assertion の email が allowlist の
-// email と一致し、 かつ Cognito federated username (`{provider}_{subject}`) がその
-// allowlist エントリの provider で始まること。 両方満たすときだけ許可、 それ以外は throw で
-// account 作成を拒否する。 AdminCreateUser (SBT が systemAdmin を作る経路) や通常 sign-up
-// は素通しする。
+// email と一致し、 かつ Cognito federated username (`{provider}_{subject}`) を最初の `_` で
+// 分割した provider 部が allowlist エントリの provider と **完全一致** すること。 provider 名は
+// `_` 禁止 (PROVIDER_RE) なので最初の `_` が確実に provider/subject の境界になる。 両方満たす
+// ときだけ許可、 それ以外は throw で account 作成を拒否する。 AdminCreateUser (SBT が
+// systemAdmin を作る経路) や通常 sign-up は素通しする。
 //
 // export しているのはテストが 「実際にデプロイされる文字列」 を sandbox 評価して挙動を
 // 検証するため (= ロジックの二重定義による drift を避ける、 ProtoShip と同方針)。
@@ -113,8 +114,10 @@ exports.handler = async function (event) {
     var attrs = (event.request && event.request.userAttributes) || {};
     var email = String(attrs.email || "").trim().toLowerCase();
     var userName = String(event.userName || "").toLowerCase();
-    var ok = !!email && ALLOW.some(function (a) {
-      return a.email === email && userName.indexOf(a.provider + "_") === 0;
+    var sep = userName.indexOf("_");
+    var federatedProvider = sep > 0 ? userName.slice(0, sep) : "";
+    var ok = !!email && !!federatedProvider && ALLOW.some(function (a) {
+      return a.email === email && federatedProvider === a.provider;
     });
     if (!ok) {
       throw new Error("This federated identity is not authorized to access the admin console.");

--- a/infrastructure/test/control-plane/saml-admin-allowlist.test.ts
+++ b/infrastructure/test/control-plane/saml-admin-allowlist.test.ts
@@ -48,6 +48,14 @@ describe("parseAdminAllowlist (#1335)", () => {
     expect(() => parseAdminAllowlist("ab/admin@example.com")).toThrow(/provider name is invalid/);
   });
 
+  it("#1386: should reject a provider name containing an underscore (prefix-collision avenue)", () => {
+    // `_` を provider 名に許すと `{provider}_{subject}` の境界が曖昧になり `corp` と `corp_evil` が
+    // 衝突しうる。 parse 時点で fail-loud に弾くことで誤マッチ経路を物理的に塞ぐ。
+    expect(() => parseAdminAllowlist("corp_evil/admin@example.com")).toThrow(
+      /provider name is invalid/,
+    );
+  });
+
   it("should surface the env var name in error messages", () => {
     expect(() => parseAdminAllowlist("bad", "TENANT_SAML_ADMIN_ALLOWLIST")).toThrow(
       /TENANT_SAML_ADMIN_ALLOWLIST/,
@@ -91,6 +99,22 @@ describe("PRE_SIGNUP_HANDLER sandbox semantics (#1335)", () => {
     await expect(
       handler(externalEvent("corp-okta_subject-xyz", "admin@example.com")),
     ).rejects.toThrow(/not authorized/);
+  });
+
+  it("#1386: should reject a sibling-prefix provider via exact {provider}_ boundary match", async () => {
+    // allowlist provider = "corp-entra"。 別 provider "corp-entra2" の federated username は
+    // 最初の `_` で分割した provider 部が "corp-entra2" となり、 完全一致しないので拒否される。
+    const handler = evalHandler("corp-entra/admin@example.com");
+    await expect(
+      handler(externalEvent("corp-entra2_subject-abc", "admin@example.com")),
+    ).rejects.toThrow(/not authorized/);
+  });
+
+  it("#1386: should reject a federated username with no underscore separator", async () => {
+    const handler = evalHandler("corp-entra/admin@example.com");
+    await expect(handler(externalEvent("corp-entra", "admin@example.com"))).rejects.toThrow(
+      /not authorized/,
+    );
   });
 
   it("should reject federated user not present in allowlist", async () => {


### PR DESCRIPTION
## Summary
**Closes #1386.** [APP] fix from the 2026-05-29 `infrastructure/lib` security review.

The federated SystemAdmin allowlist (`control-plane/saml-admin-allowlist.ts`) is the only gate deciding who becomes a Control Plane admin (there is no group→role mapping Lambda for the Control Plane, so allowlist membership = admin). Its provider binding used an **unanchored substring prefix** — `userName.indexOf(a.provider + "_") === 0` — and `PROVIDER_RE` permitted `_` in provider names. Two providers whose names collide on a `_` boundary (e.g. `corp` and `corp_evil`) could let a user federating through one provider be admitted under the other's allowlist entry, escalating to cross-tenant SystemAdmin.

**Fix (both layers):**
1. `PROVIDER_RE` now forbids `_` (`/^[A-Za-z0-9][A-Za-z0-9-]{2,31}$/`), rejected fail-loud at parse time. This physically removes the prefix-collision avenue (a `corp_evil` provider can no longer be registered).
2. The Pre-SignUp guard splits the Cognito federated username `{provider}_{subject}` on the **first** `_` and requires the provider segment to **exactly equal** the allowlist provider (with a separator-present guard), replacing the prefix check.

The tenant-template allowlist (`tenant-template/saml-admin-allowlist.ts`) is a thin wrapper that delegates to this base module (`parseAdminAllowlist` + `PRE_SIGNUP_HANDLER`), so the fix covers both the Control Plane and per-tenant Application Plane.

## Test plan
- New parse test: a provider name containing `_` (`corp_evil/...`) throws `provider name is invalid`.
- New handler (sandbox-eval) tests: a sibling-prefix provider (`corp-entra2_...` vs allowlist `corp-entra`) is rejected via the exact boundary; a federated username with no `_` separator is rejected.
- All existing allowlist tests (accept matching provider+email, reject cross-provider spoofing, fail-safe empty=deny-all, AdminCreateUser pass-through) still pass — both `control-plane` and `tenant-template` suites green.
- `make harness` clean; `make before-commit` green.

## Regression analysis
- Provider names are operator-configured via env using `-` separators in all existing configs/tests; none use `_`, so the stricter `PROVIDER_RE` does not affect current deployments (and fails loud if one ever did, which is the intended safety behaviour). For underscore-free provider names the new exact-boundary match is behaviourally identical to the old prefix check, so legitimate federated admins are unaffected.
- No data, IAM, or env changes; the inline Pre-SignUp Lambda code asset changes.

## Physical impact
- **CFn:** the `FederatedAdminAllowlistGuard` Lambda (Control Plane + any silo/Lite tenant pool) gets a new inline-code asset → **UPDATE** (in-place code update, no replacement). No new/removed resources. `cdk synth` passes.
- **Data:** none.