### PR TITLE
docs(adr): renumber inter-team coordination ADR-022 → ADR-028

### DIFF
--- a/docs/architecture/adr-024-community-voting-and-problem-registry.html
+++ b/docs/architecture/adr-024-community-voting-and-problem-registry.html
@@ -82,7 +82,7 @@
     <div><b>Related:</b>
       <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin),
       <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> (Trust Bridge),
-      <a href="./adr-022-inter-team-coordination-plugin.html">ADR-022</a> (inter-team plugin)
+      <a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a> (inter-team plugin)
     </div>
   </div>
 </header>
@@ -438,7 +438,7 @@ interface ProblemSponsorshipInterest {
 <ul>
   <li><a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>: Problem plugin architecture (problem = plugin, platform = host)</li>
   <li><a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a>: Cloud Action Intent / Trust Bridge (multi-cloud authority transfer)</li>
-  <li><a href="./adr-022-inter-team-coordination-plugin.html">ADR-022</a>: Inter-team coordination plugin contract</li>
+  <li><a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a>: Inter-team coordination plugin contract</li>
   <li><a href="https://github.com/susumutomita/TenkaCloud/issues/1269">Issue #1269</a>: Design community voting and sponsorship model for problem catalog growth</li>
 </ul>
 </section>

--- a/docs/architecture/adr-028-inter-team-coordination-plugin.html
+++ b/docs/architecture/adr-028-inter-team-coordination-plugin.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="utf-8">
-<title>ADR-022: Inter-team coordination plugin contract</title>
+<title>ADR-028: Inter-team coordination plugin contract</title>
 <style>
   :root {
     --c-text: #1f2328;
@@ -43,7 +43,7 @@
 </head>
 <body>
 <header>
-  <h1>ADR-022: Inter-team coordination plugin contract</h1>
+  <h1>ADR-028: Inter-team coordination plugin contract</h1>
   <p><em>Battle 問題が宣言する他チーム interaction primitive を platform が dispatch する plugin 契約</em></p>
   <div class="meta">
     <div><b>Status:</b> <span class="badge draft">Draft</span> 2026-05-20</div>

--- a/docs/demos/architecture-tour-30min.html
+++ b/docs/demos/architecture-tour-30min.html
@@ -124,13 +124,13 @@
 <ul>
 <li>The portal logs participants in via the team&#39;s Cognito UserPool. After login, the portal fetches the team&#39;s deployed problems, endpoints, flags, and disruption phases.</li>
 <li>One-click AWS Console SSO is implemented by federating into the team&#39;s read-only <code>ParticipantViewerRole</code> (see each problem&#39;s <code>template.yaml</code> for the scoping IAM statements).</li>
-<li>Inter-team coordination (router updates / alliances / shared resource queues) is <strong>not</strong> baked into the platform. It is dispatched to the problem&#39;s portal plugin (<code>portal/</code>) per <code>ADR-022</code>. The platform exposes a primitive; the problem owns the semantics.</li>
+<li>Inter-team coordination (router updates / alliances / shared resource queues) is <strong>not</strong> baked into the platform. It is dispatched to the problem&#39;s portal plugin (<code>portal/</code>) per <code>ADR-028</code>. The platform exposes a primitive; the problem owns the semantics.</li>
 </ul>
 <p><strong>ADR cross-references.</strong></p>
 <ul>
 <li><code>ADR-005</code> — Battle Portal UI</li>
 <li><code>ADR-006</code> — Notifications</li>
-<li><code>ADR-022</code> — Inter-team coordination plugin</li>
+<li><code>ADR-028</code> — Inter-team coordination plugin</li>
 </ul>
 <h2>Security posture (≈ 5 min)</h2>
 <p><strong>Talking points.</strong></p>

--- a/docs/demos/architecture-tour-30min.ja.html
+++ b/docs/demos/architecture-tour-30min.ja.html
@@ -124,13 +124,13 @@
 <ul>
 <li>ポータルは team の Cognito UserPool 経由で参加者をログインさせる。 ログイン後、 team が deploy 済みの問題 / endpoint / flag / disruption phase を fetch。</li>
 <li>ワンクリック AWS Console SSO は、 team の読み取り専用 <code>ParticipantViewerRole</code> への federation で実装 (scoping IAM 文は各問題の <code>template.yaml</code> 参照)。</li>
-<li>チーム間 coordination (router 更新 / 同盟 / 共有リソース queue) は <strong>プラットフォームに焼き込まない</strong>。 問題の <code>portal/</code> プラグインへ dispatch する (<code>ADR-022</code>)。 プラットフォームは primitive を提供し、 意味論は問題が所有する。</li>
+<li>チーム間 coordination (router 更新 / 同盟 / 共有リソース queue) は <strong>プラットフォームに焼き込まない</strong>。 問題の <code>portal/</code> プラグインへ dispatch する (<code>ADR-028</code>)。 プラットフォームは primitive を提供し、 意味論は問題が所有する。</li>
 </ul>
 <p><strong>ADR 参照</strong>。</p>
 <ul>
 <li><code>ADR-005</code> — Battle Portal UI</li>
 <li><code>ADR-006</code> — Notifications</li>
-<li><code>ADR-022</code> — Inter-team coordination plugin</li>
+<li><code>ADR-028</code> — Inter-team coordination plugin</li>
 </ul>
 <h2>セキュリティポスチャー (約 5 分)</h2>
 <p><strong>トークポイント</strong>。</p>

--- a/docs/demos/architecture-tour-30min.ja.md
+++ b/docs/demos/architecture-tour-30min.ja.md
@@ -85,13 +85,13 @@
 
 - ポータルは team の Cognito UserPool 経由で参加者をログインさせる。 ログイン後、 team が deploy 済みの問題 / endpoint / flag / disruption phase を fetch。
 - ワンクリック AWS Console SSO は、 team の読み取り専用 `ParticipantViewerRole` への federation で実装 (scoping IAM 文は各問題の `template.yaml` 参照)。
-- チーム間 coordination (router 更新 / 同盟 / 共有リソース queue) は **プラットフォームに焼き込まない**。 問題の `portal/` プラグインへ dispatch する (`ADR-022`)。 プラットフォームは primitive を提供し、 意味論は問題が所有する。
+- チーム間 coordination (router 更新 / 同盟 / 共有リソース queue) は **プラットフォームに焼き込まない**。 問題の `portal/` プラグインへ dispatch する (`ADR-028`)。 プラットフォームは primitive を提供し、 意味論は問題が所有する。
 
 **ADR 参照**。
 
 - `ADR-005` — Battle Portal UI
 - `ADR-006` — Notifications
-- `ADR-022` — Inter-team coordination plugin
+- `ADR-028` — Inter-team coordination plugin
 
 ## セキュリティポスチャー (約 5 分)
 

--- a/docs/demos/architecture-tour-30min.md
+++ b/docs/demos/architecture-tour-30min.md
@@ -85,13 +85,13 @@ Set the frame: TenkaCloud is built on `@cdklabs/sbt-aws` 0.3.9 and obeys four pl
 
 - The portal logs participants in via the team's Cognito UserPool. After login, the portal fetches the team's deployed problems, endpoints, flags, and disruption phases.
 - One-click AWS Console SSO is implemented by federating into the team's read-only `ParticipantViewerRole` (see each problem's `template.yaml` for the scoping IAM statements).
-- Inter-team coordination (router updates / alliances / shared resource queues) is **not** baked into the platform. It is dispatched to the problem's portal plugin (`portal/`) per `ADR-022`. The platform exposes a primitive; the problem owns the semantics.
+- Inter-team coordination (router updates / alliances / shared resource queues) is **not** baked into the platform. It is dispatched to the problem's portal plugin (`portal/`) per `ADR-028`. The platform exposes a primitive; the problem owns the semantics.
 
 **ADR cross-references.**
 
 - `ADR-005` — Battle Portal UI
 - `ADR-006` — Notifications
-- `ADR-022` — Inter-team coordination plugin
+- `ADR-028` — Inter-team coordination plugin
 
 ## Security posture (≈ 5 min)
 

--- a/docs/security/HARDENING-CHECKLIST.html
+++ b/docs/security/HARDENING-CHECKLIST.html
@@ -421,7 +421,7 @@
     <tr>
       <td><span class="item-id">PRT-06</span></td>
       <td>Inter-team interaction primitives are problem-scoped (no platform-level cross-team trust)</td>
-      <td class="evidence"><a href="../architecture/adr-022-inter-team-coordination-plugin.html">ADR-022</a> places coordination logic in the problem plugin. Platform does not provide an implicit trust channel between teams. Memory note <code>feedback_inter_team_coordination_plugin</code>.</td>
+      <td class="evidence"><a href="../architecture/adr-028-inter-team-coordination-plugin.html">ADR-028</a> places coordination logic in the problem plugin. Platform does not provide an implicit trust channel between teams. Memory note <code>feedback_inter_team_coordination_plugin</code>.</td>
       <td>Agent / Reviewer</td>
       <td><span class="badge ok">Implemented</span></td>
     </tr>


### PR DESCRIPTION
## Summary

Fixes a duplicate ADR number found during the 2026-05-30 competition-fidelity audit: two ADRs both claimed **022**.

- `adr-022-tenant-isolation-audit.html` — created 2026-05-18 (keeps 022)
- `adr-022-inter-team-coordination-plugin.html` — created 2026-05-20 → **renumbered to ADR-028** (next free number)

Changes:
- `git mv` the inter-team ADR to `adr-028-inter-team-coordination-plugin.html`; update its `<title>` + `<h1>` to ADR-028.
- Fix all inbound references: `docs/security/HARDENING-CHECKLIST.html`, `docs/architecture/adr-024-...html`, and the architecture-tour demo (edited the `.md` sources and regenerated `.html`, en + ja).
- Tenant-isolation ADR-022 references left untouched.

Part of the code-quality/doc-integrity hardening (#1418). Closes #1425.

## Test plan
- `make harness` — clean (`adr-must-be-html` / `adr-self-contained`).
- `build-docs.ts --check` — in sync (demo HTML regenerated from `.md`).
- `lint:md` + `lint:text` — pass.
- Verified: no inter-team reference points at ADR-022, every ADR number is unique, only tenant-isolation retains ADR-022.

## Regression analysis
- Docs-only. No code / CFn / test-behavior change. The renumber is referenced forward by issues #1417/#1420 (inter-team design now cites ADR-028).

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation cross-references to ensure consistent linking throughout guides, architecture tours, and security materials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->