### PR TITLE
feat(runtime): recognize ADR-026/027 reserved multi-cloud runtimes

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/adapter.ts
@@ -147,10 +147,22 @@ export interface ProblemRuntimeAdapter {
  * mismatch before any cloud mutation runs.
  */
 export class RuntimeNotSupportedError extends Error {
-  constructor(public readonly runtime: ProblemRuntime) {
+  /**
+   * `reserved` (default false) distinguishes a **planned** provider/engine
+   * (ADR-026/ADR-027, tracker #1408 — known roadmap, no adapter registered yet)
+   * from an **unknown** runtime (likely a typo in `metadata.runtime`). Both are
+   * rejected before any cloud mutation; only the operator-facing message differs.
+   * Classification is supplied by the caller (`registry.selectAdapter`) so this
+   * module stays free of a circular import back into `normalize`.
+   */
+  constructor(
+    public readonly runtime: ProblemRuntime,
+    opts: { readonly reserved?: boolean } = {},
+  ) {
     super(
-      `Runtime ${runtime.provider}/${runtime.engine} is recognized by metadata but not executable in this platform version. ` +
-        `Only aws/cloudformation is supported today (ADR-023 D4).`,
+      opts.reserved
+        ? `Runtime ${runtime.provider}/${runtime.engine} is a planned provider/engine (ADR-026/ADR-027, tracker #1408) but is not yet executable in this platform version — no adapter is registered.`
+        : `Runtime ${runtime.provider}/${runtime.engine} is not a recognized executable runtime (check metadata.runtime for typos). Only aws/cloudformation is supported today (ADR-023 D4).`,
     );
     this.name = "RuntimeNotSupportedError";
   }

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
@@ -25,10 +25,14 @@ export {
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
 export {
+  classifyRuntimeSupport,
   EXECUTABLE_ENGINE,
   EXECUTABLE_PROVIDER,
   isExecutableRuntime,
+  isReservedRuntime,
   normalizeRuntime,
+  RESERVED_RUNTIMES,
   type RuntimeMetadataInput,
+  type RuntimeSupport,
 } from "./normalize.js";
 export { type AdapterDependencies, selectAdapter } from "./registry.js";

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/normalize.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/normalize.ts
@@ -69,3 +69,36 @@ export function normalizeRuntime(meta: RuntimeMetadataInput): ProblemRuntime | u
 export function isExecutableRuntime(runtime: ProblemRuntime): boolean {
   return runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE;
 }
+
+/**
+ * [ADR-026 / ADR-027] Runtimes the metadata layer recognizes as **planned** — a
+ * real provider/engine on the roadmap — but that are **not yet executable** (no
+ * adapter is registered, so the deploy worker rejects them before any cloud
+ * mutation). Distinguishing these from a typo lets the deploy error and the
+ * validator point authors at the tracker (#1408) instead of failing generically.
+ * Each engine PR (#1410 Azure, #1411 GCP, #1412 Sakura) moves its pair out of
+ * this set as it becomes executable.
+ *
+ * Kept in lock-step with `scripts/problem-cli/problem-loader.ts` (separate bundle).
+ */
+export const RESERVED_RUNTIMES: readonly { readonly provider: string; readonly engine: string }[] =
+  [
+    { provider: "sakura", engine: "apprun" }, // ADR-026
+    { provider: "azure", engine: "bicep" }, // ADR-027
+    { provider: "gcp", engine: "infra-manager" }, // ADR-027
+  ];
+
+export function isReservedRuntime(runtime: ProblemRuntime): boolean {
+  return RESERVED_RUNTIMES.some(
+    (r) => r.provider === runtime.provider && r.engine === runtime.engine,
+  );
+}
+
+export type RuntimeSupport = "executable" | "reserved" | "unknown";
+
+/** Classify a normalized runtime as executable / reserved (planned) / unknown (likely a typo). */
+export function classifyRuntimeSupport(runtime: ProblemRuntime): RuntimeSupport {
+  if (isExecutableRuntime(runtime)) return "executable";
+  if (isReservedRuntime(runtime)) return "reserved";
+  return "unknown";
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
@@ -19,7 +19,7 @@ import {
   type AwsCloudFormationAdapterContext,
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
-import { EXECUTABLE_ENGINE, EXECUTABLE_PROVIDER } from "./normalize.js";
+import { classifyRuntimeSupport, EXECUTABLE_ENGINE, EXECUTABLE_PROVIDER } from "./normalize.js";
 
 /**
  * Dependencies any adapter might need. Phase 1 only uses the AWS subset; the
@@ -37,5 +37,9 @@ export function selectAdapter(
   if (runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE) {
     return new AwsCloudFormationRuntimeAdapter(deps.aws);
   }
-  throw new RuntimeNotSupportedError(runtime);
+  // Planned providers (ADR-026/027) get a roadmap-aware message; everything else
+  // is treated as a likely typo. Both still throw — no adapter, no cloud mutation.
+  throw new RuntimeNotSupportedError(runtime, {
+    reserved: classifyRuntimeSupport(runtime) === "reserved",
+  });
 }

--- a/infrastructure/test/problem-deploy/runtime-adapter.test.ts
+++ b/infrastructure/test/problem-deploy/runtime-adapter.test.ts
@@ -19,11 +19,14 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AdapterMethodNotWiredError,
   AwsCloudFormationRuntimeAdapter,
+  classifyRuntimeSupport,
   EXECUTABLE_ENGINE,
   EXECUTABLE_PROVIDER,
   isExecutableRuntime,
+  isReservedRuntime,
   normalizeRuntime,
   type ProblemRuntime,
+  RESERVED_RUNTIMES,
   RuntimeNotSupportedError,
   selectAdapter,
 } from "../../lib/problem-deploy/handlers/shared/runtime/index";
@@ -83,6 +86,44 @@ describe("normalizeRuntime", () => {
   });
 });
 
+describe("classifyRuntimeSupport (ADR-026 / ADR-027 reserved runtimes)", () => {
+  it("should classify aws/cloudformation as executable", () => {
+    expect(
+      classifyRuntimeSupport({ provider: "aws", engine: "cloudformation", entry: "template.yaml" }),
+    ).toBe("executable");
+  });
+
+  it.each(
+    RESERVED_RUNTIMES.map((r) => [r.provider, r.engine] as const),
+  )("should classify the planned runtime %s/%s as reserved", (provider, engine) => {
+    const runtime: ProblemRuntime = { provider, engine, entry: "entry" };
+    expect(classifyRuntimeSupport(runtime)).toBe("reserved");
+    expect(isReservedRuntime(runtime)).toBe(true);
+  });
+
+  it("should reserve the three roadmap providers from ADR-026/027", () => {
+    expect(RESERVED_RUNTIMES).toEqual([
+      { provider: "sakura", engine: "apprun" },
+      { provider: "azure", engine: "bicep" },
+      { provider: "gcp", engine: "infra-manager" },
+    ]);
+  });
+
+  it("should classify an unrecognized runtime as unknown (likely a typo)", () => {
+    const runtime: ProblemRuntime = { provider: "kubernetes", engine: "helm", entry: "Chart.yaml" };
+    expect(classifyRuntimeSupport(runtime)).toBe("unknown");
+    expect(isReservedRuntime(runtime)).toBe(false);
+  });
+
+  it("should not treat a reserved provider with a different engine as reserved", () => {
+    // azure/bicep is reserved, but azure/arm-template is not — only the exact
+    // pair on the roadmap counts, so a typo'd engine still reads as unknown.
+    expect(classifyRuntimeSupport({ provider: "azure", engine: "arm-template", entry: "x" })).toBe(
+      "unknown",
+    );
+  });
+});
+
 describe("selectAdapter", () => {
   const deps = {
     aws: {
@@ -112,7 +153,25 @@ describe("selectAdapter", () => {
     expect(() => selectAdapter(runtime, deps)).toThrow(RuntimeNotSupportedError);
   });
 
-  it("should include the rejected runtime in the error so operators can diagnose", () => {
+  it("should point a planned (reserved) runtime at the roadmap tracker, not call it a typo", () => {
+    // azure/bicep is on the ADR-027 roadmap, so the rejection must say "planned"
+    // and cite the tracker — never the typo-oriented message.
+    const runtime: ProblemRuntime = { provider: "azure", engine: "bicep", entry: "main.bicep" };
+    try {
+      selectAdapter(runtime, deps);
+      throw new Error("expected selectAdapter to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RuntimeNotSupportedError);
+      if (err instanceof RuntimeNotSupportedError) {
+        expect(err.message).toContain("azure/bicep");
+        expect(err.message).toContain("planned");
+        expect(err.message).toContain("#1408");
+        expect(err.message).not.toContain("typo");
+      }
+    }
+  });
+
+  it("should include the rejected runtime in the error and flag an unknown runtime as a typo", () => {
     const runtime: ProblemRuntime = {
       provider: "kubernetes",
       engine: "helm",
@@ -127,6 +186,7 @@ describe("selectAdapter", () => {
         expect(err.runtime).toEqual(runtime);
         expect(err.message).toContain("kubernetes/helm");
         expect(err.message).toContain("aws/cloudformation");
+        expect(err.message).toContain("typo");
       }
     }
   });

--- a/infrastructure/test/scripts/problem-runtime-metadata.test.ts
+++ b/infrastructure/test/scripts/problem-runtime-metadata.test.ts
@@ -10,7 +10,8 @@ import { runCreate, runValidate } from "../../../scripts/tenkacloud-problem";
  *   1. legacy (= `cfnTemplate` のみ) 問題は引き続き valid (= 後方互換)
  *   2. 明示宣言 `{aws, cloudformation, template.yaml}` は valid
  *   3. `runtime.entry` と `cfnTemplate` が食い違うと reject
- *   4. AWS / CloudFormation 以外の組み合わせは reservation として reject (= 実行不能であることを明示)
+ *   4. AWS / CloudFormation 以外は reject。 ADR-026/027 の roadmap provider (reserved) は
+ *      tracker #1408 を案内し、 それ以外 (unknown) は typo として案内する (= メッセージを分岐)
  *   5. `runCreate` (= `/create-problem` scaffold) が runtime block を含む metadata を吐く
  */
 
@@ -123,7 +124,9 @@ describe("ADR-023 / Issue #1267: provider-specific runtime metadata", () => {
     expect(r.errors.some((e) => e.includes("must match"))).toBe(true);
   });
 
-  it("should reject unsupported provider/engine with a clear reservation message", () => {
+  it("should reject a planned (reserved) provider/engine and point at the roadmap tracker", () => {
+    // azure/bicep is on the ADR-027 roadmap: rejected (no adapter yet) but the
+    // message must say "planned" and cite the tracker, not treat it as a typo.
     const uniqueId = `test-runtime-azure-${Date.now().toString(36)}`;
     writeFixtureProblem({
       uniqueId,
@@ -138,9 +141,30 @@ describe("ADR-023 / Issue #1267: provider-specific runtime metadata", () => {
     });
     const r = runValidate(uniqueId);
     expect(r.ok).toBe(false);
-    expect(r.errors.some((e) => e.includes("azure/bicep") && e.includes("not executable"))).toBe(
-      true,
-    );
+    expect(
+      r.errors.some(
+        (e) => e.includes("azure/bicep") && e.includes("planned") && e.includes("#1408"),
+      ),
+    ).toBe(true);
+    expect(r.errors.some((e) => e.includes("azure/bicep") && e.includes("typo"))).toBe(false);
+  });
+
+  it("should reject an unrecognized provider/engine as a likely typo", () => {
+    const uniqueId = `test-runtime-typo-${Date.now().toString(36)}`;
+    writeFixtureProblem({
+      uniqueId,
+      category: "challenges",
+      mutate: (meta) => {
+        meta.runtime = {
+          provider: "kuberntes", // intentional misspelling of "kubernetes"
+          engine: "helm",
+          entry: "template.yaml",
+        };
+      },
+    });
+    const r = runValidate(uniqueId);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("kuberntes/helm") && e.includes("typo"))).toBe(true);
   });
 
   it("should scaffold new problems with an explicit aws/cloudformation runtime block", () => {

--- a/scripts/problem-cli/problem-loader.ts
+++ b/scripts/problem-cli/problem-loader.ts
@@ -67,3 +67,28 @@ export function normalizeRuntime(meta: ProblemMetadata): NormalizedRuntime | und
 export function isExecutableRuntime(runtime: NormalizedRuntime): boolean {
   return runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE;
 }
+
+/**
+ * [ADR-026 / ADR-027] Runtimes recognized as **planned** roadmap providers but
+ * not yet executable (no engine adapter). Distinguishing them from a typo lets
+ * the validator tell an author "author it once the adapter lands (#1408)" vs
+ * "you misspelled the provider". Kept in lock-step with the Lambda-side
+ * `infrastructure/lib/problem-deploy/handlers/shared/runtime/normalize.ts`
+ * (the two run in separate bundles and cannot share a module).
+ */
+export const RESERVED_RUNTIMES: readonly { readonly provider: string; readonly engine: string }[] =
+  [
+    { provider: "sakura", engine: "apprun" }, // ADR-026
+    { provider: "azure", engine: "bicep" }, // ADR-027
+    { provider: "gcp", engine: "infra-manager" }, // ADR-027
+  ];
+
+export type RuntimeSupport = "executable" | "reserved" | "unknown";
+
+/** Classify a normalized runtime as executable / reserved (planned) / unknown (likely a typo). */
+export function classifyRuntimeSupport(runtime: NormalizedRuntime): RuntimeSupport {
+  if (isExecutableRuntime(runtime)) return "executable";
+  if (RESERVED_RUNTIMES.some((r) => r.provider === runtime.provider && r.engine === runtime.engine))
+    return "reserved";
+  return "unknown";
+}

--- a/scripts/problem-cli/validate.ts
+++ b/scripts/problem-cli/validate.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import { KINDS } from "./constants";
 import {
+  classifyRuntimeSupport,
   EXECUTABLE_ENGINE,
   EXECUTABLE_PROVIDER,
   findProblemDir,
@@ -47,8 +48,10 @@ export function runValidate(problemId: string): ValidateResult {
  * [ADR-023] Phase 1: optional `runtime` field の検証。
  *   - normalize 失敗 (= 不完全な runtime block) は明示エラー
  *   - `runtime` と `cfnTemplate` 両方宣言時は `runtime.entry === cfnTemplate` を強制 (= 互換期間)
- *   - 認識できる combination は `aws` + `cloudformation` のみ。 それ以外は reservation として
- *     reject する (= author が deploy できない問題を ship するのを止める)
+ *   - executable な combination は `aws` + `cloudformation` のみ。 それ以外は reject する
+ *     (= author が deploy できない問題を ship するのを止める)。 reject 理由は 2 種に分岐:
+ *       - reserved (ADR-026/027 の roadmap provider, tracker #1408) → 「adapter 着地後に author 可」
+ *       - unknown (typo の可能性) → 「provider/engine の綴りを確認」
  */
 function validateRuntime(meta: Record<string, unknown>, errors: string[]): void {
   const runtimeBlock = meta.runtime;
@@ -66,9 +69,14 @@ function validateRuntime(meta: Record<string, unknown>, errors: string[]): void 
         `runtime.entry="${normalized.entry}" and cfnTemplate="${cfnTemplate}" must match during the dual-field compatibility window (ADR-023 D2).`,
       );
     }
-    if (normalized.provider !== EXECUTABLE_PROVIDER || normalized.engine !== EXECUTABLE_ENGINE) {
+    const support = classifyRuntimeSupport(normalized);
+    if (support === "reserved") {
       errors.push(
-        `Runtime ${normalized.provider}/${normalized.engine} is recognized but not executable in this platform version. Only ${EXECUTABLE_PROVIDER}/${EXECUTABLE_ENGINE} is supported today (ADR-023 D4).`,
+        `Runtime ${normalized.provider}/${normalized.engine} is a planned provider/engine (ADR-026/ADR-027, tracker #1408) but is not yet executable — author it once the engine adapter lands. Executable today: ${EXECUTABLE_PROVIDER}/${EXECUTABLE_ENGINE} (ADR-023 D4).`,
+      );
+    } else if (support === "unknown") {
+      errors.push(
+        `Runtime ${normalized.provider}/${normalized.engine} is not a recognized runtime (check provider/engine for typos). Executable today: ${EXECUTABLE_PROVIDER}/${EXECUTABLE_ENGINE} (ADR-023 D4).`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Foundation slice for multi-cloud problem targets (ADR-026 Sakura, ADR-027 Azure/GCP). It teaches the runtime layer to *recognize* the planned provider/engine pairs without making any of them executable — so authors and operators get a roadmap-aware message instead of a generic rejection, and deploy safety is completely unchanged.

- New typed set `RESERVED_RUNTIMES = [sakura/apprun, azure/bicep, gcp/infra-manager]`, declared on **both** the Lambda deploy worker (`normalize.ts`) and the problem CLI (`problem-loader.ts`), kept in lock-step across the two bundles (the Lambda cannot import from `scripts/`).
- New `classifyRuntimeSupport(runtime) → "executable" | "reserved" | "unknown"`.
  - **reserved** = a known roadmap provider → message points at tracker #1408 / ADR-026/027 ("author it once the engine adapter lands").
  - **unknown** = a likely typo → message says "check provider/engine for typos".
- `RuntimeNotSupportedError` (deploy worker) and `validateRuntime` (CLI) now emit the matching message. Both paths still **reject** every non-`aws/cloudformation` runtime before any cloud mutation.

This is the safe, testable app-layer part of the multi-cloud backlog. The actual engine adapters are infra-owned and tracked separately:

- Parent: #1408
- Closes #1409
- Engine adapters (infra, owner-driven): #1410 (Azure), #1411 (GCP), #1412 (Sakura), #1413 (federation bootstrap), #1414 (catalog UI)
- Design: ADR-026, ADR-027

## Test plan

- `make harness` — no findings
- `make before-commit` — lint / typecheck / test / build / validate-problems all green (also re-run by the pre-commit hook)
- New/updated unit tests:
  - `runtime-adapter.test.ts`: `classifyRuntimeSupport` table over `RESERVED_RUNTIMES`, exact-set pin, reserved-engine-mismatch → unknown, and `selectAdapter` reserved-vs-typo message assertions.
  - `problem-runtime-metadata.test.ts`: CLI validator now asserts the roadmap-aware message for `azure/bicep` and a typo message for a misspelled provider.

## Regression analysis

- `selectAdapter` still throws `RuntimeNotSupportedError` for every non-`aws/cloudformation` runtime; only the message text branches. The existing `azure/bicep` rejection test was updated to assert the new roadmap-aware wording.
- `problem-cli/validate.ts` still pushes an error for any reserved/unknown runtime, so no previously-invalid problem becomes shippable.
- No change to `AwsCloudFormationRuntimeAdapter` or the deploy/scoring path.
- `RESERVED_RUNTIMES` is duplicated by design; a unit test pins the exact set on the Lambda side so drift surfaces as a failing test.

## Physical impact

- **NO-OP** on CloudFormation / deployed artifacts. Pure application-layer logic + tests; no construct, table, or IAM change. `cdk synth` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages for unsupported runtimes, now clearly distinguishing between planned/roadmap providers and unrecognized configurations (likely typos).

* **Tests**
  * Added comprehensive test coverage for runtime support classification and error message validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->