### PR TITLE
feat(ci): coverage ratchet gate (climb to 100% without regressions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
         run: |
           make test-coverage
 
+      # #1424: ratchet gate. Reuses the lcov just generated above (no extra run).
+      # Fails the build if any workspace's coverage drops below its recorded floor
+      # in scripts/coverage-baseline.json. Floors only move up (via --update after
+      # a genuine improvement), so coverage can never silently slide back.
+      - name: Coverage ratchet gate
+        run: |
+          make coverage-gate
+
       - name: Build
         run: |
           make build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ We don't use a single-table DynamoDB design. Each stack owns its own tables (Ten
 | `make build`            | Build every workspace (`infrastructure` → 3 SPAs)                        |
 | `make typecheck`        | `tsc --noEmit` across every workspace                                    |
 | `make test`             | `vitest` across every workspace                                          |
+| `make test-coverage`    | `vitest --coverage` across every workspace (emits `coverage/lcov.info`)  |
+| `make coverage-gate`    | Ratchet gate (`scripts/check-coverage.ts`): fail if any workspace drops below its floor in `scripts/coverage-baseline.json`. Run after `make test-coverage` |
 | `make lint`             | markdownlint + textlint + biome                                          |
 | `make fix`              | Auto-fix variant of the above (`make format` works too)                  |
 | `make validate-problems`| Validate `problems/**/metadata.json` against `problems/SCHEMA.json`      |

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export JSII_DEPRECATED := quiet
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install install_ci build typecheck test test-coverage clean-test-outdir check before-commit beforecommit \
+.PHONY: help install install_ci build typecheck test test-coverage coverage-gate clean-test-outdir check before-commit beforecommit \
         build-docs check-docs audit-deps build-problems-index check-problems-index \
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
@@ -37,6 +37,9 @@ build:         ; bun run build
 typecheck:     ; bun run typecheck
 test:          ; bun run test
 test-coverage: ; bun run test:coverage
+# #1424: ratchet gate over the lcov that `test-coverage` emits. Run `make test-coverage`
+# first (CI does). Fails if any workspace drops below its floor in scripts/coverage-baseline.json.
+coverage-gate: ; bun run scripts/check-coverage.ts
 # Issue #1295: vitest setup (infrastructure/test/setup.ts) pins
 # CDK_OUTDIR to infrastructure/cdk.out.test/<worker>. Output is
 # overwritten per synth (= no accumulation), but a manual purge is

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env bun
+/**
+ * Coverage ratchet gate (#1424).
+ *
+ * Reads each workspace's `coverage/lcov.info` (already emitted by the per-workspace
+ * `test:coverage` scripts), computes line / branch / function coverage, and fails
+ * if any metric drops below the recorded floor in `scripts/coverage-baseline.json`.
+ *
+ * This is a *ratchet*: floors only move up, when a contributor runs `--update`
+ * after genuinely improving coverage. Between updates the gate blocks any
+ * regression, so the repo climbs toward 100% and can never silently slide back.
+ *
+ * Deliberately a standalone gate over lcov rather than a `vitest.config` change:
+ * editing the shared test configs to enforce/relax thresholds is exactly the
+ * "edit config to mask failures" pattern the repo prohibits. This script only
+ * reads output and is wired into CI as its own step.
+ *
+ * Usage:
+ *   bun run scripts/check-coverage.ts            # gate (CI): fail on regression
+ *   bun run scripts/check-coverage.ts --update   # ratchet the baseline to current
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE_PATH = join(REPO_ROOT, "scripts", "coverage-baseline.json");
+
+/**
+ * Workspaces that emit coverage. Must stay in sync with the root `test:coverage`
+ * script chain in `package.json`. (`apps/cli` has no `test:coverage`; the
+ * `@tenkacloud/problem-runtime` package is added once PR #1427 lands.)
+ */
+const WORKSPACES = [
+  "infrastructure",
+  "apps/admin-console",
+  "apps/application-admin-console",
+  "apps/participant-portal",
+  "packages/trust-bridge",
+  "packages/auth-client",
+  "packages/saml-utils",
+] as const;
+
+/** Floating-point / line-count dust tolerance, in percentage points. */
+const EPSILON = 0.05;
+
+type Metric = "lines" | "branches" | "functions";
+type Metrics = Record<Metric, number>;
+
+function pct(hit: number, found: number): number {
+  return found === 0 ? 100 : (hit / found) * 100;
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+function parseLcov(lcovPath: string): Metrics {
+  const totals = { LF: 0, LH: 0, BRF: 0, BRH: 0, FNF: 0, FNH: 0 };
+  for (const line of readFileSync(lcovPath, "utf8").split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const key = line.slice(0, colon);
+    if (key in totals) totals[key as keyof typeof totals] += Number(line.slice(colon + 1)) || 0;
+  }
+  return {
+    lines: pct(totals.LH, totals.LF),
+    branches: pct(totals.BRH, totals.BRF),
+    functions: pct(totals.FNH, totals.FNF),
+  };
+}
+
+function collectCurrent(): Record<string, Metrics> {
+  const out: Record<string, Metrics> = {};
+  const missing: string[] = [];
+  for (const ws of WORKSPACES) {
+    const lcov = join(REPO_ROOT, ws, "coverage", "lcov.info");
+    if (!existsSync(lcov)) {
+      missing.push(ws);
+      continue;
+    }
+    out[ws] = parseLcov(lcov);
+  }
+  if (missing.length > 0) {
+    console.error(
+      `[coverage-gate] missing lcov for: ${missing.join(", ")}\n` +
+        "Run `make test-coverage` first so every workspace emits coverage/lcov.info.",
+    );
+    process.exit(2);
+  }
+  return out;
+}
+
+const METRICS: readonly Metric[] = ["lines", "branches", "functions"];
+const current = collectCurrent();
+
+if (process.argv.includes("--update")) {
+  const rounded: Record<string, Metrics> = {};
+  for (const ws of WORKSPACES) {
+    const m = current[ws];
+    rounded[ws] = {
+      lines: round2(m.lines),
+      branches: round2(m.branches),
+      functions: round2(m.functions),
+    };
+  }
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(rounded, null, 2)}\n`);
+  console.log(`[coverage-gate] baseline written: scripts/coverage-baseline.json`);
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error(
+    "[coverage-gate] no baseline found. Seed it with `bun run scripts/check-coverage.ts --update`.",
+  );
+  process.exit(2);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as Record<string, Metrics>;
+let regressed = false;
+const lines: string[] = [];
+
+for (const ws of WORKSPACES) {
+  const cur = current[ws];
+  const floor = baseline[ws] ?? { lines: 0, branches: 0, functions: 0 };
+  for (const metric of METRICS) {
+    const ok = cur[metric] + EPSILON >= floor[metric];
+    if (!ok) regressed = true;
+    lines.push(
+      `${ok ? "OK  " : "DROP"} ${ws} ${metric}: ${round2(cur[metric])}% (floor ${floor[metric]}%)`,
+    );
+  }
+}
+
+console.log(lines.join("\n"));
+
+if (regressed) {
+  console.error(
+    "\n[coverage-gate] FAIL — coverage dropped below the baseline floor.\n" +
+      "Add tests to cover the new/uncovered code. After a genuine improvement, run\n" +
+      "`bun run scripts/check-coverage.ts --update` to ratchet the floor up.",
+  );
+  process.exit(1);
+}
+
+console.log("\n[coverage-gate] OK — no workspace regressed below its coverage floor.");

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,0 +1,37 @@
+{
+  "infrastructure": {
+    "lines": 85.14,
+    "branches": 71.19,
+    "functions": 86.22
+  },
+  "apps/admin-console": {
+    "lines": 66.9,
+    "branches": 63.82,
+    "functions": 65.08
+  },
+  "apps/application-admin-console": {
+    "lines": 61.21,
+    "branches": 57.66,
+    "functions": 53.09
+  },
+  "apps/participant-portal": {
+    "lines": 60.21,
+    "branches": 48.18,
+    "functions": 58.78
+  },
+  "packages/trust-bridge": {
+    "lines": 94.64,
+    "branches": 90.22,
+    "functions": 95.24
+  },
+  "packages/auth-client": {
+    "lines": 100,
+    "branches": 100,
+    "functions": 100
+  },
+  "packages/saml-utils": {
+    "lines": 96.23,
+    "branches": 90,
+    "functions": 90
+  }
+}


### PR DESCRIPTION
## Summary

Part of code-quality hardening (#1424, tracker #1418). 100% coverage in one shot is impractical — current floors are infra **85/71/86**, SPAs **50–67%**, packages **90–100%**. So instead of a big-bang push, this installs a **ratchet**: a gate that locks in current coverage and only lets it climb.

- **`scripts/check-coverage.ts`** — parses each workspace's `coverage/lcov.info` (already emitted by the existing `test:coverage` scripts), computes line/branch/function %, and fails if any metric drops below its floor. `--update` re-baselines to current (ratchet up after a genuine improvement).
- **`scripts/coverage-baseline.json`** — the recorded floors (seeded from current).
- **CI**: a `Coverage ratchet gate` step runs right after `make test-coverage`, **reusing the lcov already generated** (no extra coverage run).
- **`make coverage-gate`** target + CLAUDE.md command-table row.

Deliberately **not** a `vitest.config` threshold edit — changing the shared test configs to enforce/relax thresholds is exactly the "edit config to mask failures" pattern the repo prohibits. This gate only *reads* lcov output.

## Why a ratchet
It immediately blocks any coverage regression while letting us raise floors incrementally (close gaps → `--update`). Follow-up PRs climb the SPAs toward 100%; this PR is the mechanism.

## Test plan
- `make harness` — clean
- `make before-commit` — green (re-run by pre-commit hook)
- `make test-coverage && make coverage-gate` — gate passes at seeded floors
- `--update` round-trips; missing-lcov / no-baseline paths exit non-zero with guidance

## Regression analysis
- No application code changed; pure tooling + one CI step + docs.
- EPSILON=0.05pp tolerance prevents line-count-dust false failures.
- Floors seeded at current coverage → CI stays green today; the gate only fires on a real drop.
- Not added to `make before-commit` (kept fast); CI-only per the issue's scope. `@tenkacloud/problem-runtime` joins the gate once #1427 lands.

## Physical impact
- **NO-OP** on CFn / deployed artifacts. CI / developer tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated code coverage verification in the CI pipeline that enforces minimum coverage thresholds across workspaces, preventing coverage regressions and maintaining code quality standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->