### PR TITLE
fix(admin-insight): drop wildcard Hono CORS (API Gateway owns CORS)

### DIFF
--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -2,7 +2,6 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
-import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import { exportAuditEntriesCsv, listAuditEntries } from "./audit.js";
 import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
@@ -49,16 +48,10 @@ const LIST_LIMIT_MAX = 200;
 
 const app = new Hono();
 
-app.use(
-  "*",
-  cors({
-    origin: "*",
-    allowHeaders: ["Authorization", "Content-Type"],
-    allowMethods: ["GET", "OPTIONS"],
-    maxAge: 600,
-  }),
-);
-
+// #1392: CORS は API Gateway HTTP API の corsPreflight (admin-console-insight-stack.ts) が
+// localhost dev + admin-console CloudFront origin の allowlist で一元管理する。 ここで Hono の
+// `cors({ origin: "*" })` を重ねると、 認証済み SystemAdmin surface に対し任意 origin への
+// `Access-Control-Allow-Origin: *` を返してしまうため middleware を置かない。
 app.onError((err, c) => {
   const message = err instanceof Error ? err.message : "unknown error";
   console.error("[admin-insight] uncaught handler error", { path: c.req.path, message });

--- a/infrastructure/test/admin-insight/admin-insight-routes.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-routes.test.ts
@@ -33,6 +33,16 @@ function withClaims(claims: Record<string, unknown>) {
   };
 }
 
+describe("#1392: CORS is owned by API Gateway, not the Hono app", () => {
+  it("should NOT emit a wildcard Access-Control-Allow-Origin header from the Lambda", async () => {
+    const res = await app.request("/admin/insight/healthz");
+    expect(res.status).toBe(200);
+    // API Gateway HTTP API の corsPreflight allowlist が CORS を一元管理する。 handler 側で
+    // `cors({ origin: "*" })` を重ねていた wildcard を撤去したことを pin する。
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});
+
 describe("GET /admin/insight/tenants/summary", () => {
   beforeEach(() => vi.clearAllMocks());
 


### PR DESCRIPTION
## Summary
[APP] fix from the 2026-05-29 `infrastructure/lib` security review (#1392 item).

The AdminInsight Lambda's Hono app applied `cors({ origin: "*" })` on every route, echoing `Access-Control-Allow-Origin: *` on an authenticated **System-Admin** surface. This contradicts the API Gateway HTTP API `corsPreflight` allowlist (localhost dev ports + admin-console CloudFront origin) configured in `admin-console-insight-stack.ts`.

API Gateway already handles CORS (preflight + response headers) for this HTTP API, so the handler-level middleware was redundant and widened what arbitrary web origins could read. Removed the middleware (and its unused import); CORS is now owned solely by the restricted API Gateway allowlist.

Not directly exploitable (the endpoint requires a Cognito JWT and `allowCredentials` is false), so this is defense-in-depth — but a `*` ACAO on an authenticated admin surface should not be emitted.

## Test plan
- New `admin-insight-routes.test.ts` case: `GET /admin/insight/healthz` no longer returns an `Access-Control-Allow-Origin` header from the Lambda.
- All existing admin-insight route + stack tests pass (the API Gateway `corsPreflight` allowlist test is unchanged).
- `make harness` clean; `make before-commit` green.

## Regression analysis
- Browsers still receive CORS headers from API Gateway for allowed origins; behaviour for the allowlisted admin-console origin + localhost is unchanged. Only the redundant wildcard echoed by the Lambda is gone.
- No data, IAM, or env changes.

## Physical impact
- **CFn:** NO-OP topology. The AdminInsight Lambda gets a new code asset hash → **UPDATE** (in-place). `cdk synth` passes.
- **Data:** none.