### PR TITLE
fix(provisioning): scope SBT BashJobRunner IAM to least-privilege [INFRA]

### DIFF
--- a/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
+++ b/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
@@ -9,10 +9,10 @@ import {
 import { Stack, type StackProps } from "aws-cdk-lib";
 import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
-import { PolicyDocument } from "aws-cdk-lib/aws-iam";
 import type { Construct } from "constructs";
 import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
 import { TenantStatusReconciler } from "../tenant-status-reconciler/tenant-status-reconciler.js";
+import { buildTenantJobRunnerPermissions } from "./job-runner-permissions.js";
 import { TenantApiKey } from "./tenant-api-key.js";
 
 interface BootstrapTemplateStackProps extends StackProps {
@@ -70,25 +70,15 @@ export class BootstrapTemplateStack extends Stack {
         : {}),
     });
 
-    // Todo: reduce permission scope
+    // #1382: SBT reference-arch の BashJobRunner は example で `Action:* Resource:*` を渡すが、
+    // TenkaCloud の provision/deprovision script が実際に必要とする最小権限へ絞る
+    // (= SBT construct 自体は不変、 渡す permissions のみ TenkaCloud 固有に scope)。 詳細・前提は
+    // buildTenantJobRunnerPermissions の docblock 参照。 cross-account 化 (#857) で更に縮む。
+    const jobRunnerPermissions = buildTenantJobRunnerPermissions(this.account, this.region);
+
     const provisioningJobRunnerProps: BashJobRunnerProps = {
       eventManager: eventManager,
-      permissions: PolicyDocument.fromJson(
-        JSON.parse(`
-{
-  "Version":"2012-10-17",
-  "Statement":[
-      {
-        "Action":[
-            "*"
-        ],
-        "Resource":"*",
-        "Effect":"Allow"
-      }
-  ]
-}
-`),
-      ),
+      permissions: jobRunnerPermissions,
       script: fs.readFileSync("../scripts/provision-tenant.sh", "utf8"),
       postScript: "",
       environmentStringVariablesFromIncomingEvent: ["tenantId", "tier", "tenantName", "email"],
@@ -109,24 +99,11 @@ export class BootstrapTemplateStack extends Stack {
       incomingEvent: DetailType.ONBOARDING_REQUEST,
     };
 
+    // #1382: provisioning と同じ least-privilege scope を共有する (deprovision は cdk destroy +
+    // tenant user/group の削除なので、 provisioning の superset で過不足ない)。
     const deprovisioningJobRunnerProps: BashJobRunnerProps = {
       eventManager: eventManager,
-      permissions: PolicyDocument.fromJson(
-        JSON.parse(`
-{
-  "Version":"2012-10-17",
-  "Statement":[
-      {
-        "Action":[
-            "*"
-        ],
-        "Resource":"*",
-        "Effect":"Allow"
-      }
-  ]
-}
-`),
-      ),
+      permissions: jobRunnerPermissions,
       script: fs.readFileSync("../scripts/deprovision-tenant.sh", "utf8"),
       environmentStringVariablesFromIncomingEvent: ["tenantId"],
       environmentVariablesToOutgoingEvent: ["tenantStatus"],

--- a/infrastructure/lib/bootstrap-template/job-runner-permissions.ts
+++ b/infrastructure/lib/bootstrap-template/job-runner-permissions.ts
@@ -1,0 +1,84 @@
+import { Effect, PolicyDocument, PolicyStatement } from "aws-cdk-lib/aws-iam";
+
+/**
+ * #1382: least-privilege IAM for the SBT `BashJobRunner` roles that run
+ * `provision-tenant.sh` / `deprovision-tenant.sh`.
+ *
+ * SBT's reference-arch example passes `Action:* Resource:*` to the BashJobRunner, which makes
+ * each provisioning CodeBuild role an account administrator driven by EventBridge-supplied input.
+ * TenkaCloud's scripts only ever:
+ *   - run `bun cdk deploy/destroy` — which, with the modern role-based CDK bootstrap, delegates
+ *     all resource creation to the `cdk-*` bootstrap roles (job runner only needs `sts:AssumeRole`
+ *     to them; the `cdk-…-cfn-exec-role` is what actually creates resources),
+ *   - read the source bundle from `tenkacloud-source-<account>-<region>`,
+ *   - read tenant-template stack outputs (`cloudformation:DescribeStacks`),
+ *   - create/update the tenant admin user + group on the (dynamically created) tenant UserPool.
+ *
+ * We therefore scope the runner role to exactly that set. The SBT construct itself is unchanged —
+ * only the `permissions` input is tightened. The cross-account migration (#857) shrinks it further.
+ *
+ * NOTE: assumes a modern (role-based) CDK bootstrap. If the account uses a legacy bootstrap, or the
+ * scripts gain new direct AWS calls, this must be re-validated against a real `make deploy-saas`.
+ */
+export function buildTenantJobRunnerPermissions(account: string, region: string): PolicyDocument {
+  return new PolicyDocument({
+    statements: [
+      // cdk deploy/destroy assumes the bootstrap roles; resource creation happens via cdk-cfn-exec-role.
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        resources: [`arn:aws:iam::${account}:role/cdk-*`],
+      }),
+      // justify: sts:GetCallerIdentity has no resource-level scoping (AWS API design).
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["sts:GetCallerIdentity"],
+        resources: ["*"],
+      }),
+      // CodeBuild execution logs + cdk bootstrap version (SSM) read.
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        resources: [`arn:aws:logs:${region}:${account}:*`],
+      }),
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["ssm:GetParameter", "ssm:GetParameters"],
+        resources: [`arn:aws:ssm:${region}:${account}:parameter/cdk-bootstrap/*`],
+      }),
+      // source bundle (`tenkacloud-source-<account>-<region>`, uploaded by install.sh) read.
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["s3:GetObject", "s3:GetObjectVersion", "s3:ListBucket", "s3:ListBucketVersions"],
+        resources: [
+          `arn:aws:s3:::tenkacloud-source-${account}-${region}`,
+          `arn:aws:s3:::tenkacloud-source-${account}-${region}/*`,
+        ],
+      }),
+      // tenant-template stack output read.
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["cloudformation:DescribeStacks"],
+        resources: [
+          `arn:aws:cloudformation:${region}:${account}:stack/tenkacloud-tenant-template-*/*`,
+        ],
+      }),
+      // tenant admin user/group management on the (dynamically created) tenant UserPool.
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          "cognito-idp:AdminCreateUser",
+          "cognito-idp:AdminGetUser",
+          "cognito-idp:AdminUpdateUserAttributes",
+          "cognito-idp:AdminAddUserToGroup",
+          "cognito-idp:AdminRemoveUserFromGroup",
+          "cognito-idp:AdminDeleteUser",
+          "cognito-idp:CreateGroup",
+          "cognito-idp:GetGroup",
+          "cognito-idp:DeleteGroup",
+        ],
+        resources: [`arn:aws:cognito-idp:${region}:${account}:userpool/*`],
+      }),
+    ],
+  });
+}

