### PR TITLE
fix(harness): stop flagging named timeout/port constants as magic numbers

### DIFF
--- a/.claude/harness/src/tech-debt/magic-number.test.ts
+++ b/.claude/harness/src/tech-debt/magic-number.test.ts
@@ -65,6 +65,46 @@ describe("magic-number", () => {
       expect(findings).toHaveLength(1);
       expect(findings[0]?.match).toBe("timeout-ms:30000");
     });
+
+    it("should NOT flag a SCREAMING_SNAKE named timeout constant (= the recommended named form)", () => {
+      // `const POLL_INTERVAL_MS = 30_000;` contains the hint word "INTERVAL" but is
+      // itself the named constant the rule asks for — flagging it would flag the fix.
+      const code = "const POLL_INTERVAL_MS = 30_000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should NOT flag an exported named timeout constant", () => {
+      const code = "export const NOTIFICATIONS_POLL_INTERVAL_MS = 60_000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(0);
+    });
+
+    it("should still flag a bare timeout literal used at a call site", () => {
+      // The exemption is only for the named declaration, not for bare uses.
+      const code = "const NOTIFY_MS = 60_000;\nsetTimeout(() => setCopied(false), 30000);";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.match).toBe("timeout-ms:30000");
+    });
+
+    it("should still flag a camelCase numeric binding (only SCREAMING_SNAKE is the named form)", () => {
+      const code = "const pollIntervalMs = 30000;";
+      const findings = magicNumber.check({
+        files: [PROD_PATH],
+        readFile: () => code,
+      });
+      expect(findings).toHaveLength(1);
+    });
   });
 
   describe("port detection", () => {

--- a/.claude/harness/src/tech-debt/magic-number.ts
+++ b/.claude/harness/src/tech-debt/magic-number.ts
@@ -65,6 +65,17 @@ const TIMEOUT_CONTEXT_RES = [
 ];
 const PORT_CONTEXT_RE = /\b(port|PORT|listen|bind|endpoint|url|URL|origin)\b/;
 
+/**
+ * A SCREAMING_SNAKE_CASE constant assigned a numeric literal is the *named* form
+ * this rule recommends (e.g. `const POLL_INTERVAL_MS = 30_000`). The single
+ * declaration line must not itself be flagged for timeout / port literals —
+ * otherwise the detector flags the very fix it asks for. Bare *uses* elsewhere
+ * (`setTimeout(fn, 30000)`) are still flagged. HTTP status codes are excluded
+ * from this exemption: their named form is the `StatusCodes` enum, not a local
+ * `const HTTP_OK = 200`, so those declarations stay flagged.
+ */
+const NAMED_CONST_DECL_RE = /\b(?:const|let|var)\s+[A-Z][A-Z0-9_]*\s*(?::\s*[\w<>[\]]+\s*)?=/;
+
 function shouldInspect(path: string): boolean {
   if (!/\.tsx?$/.test(path)) return false;
   if (EXCLUDE_PATTERNS.some((re) => re.test(path))) return false;
@@ -84,9 +95,11 @@ function classify(value: number, lineText: string): Classification | undefined {
     return { kind: "http-status", value };
   }
   if (TIMEOUT_VALUES.has(value) && TIMEOUT_CONTEXT_RES.some((re) => re.test(lineText))) {
+    if (NAMED_CONST_DECL_RE.test(lineText)) return undefined;
     return { kind: "timeout-ms", value };
   }
   if (COMMON_PORTS.has(value) && PORT_CONTEXT_RE.test(lineText)) {
+    if (NAMED_CONST_DECL_RE.test(lineText)) return undefined;
     return { kind: "port", value };
   }
   return undefined;

--- a/apps/application-admin-console/src/pages/competitor-accounts/SecretRevealModal.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/SecretRevealModal.tsx
@@ -16,6 +16,9 @@ import {
   COMPETITOR_BOOTSTRAP_TEMPLATE_URL,
 } from "../../lib/competitor-bootstrap";
 
+/** How long the "Copied" confirmation stays lit after copying the full payload. */
+const COPIED_FEEDBACK_RESET_MS = 2_000;
+
 interface SecretRevealModalProps {
   secret: CreateCompetitorAccountResponse | null;
   onDismiss: () => void;
@@ -37,7 +40,7 @@ export function SecretRevealModal({ secret, onDismiss, templateUrl }: SecretReve
   const onCopyAll = async () => {
     await navigator.clipboard.writeText(payload);
     setAllCopied(true);
-    setTimeout(() => setAllCopied(false), 2000);
+    setTimeout(() => setAllCopied(false), COPIED_FEEDBACK_RESET_MS);
   };
   return (
     <Modal


### PR DESCRIPTION
## Summary

The tech-debt **magic-number** detector was flagging `const POLL_INTERVAL_MS = 30_000` — the named-constant form it *recommends* — because the line contains the hint word "INTERVAL". It flagged the very fix it asks for, producing false positives in `useDeploymentDetail`, `ScoreEvents`, and `TeamViewProvider` (×2). A detector you can't trust undermines its own purpose (#1418 — code worthy of scrutiny).

- **Rule fix** (`.claude/harness/src/tech-debt/magic-number.ts`): exempt SCREAMING_SNAKE named-constant declarations from `timeout-ms` / `port` flagging. Bare uses (`setTimeout(fn, 30000)`) and camelCase bindings are still flagged. **HTTP status codes are NOT exempted** — their named form is the `StatusCodes` enum, not a local `const HTTP_OK = 200`.
- **Tests** (`magic-number.test.ts`): new cases for the exemption (SCREAMING_SNAKE + `export` variant) and that bare uses / camelCase still fire.
- **One genuine inline literal extracted**: `SecretRevealModal`'s `setTimeout(…, 2000)` → `COPIED_FEEDBACK_RESET_MS`.

**Net: `make tech-debt` magic-number findings → 0** (4 false positives removed by the rule, 1 real literal named; the 3 prior saml-routes HTTP literals were already fixed by #1416).

## Test plan
- `make harness-test` — 137 tests pass (incl. 4 new magic-number cases)
- `make before-commit` — green (re-run by pre-commit hook)
- `make tech-debt` — magic-number rule now reports 0 findings (report drops from 3 rules to 2)
- Rebased onto current `origin/main` (had drifted 1 commit / #1416).

## Regression analysis
- Rule change is restrictive-only (removes false positives); no production behavior change. `SecretRevealModal` keeps the identical 2000ms reset, now named.
- HTTP-status detection intentionally unchanged (still nudges toward `StatusCodes`).

## Physical impact
- **NO-OP** on CFn / deployed artifacts. Harness tooling + one frontend constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)