### PR TITLE
fix(saml): block pooled-tier SAML config mutation (shared UserPool)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import { StatusCodes } from "http-status-codes";
 import { extractClaims, resolveCognitoSub, resolveTenantId } from "../deploy-handler/auth.js";
 import {
   allowCognitoOnClient,
@@ -232,12 +233,39 @@ export function defaultMakeCognitoDeps(
   };
 }
 
+// #1385: pooled tier (BASIC / STANDARD / PREMIUM) は UserPool + UserPoolClient を全 pooled tenant で
+// 共有する (ADR-018)。 そこで SAML config を mutate (= UserPoolClient の SupportedIdentityProviders /
+// ExplicitAuthFlows 書き換え) すると他 pooled tenant のログインを巻き込む (cross-tenant DoS /
+// 認証ハイジャック)。 専有 UserPool を持つ silo (PLATINUM) / Lite mode のみ mutation を許可する。
+// `custom:tenantTier` は provision 時に server-set され、 API GW JWT authorizer が署名検証するため
+// 詐称不能。 claim 不在 (= silo / Lite / admin 経路) は許可側に倒す (pooled は必ず tier claim を持つ)。
+const POOLED_TIERS: ReadonlySet<string> = new Set(["BASIC", "STANDARD", "PREMIUM"]);
+
+export function pooledTierSamlBlock(c: Context): SamlRouteResult | undefined {
+  const claims = extractClaims(c) as JwtClaims | undefined;
+  const raw = claims?.["custom:tenantTier"];
+  const tier = typeof raw === "string" ? raw.trim().toUpperCase() : undefined;
+  if (tier && POOLED_TIERS.has(tier)) {
+    return {
+      status: StatusCodes.SERVICE_UNAVAILABLE,
+      body: {
+        error: "tenant_tier_not_silo",
+        message:
+          "SAML SSO configuration requires a dedicated UserPool (PLATINUM tier). Pooled tiers share a UserPool and cannot enable SAML.",
+      },
+    };
+  }
+  return undefined;
+}
+
 export async function routeGet(deps: SamlOrchestratorDeps, c: Context): Promise<SamlRouteResult> {
   const tenantId = resolveTenantId(c);
   return handleGetTenantSamlConfig(deps.shared, tenantId);
 }
 
 export async function routePut(deps: SamlOrchestratorDeps, c: Context): Promise<SamlRouteResult> {
+  const tierBlock = pooledTierSamlBlock(c);
+  if (tierBlock) return tierBlock;
   const tenantId = resolveTenantId(c);
   const sub = resolveCognitoSub(c);
   const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));
@@ -267,6 +295,8 @@ export async function routeDelete(
   deps: SamlOrchestratorDeps,
   c: Context,
 ): Promise<SamlRouteResult> {
+  const tierBlock = pooledTierSamlBlock(c);
+  if (tierBlock) return tierBlock;
   const tenantId = resolveTenantId(c);
   const sub = resolveCognitoSub(c);
   const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));

