### PR TITLE
fix(deploy): scope CodeBuild role via a CloudFormation exec role [INFRA]

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
+++ b/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
@@ -77,8 +77,35 @@ export interface DeployCodeBuildProjectProps {
 export class DeployCodeBuildProject extends Construct {
   public readonly project: Project;
 
+  /** CloudFormation execution role passed via `aws cloudformation deploy --role-arn`. */
+  public readonly cfnExecRole: iam.Role;
+
   constructor(scope: Construct, id: string, props: DeployCodeBuildProjectProps) {
     super(scope, id);
+
+    // #1381: CloudFormation 実行ロール。 問題テンプレが作る任意リソース (EC2 / IAM Role / S3 等)
+    // を CFn が create するための広域権限はこの **CFn 専用 service role** に閉じ込め、 CodeBuild role
+    // からは剥がす。 CodeBuild は同一 account deploy 時に `aws cloudformation deploy --role-arn` で
+    // この role を PassRole するだけ (= build script injection が直接 iam:CreateRole 等を呼べない)。
+    // 注: 悪意ある問題テンプレは CFn 経由で依然 admin IAM を作れる (= テンプレ境界の信頼は別問題、
+    // テンプレ審査 #1353 で担保)。 本変更が塞ぐのは「CodeBuild role 自体 = 実質 account admin」の方。
+    this.cfnExecRole = new iam.Role(this, "CfnExecRole", {
+      assumedBy: new iam.ServicePrincipal("cloudformation.amazonaws.com"),
+      inlinePolicies: {
+        ResourceCreation: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ["ec2:*", "iam:*", "ssm:*", "logs:*", "s3:*", "events:*", "lambda:*"],
+              // justify: (#1381) 問題テンプレが作る任意リソースを CFn が create するための広域権限。
+              // CodeBuild role からは剥がし、 cloudformation.amazonaws.com だけが assume できるこの
+              // 専用 role に閉じ込めた (= PassRole 条件付き)。 テンプレ自体の信頼境界は審査 #1353 で担保。
+              resources: ["*"],
+            }),
+          ],
+        }),
+      },
+    });
 
     this.project = new Project(this, "Project", {
       description: "TenkaCloud problem deploy executor (runs scripts/deploy-battles.sh).",
@@ -147,6 +174,12 @@ export class DeployCodeBuildProject extends Construct {
           type: BuildEnvironmentVariableType.PLAINTEXT,
           value: "",
         },
+        // #1381: same-account deploy で `aws cloudformation deploy --role-arn` に渡す CFn 実行ロール。
+        // cross-account 経路 (COMPETITOR_ROLE_ARN set) では使わない (assumed role の権限で動く)。
+        CFN_EXEC_ROLE_ARN: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: this.cfnExecRole.roleArn,
+        },
       },
       buildSpec: BuildSpec.fromObject({
         version: "0.2",
@@ -162,13 +195,12 @@ export class DeployCodeBuildProject extends Construct {
       }),
     });
 
-    // 同一 account 内の CFn deploy 権限を Project Role に付与する。MVP-1 は same-account
-    // のみなので Resource は account 内全リソースを許可 (CFn が必要な権限は問題テンプレ次第)。
-    // Phase 2 で cross-account になったら ここを sts:AssumeRole に絞り、target account 側で
-    // CFn 権限を持たせる。
-    // Issue #857 justify: same-account CFn deploy で問題 stack ARN を synth 時に決定不能
-    // (= competitor が CodeBuild script から動的に CreateStack するため)。 Phase 2 cross-account
-    // で AssumeRole + 競技者側 Role に CFn 権限を持たせる移行が予定済 (= MVP-1 の一時許容)。
+    const stack = Stack.of(this);
+
+    // #1381: stack 操作系の CFn action は deploy stack の命名規約 `tc-{problemSlug}-{teamSlug}`
+    // (= battles-common.sh build_name_prefix、 contract `^tc-[a-z0-9]+(-[a-z0-9]+)+$`) に scope する。
+    // region は deploy 先が可変なので `*`。 これにより CodeBuild role は自分が作る tc-* stack 以外を
+    // 操作できない。
     this.project.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -181,7 +213,6 @@ export class DeployCodeBuildProject extends Construct {
           "cloudformation:DescribeStackResource",
           "cloudformation:DescribeStackResources",
           "cloudformation:GetTemplate",
-          "cloudformation:GetTemplateSummary",
           "cloudformation:CreateChangeSet",
           "cloudformation:DescribeChangeSet",
           "cloudformation:ExecuteChangeSet",
@@ -189,19 +220,32 @@ export class DeployCodeBuildProject extends Construct {
           "cloudformation:ListChangeSets",
           "cloudformation:ListStackResources",
         ],
-        // Issue #857 justify: same-account の動的 stack ARN を synth 時に決定不能 (= 上のコメント参照)
+        resources: [`arn:aws:cloudformation:*:${stack.account}:stack/tc-*/*`],
+      }),
+    );
+    // template introspection 系 (`GetTemplateSummary` 等) は IAM の resource-level 制約を
+    // サポートしないため `*` 据え置き (= `aws cloudformation deploy` が parameter/capability 検出で叩く)。
+    this.project.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudformation:GetTemplateSummary"],
+        // justify: (#1381) GetTemplateSummary は IAM の resource-level 制約をサポートしない
+        // (AWS API design)。 stack ARN に絞れないため `*` 据え置き。 stack 操作系は別 statement で tc-* に scope 済。
         resources: ["*"],
       }),
     );
 
