### PR TITLE
docs(adr): ADR-029 — attack resilience, the competition always ends

### DIFF
--- a/docs/architecture/adr-029-attack-resilience-game-always-ends.html
+++ b/docs/architecture/adr-029-attack-resilience-game-always-ends.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ADR-029: Attack resilience — the competition always ends</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  tr.reject td { background: #fff5f5; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft  { background: #ddf4ff; color: var(--c-link); }
+  .badge.accept { background: #ddf4e0; color: var(--c-accept); }
+  .badge.reject { background: #ffe9e9; color: var(--c-reject); }
+  .decision-box {
+    border: 2px solid var(--c-accept); border-radius: 6px;
+    background: #f0faf2; padding: 1rem 1.2rem; margin: 1.2rem 0;
+  }
+  .decision-box h3 { margin-top: 0; color: var(--c-accept); }
+  .nongoals-box {
+    border: 2px solid var(--c-reject); border-radius: 6px;
+    background: #fff5f5; padding: 1rem 1.2rem; margin: 1.2rem 0;
+  }
+  .nongoals-box h3 { margin-top: 0; color: var(--c-reject); }
+  .nongoals-box ul { list-style: none; padding-left: 0; }
+  .nongoals-box li::before { content: "\00d7  "; color: var(--c-reject); font-weight: 700; }
+  .invariant { border-left: 4px solid var(--c-accept); background: var(--c-bg-soft);
+               padding: .6rem 1rem; margin: .8rem 0; border-radius: 0 4px 4px 0; }
+  .invariant b { color: var(--c-accept); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  ul, ol { margin: 0.4rem 0; }
+  li { margin: 0.15rem 0; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-029: Attack resilience — the competition always ends</h1>
+  <p><em>Once disruptions and inter-team attacks actually land in a competitor's account, the platform must guarantee that no team is permanently knocked out and every round reaches a terminal state.</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge draft">Proposed</span> 2026-05-30</div>
+    <div><b>Tracking:</b> <a href="https://github.com/susumutomita/TenkaCloud/issues/1421">#1421</a> (program: <a href="https://github.com/susumutomita/TenkaCloud/issues/1417">#1417</a>)</div>
+    <div><b>Related:</b>
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin),
+      <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a> (condition-triggered disruptions),
+      <a href="./adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a> (reconciliation),
+      <a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a> (inter-team coordination)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p>Battle is gaining two capabilities that, for the first time, let one actor degrade another team's running environment:</p>
+<ul>
+  <li><b>Operator-fired disruptions</b> that reach the competitor account (cross-account dispatch, <a href="https://github.com/susumutomita/TenkaCloud/issues/1419">#1419</a>) — a referee injects a fault (latency, a killed instance, a flipped security group) into a team's deployed problem.</li>
+  <li><b>Inter-team interaction</b> (<a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a>) — a problem plugin lets teams attack, ally, or contend for a shared resource.</li>
+</ul>
+
+<p>Today neither attacks nor any recovery mechanism exists, so the two must be designed <em>together</em>: shipping attacks without a resilience contract would let a single fault or a coordinated attack put a victim team into a state from which they cannot score, and let a round run past its intended end with no terminal condition. For a timed, scored competition that is a correctness failure, not just a balance problem — a paying operator cannot run an event where a team can be eliminated for good or where the leaderboard never finalizes.</p>
+
+<p>The requirement is therefore a hard invariant, not a tuning knob: <strong>an attack must never make the game un-finishable.</strong> This ADR defines what "resilient" means as a set of platform-enforced invariants and the mechanisms that uphold them, so that every problem author and every operator inherits the guarantee by construction rather than by discipline.</p>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<div class="decision-box">
+  <h3>Three platform invariants, enforced for every Battle round</h3>
+
+  <div class="invariant"><b>I1 — No permanent fault.</b> Every disruption is time-boxed and auto-reverting. A fault carries a bounded <code>maxDurationMinutes</code> and a guaranteed revert path; the platform never leaves an injected fault open-ended, and a fault can never outlive its window or the round.</div>
+
+  <div class="invariant"><b>I2 — Bounded victim recovery.</b> A team can always return to a scoreable state within a bounded <code>recoveryBudgetMinutes</code>: faults revert automatically (I1), and a team may trigger an idempotent re-deploy / reset of its own problem stack subject to a cooldown. Recovery never depends on operator intervention.</div>
+
+  <div class="invariant"><b>I3 — Guaranteed termination, disruption-aware scoring.</b> Every round reaches a terminal state at its <code>endTime</code> (scoreboard freezes), and scoring is disruption-aware: by default an active fault <em>pauses</em> a victim's penalty rather than sinking their score, so a team cannot be driven below their pre-attack baseline by something outside their control. A round's terminal transition is guaranteed even if a poll is missed.</div>
+</div>
+
+<p>These invariants are <em>platform</em> guarantees. Problem plugins declare disruptions and inter-team primitives; they cannot opt out of time-boxing, recovery, or termination — only configure them within platform-enforced bounds.</p>
+</section>
+
+<section>
+<h2>Mechanisms</h2>
+
+<table>
+  <thead><tr><th style="width:22%">Mechanism</th><th>How it upholds the invariant</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>maxDurationMinutes</code> (per disruption)</td>
+      <td><b>I1.</b> Required field on each <code>disruptions[]</code> entry, bounded to <code>&le;</code> the round length. The validator rejects an out-of-bounds value at authoring time; the disruption-fire handler rejects a fire request that would exceed it at runtime.</td>
+    </tr>
+    <tr>
+      <td>Auto-revert contract</td>
+      <td><b>I1 / I2.</b> Every disruption ships its undo. The competitor-side mechanism (the CFn-deployed disruption Lambda / SSM document) schedules its own revert at <code>maxDurationMinutes</code>, and the platform also emits a <code>DisruptionExpired</code> event the mechanism consumes — belt-and-suspenders so a fault reverts even if the in-account timer is lost. Reverts are idempotent.</td>
+    </tr>
+    <tr>
+      <td>Self-reset (idempotent re-deploy)</td>
+      <td><b>I2.</b> A team can re-trigger the deploy of its own problem stack (the existing idempotent <code>DeployRequested</code> path keyed by <code>(tenantId, eventId, teamId, problemId)</code>) behind a cooldown, returning to a clean scoreable baseline without a referee.</td>
+    </tr>
+    <tr>
+      <td>Round terminator</td>
+      <td><b>I3.</b> At <code>endTime</code> the round transitions to <code>ENDED</code> and the scoreboard freezes (the freeze already exists). The transition is driven by EventBridge reconciliation (<a href="./adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>) so a missed poll cannot leave a round hanging.</td>
+    </tr>
+    <tr>
+      <td><code>scoreImpact</code> policy (per disruption)</td>
+      <td><b>I3.</b> Enum <code>pause</code> | <code>count</code>. <code>pause</code> (default) means uptime/availability scoring is not penalized for the duration of the fault — the team is held at their pre-fault value, never sunk below baseline. <code>count</code> means the fault <em>is</em> the challenge (e.g. the <code>attack-detection</code> scoring kind) and the team is expected to respond; even then the round still terminates (I3) and the fault still reverts (I1).</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section>
+<h2>Schema changes (<code>problems/SCHEMA.json</code>)</h2>
+
+<p>The <code>disruptions[]</code> entries gain three fields:</p>
+
+<pre>"disruptions": [
+  {
+    "id": "availability-flood",
+    "name": "Availability flood",
+    "maxDurationMinutes": 10,        // required, &le; round length (I1)
+    "autoRevert": true,              // required true; the disruption must ship its undo (I1/I2)
+    "scoreImpact": "pause"           // "pause" (default) | "count"            (I3)
+    // ... existing fields (eventDetailType, parameters, triggers, ...)
+  }
+]</pre>
+
+<p>The validator (extending the existing <code>scripts/problem-cli/validate.ts</code> + <code>problems/SCHEMA.json</code>) enforces: <code>maxDurationMinutes</code> present and within bounds, <code>autoRevert: true</code> present, and <code>scoreImpact</code> one of the enum. A problem that declares a disruption without a bounded duration or a revert fails validation — it cannot be shipped.</p>
+</section>
+
+<section>
+<h2>Alternatives considered</h2>
+
+<table>
+  <thead><tr><th style="width:30%">Alternative</th><th>Why rejected</th></tr></thead>
+  <tbody>
+    <tr class="reject">
+      <td>No time-box — faults persist until an operator manually reverts.</td>
+      <td>Operator error or absence leaves the game hung. Directly violates "the game always ends." Manual revert is a recovery path, not a guarantee.</td>
+    </tr>
+    <tr class="reject">
+      <td>Platform owns recovery by auto-redeploying victim stacks on every fault.</td>
+      <td>Heavy, cross-account, and problem-specific; redeploying mid-round can itself destroy legitimate progress. Recovery is instead delivered by making faults reversible (I1) plus a team-initiated, cooldown-gated self-reset (I2).</td>
+    </tr>
+    <tr class="reject">
+      <td>Scoring ignores disruptions entirely (faults never affect score).</td>
+      <td>Some problems intentionally make the disruption the challenge (<code>attack-detection</code>). A blanket ignore removes that design space. The per-disruption <code>scoreImpact</code> policy keeps both modes while still guaranteeing termination and revert.</td>
+    </tr>
+    <tr class="reject">
+      <td>Cap total attacks per team instead of bounding each fault.</td>
+      <td>A cap limits frequency but not the duration or reversibility of any single fault — a team could still be stuck by one open-ended attack. Bounding each fault (I1) is the property that actually guarantees recovery.</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section>
+<h2>Migration</h2>
+
+<p>Phased so the app-layer guarantees land before any cross-account injection is enabled (the resilience contract must exist before attacks do):</p>
+
+<ol>
+  <li><b>Phase 1 — schema + validator (app).</b> Add <code>maxDurationMinutes</code> / <code>autoRevert</code> / <code>scoreImpact</code> to <code>SCHEMA.json</code> and enforce them in the CLI validator. No problem can declare a non-conforming disruption.</li>
+  <li><b>Phase 2 — fire-time enforcement (app).</b> The disruption-fire handler rejects any fire whose effective duration would exceed <code>maxDurationMinutes</code> or the remaining round time, and stamps an expiry on the dispatched event.</li>
+  <li><b>Phase 3 — auto-revert contract (infra + problem-side).</b> The cross-account dispatch (<a href="https://github.com/susumutomita/TenkaCloud/issues/1419">#1419</a>) carries the expiry; the competitor-side mechanism self-reverts and also honors a platform <code>DisruptionExpired</code> event. Reverts are idempotent.</li>
+  <li><b>Phase 4 — termination + disruption-aware scoring (infra + scoring).</b> The round terminator (ADR-014 reconciliation) finalizes every round at <code>endTime</code>; the generic scoring path applies the <code>scoreImpact</code> policy so a <code>pause</code> fault holds the victim at baseline.</li>
+</ol>
+
+<p>Infrastructure-touching phases (3–4: cross-account, IAM, scoring Lambda) are owned by the platform maintainer; the schema/validator and the scoring-policy logic are app-layer.</p>
+</section>
+
+<section>
+<h2>Consequences</h2>
+<ul>
+  <li><b>Every disruption is bounded and reversible by construction</b> — the validator refuses to ship anything else, so resilience is not a per-event operator checklist item.</li>
+  <li><b>Two testable platform invariants</b> emerge that can be pinned in CI: "no disruption duration exceeds the round length" and "every round reaches a terminal state." These become harness-style guarantees rather than prose.</li>
+  <li>Problem authors gain a small, explicit vocabulary (<code>maxDurationMinutes</code> / <code>autoRevert</code> / <code>scoreImpact</code>) instead of an implicit, unsafe default.</li>
+  <li>The <code>count</code> policy preserves the adversarial problem genre (attack-detection) while the platform still guarantees the round ends and the fault reverts.</li>
+  <li>This ADR constrains, but does not implement, <a href="https://github.com/susumutomita/TenkaCloud/issues/1419">#1419</a> (cross-account dispatch) and <a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a> (inter-team) — both must satisfy I1–I3.</li>
+</ul>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Proposed design for **#1421** (program #1417) — the concern that a real attack could make a Battle un-finishable. Once disruptions reach the competitor account (#1419) and inter-team interaction lands (ADR-028), one actor can degrade another team's environment; this ADR defines the resilience contract that must ship **with** those features.

Three platform-enforced invariants:
- **I1 — no permanent fault**: every disruption is time-boxed (`maxDurationMinutes` ≤ round length) and auto-reverting.
- **I2 — bounded victim recovery**: faults revert automatically + idempotent self-reset within a budget; never depends on an operator.
- **I3 — guaranteed termination + disruption-aware scoring**: round ends at `endTime` (scoreboard freeze, ADR-014 reconciliation backstop); `scoreImpact=pause` (default) holds a victim at baseline so an attack can't sink their score below it. `scoreImpact=count` preserves the attack-detection genre.

Adds `disruptions[].{maxDurationMinutes, autoRevert, scoreImpact}` to `SCHEMA.json` (validator-enforced), with a phased migration: app-layer schema/validator + scoring policy first, infra (cross-account, scoring Lambda) later.

**Status: Proposed** — for your review/steer before implementation. The ADR proposes product/game-design decisions (recovery model, scoring-pause default, round-termination guarantee); please weigh in on those before #1421 is implemented.

## Test plan
- `make harness` — clean (`adr-must-be-html`, `adr-self-contained`)
- `build-docs --check` — in sync (ADRs are hand-written HTML, no `.md`)

## Regression analysis
- Docs-only; no code / CFn change. Self-contained HTML ADR.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architecture guidance defining platform resilience requirements for competitive rounds, ensuring all games complete reliably within specified timeframes with fair scoring adjustments during system disruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->