--- a/infrastructure/test/problem-deploy/tenant-saml-tier-guard.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml-tier-guard.test.ts
@@ -1,0 +1,63 @@
+import type { Context } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { describe, expect, it, vi } from "vitest";
+import {
+  pooledTierSamlBlock,
+  routeDelete,
+  routePut,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes";
+
+/**
+ * #1385: pooled tier (BASIC / STANDARD / PREMIUM) は UserPool + UserPoolClient を全 pooled tenant で
+ * 共有するため、 SAML config mutation を silo (PLATINUM) / Lite のみに制限する。 tenantTier claim は
+ * server-set + 署名検証済みなので詐称不能。 claim 不在は許可側 (silo/Lite)。
+ */
+function ctxWithTier(tier?: string): Context {
+  return {
+    env: {
+      event: {
+        requestContext: {
+          authorizer: { jwt: { claims: tier ? { "custom:tenantTier": tier } : {} } },
+        },
+      },
+    },
+  } as unknown as Context;
+}
+
+describe("pooledTierSamlBlock (#1385)", () => {
+  it.each([
+    "BASIC",
+    "STANDARD",
+    "PREMIUM",
+    "basic",
+    "Premium",
+  ])("should block SAML config mutation for pooled tier %s (shared UserPool)", (tier) => {
+    const block = pooledTierSamlBlock(ctxWithTier(tier));
+    expect(block?.status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
+    expect((block?.body as { error?: string })?.error).toBe("tenant_tier_not_silo");
+  });
+
+  it("should allow PLATINUM (silo, dedicated UserPool)", () => {
+    expect(pooledTierSamlBlock(ctxWithTier("PLATINUM"))).toBeUndefined();
+  });
+
+  it("should allow when the tenantTier claim is absent (silo / Lite / admin path)", () => {
+    expect(pooledTierSamlBlock(ctxWithTier(undefined))).toBeUndefined();
+  });
+});
+
+describe("routePut / routeDelete pooled-tier guard (#1385)", () => {
+  it("routePut should 503 for a pooled tier without invoking Cognito self-targeting", async () => {
+    const makeCognitoDeps = vi.fn();
+    const res = await routePut({ shared: {} as never, makeCognitoDeps }, ctxWithTier("STANDARD"));
+    expect(res.status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
+    expect(makeCognitoDeps).not.toHaveBeenCalled();
+  });
+
+  it("routeDelete should 503 for a pooled tier without invoking Cognito self-targeting", async () => {
+    const makeCognitoDeps = vi.fn();
+    const res = await routeDelete({ shared: {} as never, makeCognitoDeps }, ctxWithTier("BASIC"));
+    expect(res.status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
+    expect(makeCognitoDeps).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
**Closes #1385.** [APP] fix from the 2026-05-29 `infrastructure/lib` security review.

The competitor-accounts SAML routes (`PUT` / `DELETE /admin/tenant-saml-config`) self-target the Cognito UserPool + UserPoolClient resolved from the caller's JWT `iss`/`aud`. In **pooled** mode (ADR-018), BASIC/STANDARD/PREMIUM tenants share **one** UserPool + UserPoolClient, so a pooled TenantAdmin who enables `enforceSamlOnly` (or deletes the config) rewrites the shared client's `SupportedIdentityProviders` / `ExplicitAuthFlows` and **locks out / hijacks every other pooled tenant**. The routes were gated only by `requireRole(TENANT_ADMIN_ROLE)` — no tier guard (the sibling per-tenant IdP handler already fail-closes pooled tenants).

This handler is a **single shared Lambda** (problem-deploy backend), not per-tenant, so the existing env-based `IDP_TIER_GUARD` pattern cannot distinguish per request. Instead `routePut` / `routeDelete` now call `pooledTierSamlBlock`, which reads the **server-set, signature-validated** `custom:tenantTier` claim and returns `503 tenant_tier_not_silo` for the pooled tiers (`BASIC`/`STANDARD`/`PREMIUM`). Silo (`PLATINUM`) and Lite (dedicated UserPool; claim absent) are allowed.

### Why this is safe (no infra wiring, no silo/Lite breakage)
- `custom:tenantTier` is set by `provision-tenant.sh` (uppercased) on the tenant admin user and rides in the id_token; the API GW Cognito JWT authorizer validates the signature, so a pooled tenant **cannot** present a token without its pooled tier.
- The guard blocks **only known pooled tiers** and allows everything else, so silo (PLATINUM) and Lite (no tier claim) SAML configuration keeps working. No CDK/env change required.
- `GET` (read-only) is unaffected.

## Test plan
- New `tenant-saml-tier-guard.test.ts`: `pooledTierSamlBlock` blocks `BASIC`/`STANDARD`/`PREMIUM` (case-insensitive) with `503 tenant_tier_not_silo`; allows `PLATINUM` and absent claim; `routePut`/`routeDelete` return 503 for a pooled tier **without invoking** the Cognito self-targeting deps.
- Existing `tenant-saml.test.ts` (lower-level `handlePut`/`handleDelete`) and `role-gates.test.ts` (no tier claim → allowed → role gate still enforced) remain green.
- `make harness` clean; `make before-commit` green.

## Regression analysis
- Silo (PLATINUM) and Lite SAML config flows are unchanged (allowed). Only pooled tiers — which previously could corrupt the shared client — are now blocked with a clear 503. The block runs before any Cognito mutation, so no partial state.
- No data, IAM, or env changes.

## Physical impact
- **CFn:** NO-OP topology. The competitor-accounts API Lambda gets a new code asset hash → **UPDATE** (in-place). `cdk synth` passes.
- **Data:** none.