--- a/infrastructure/test/bootstrap-template/job-runner-permissions.test.ts
+++ b/infrastructure/test/bootstrap-template/job-runner-permissions.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildTenantJobRunnerPermissions } from "../../lib/bootstrap-template/job-runner-permissions";
+
+/**
+ * #1382: SBT BashJobRunner の `Action:* Resource:*` を provision/deprovision-tenant.sh が実際に
+ * 必要とする最小権限へ絞ったことを pin する。 SBT construct 自体は不変、 渡す permissions のみ scope。
+ */
+function statements(account = "123456789012", region = "ap-northeast-1") {
+  const doc = buildTenantJobRunnerPermissions(account, region);
+  const json = doc.toJSON() as { Statement: Array<Record<string, unknown>> };
+  return json.Statement;
+}
+
+function actionsOf(stmts: Array<Record<string, unknown>>): string[] {
+  return stmts.flatMap((s) => {
+    const a = s.Action;
+    return Array.isArray(a) ? (a as string[]) : typeof a === "string" ? [a] : [];
+  });
+}
+
+describe("buildTenantJobRunnerPermissions (#1382)", () => {
+  it("should NOT grant the SBT-example account-admin wildcard (Action:* / Resource:*)", () => {
+    const stmts = statements();
+    const actions = actionsOf(stmts);
+    expect(actions).not.toContain("*");
+    // 唯一の Resource:* は sts:GetCallerIdentity (resource-level 非対応) のみ。
+    const starResourceStmts = stmts.filter((s) => s.Resource === "*");
+    expect(starResourceStmts).toHaveLength(1);
+    expect(actionsOf(starResourceStmts)).toEqual(["sts:GetCallerIdentity"]);
+  });
+
+  it("should delegate resource creation to the cdk-* bootstrap roles via sts:AssumeRole", () => {
+    const stmts = statements();
+    const assume = stmts.find(
+      (s) => Array.isArray(s.Action) === false && s.Action === "sts:AssumeRole",
+    );
+    expect(assume?.Resource).toBe("arn:aws:iam::123456789012:role/cdk-*");
+  });
+
+  it("should scope cloudformation/cognito/s3/ssm to TenkaCloud-specific ARNs", () => {
+    const stmts = statements();
+    const resources = stmts.flatMap((s) => {
+      const r = s.Resource;
+      return Array.isArray(r) ? (r as string[]) : typeof r === "string" ? [r] : [];
+    });
+    expect(resources).toContain(
+      "arn:aws:cloudformation:ap-northeast-1:123456789012:stack/tenkacloud-tenant-template-*/*",
+    );
+    expect(resources).toContain("arn:aws:cognito-idp:ap-northeast-1:123456789012:userpool/*");
+    expect(resources).toContain("arn:aws:s3:::tenkacloud-source-123456789012-ap-northeast-1");
+    expect(resources).toContain(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/cdk-bootstrap/*",
+    );
+  });
+
+  it("should grant the Cognito admin actions the provision script uses (and only those)", () => {
+    const actions = actionsOf(statements());
+    for (const a of [
+      "cognito-idp:AdminCreateUser",
+      "cognito-idp:AdminGetUser",
+      "cognito-idp:AdminUpdateUserAttributes",
+      "cognito-idp:AdminAddUserToGroup",
+      "cognito-idp:CreateGroup",
+      "cognito-idp:GetGroup",
+    ]) {
+      expect(actions).toContain(a);
+    }
+    // tenant 越境の温床になりやすい広域 cognito 権限は持たない。
+    expect(actions).not.toContain("cognito-idp:*");
+    expect(actions).not.toContain("cognito-idp:ListUserPools");
+  });
+});


### PR DESCRIPTION
## Summary
**[INFRA] — owner-review. Closes #1382 · Relates #1383 #857** (2026-05-29 security review).

**#1382:** the bootstrap provisioning / deprovisioning SBT `BashJobRunner` roles used the reference-arch `Action:* Resource:*` (account administrator) driven by EventBridge onboarding input — and `provision-tenant.sh` interpolates `tenantId`/`email` into the shell of an all-powerful role.

`provision-tenant.sh` / `deprovision-tenant.sh` only ever run `bun cdk deploy/destroy` (which, with the **modern role-based CDK bootstrap**, delegates all resource creation to the `cdk-*` bootstrap roles — the runner role just needs `sts:AssumeRole` to them) plus a fixed set of direct calls: source-bundle S3 read, `cloudformation:DescribeStacks`, and the tenant-admin Cognito `Admin*`/group ops. The runner role is now scoped to exactly that via a new **testable pure helper** `buildTenantJobRunnerPermissions(account, region)`. The SBT construct is unchanged — only the `permissions` input is tightened. The only remaining `Resource:*` is `sts:GetCallerIdentity` (no resource-level support).

**#1383** (`serverless-saas-pipeline.ts` CodeBuild + Step Functions roles) is **left as-is**: those are hand-written and already carry `// Issue #857 justify: SBT vendored` comments documenting a *conscious* decision to stay upstream-compatible (`"upstream pattern を保つため Resource: '*' を維持"`). Their real fix is the cross-account migration (#857), not a divergent rewrite that breaks on SBT version bumps. Flagged as the residual on #1383.

## ⚠️ Owner-review note (validate before merge)
Assumes a **modern (role-based) CDK bootstrap** (the CDK 2 default). Please run a real `make deploy-saas` tenant onboarding before merge — if the scripts make a direct AWS call I didn't account for, or the account uses a legacy bootstrap, provisioning will fail (uncatchable by `cdk synth`). I deliberately included CodeBuild logs perms to avoid breaking the build's own logging.

## Test plan
- New `job-runner-permissions.test.ts`: asserts no `Action:"*"`; the only `Resource:"*"` is `sts:GetCallerIdentity`; resource creation delegates via `sts:AssumeRole` to `cdk-*`; CFn/Cognito/S3/SSM scoped to TenkaCloud ARNs; the exact Cognito admin actions the script uses are present and `cognito-idp:*` is not.
- `make harness` clean (justify comment on the lone `*`); `make before-commit` green (`cdk synth` exercises the stack).

## Regression analysis
- Same provisioning behaviour as long as the account uses role-based CDK bootstrap (the default). Resource creation now flows through the `cdk-*` roles instead of the runner role directly. `#1383` roles unchanged.
- No data-store changes.

## Physical impact
- **CFn:** **UPDATE** (narrower) of the two `BashJobRunner` CodeBuild role policies (from `*/*` to the scoped set). No new/removed resources. `cdk synth` passes.
- **Data:** none.