-    // `security-battle-royale` 等の問題テンプレが作るリソース (EC2 / VPC / IAM Role 等)
-    // を CFn が自前で create するための権限。MVP-1 は same-account なので Project Role
-    // が直接これらを持つ必要がある。最小権限化は問題テンプレが固まってから別途検討。
+    // #1381: 問題テンプレが作る任意リソースの広域権限は CodeBuild role からは付けず、 CFn 実行ロール
+    // (cfnExecRole) に閉じ込めた。 CodeBuild は same-account deploy 時にその role を CFn に PassRole
+    // するだけ (= cloudformation.amazonaws.com にのみ渡せるよう条件付き)。
     this.project.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ["ec2:*", "iam:*", "ssm:*", "logs:*", "s3:*", "events:*", "lambda:*"],
-        resources: ["*"],
+        actions: ["iam:PassRole"],
+        resources: [this.cfnExecRole.roleArn],
+        conditions: {
+          StringEquals: { "iam:PassedToService": "cloudformation.amazonaws.com" },
+        },
       }),
     );
 
@@ -211,7 +255,6 @@ export class DeployCodeBuildProject extends Construct {
     //   2. `arn:aws:iam::<account>:role/TenkaCloud-*` に AssumeRole (with ExternalId)
     //   3. 取得した tmp credentials で `aws cloudformation deploy` を target account に実行
     // を行うため、本 Project Role に各権限を付与する。
-    const stack = Stack.of(this);
     const ssmArn = buildExternalIdParameterArnPattern(
       stack.region,
       stack.account,

--- a/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-codebuild-project.test.ts
@@ -120,3 +120,109 @@ describe("DeployCodeBuildProject — Phase 2.2 cross-account perms (Issue #459)"
     );
   });
 });
