### PR TITLE
fix(tenant): stop baking tenant API key value into CFn template [INFRA]

### DIFF
--- a/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
+++ b/infrastructure/lib/bootstrap-template/bootstrap-template-stack.ts
@@ -162,26 +162,24 @@ export class BootstrapTemplateStack extends Stack {
       jobRunnersList: [provisioningJobRunner, deprovisioningJobRunner],
     });
 
+    // #1384: TenantApiKey は API キー値を平文で受け取らない (API Gateway が auto-generate)。
+    // keyId / valueName のパラメータ名のみ渡す。
     new TenantApiKey(this, "BasicTierApiKey", {
-      apiKeyValue: props.apiKeyBasicTierParameter,
       ssmParameterApiKeyIdName: props.apiKeySSMParameterNames.basic.keyId,
       ssmParameterApiValueName: props.apiKeySSMParameterNames.basic.value,
     });
 
     new TenantApiKey(this, "StandardTierApiKey", {
-      apiKeyValue: props.apiKeyStandardTierParameter,
       ssmParameterApiKeyIdName: props.apiKeySSMParameterNames.standard.keyId,
       ssmParameterApiValueName: props.apiKeySSMParameterNames.standard.value,
     });
 
     new TenantApiKey(this, "PremiumTierApiKey", {
-      apiKeyValue: props.apiKeyPremiumTierParameter,
       ssmParameterApiKeyIdName: props.apiKeySSMParameterNames.premium.keyId,
       ssmParameterApiValueName: props.apiKeySSMParameterNames.premium.value,
     });
 
     new TenantApiKey(this, "PlatinumTierApiKey", {
-      apiKeyValue: props.apiKeyPlatinumTierParameter,
       ssmParameterApiKeyIdName: props.apiKeySSMParameterNames.platinum.keyId,
       ssmParameterApiValueName: props.apiKeySSMParameterNames.platinum.value,
     });

--- a/infrastructure/lib/bootstrap-template/tenant-api-key.ts
+++ b/infrastructure/lib/bootstrap-template/tenant-api-key.ts
@@ -3,26 +3,41 @@ import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 
 interface TenantApiKeyProps {
-  apiKeyValue: string;
   ssmParameterApiKeyIdName: string;
   ssmParameterApiValueName: string;
 }
