### PR TITLE
test(saml): pin Cognito self-targeting guard vs iss spoofing [INFRA]

### DIFF
--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -130,8 +130,14 @@ export class CompetitorAccountsApiLambda extends Construct {
     //    全 UserPool に絞り (= account-level blast radius)、 runtime 側で JWT iss claim から
     //    呼び出した UserPool ID を抽出して self-targeting のみ許可する。
     //
-    //    cross-stack で具体 UserPool ARN を渡すと TenantTemplateStack ↔ ProblemDeployBackendStack
-    //    間に CFn export 依存が増えるため、 wildcard + runtime guard で代用する設計判断。
+    //    #1391: 具体 UserPool ARN への scope は **不能**。 silo (PLATINUM) tenant の UserPool は
+    //    provision-tenant.sh が per-tenant stack で動的に作るため、 この共有 Lambda の synth 時点では
+    //    ARN を列挙できない (random pool-id、 命名 prefix も無い)。 よって `userpool/*` は
+    //    アーキ上必須で、 越境防止の実効的な制御は IAM ではなく runtime の self-targeting guard
+    //    (`extractUserPoolIdFromIss`、 = API GW JWT authorizer が署名検証した iss の pool だけを mutate)。
+    //    guard の spoofing 耐性は tenant-saml.test.ts の adversarial cases で pin している。
+    //    cross-stack で ARN を export すると TenantTemplateStack ↔ ProblemDeployBackendStack 間に
+    //    CFn 循環依存が増えるトレードオフもある。
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/infrastructure/test/problem-deploy/tenant-saml.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml.test.ts
@@ -120,6 +120,39 @@ describe("extractUserPoolIdFromIss", () => {
     expect(extractUserPoolIdFromIss("https://example.com")).toBeUndefined();
     expect(extractUserPoolIdFromIss("not-a-url")).toBeUndefined();
   });
+
+  // #1391: this extraction is the runtime self-targeting control behind the (architecturally
+  // required) `cognito-idp:*` on `userpool/*` IAM grant — the Lambda mutates only the pool that
+  // issued the caller's (API-GW-signature-validated) JWT. These adversarial cases pin that an
+  // attacker cannot steer the extracted pool id to a victim pool via a crafted iss.
+  it.each([
+    ["http (not https) scheme", "http://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_x"],
+    [
+      "suffix-domain spoof",
+      "https://cognito-idp.ap-northeast-1.amazonaws.com.evil.com/ap-northeast-1_x",
+    ],
+    [
+      "extra path segment / traversal",
+      "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_x/../victim_pool",
+    ],
+    [
+      "query string appended",
+      "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_x?next=victim",
+    ],
+    [
+      "embedded userinfo host spoof",
+      "https://cognito-idp.ap-northeast-1.amazonaws.com@evil.com/victim_pool",
+    ],
+    ["non-cognito host", "https://login.evil.com/ap-northeast-1_x"],
+  ])("should return undefined for a spoofed iss: %s", (_, iss) => {
+    expect(extractUserPoolIdFromIss(iss)).toBeUndefined();
+  });
+
+  it("should extract only the final pool-id segment exactly (no host/region carry-over)", () => {
+    expect(
+      extractUserPoolIdFromIss("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_Pool9"),
+    ).toBe("us-east-1_Pool9");
+  });
 });
 
 /* ------------------------- Cognito SDK wrapper tests ------------------------- */


### PR DESCRIPTION
## Summary
**[INFRA] — owner-review. Closes #1391** (2026-05-29 security review).

The competitor-accounts API Lambda holds `cognito-idp:*` on `arn:…:userpool/*`. The finding asked to scope this to concrete UserPool ARNs — but that is **architecturally impossible**: silo (PLATINUM) tenant pools are created dynamically by `provision-tenant.sh` in per-tenant stacks, so this *shared* Lambda cannot enumerate their ARNs at synth (random pool-id, no name prefix). The effective cross-tenant control is therefore **not IAM scoping** but the runtime self-targeting guard — the Lambda mutates only the pool that issued the caller's **API-Gateway-signature-validated** JWT (`extractUserPoolIdFromIss`).

Per the finding's alternative ("if the wildcard must remain, harden + unit-test the runtime guard"), this PR:
- Adds **adversarial unit tests** proving `extractUserPoolIdFromIss` rejects spoofed `iss` values: `http` scheme, suffix-domain spoof (`…amazonaws.com.evil.com`), extra path segment / traversal, query string, embedded-userinfo host spoof (`…amazonaws.com@evil.com`), non-cognito host. An attacker cannot steer the extracted pool id to a victim pool.
- **Documents the IAM rationale** in the construct (why `userpool/*` is required + that the signature-validated `iss` self-targeting guard is the real control + the cross-stack-circular-dep tradeoff).

No IAM change is made (the wildcard is genuinely required). This is the defensible resolution; a "scope to ARN" PR would be incorrect for this architecture.

## Owner-review note
Confirm you agree `userpool/*` must remain for dynamic silo pools. If you later prefer IAM scoping, it would require exporting every silo pool ARN cross-stack (CFn circular-dep risk) or a per-tenant deployment of this Lambda.

## Test plan
- `tenant-saml.test.ts`: 6 new adversarial `extractUserPoolIdFromIss` cases + an exact-segment-extraction case (34 tests pass).
- `make harness` clean; `make before-commit` green (`cdk synth` passes — no resource change).

## Regression analysis
- No runtime or IAM change; only tests + a clarifying comment. Behavior identical.

## Physical impact
- **CFn:** NO-OP. Only test + comment changes; the Lambda code asset hash is unchanged (comment is in CDK TS, not bundled handler) → effectively no CFn diff. `cdk synth` passes.
- **Data:** none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced security test coverage for tenant isolation and authentication validation scenarios.

* **Chores**
  * Updated internal infrastructure documentation to clarify tenant security scoping decisions and implementation constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->