### PR TITLE
fix(idp): enforce per-pool SAML IdP limit + lowercase idpId

### DIFF
--- a/infrastructure/lib/control-plane/handlers/idp-handler/core.ts
+++ b/infrastructure/lib/control-plane/handlers/idp-handler/core.ts
@@ -12,6 +12,7 @@
 
 import {
   CreateIdpInputSchema,
+  SAML_IDP_LIMIT_PER_USERPOOL,
   type SamlIdpConfig,
   type UpdateIdpInput,
   UpdateIdpInputSchema,
@@ -92,13 +93,26 @@ export async function createIdp(
   if (!validated.ok) {
     return { error: { kind: "invalid_metadata", reason: validated.reason ?? "unknown" } };
   }
-  const existing = await deps.store.get(scope, parsed.data.idpId);
+  // idpId は Cognito ProviderName になるため lowercase 正規化する (#1392): 大小文字違いの重複
+  // provider (`Foo` と `foo`) を防ぎ、 federated username の小文字化 (saml-admin-allowlist) と整合させる。
+  const idpId = parsed.data.idpId.toLowerCase();
+  const existing = await deps.store.get(scope, idpId);
   if (existing) {
-    return { error: { kind: "conflict", message: `idp ${parsed.data.idpId} already exists` } };
+    return { error: { kind: "conflict", message: `idp ${idpId} already exists` } };
+  }
+  // documented per-UserPool 上限 (= Cognito 制約 / list query が 25 件 bound 前提) を write 時に強制 (#1392)。
+  const current = await deps.store.list(scope);
+  if (current.length >= SAML_IDP_LIMIT_PER_USERPOOL) {
+    return {
+      error: {
+        kind: "conflict",
+        message: `idp limit reached (max ${SAML_IDP_LIMIT_PER_USERPOOL} per user pool)`,
+      },
+    };
   }
   const ts = nowIso(deps);
   const config: SamlIdpConfig = {
-    idpId: parsed.data.idpId,
+    idpId,
     displayName: parsed.data.displayName,
     ...(parsed.data.description !== undefined ? { description: parsed.data.description } : {}),
     metadataXml: parsed.data.metadataXml,

--- a/infrastructure/test/idp/core.test.ts
+++ b/infrastructure/test/idp/core.test.ts
@@ -124,6 +124,43 @@ describe("createIdp (Control Plane scope)", () => {
     const second = await createIdp(deps, scope, happyBody);
     expect("error" in second && second.error.kind).toBe("conflict");
   });
+
+  it("#1392: should lowercase idpId before storing (no case-variant duplicate providers)", async () => {
+    const deps = makeDeps();
+    const res = await createIdp(deps, scope, { ...happyBody, idpId: "Okta-ACME" });
+    expect("error" in res).toBe(false);
+    if ("error" in res) return;
+    expect(res.idpId).toBe("okta-acme");
+    expect(deps.cognito.created[0]?.idpId).toBe("okta-acme");
+    // 大文字違いで再作成しても同一 row 扱い → conflict
+    const dup = await createIdp(deps, scope, { ...happyBody, idpId: "okta-acme" });
+    expect("error" in dup && dup.error.kind).toBe("conflict");
+  });
+
+  it("#1392: should reject creation beyond SAML_IDP_LIMIT_PER_USERPOOL (25)", async () => {
+    const deps = makeDeps();
+    for (let i = 0; i < 25; i++) {
+      await deps.store.put(scope, {
+        idpId: `idp-${i}`,
+        displayName: `idp ${i}`,
+        metadataXml: VALID_METADATA,
+        attributeMapping: { email: "e" },
+        groupToRole: { admins: "TenantAdmin" },
+        createdAt: "2026-05-24T00:00:00.000Z",
+        updatedAt: "2026-05-24T00:00:00.000Z",
+      } as SamlIdpConfig);
+    }
+    const res = await createIdp(deps, scope, happyBody);
+    expect("error" in res).toBe(true);
+    if ("error" in res && res.error.kind === "conflict") {
+      expect(res.error.message).toMatch(/limit reached/);
+    } else {
+      throw new Error("expected a conflict error at the IdP limit");
+    }
+    // Cognito も DDB も触っていない (= 上限で fail-loud)
+    expect(deps.cognito.created).toHaveLength(0);
+    expect(await deps.store.get(scope, "okta-acme")).toBeNull();
+  });
 });
 
 describe("createIdp (Application Plane scope)", () => {


### PR DESCRIPTION
## Summary
[APP] fix from the 2026-05-29 `infrastructure/lib` security review (#1392 items).

The shared IdP CRUD core (`control-plane/handlers/idp-handler/core.ts`, used by both the Control Plane system scope and the Application Plane tenant scope) had two gaps:

1. **No limit enforcement** — `createIdp` never checked `SAML_IDP_LIMIT_PER_USERPOOL` (25), even though the list query and the `ddb-store` comment assume that bound. A SystemAdmin could create providers past it, inflating the UserPool/IdP table beyond the design's assumption.
2. **idpId not normalized** — `IdpIdSchema`'s doc says "We always lowercase before storing", but nothing did. `idpId` becomes the Cognito `ProviderName`, so `Foo` and `foo` could coexist as distinct providers and drift from the federated-username lowercasing in `saml-admin-allowlist`.

**Fix:** `createIdp` now lowercases `idpId` before the conflict check / Cognito create / DDB put (case-variant duplicates collapse to one provider), and enforces `SAML_IDP_LIMIT_PER_USERPOOL` at write time, returning a `conflict` before touching Cognito or DDB.

## Test plan
- New `core.test.ts` tests: `Okta-ACME` is stored as `okta-acme` and a re-create with `okta-acme` conflicts; creating beyond 25 IdPs returns a `conflict` (`/limit reached/`) without touching Cognito or DDB.
- All existing IdP core + routes tests pass.
- `make harness` clean; `make before-commit` green.

## Regression analysis
- The limit check adds one `store.list(scope)` read per create (creates are rare; ≤25 items). Lowercasing affects only newly-created IdPs; existing lookups (update/delete) use ids returned by `list`, which are now lowercased on create. No data migration is performed for any pre-existing mixed-case rows (acceptable: trusted-admin, few IdPs; they can be recreated).
- No IAM, env, or table changes.

## Physical impact
- **CFn:** NO-OP topology. The Control Plane + Application Plane IdP-handler Lambdas get new code asset hashes → **UPDATE** (in-place). `cdk synth` passes.
- **Data:** none.