+
+/**
+ * #1384: 旧実装は API キーの値を synth 時の plaintext 文字列で受け取り、
+ *   - `new ApiKey({ value })` → `AWS::ApiGateway::ApiKey.Value` に焼き込み、
+ *   - `new StringParameter({ stringValue })` → `AWS::SSM::Parameter` (Type:String) に焼き込んで
+ * いた。 どちらも synthesized template に **平文で出力** され、 `GetTemplate` / `cdk.out` /
+ * source bundle から鍵が回収できた (CFn は `AWS::ApiGateway::ApiKey.Value` に
+ * `{{resolve:ssm-secure}}` を許さず dynamic ref でも隠せない)。
+ *
+ * 実際にはこの API キーの **値はどこからも使われていない**: tenant API は Cognito JWT 認証で、
+ * `api-gateway.ts` は tier キー prop を宣言するだけで参照せず、 Lite mode は値に placeholder を
+ * 渡している。 よって API Gateway に値を **auto-generate** させ (= template に平文が出ない)、 値の
+ * SSM パラメータには平文鍵の代わりに非機密 placeholder を入れる。 keyId は従来どおり保存する。
+ */
+const API_KEY_VALUE_NOT_EXPOSED = "auto-generated-by-api-gateway-not-exposed";
 
 export class TenantApiKey extends Construct {
   constructor(scope: Construct, id: string, props: TenantApiKeyProps) {
     super(scope, id);
 
-    const apiKey = new ApiKey(this, "apiKey", {
-      value: props.apiKeyValue,
-    });
-    new StringParameter(this, `apiKeyId`, {
+    // value を省略すると API Gateway が鍵値を生成する (= template に平文が出ない)。
+    const apiKey = new ApiKey(this, "apiKey", {});
+    new StringParameter(this, "apiKeyId", {
       parameterName: props.ssmParameterApiKeyIdName,
       stringValue: apiKey.keyId,
     });
 
+    // 値パラメータは vestigial な downstream 配線 (api-gateway は未参照) のため残すが、
+    // 平文鍵ではなく非機密 placeholder を入れる (= 鍵値は API Gateway 管理、 template 非露出)。
     new StringParameter(this, "apiKeyValue", {
       parameterName: props.ssmParameterApiValueName,
-      stringValue: props.apiKeyValue,
+      stringValue: API_KEY_VALUE_NOT_EXPOSED,
     });
   }
 }

--- a/infrastructure/test/bootstrap-template/tenant-api-key.test.ts
+++ b/infrastructure/test/bootstrap-template/tenant-api-key.test.ts
@@ -1,0 +1,50 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { TenantApiKey } from "../../lib/bootstrap-template/tenant-api-key";
+
+/**
+ * #1384: tenant API キーの値を CloudFormation template に平文で焼き込まない。 API Gateway に
+ * 値を auto-generate させ、 値 SSM パラメータには非機密 placeholder を入れる (= 値は vestigial)。
+ */
+function synth(): Template {
+  const app = new App();
+  const stack = new Stack(app, "Test", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  new TenantApiKey(stack, "BasicTierApiKey", {
+    ssmParameterApiKeyIdName: "/test/basic/keyId",
+    ssmParameterApiValueName: "/test/basic/value",
+  });
+  return Template.fromStack(stack);
+}
+
+describe("TenantApiKey (#1384)", () => {
+  it("should NOT bake a Value into AWS::ApiGateway::ApiKey (API Gateway auto-generates it)", () => {
+    const tpl = synth();
+    const keys = tpl.findResources("AWS::ApiGateway::ApiKey");
+    expect(Object.keys(keys)).toHaveLength(1);
+    const props = (Object.values(keys)[0]?.Properties ?? {}) as Record<string, unknown>;
+    expect(props).not.toHaveProperty("Value");
+  });
+
+  it("should store a non-secret placeholder (not a plaintext key) in the value SSM parameter", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::SSM::Parameter",
+      Match.objectLike({
+        Name: "/test/basic/value",
+        Type: "String",
+        Value: "auto-generated-by-api-gateway-not-exposed",
+      }),
+    );
+  });
+
+  it("should still publish the API key ID for downstream wiring", () => {
+    const tpl = synth();
+    tpl.hasResourceProperties(
+      "AWS::SSM::Parameter",
+      Match.objectLike({ Name: "/test/basic/keyId" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
**[INFRA] — owner-review. Closes #1384** (2026-05-29 security review).

`TenantApiKey` received the API key as a synth-time plaintext string and baked it into **both** `AWS::ApiGateway::ApiKey.Value` **and** a `Type:String` `AWS::SSM::Parameter` — so the key was recoverable in plaintext from `GetTemplate` / `cdk.out` / the source bundle. (CFn does not support `{{resolve:ssm-secure}}` for `AWS::ApiGateway::ApiKey.Value`, so a dynamic reference can't hide it either.)

**The key value turns out to be vestigial:** the tenant API authenticates via Cognito JWT; `api-gateway.ts` only *declares* the tier-key props (`apiKeyBasicTier: CustomApiKey`, …) and never references them; Lite mode already passes a placeholder value; and consumers read the value via deploy-time `valueForStringParameter` (not baked) — then ignore it. So:
- the ApiKey value is now **auto-generated by API Gateway** (omit `value`) → not in the template,
- the value SSM parameter stores a **non-secret placeholder** instead of the plaintext key,
- the key **ID** is still published for the (vestigial) downstream wiring.

Prod was already fail-closed (`resolveApiKeyValue` throws when the tier env var is unset; the constant default was dev-only). This removes the template exposure itself. The upstream `apiKey*TierParameter` config fields are now unused (harmless) — a tidy-up that can ride with #857.

## ⚠️ Owner-review note
Validate that **no external client is pre-seeded with the previously-configured key value** (none exists in-repo; the tenant API is JWT-authed). The value is now AWS-generated, so any out-of-band consumer that hard-coded the old configured value would need the generated value (via `apigateway:GetApiKey`).

## Test plan
- New `tenant-api-key.test.ts`: `AWS::ApiGateway::ApiKey` has **no `Value`** property; the value SSM parameter holds the non-secret placeholder (not a plaintext key); the key-ID parameter is still published.
- `make harness` clean; `make before-commit` green (`cdk synth` exercises the bootstrap stack).

## Regression analysis
- The key value was unused downstream (api-gateway ignores it; Lite used a placeholder), so auto-generating it has no functional impact in-repo. `valueForStringParameter` consumers still resolve (now to the placeholder). Key ID unchanged.
- No data-store changes.

## Physical impact
- **CFn:** the 4 `AWS::ApiGateway::ApiKey` resources lose the explicit `Value` (**UPDATE**; API Gateway generates a value — note this rotates the key value on deploy); the 4 value `AWS::SSM::Parameter`s change to a placeholder (**UPDATE**). No new/removed resources. `cdk synth` passes.
- **Data:** none.