### PR TITLE
test(trust-bridge): reach 100% workspace coverage; drop dead JWS reason

### DIFF
--- a/packages/trust-bridge/src/jws.ts
+++ b/packages/trust-bridge/src/jws.ts
@@ -47,8 +47,7 @@ export type VerifyFailureReason =
   | "unknown-algorithm"
   | "secret-not-resolved"
   | "signature-mismatch"
-  | "payload-parse-failed"
-  | "payload-schema-invalid";
+  | "payload-parse-failed";
 
 function base64urlEncode(bytes: Uint8Array): string {
   return Buffer.from(bytes)

--- a/packages/trust-bridge/src/schema.ts
+++ b/packages/trust-bridge/src/schema.ts
@@ -115,7 +115,8 @@ export function canonicalize(value: unknown): string {
   }
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([, v]) => v !== undefined)
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    // Object keys are unique, so the equal case never occurs: a is either < or > b.
+    .sort(([a], [b]) => (a < b ? -1 : 1));
   const body = entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",");
   return `{${body}}`;
 }

--- a/packages/trust-bridge/src/verify.ts
+++ b/packages/trust-bridge/src/verify.ts
@@ -70,8 +70,6 @@ function mapJwsReason(reason: VerifyOutcome & { ok: false }): IntentVerifyFailur
       return "jws-signature-mismatch";
     case "payload-parse-failed":
       return "jws-payload-parse-failed";
-    case "payload-schema-invalid":
-      return "schema-invalid";
   }
 }
 
@@ -92,18 +90,26 @@ export async function verifyIntent(
   const intent = schemaOutcome.intent;
   const now = (options.now ?? (() => new Date()))();
   const expiresAt = new Date(intent.constraints.expiresAt);
+  // Defense-in-depth: ConstraintsSchema enforces `z.string().datetime()`, so a value reaching
+  // here always parses to a valid Date — provably unreachable through the validated path. Kept
+  // in case the schema is ever loosened.
+  /* v8 ignore start */
   if (Number.isNaN(expiresAt.getTime())) {
-    // datetime() で schema が弾く想定だが防御的に。
     return { ok: false, reason: "schema-invalid", details: ["constraints.expiresAt"] };
   }
+  /* v8 ignore stop */
   if (expiresAt.getTime() <= now.getTime()) {
     return { ok: false, reason: "expired" };
   }
   if (intent.constraints.notBefore) {
     const nbf = new Date(intent.constraints.notBefore);
+    // Defense-in-depth: `notBefore` is `z.string().datetime().optional()`, so a present value
+    // always parses — provably unreachable through the validated path.
+    /* v8 ignore start */
     if (Number.isNaN(nbf.getTime())) {
       return { ok: false, reason: "schema-invalid", details: ["constraints.notBefore"] };
     }
+    /* v8 ignore stop */
     if (now.getTime() < nbf.getTime()) {
       return { ok: false, reason: "not-yet-valid" };
     }

--- a/packages/trust-bridge/test/audit.test.ts
+++ b/packages/trust-bridge/test/audit.test.ts
@@ -57,6 +57,19 @@ describe("buildAuditRecord (#795 Phase 1)", () => {
     });
   });
 
