### PR TITLE
refactor(saml): use StatusCodes enum for SAML route status codes

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
@@ -91,9 +91,9 @@ export async function handleGetTenantSamlConfig(
   );
   if (!view) {
     const disabled: TenantSamlConfigView = { enabled: false };
-    return { status: 200, body: disabled };
+    return { status: StatusCodes.OK, body: disabled };
   }
-  return { status: 200, body: view };
+  return { status: StatusCodes.OK, body: view };
 }
 
 /**
@@ -110,7 +110,7 @@ export async function handlePutTenantSamlConfig(
   const parsed = TenantSamlConfigInputSchema.safeParse(rawBody);
   if (!parsed.success) {
     return {
-      status: 400,
+      status: StatusCodes.BAD_REQUEST,
       body: { error: "validation_failed", issues: parsed.error.issues },
     };
   }
@@ -157,7 +157,7 @@ export async function handlePutTenantSamlConfig(
     }),
   );
 
-  return { status: 200, body: view };
+  return { status: StatusCodes.OK, body: view };
 }
 
 /**
@@ -202,7 +202,7 @@ export async function handleDeleteTenantSamlConfig(
     }),
   );
 
-  return { status: 200, body: { deleted: true } };
+  return { status: StatusCodes.OK, body: { deleted: true } };
 }
 
 /**
@@ -271,13 +271,13 @@ export async function routePut(deps: SamlOrchestratorDeps, c: Context): Promise<
   const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));
   if (!cognitoDeps) {
     return {
-      status: 422,
+      status: StatusCodes.UNPROCESSABLE_ENTITY,
       body: { error: "missing_cognito_claims", message: "iss / aud claims are required" },
     };
   }
   const body = await c.req.json().catch(() => null);
   if (body === null) {
-    return { status: 400, body: { error: "invalid_body" } };
+    return { status: StatusCodes.BAD_REQUEST, body: { error: "invalid_body" } };
   }
   return handlePutTenantSamlConfig(
     deps.shared,
@@ -302,7 +302,7 @@ export async function routeDelete(
   const cognitoDeps = await (deps.makeCognitoDeps?.(c) ?? defaultMakeCognitoDeps(deps.shared)(c));
   if (!cognitoDeps) {
     return {
-      status: 422,
+      status: StatusCodes.UNPROCESSABLE_ENTITY,
       body: { error: "missing_cognito_claims", message: "iss / aud claims are required" },
     };
   }

--- a/infrastructure/test/problem-deploy/tenant-saml.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml.test.ts
@@ -6,6 +6,7 @@ import {
   type UpdateUserPoolClientCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import type { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { StatusCodes } from "http-status-codes";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   allowCognitoOnClient,
@@ -371,7 +372,7 @@ describe("handleGetTenantSamlConfig", () => {
     const { shared, ddbSend } = makeSharedAndDdb();
     ddbSend.mockResolvedValueOnce({});
     const r = await handleGetTenantSamlConfig(shared, "t1");
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(StatusCodes.OK);
     expect(r.body).toEqual({ enabled: false });
   });
 
@@ -390,7 +391,7 @@ describe("handleGetTenantSamlConfig", () => {
       },
     });
     const r = await handleGetTenantSamlConfig(shared, "t1");
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(StatusCodes.OK);
     expect((r.body as { enabled: boolean }).enabled).toBe(true);
   });
 });
@@ -408,7 +409,7 @@ describe("handlePutTenantSamlConfig", () => {
       { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
       { metadataUrl: "http://insecure" }, // HTTP は reject
     );
-    expect(r.status).toBe(400);
+    expect(r.status).toBe(StatusCodes.BAD_REQUEST);
     expect(ddbSend).not.toHaveBeenCalled();
     expect(cognitoSend).not.toHaveBeenCalled();
   });
@@ -440,7 +441,7 @@ describe("handlePutTenantSamlConfig", () => {
         enforceSamlOnly: false,
       },
     );
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(StatusCodes.OK);
     expect((r.body as { enabled: boolean }).enabled).toBe(true);
     expect(cognitoSend).toHaveBeenCalledTimes(4);
     expect(ddbSend).toHaveBeenCalledTimes(1);
@@ -493,7 +494,7 @@ describe("handleDeleteTenantSamlConfig", () => {
       { tenantId: "t1", updatedBy: "sub", nowIso: "2026-05-16T00:00:00Z" },
     );
 
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(StatusCodes.OK);
     expect((r.body as { deleted: boolean }).deleted).toBe(true);
     // 4 cognito calls (Describe + Update for revert, Delete IdP) + 2 DDB calls (Get + Delete)
     expect(cognitoSend).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary

A focused, NO-OP refactor surfaced by `make tech-debt` (magic-number rule). `saml-routes.ts` **already** imported `StatusCodes` and used `StatusCodes.SERVICE_UNAVAILABLE`, but 8 sibling returns still hard-coded numeric HTTP status literals (`200` / `400` / `422`) on the `SamlRouteResult` DTO — inconsistent with that usage and contrary to the CLAUDE.md / AGENTS.md "no HTTP status code literals" rule.

- Replace all 8 literals with the named enum: `StatusCodes.OK` / `StatusCodes.BAD_REQUEST` / `StatusCodes.UNPROCESSABLE_ENTITY`.
- Update the 5 direct unit-test assertions in `tenant-saml.test.ts` to the named enum (sibling `tenant-saml-tier-guard.test.ts` already did this).

This clears the 3 `saml-routes.ts` magic-number findings (`make tech-debt` magic-number: 8 → 5; the remaining 5 are frontend polling intervals, a separate concern).

## Test plan

- `make harness` — no findings
- `make before-commit` — lint / typecheck / test / build / validate-problems all green (also re-run by the pre-commit hook); `check-http-magic-numbers` + `cdk synth` pass
- `tenant-saml.test.ts` + `role-gates.test.ts` + `tenant-saml-tier-guard.test.ts` — 77 tests pass

## Regression analysis

- **No behavior change**: `StatusCodes.OK===200`, `BAD_REQUEST===400`, `UNPROCESSABLE_ENTITY===422`. `SamlRouteResult.status` is typed `number`, so the enum members assign cleanly (as `SERVICE_UNAVAILABLE` already did), and the `index.ts` consumers still cast `result.status as 200 | 400 | 422` unchanged — the Hono `c.json` status union is identical.
- Existing tests cover every status path (handleGet/Put/Delete + tier guard); they pass unchanged except the 5 assertions updated here.
- Scope limited to `saml-routes.ts` and its direct unit test. `role-gates.test.ts` mock literals belong to a separate role-gating concern and are intentionally untouched.

## Physical impact

- **NO-OP** on CloudFormation / deployed artifacts. Lambda source-only rename; bundle behavior identical. `cdk synth` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)