### PR TITLE
fix(admin-insight): remove dead system-users routes + unused Cognito IAM [INFRA]

### DIFF
--- a/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
+++ b/infrastructure/lib/admin-insight/admin-console-insight-stack.ts
@@ -115,10 +115,6 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       deploymentsTable: props.deploymentsTable,
       eventsTable: props.eventsTable,
       teamsTable: props.teamsTable,
-      // Issue #949: SystemAdmin user CRUD のため ControlPlane UserPool を渡す。
-      // Lambda は env CONTROL_PLANE_USER_POOL_ID + IAM Allow を取得し、
-      // /admin/insight/system-users route 群を実装する。
-      controlPlaneUserPool: props.cognitoUserPool,
       ...(props.deprovisioningStateMachineArn
         ? { deprovisioningStateMachineArn: props.deprovisioningStateMachineArn }
         : {}),
@@ -224,20 +220,11 @@ export class AdminConsoleInsightStack extends cdk.Stack {
       integration,
     });
 
-    // Issue #949 (ADR-020 Phase C): SystemAdmin user の CRUD route 群。
-    // 全 route で JWT Authorizer + handler 内の `cognito:groups ⊇ {SystemAdmin}` の 2 段 check で
-    // 認可する。 list / detail は SystemAuditor も pass、 mutate (POST / DELETE / PATCH) は
-    // SystemAdmin only にする予定 (= handler 内 granular gate)。
-    httpApi.addRoutes({
-      path: "/admin/insight/system-users",
-      methods: [HttpMethod.GET, HttpMethod.POST],
-      integration,
-    });
-    httpApi.addRoutes({
-      path: "/admin/insight/system-users/{username}",
-      methods: [HttpMethod.GET, HttpMethod.DELETE, HttpMethod.PATCH],
-      integration,
-    });
+    // #1392: `/admin/insight/system-users*` routes は handler から削除済 (index.ts: UI 経路は
+    // token security hole になりやすいため Cognito 直 = admin-create-user / Hosted UI に倒した)。
+    // 配線だけ残ると handlerless route + 未使用の cognito-idp:Admin* 権限が standing privilege と
+    // して残り、 least-privilege に反する + 再 handler 追加時に無審査で再武装するため、 route 登録と
+    // Lambda 側の ControlPlane UserPool 権限/env を撤去した。
 
     // Issue #950 (ADR-020 Phase D): admin audit log read route (= cross-tenant 監査)
     httpApi.addRoutes({

--- a/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
+++ b/infrastructure/lib/admin-insight/admin-insight-api-lambda.ts
@@ -1,6 +1,5 @@
 import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
-import type { IUserPool } from "aws-cdk-lib/aws-cognito";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
@@ -37,15 +36,6 @@ export interface AdminInsightApiLambdaProps {
    * 503 を返す or placeholder)。
    */
   readonly deprovisioningStateMachineArn?: string;
-  /**
-   * Issue #949 (ADR-020 Phase C): SBT ControlPlane の UserPool (= SystemAdmin が登録される pool)。
-   * 指定時は Lambda に `cognito-idp:AdminCreateUser` / `AdminDeleteUser` / `AdminGetUser` /
-   * `AdminUpdateUserAttributes` / `ListUsers` / `AdminAddUserToGroup` / `AdminRemoveUserFromGroup`
-   * 権限を付与し、 `/admin/insight/system-users` route が SystemAdmin user の CRUD を実装する。
-   *
-   * Resource scope は `userPool.userPoolArn` で固定 (= 他 tenant pool への越境を禁止)。
-   */
-  readonly controlPlaneUserPool?: IUserPool;
   /**
    * Issue #950 (ADR-020 Phase D): admin audit log table。 指定時は SystemAdmin が
    * /admin/insight/audit route で cross-tenant に audit を読めるようになる (= read-only)。
@@ -94,9 +84,6 @@ export class AdminInsightApiLambda extends Construct {
         // Issue #814 Phase 2: deprovisioning Step Functions ARN を env に渡す (= 未指定なら空)。
         // handler は env の有無で route を 503 にするか実 SFN.ListExecutions を呼ぶか分岐する。
         DEPROVISIONING_STATE_MACHINE_ARN: props.deprovisioningStateMachineArn ?? "",
-        // Issue #949 (ADR-020 Phase C): ControlPlane UserPool ID を env で渡す。 未指定なら空文字
-        // (= /admin/insight/system-users route は 503 を返す)。 prod では必ず注入する想定。
-        CONTROL_PLANE_USER_POOL_ID: props.controlPlaneUserPool?.userPoolId ?? "",
         // Issue #950 (ADR-020 Phase D): admin audit log table 名 (= read-only 経由で表示)
         ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
         ...(props.auditRetentionDays !== undefined
@@ -148,37 +135,9 @@ export class AdminInsightApiLambda extends Construct {
       }),
     );
 
-    // Issue #949 (ADR-020 Phase C): ControlPlane UserPool への SystemAdmin user CRUD 権限。
-    // 指定 UserPool ARN に scope して付与する (= 越境攻撃の防御)。 未指定なら付与しない (= 旧 stack 互換)。
-    // 含む actions:
-    //   - AdminCreateUser  (= 招待 + temp password)
-    //   - AdminDeleteUser  (= 削除)
-    //   - AdminGetUser     (= detail / role 読み取り)
-    //   - AdminUpdateUserAttributes (= role 変更)
-    //   - ListUsers        (= 全 user 一覧、 旧 phase 用に維持)
-    //   - ListUsersInGroup (= Issue #987: SystemAdmin / SystemAuditor 別の一覧、
-    //     handler は ListUsersInGroupCommand を使っているのに本 action が欠落していて 500 で
-    //     fail していた)
-    //   - AdminAddUserToGroup / AdminRemoveUserFromGroup (= SystemAdmin / SystemAuditor group 操作)
-    if (props.controlPlaneUserPool) {
-      this.fn.addToRolePolicy(
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: [
-            "cognito-idp:AdminCreateUser",
-            "cognito-idp:AdminDeleteUser",
-            "cognito-idp:AdminGetUser",
-            "cognito-idp:AdminUpdateUserAttributes",
-            "cognito-idp:ListUsers",
-            "cognito-idp:ListUsersInGroup",
-            "cognito-idp:AdminAddUserToGroup",
-            "cognito-idp:AdminRemoveUserFromGroup",
-            "cognito-idp:AdminListGroupsForUser",
-          ],
-          resources: [props.controlPlaneUserPool.userPoolArn],
-        }),
-      );
-    }
+    // #1392: `/admin/insight/system-users*` routes は handler から削除済のため、 それ専用だった
+    // ControlPlane UserPool への `cognito-idp:Admin*` 権限 (旧 Issue #949) も撤去した。 未使用の
+    // standing privilege を残さず、 route 再追加時に再 review を強制する。
 
     // Issue #814 Phase 2: Deprovisioning Jobs route の Step Functions ListExecutions 権限。
     // 指定された SBT BashJobRunner の state machine ARN に scope する。 未指定なら付与しない

--- a/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
+++ b/infrastructure/test/admin-insight/admin-console-insight-stack.test.ts
@@ -204,6 +204,34 @@ describe("AdminConsoleInsightStack (ADR-011 Phase 1.A)", () => {
     });
   });
 
+  describe("#1392: dead system-users routes + unused Cognito Admin* IAM removed", () => {
+    it("should NOT register any /admin/insight/system-users route (handler was removed)", () => {
+      const tpl = synthInsightStack();
+      tpl.resourcePropertiesCountIs(
+        "AWS::ApiGatewayV2::Route",
+        { RouteKey: Match.stringLikeRegexp("system-users") },
+        0,
+      );
+    });
+
+    it("should NOT grant cognito-idp:Admin* on any IAM policy (no standing privilege)", () => {
+      const tpl = synthInsightStack();
+      tpl.resourcePropertiesCountIs(
+        "AWS::IAM::Policy",
+        {
+          PolicyDocument: {
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Action: Match.arrayWith(["cognito-idp:AdminCreateUser"]),
+              }),
+            ]),
+          },
+        },
+        0,
+      );
+    });
+  });
+
   describe("Outputs", () => {
     it("should expose AdminInsightApiUrl as a stack Output", () => {
       const tpl = synthInsightStack();


### PR DESCRIPTION
## Summary
**[INFRA] — owner-review.** Addresses the dead-routes / standing-privilege item of #1392 (2026-05-29 security review).

`admin-console-insight-stack.ts` still registered `/admin/insight/system-users` and `/admin/insight/system-users/{username}` routes whose **handlers were removed** from `index.ts` (the System-Admin user CRUD UI path was deliberately moved to Cognito direct `admin-create-user` / Hosted UI to avoid a token security hole). The handlerless routes pass the JWT authorizer and fall through to a 404, but the AdminInsight Lambda kept holding `cognito-idp:Admin*` on the ControlPlane UserPool (`AdminCreateUser` / `AdminDeleteUser` / `AdminUpdateUserAttributes` / `AdminAddUserToGroup` / `ListUsersInGroup` / …) plus the `CONTROL_PLANE_USER_POOL_ID` env — with **no code path using them**. That is excess standing privilege that would silently re-arm if a `system-users` handler were ever re-added without re-review.

**Change (pure privilege reduction):**
- Remove the dead `system-users` route registrations.
- Remove the `controlPlaneUserPool` prop + `CONTROL_PLANE_USER_POOL_ID` env from the Lambda construct.
- Remove the `cognito-idp:Admin*` `PolicyStatement`.
- Retain `cognitoUserPool` (still used for the JWT authorizer + sign-in-audit).

## Owner-review note
CDK/IAM is owner-owned per the role split. This PR is **synth + Template-assertion validated only** — please confirm on a real deploy that no out-of-band consumer relies on these routes/permissions (none exist in this repo). It strictly *removes* a route + permissions, so the blast radius is "a removed capability that already had no handler".

## Test plan
- New Template assertions in `admin-console-insight-stack.test.ts`: **zero** `AWS::ApiGatewayV2::Route` with a `system-users` RouteKey; **zero** `AWS::IAM::Policy` granting `cognito-idp:AdminCreateUser`.
- All existing admin-insight stack + route + lambda tests pass.
- `make harness` clean; `make before-commit` green (incl. `cdk synth`).

## Regression analysis
- The removed routes had no handler (404 today); removing them changes a 404 to a 404 (route simply absent). No runtime behavior relies on the removed IAM/env. `cognitoUserPool` (authorizer + sign-in-audit) is untouched.
- No data changes.

## Physical impact
- **CFn:** **DELETE** of 2 `AWS::ApiGatewayV2::Route` (+ their integrations if unshared), removal of `cognito-idp:Admin*` statements from the Lambda role policy (**UPDATE** of the IAM policy → narrower), and removal of one Lambda env var (**UPDATE**, new code/env asset). No data-store changes. `cdk synth` passes.