+  it("should default createdAt to the current time and include targetId when the source has one", () => {
+    const base = makeIntent();
+    const intent = brandVerified({ ...base, source: { ...base.source, targetId: "target-7" } });
+    const record = buildAuditRecord({
+      outcome: { ok: true, intent },
+      issuedCredentialExpiresAt: "2026-05-15T19:45:00.000Z",
+      // `now` omitted on purpose → exercises the `() => new Date()` default.
+    });
+    expect(record.decision).toBe("allow");
+    expect(record.targetId).toBe("target-7");
+    expect(typeof record.createdAt).toBe("string");
+  });
+
   it("should set decision to deny and include denialReason when override specifies deny", () => {
     const intent = makeIntent();
     const record = buildAuditRecord({

--- a/packages/trust-bridge/test/aws-assume-role.test.ts
+++ b/packages/trust-bridge/test/aws-assume-role.test.ts
@@ -89,6 +89,48 @@ describe("AwsAssumeRoleExchange (#795 Phase 2)", () => {
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
+  it("should add eventId and teamId session tags when the intent carries them", async () => {
+    let captured: AssumeRoleInput | undefined;
+    const ex = new AwsAssumeRoleExchange({
+      sts: makeStub({}, (input) => {
+        captured = input;
+      }),
+    });
+    const intent = makeIntent({
+      source: {
+        system: "tenkacloud",
+        tenantId: "tenant-a",
+        workloadId: "deploy-worker",
+        eventId: "event-7",
+        teamId: "team-7",
+      },
+    });
+    const out = await ex.exchange(intent, {
+      roleArn: "arn:aws:iam::123456789012:role/x",
+      externalId: "ext-1",
+    });
+    expect(out).toBeDefined();
+    const tags = captured?.Tags ?? [];
+    expect(tags).toEqual(
+      expect.arrayContaining([
+        { Key: "tenkacloud:eventId", Value: "event-7" },
+        { Key: "tenkacloud:teamId", Value: "team-7" },
+      ]),
+    );
+  });
+
+  it("should omit optional session tags when the source carries only required fields", async () => {
+    const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
+    const intent = makeIntent({
+      source: { system: "tenkacloud", tenantId: "tenant-a", workloadId: "deploy-worker" },
+    });
+    const out = await ex.exchange(intent, {
+      roleArn: "arn:aws:iam::123456789012:role/x",
+      externalId: "ext-1",
+    });
+    expect(out).toBeDefined();
+  });
+
   it("should throw ttl-exceeded-provider-limit when ttlSeconds is below the STS minimum of 900", async () => {
     const ex = new AwsAssumeRoleExchange({ sts: makeStub() });
     const intent = makeIntent();

--- a/packages/trust-bridge/test/gcp-workload-identity.test.ts
+++ b/packages/trust-bridge/test/gcp-workload-identity.test.ts
@@ -84,6 +84,19 @@ describe("GcpWorkloadIdentityFederationExchange (#795 Phase 4 prototype)", () =>
     ).rejects.toMatchObject({ reason: "context-missing" });
   });
 
+  it("should throw context-missing when serviceAccountEmail is absent", async () => {
+    const ex = new GcpWorkloadIdentityFederationExchange({
+      stsClient: makeStubClient(),
+      toSubjectToken: () => "jwt",
+    });
+    await expect(
+      ex.exchange(makeIntent(), {
+        wifAudience: "audience",
+        oauthScopes: ["scope"],
+      } as Record<string, unknown>),
+    ).rejects.toMatchObject({ reason: "context-missing" });
+  });
+
   it("should throw context-missing when oauthScopes is an empty array", async () => {
     const ex = new GcpWorkloadIdentityFederationExchange({
       stsClient: makeStubClient(),

--- a/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
+++ b/packages/trust-bridge/test/localstack-cloud-adapter.test.ts
@@ -74,6 +74,20 @@ describe("LocalStackCloudAdapter (#1122)", () => {
     expect(credential.endpointUrl).toBe("http://127.0.0.1:4567");
   });
 
+  it("should default region to ap-northeast-1 when neither intent nor adapter sets it", async () => {
+    const adapter = new LocalStackCloudAdapter({ endpointUrl: "http://localhost:4566" });
+    const intent = makeIntent({ target: { provider: "aws", providerAccountRef: "000000000000" } });
+    const credential = await adapter.exchange(intent, {});
+    expect(credential.region).toBe("ap-northeast-1");
+  });
+
+  it("should throw for an invalid endpoint URL passed via context", async () => {
+    const adapter = new LocalStackCloudAdapter({ endpointUrl: "http://localhost:4566" });
+    await expect(
+      adapter.exchange(makeIntent(), { endpointUrl: "not-a-valid-url" }),
+    ).rejects.toBeInstanceOf(ExchangeError);
+  });
+
   it("should throw provider-mismatch when the target provider is not aws", async () => {
     const adapter = new LocalStackCloudAdapter();
     await expect(

--- a/packages/trust-bridge/test/verify.test.ts
+++ b/packages/trust-bridge/test/verify.test.ts
@@ -205,4 +205,29 @@ describe("verifyIntent (#795 Phase 1)", () => {
     const result = await verifyIntent(token, { resolveSecret: () => secret });
     expect(result.ok).toBe(true);
   });
+
+  it("should proceed to ok=true when the nonce store accepts the nonce", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(intent(), { secret });
+    const acceptStore: NonceStore = { recordNonce: async () => "accepted" };
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+      nonceStore: acceptStore,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("should accept a token whose notBefore is already in the past", async () => {
+    const secret = randomBytes(32);
+    const token = signIntent(
+      intent({ notBefore: "2026-05-15T18:00:00.000Z", expiresAt: "2026-05-15T22:00:00.000Z" }),
+      { secret },
+    );
+    const result = await verifyIntent(token, {
+      resolveSecret: () => secret,
+      now: () => new Date("2026-05-15T19:00:00.000Z"),
+    });
+    expect(result.ok).toBe(true);
+  });
 });

--- a/packages/trust-bridge/test/verify.test.ts
+++ b/packages/trust-bridge/test/verify.test.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { signIntent } from "../src/jws.js";
 import { type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
@@ -23,6 +23,28 @@ function intent(overrides: Partial<CloudActionIntent["constraints"]> = {}): Clou
       ...overrides,
     },
   };
+}
+
+/** base64url without padding — matches jws.ts encoding. */
+function b64url(input: string | Uint8Array): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Build a JWS-shaped token from an arbitrary header object + raw payload string,
+ * signing `header.payload` with `secret` so the HMAC check passes. Lets the tests
+ * reach verifySignature failure branches that `signIntent` (which always emits a
+ * valid HS256 header and JSON payload) cannot produce.
+ */
+function craftToken(header: unknown, payload: string, secret: Uint8Array): string {
+  const h = b64url(JSON.stringify(header));
+  const p = b64url(payload);
+  const sig = b64url(new Uint8Array(createHmac("sha256", secret).update(`${h}.${p}`).digest()));
+  return `${h}.${p}.${sig}`;
 }
 
 describe("verifyIntent (#795 Phase 1)", () => {
@@ -130,5 +152,57 @@ describe("verifyIntent (#795 Phase 1)", () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("jws-signature-mismatch");
+  });
+
+  it("should map a token without three segments to jws-malformed", async () => {
+    const result = await verifyIntent("only.two", { resolveSecret: () => randomBytes(32) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-malformed");
+  });
+
+  it("should map a header with typ != JWS to jws-malformed", async () => {
+    const secret = randomBytes(32);
+    const token = craftToken({ alg: "HS256", typ: "NOPE" }, JSON.stringify(intent()), secret);
+    const result = await verifyIntent(token, { resolveSecret: () => secret });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-malformed");
+  });
+
+  it("should map a non-JSON header to jws-malformed", async () => {
+    const token = `${b64url("not-json{")}.${b64url("{}")}.${b64url("sig")}`;
+    const result = await verifyIntent(token, { resolveSecret: () => randomBytes(32) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-malformed");
+  });
+
+  it("should map an unsupported alg to jws-unknown-algorithm", async () => {
+    const secret = randomBytes(32);
+    const token = craftToken({ alg: "RS256", typ: "JWS" }, JSON.stringify(intent()), secret);
+    const result = await verifyIntent(token, { resolveSecret: () => secret });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-unknown-algorithm");
+  });
+
+  it("should map an unresolved secret to jws-secret-not-resolved", async () => {
+    const token = signIntent(intent(), { secret: randomBytes(32) });
+    const result = await verifyIntent(token, { resolveSecret: () => undefined });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-secret-not-resolved");
+  });
+
+  it("should map a non-JSON payload with a valid signature to jws-payload-parse-failed", async () => {
+    const secret = randomBytes(32);
+    const token = craftToken({ alg: "HS256", typ: "JWS" }, "not-json{", secret);
+    const result = await verifyIntent(token, { resolveSecret: () => secret });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("jws-payload-parse-failed");
+  });
+
+  it("should default `now` to the current time when the option is omitted", async () => {
+    const secret = randomBytes(32);
+    // Far-future expiry so the real wall-clock default stays valid regardless of run date.
+    const token = signIntent(intent({ expiresAt: "2999-01-01T00:00:00.000Z" }), { secret });
+    const result = await verifyIntent(token, { resolveSecret: () => secret });
+    expect(result.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Takes the **`trust-bridge` package to 100% coverage** (statements 230/230, branches 177/177, functions 42/42) — a concrete goal-#4 milestone — while also removing dead code (goal #2) on the security-critical JWS verification path (ADR-017).

### JWS verify path (security-critical)
- The verify path had untested failure branches: **5 of 6** `verifySignature` reasons were never mapped through `verifyIntent`, and jws.ts's malformed/parse-error branches were uncovered — a regression in the failure mapping would have shipped silently.
- New `craftToken` helper builds JWS-shaped tokens with arbitrary header/payload (which `signIntent` can't), enabling tests for every failure: `jws-malformed` (×3), `jws-unknown-algorithm`, `jws-secret-not-resolved`, `jws-payload-parse-failed`.
- **Removed the dead `payload-schema-invalid` reason** — `verifySignature` never returns it, so the enum member + its `mapJwsReason` case were unreachable dead code.

### Full-workspace coverage
- **gcp**: missing-`serviceAccountEmail` error. **aws-assume-role**: present + absent optional session tags via a real exchange. **localstack**: region default + invalid-endpoint-URL error. **audit**: `now`-default + `targetId`. **verify**: nonce-accepted, past-`notBefore`, `now`-default.
- **schema**: simplified the `canonicalize` key comparator `a<b?-1:a>b?1:0` → `a<b?-1:1` — object keys are unique, so the `:0` (equal) branch was unreachable dead code (removed, not ignored).
- The two genuinely-unreachable defensive NaN guards (schema enforces `z.string().datetime()`) are annotated with `/* v8 ignore start/stop */` + justification.

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook); full typecheck confirms the removed enum member breaks no consumer (`trust-bridge-shadow.ts`)
- 79 trust-bridge tests pass; `make test-coverage` → trust-bridge **100%** stmts/branches/funcs

## Regression analysis
- No production behavior change: removing a never-produced union member + a provably-equivalent comparator simplification (unique keys never hit the removed branch) + test additions + coverage-ignore on provably-unreachable defensive code.

## Physical impact
- **NO-OP** on CFn / deployed artifacts. Package source + tests only.