+
+describe("DeployCodeBuildProject — #1381 CFn service-role least-privilege", () => {
+  // CodeBuild role に attach された AWS::IAM::Policy 群の全 Action を集める。
+  // 注: cfnExecRole の広域権限は AWS::IAM::Role の inlinePolicies (= Policies) に入るので
+  // AWS::IAM::Policy には現れない。 よって AWS::IAM::Policy の Action 集合 = CodeBuild role 等の
+  // addToRolePolicy 由来であり、 ここに iam:*/ec2:* が無いことが CodeBuild role から剥がれた証拠。
+  function iamPolicyActions(tpl: Template): string[] {
+    const policies = tpl.findResources("AWS::IAM::Policy");
+    return Object.values(policies).flatMap((p) => {
+      const statements =
+        (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } }).Properties
+          ?.PolicyDocument?.Statement ?? [];
+      return statements.flatMap((s) => {
+        const action = (s as { Action?: string | string[] }).Action;
+        return Array.isArray(action) ? action : typeof action === "string" ? [action] : [];
+      });
+    });
+  }
+
+  it("should NOT grant iam:* / ec2:* on the CodeBuild project role (moved to the CFn exec role)", () => {
+    const actions = iamPolicyActions(synth());
+    expect(actions).not.toContain("iam:*");
+    expect(actions).not.toContain("ec2:*");
+    expect(actions).not.toContain("s3:*");
+  });
+
+  it("should create a CloudFormation execution role assumable only by cloudformation.amazonaws.com with the resource-creation perms", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::IAM::Role",
+      Match.objectLike({
+        AssumeRolePolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: "sts:AssumeRole",
+              Principal: { Service: "cloudformation.amazonaws.com" },
+            }),
+          ]),
+        }),
+        Policies: Match.arrayWith([
+          Match.objectLike({
+            PolicyDocument: Match.objectLike({
+              Statement: Match.arrayWith([
+                Match.objectLike({
+                  Effect: "Allow",
+                  Action: Match.arrayWith(["iam:*"]),
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("should let CodeBuild only PassRole the exec role to CloudFormation (conditioned)", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: "iam:PassRole",
+              Condition: {
+                StringEquals: { "iam:PassedToService": "cloudformation.amazonaws.com" },
+              },
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("should scope stack-operating cloudformation actions to the tc-* stack name prefix", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::IAM::Policy",
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: Match.arrayWith(["cloudformation:CreateStack"]),
+              Resource: "arn:aws:cloudformation:*:123456789012:stack/tc-*/*",
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("should pass CFN_EXEC_ROLE_ARN to the CodeBuild env (same-account --role-arn source)", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::CodeBuild::Project",
+      Match.objectLike({
+        Environment: Match.objectLike({
+          EnvironmentVariables: Match.arrayWith([Match.objectLike({ Name: "CFN_EXEC_ROLE_ARN" })]),
+        }),
+      }),
+    );
+  });
+});

--- a/scripts/delete-battles.sh
+++ b/scripts/delete-battles.sh
@@ -43,10 +43,18 @@ trace_log "deploy.cfn.delete.start" stackName "${STACK_NAME}" region "${REGION}"
 # 既存リソースに影響なし)。pre-check の describe-stacks は TOCTOU race を生む (= check と
 # delete の間に他 actor が消すと describe は OK でも delete が ValidationError) ので入れない。
 # 直接 delete-stack → 既に削除済みなら "does not exist" を握って no-op exit、それ以外は loud に fail。
+# #1381: same-account 経路では deploy 時と同じ CFn service role を渡す (= CodeBuild role から
+# 直接の resource 削除権限を剥がした分、 CFn がこの role を assume して削除する)。 cross-account 経路は
+# assumed competitor role の権限で動くため --role-arn は付けない。
+cfn_delete_role_args=()
+if [[ -z "${COMPETITOR_ROLE_ARN:-}" && -n "${CFN_EXEC_ROLE_ARN:-}" ]]; then
+  cfn_delete_role_args=(--role-arn "${CFN_EXEC_ROLE_ARN}")
+fi
 delete_err="$(
   aws cloudformation delete-stack \
     --region "${REGION}" \
-    --stack-name "${STACK_NAME}" 2>&1
+    --stack-name "${STACK_NAME}" \
+    ${cfn_delete_role_args[@]+"${cfn_delete_role_args[@]}"} 2>&1
 )" || {
   if grep -qiE "ValidationError|does not exist" <<<"${delete_err}"; then
     trace_log "deploy.cfn.delete.already_deleted" stackName "${STACK_NAME}" region "${REGION}"

--- a/scripts/deploy-battles.sh
+++ b/scripts/deploy-battles.sh
@@ -202,12 +202,21 @@ deploy_one() {
   TENKACLOUD_TENANT_ID="${TENKACLOUD_TENANT_ID:-unknown}"
   TENKACLOUD_JOB_ID="${TENKACLOUD_JOB_ID:-${TENKACLOUD_CORRELATION_ID:-unknown}}"
   TENKACLOUD_BATCH_ID="${TENKACLOUD_BATCH_ID:-${TENKACLOUD_JOB_ID}}"
+  # #1381: same-account 経路では CFn 専用 service role (CFN_EXEC_ROLE_ARN) を CFn に渡す。
+  # CodeBuild role 自体からは iam:*/ec2:* を剥がしたので、 リソース作成は CFn がこの role を
+  # assume して行う。 cross-account 経路 (COMPETITOR_ROLE_ARN set) では assumed competitor role
+  # の権限で動くため --role-arn は付けない。
+  local -a cfn_deploy_role_args=()
+  if [[ -z "${COMPETITOR_ROLE_ARN:-}" && -n "${CFN_EXEC_ROLE_ARN:-}" ]]; then
+    cfn_deploy_role_args=(--role-arn "${CFN_EXEC_ROLE_ARN}")
+  fi
   if ! aws cloudformation deploy \
     --region "${AWS_REGION}" \
     --stack-name "${name_prefix}" \
     --template-file "${template}" \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset \
+    ${cfn_deploy_role_args[@]+"${cfn_deploy_role_args[@]}"} \
     --parameter-overrides "${parameter_overrides[@]}" \
     --tags \
       "TenkaCloud:NamePrefix=${name_prefix}" \


### PR DESCRIPTION
## Summary
**[INFRA] — owner-review. Closes #1381** (2026-05-29 security review; Relates #857).

The problem-deploy CodeBuild role held `iam:*` / `ec2:*` / `ssm:*` / `s3:*` / `logs:*` / `events:*` / `lambda:*` on `Resource:*` (effectively **account administrator**) plus `cloudformation:*` on `*`. A build-script injection or a compromised problem template could mint IAM admin roles, read any bucket, etc.

This applies the **CloudFormation service-role pattern**:
- **New `CfnExecRole`** — assumable only by `cloudformation.amazonaws.com` — holds the broad resource-creation perms (problem templates legitimately create arbitrary resources).
- **The CodeBuild role loses `iam:*`/`ec2:*`/… entirely.** It now only gets: CloudFormation **stack-ops scoped to the `tc-*` stack-name prefix** (the `deploy-battles.sh` `tc-{problem}-{team}` contract), `cloudformation:GetTemplateSummary` on `*` (no resource-level IAM support), and `iam:PassRole` limited to `CfnExecRole` with an `iam:PassedToService=cloudformation.amazonaws.com` condition.
- **`deploy-battles.sh` / `delete-battles.sh`** pass `--role-arn $CFN_EXEC_ROLE_ARN` **only in same-account mode** (`COMPETITOR_ROLE_ARN` empty). The cross-account path is unchanged (runs under the assumed competitor role; no `--role-arn`).

Net effect: a build-script injection can no longer call IAM/EC2/S3 directly — it can only deploy CFn templates *through* the scoped service role.

## ⚠️ Owner-review note (validate before merge)
CDK/IAM is owner-owned and this is validated by `cdk synth` + Template assertions only — **please run a real same-account deploy** to confirm `aws cloudformation deploy --role-arn` succeeds and the scoped `cloudformation:*` (tc-*) covers every API the deploy makes. A residual risk: a malicious *problem template* can still create privileged IAM via CFn (template trust boundary is separate — tracked by review #1353). This PR closes the "CodeBuild role == account admin" hole, not template trust.

## Test plan
- `deploy-codebuild-project.test.ts`: asserts no `iam:*`/`ec2:*`/`s3:*` on any CodeBuild `AWS::IAM::Policy`; a CFn-assumable exec role with the resource-creation perms exists; `iam:PassRole` is conditioned to `cloudformation.amazonaws.com`; stack-ops scoped to `tc-*`; `CFN_EXEC_ROLE_ARN` env present.
- `bash -n` on both scripts; set-u-safe optional `--role-arn` array expansion.
- `make harness` clean (justify comments on the two unavoidable `*`); `make before-commit` green (`cdk synth` passes).

## Regression analysis
- Same-account deploys now route resource creation through `CfnExecRole` via `--role-arn`; existing stacks update fine (CFn re-associates the role). Cross-account deploys are unchanged (no `--role-arn`; assumed-role perms). The scoped `cloudformation:*` matches the long-standing `tc-*` naming contract shared by frontend/backend.
- No data-store changes.

## Physical impact
- **CFn:** **CREATE** of one IAM Role (`CfnExecRole`); **UPDATE** (narrower) of the CodeBuild project role policy; **UPDATE** of the CodeBuild project (new `CFN_EXEC_ROLE_ARN` env). `cdk synth` passes.
- **Data:** none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a dedicated CloudFormation execution role with least-privilege permissions, restricting stack operations to designated naming patterns
  * Updated deployment and deletion scripts to utilize the new execution role for same-account deployments
  * Added comprehensive test coverage validating CloudFormation service-role security policies and permission scoping

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->