### PR TITLE
refactor(event-detail): split the two heavyweight tabs out of tabs.tsx

### DIFF
--- a/apps/application-admin-console/src/pages/event-detail/OperationsTab.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/OperationsTab.tsx
@@ -1,0 +1,125 @@
+import Alert from "@cloudscape-design/components/alert";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { DeployProgressPanel } from "../../components/event-detail/DeployProgressPanel";
+import { EventRescuePanel } from "../../components/event-detail/EventWizardPanel";
+import type { EventTabContentProps } from "./tab-content-props";
+
+/**
+ * Operations tab: 普段使わない高度操作を集約する。
+ *
+ * Issue #1318 で 「rescue 系を Operations に集約」 と決めたが、 #1324 で実装したときに
+ * EventRescuePanel (TEARDOWN 時のみ render) のみを置いてしまい、 非 TEARDOWN 状態では
+ * tab が完全に空になっていた (issue #1328)。 本コミットで 4 section を常時表示するようにし、
+ * status を問わず 運用 tab に内容があることを保証する。
+ *
+ * 表示 section:
+ *  1. EventRescuePanel — 既存。 status === TEARDOWN のときだけ render
+ *  2. 一括操作 — Bulk redeploy / Bulk teardown。 header にも同等 button があるが Operations tab
+ *     の主目的 (= 高度操作の集約先) として明示的に重複配置する
+ *  3. Deploy 進捗詳細 — DeployProgressPanel。 deployment が 0 件のときは empty hint
+ *  4. Event 削除 (danger zone) — header の Delete と同じ confirmTeardown modal を開く
+ */
+export function OperationsTab({
+  counts,
+  detail,
+  manualRefresh,
+  manualRefreshInFlight,
+  operations,
+  t,
+}: EventTabContentProps) {
+  const bulkDisabled =
+    detail.status === "ENDED" || detail.status === "TEARDOWN" || detail.status === "ARCHIVED";
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h2">{t("event_detail.operations_header")}</Header>
+      <Alert type="info" data-testid="operations-tab-intro">
+        {t("event_detail.operations_intro")}
+      </Alert>
+
+      <EventRescuePanel
+        detail={detail}
+        forceArchiveInFlight={operations.forceArchiveInFlight}
+        onForceArchive={() => operations.setConfirmForceArchive(true)}
+        t={t}
+      />
+
+      <Container
+        data-testid="operations-bulk-section"
+        header={
+          <Header variant="h3" description={t("event_detail.operations_bulk_description")}>
+            {t("event_detail.operations_bulk_header")}
+          </Header>
+        }
+      >
+        <SpaceBetween size="xs" direction="horizontal">
+          <Button
+            data-testid="operations-bulk-deploy"
+            loading={operations.bulkInFlight === "deploy"}
+            disabled={
+              detail.problems.length === 0 ||
+              detail.teams.length === 0 ||
+              bulkDisabled ||
+              operations.bulkInFlight !== null
+            }
+            onClick={() => void operations.handleBulkDeploy()}
+          >
+            {t("event_detail.operations_bulk_deploy")}
+          </Button>
+          <Button
+            data-testid="operations-bulk-teardown"
+            loading={operations.bulkInFlight === "teardown"}
+            disabled={operations.bulkInFlight !== null}
+            onClick={() => operations.setConfirmTeardown(true)}
+          >
+            {t("event_detail.operations_bulk_teardown")}
+          </Button>
+        </SpaceBetween>
+      </Container>
+
+      <Container
+        header={<Header variant="h3">{t("event_detail.operations_deploy_progress_header")}</Header>}
+      >
+        {counts.totalDeployCount > 0 ? (
+          <DeployProgressPanel
+            allDoneCount={counts.allDoneCount}
+            completeCount={counts.completeCount}
+            failedCount={counts.failedCount}
+            inFlightCount={counts.inFlightCount}
+            manualRefreshInFlight={manualRefreshInFlight}
+            onManualRefresh={manualRefresh}
+            t={t}
+            totalDeployCount={counts.totalDeployCount}
+          />
+        ) : (
+          <Alert type="info">{t("event_detail.operations_deploy_progress_empty")}</Alert>
+        )}
+      </Container>
+
+      <Container
+        data-testid="operations-delete-section"
+        header={
+          <Header
+            variant="h3"
+            actions={
+              <Button
+                variant="primary"
+                data-testid="operations-delete-button"
+                loading={operations.bulkInFlight === "teardown"}
+                onClick={() => operations.setConfirmTeardown(true)}
+              >
+                {t("event_detail.operations_delete_button")}
+              </Button>
+            }
+          >
+            {t("event_detail.operations_delete_header")}
+          </Header>
+        }
+      >
+        <Alert type="warning">{t("event_detail.operations_delete_warning")}</Alert>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-detail/OverviewTab.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/OverviewTab.tsx
@@ -1,0 +1,55 @@
+import { DeployProgressPanel } from "../../components/event-detail/DeployProgressPanel";
+import { EventChecklistPanel } from "../../components/event-detail/EventChecklistPanel";
+import { EventPhaseBanner } from "../../components/event-detail/EventPhaseBanner";
+import { EventReadinessPanel } from "../../components/event-detail/EventReadinessPanel";
+import { EventWizardPanel } from "../../components/event-detail/EventWizardPanel";
+import { ScoringLockPanel } from "../../components/event-detail/ScoringLockPanel";
+import type { EventTabContentProps } from "./tab-content-props";
+
+/**
+ * Issue #1362: Qiita 「用途別グルーピング」 原則で Overview tab を 3 グループに整理。
+ *
+ *   1. 現状 (status)        — Event 概要 (ScoringLockPanel) + 現在のフェーズ
+ *   2. 次のアクション (hero) — operator が押すべき button (EventWizardPanel の CTA half)
+ *   3. リソース / Deploy 進捗 — チーム / 問題 / deployment 進捗
+ *
+ * `EventWizardPanel` 内部で「現状 (phase indicator)」 と「次のアクション (CTA)」 を別
+ * Container に分割している (= 上の 1+2)。 視線は 画面 title → 現状 → 次のアクション →
+ * リソース の順に降りていく。
+ */
+export function OverviewTab({
+  counts,
+  detail,
+  manualRefresh,
+  manualRefreshInFlight,
+  t,
+  wizard,
+}: EventTabContentProps) {
+  return (
+    <>
+      {/* Issue #1350: Setup / Live / Teardown の phase 帯を冒頭に表示 (色 cue) */}
+      <EventPhaseBanner detail={detail} t={t} />
+      <ScoringLockPanel detail={detail} t={t} />
+      <EventWizardPanel t={t} wizard={wizard} />
+      {/* Issue #1350: 4 項目の readiness check + 全 ✓ で 「準備完了」 大 badge */}
+      <EventReadinessPanel
+        completeCount={counts.completeCount}
+        detail={detail}
+        t={t}
+        totalDeployCount={counts.totalDeployCount}
+      />
+      <DeployProgressPanel
+        allDoneCount={counts.allDoneCount}
+        completeCount={counts.completeCount}
+        failedCount={counts.failedCount}
+        inFlightCount={counts.inFlightCount}
+        manualRefreshInFlight={manualRefreshInFlight}
+        onManualRefresh={manualRefresh}
+        t={t}
+        totalDeployCount={counts.totalDeployCount}
+      />
+      {/* Issue #1350: T-7 / T-1 / T-0 / T+0 phase 別 operator checklist */}
+      <EventChecklistPanel t={t} />
+    </>
+  );
+}

--- a/apps/application-admin-console/src/pages/event-detail/tab-content-props.ts
+++ b/apps/application-admin-console/src/pages/event-detail/tab-content-props.ts
@@ -1,0 +1,32 @@
+import type { ApiClient } from "../../api/client";
+import type { EventDetail } from "../../api/events-client";
+import type { AppConfig } from "../../config";
+import type { useEventOperations } from "../../hooks/useEventOperations";
+import type { useT } from "../../i18n";
+import type { WizardState } from "../../lib/event-wizard";
+
+/**
+ * Shared prop contract for every Event Detail workflow tab (Issue #1318).
+ * Extracted from `tabs.tsx` so each tab module depends only on this contract and
+ * the panels it renders, rather than on the union of all tabs' dependencies.
+ */
+export type Translate = ReturnType<typeof useT>;
+export type EventOperations = ReturnType<typeof useEventOperations>;
+
+export interface EventTabContentProps {
+  readonly apiClient: ApiClient | null;
+  readonly config: AppConfig;
+  readonly counts: {
+    readonly allDoneCount: number;
+    readonly completeCount: number;
+    readonly failedCount: number;
+    readonly inFlightCount: number;
+    readonly totalDeployCount: number;
+  };
+  readonly detail: EventDetail;
+  readonly manualRefresh: () => void;
+  readonly manualRefreshInFlight: boolean;
+  readonly operations: EventOperations;
+  readonly t: Translate;
+  readonly wizard: WizardState;
+}

--- a/apps/application-admin-console/src/pages/event-detail/tabs.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/tabs.tsx
@@ -6,57 +6,26 @@
  * 典型 workflow 順 (Overview / Schedule / Problems / Teams / Scoreboard / Notifications / Operations)
  * に並べる。
  *
- * 機能削除はなし。 既存 panel component を tab content に振り分けるだけ。 modals 群 (EventDangerZone)
- * は tab 外 (page 直下) に残し、 どの tab からも開けるようにする。
+ * 各 tab content は独立した module。 重量級の 2 tab (Overview / Operations — 複数 panel + JSX)
+ * は専用ファイルに分離し (`./OverviewTab` / `./OperationsTab`)、 残り 5 tab は単一 / 二重 panel の
+ * 薄い wrapper なのでここに同居させる。 共有 prop 契約は `./tab-content-props`。 これにより各
+ * module は自分が描画する panel だけに依存する (= 旧 24-import 集約の解消)。
  *
  * Tab id は URL fragment (`#tab=schedule` 等) で deep-link 可能。
  */
 
-import Alert from "@cloudscape-design/components/alert";
-import Button from "@cloudscape-design/components/button";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
-import SpaceBetween from "@cloudscape-design/components/space-between";
-import type { ApiClient } from "../../api/client";
-import type { EventDetail } from "../../api/events-client";
-import { DeployProgressPanel } from "../../components/event-detail/DeployProgressPanel";
-import { EventChecklistPanel } from "../../components/event-detail/EventChecklistPanel";
 import { EventNotificationsPanel } from "../../components/event-detail/EventNotificationsPanel";
 import { EventParticipantsPanel } from "../../components/event-detail/EventParticipantsPanel";
-import { EventPhaseBanner } from "../../components/event-detail/EventPhaseBanner";
 import { EventProblemSetPanel } from "../../components/event-detail/EventProblemSetPanel";
-import { EventReadinessPanel } from "../../components/event-detail/EventReadinessPanel";
 import { EventSchedulePanel } from "../../components/event-detail/EventSchedulePanel";
 import { EventTeamsPanel } from "../../components/event-detail/EventTeamsPanel";
-import { EventRescuePanel, EventWizardPanel } from "../../components/event-detail/EventWizardPanel";
-import { ScoringLockPanel } from "../../components/event-detail/ScoringLockPanel";
 import { TeamRankingPanel } from "../../components/TeamRankingPanel";
 import { TeamScoreEventsPanel } from "../../components/TeamScoreEventsPanel";
-import type { AppConfig } from "../../config";
-import type { useEventOperations } from "../../hooks/useEventOperations";
-import type { useT } from "../../i18n";
-import type { WizardState } from "../../lib/event-wizard";
+import type { EventTabContentProps } from "./tab-content-props";
 
-type Translate = ReturnType<typeof useT>;
-type EventOperations = ReturnType<typeof useEventOperations>;
-
-export interface EventTabContentProps {
-  readonly apiClient: ApiClient | null;
-  readonly config: AppConfig;
-  readonly counts: {
-    readonly allDoneCount: number;
-    readonly completeCount: number;
-    readonly failedCount: number;
-    readonly inFlightCount: number;
-    readonly totalDeployCount: number;
-  };
-  readonly detail: EventDetail;
-  readonly manualRefresh: () => void;
-  readonly manualRefreshInFlight: boolean;
-  readonly operations: EventOperations;
-  readonly t: Translate;
-  readonly wizard: WizardState;
-}
+export { OperationsTab } from "./OperationsTab";
+export { OverviewTab } from "./OverviewTab";
+export type { EventTabContentProps } from "./tab-content-props";
 
 export const EVENT_TAB_IDS = [
   "overview",
@@ -86,54 +55,6 @@ export function readTabFromHash(hash: string): EventTabId {
   if (!m) return "overview";
   const candidate = m[1];
   return isEventTabId(candidate) ? candidate : "overview";
-}
-
-/**
- * Issue #1362: Qiita 「用途別グルーピング」 原則で Overview tab を 3 グループに整理。
- *
- *   1. 現状 (status)        — Event 概要 (ScoringLockPanel) + 現在のフェーズ
- *   2. 次のアクション (hero) — operator が押すべき button (EventWizardPanel の CTA half)
- *   3. リソース / Deploy 進捗 — チーム / 問題 / deployment 進捗
- *
- * `EventWizardPanel` 内部で「現状 (phase indicator)」 と「次のアクション (CTA)」 を別
- * Container に分割している (= 上の 1+2)。 視線は 画面 title → 現状 → 次のアクション →
- * リソース の順に降りていく。
- */
-export function OverviewTab({
-  counts,
-  detail,
-  manualRefresh,
-  manualRefreshInFlight,
-  t,
-  wizard,
-}: EventTabContentProps) {
-  return (
-    <>
-      {/* Issue #1350: Setup / Live / Teardown の phase 帯を冒頭に表示 (色 cue) */}
-      <EventPhaseBanner detail={detail} t={t} />
-      <ScoringLockPanel detail={detail} t={t} />
-      <EventWizardPanel t={t} wizard={wizard} />
-      {/* Issue #1350: 4 項目の readiness check + 全 ✓ で 「準備完了」 大 badge */}
-      <EventReadinessPanel
-        completeCount={counts.completeCount}
-        detail={detail}
-        t={t}
-        totalDeployCount={counts.totalDeployCount}
-      />
-      <DeployProgressPanel
-        allDoneCount={counts.allDoneCount}
-        completeCount={counts.completeCount}
-        failedCount={counts.failedCount}
-        inFlightCount={counts.inFlightCount}
-        manualRefreshInFlight={manualRefreshInFlight}
-        onManualRefresh={manualRefresh}
-        t={t}
-        totalDeployCount={counts.totalDeployCount}
-      />
-      {/* Issue #1350: T-7 / T-1 / T-0 / T+0 phase 別 operator checklist */}
-      <EventChecklistPanel t={t} />
-    </>
-  );
 }
 
 export function ScheduleTab({ apiClient, detail, operations, t, wizard }: EventTabContentProps) {
@@ -186,122 +107,5 @@ export function NotificationsTab({ detail, operations, t }: EventTabContentProps
       onOpen={() => operations.setNotifyModalOpen(true)}
       t={t}
     />
-  );
-}
-
-/**
- * Operations tab: 普段使わない高度操作を集約する。
- *
- * Issue #1318 で 「rescue 系を Operations に集約」 と決めたが、 #1324 で実装したときに
- * EventRescuePanel (TEARDOWN 時のみ render) のみを置いてしまい、 非 TEARDOWN 状態では
- * tab が完全に空になっていた (issue #1328)。 本コミットで 4 section を常時表示するようにし、
- * status を問わず 運用 tab に内容があることを保証する。
- *
- * 表示 section:
- *  1. EventRescuePanel — 既存。 status === TEARDOWN のときだけ render
- *  2. 一括操作 — Bulk redeploy / Bulk teardown。 header にも同等 button があるが Operations tab
- *     の主目的 (= 高度操作の集約先) として明示的に重複配置する
- *  3. Deploy 進捗詳細 — DeployProgressPanel。 deployment が 0 件のときは empty hint
- *  4. Event 削除 (danger zone) — header の Delete と同じ confirmTeardown modal を開く
- */
-export function OperationsTab({
-  counts,
-  detail,
-  manualRefresh,
-  manualRefreshInFlight,
-  operations,
-  t,
-}: EventTabContentProps) {
-  const bulkDisabled =
-    detail.status === "ENDED" || detail.status === "TEARDOWN" || detail.status === "ARCHIVED";
-  return (
-    <SpaceBetween size="l">
-      <Header variant="h2">{t("event_detail.operations_header")}</Header>
-      <Alert type="info" data-testid="operations-tab-intro">
-        {t("event_detail.operations_intro")}
-      </Alert>
-
-      <EventRescuePanel
-        detail={detail}
-        forceArchiveInFlight={operations.forceArchiveInFlight}
-        onForceArchive={() => operations.setConfirmForceArchive(true)}
-        t={t}
-      />
-
-      <Container
-        data-testid="operations-bulk-section"
-        header={
-          <Header variant="h3" description={t("event_detail.operations_bulk_description")}>
-            {t("event_detail.operations_bulk_header")}
-          </Header>
-        }
-      >
-        <SpaceBetween size="xs" direction="horizontal">
-          <Button
-            data-testid="operations-bulk-deploy"
-            loading={operations.bulkInFlight === "deploy"}
-            disabled={
-              detail.problems.length === 0 ||
-              detail.teams.length === 0 ||
-              bulkDisabled ||
-              operations.bulkInFlight !== null
-            }
-            onClick={() => void operations.handleBulkDeploy()}
-          >
-            {t("event_detail.operations_bulk_deploy")}
-          </Button>
-          <Button
-            data-testid="operations-bulk-teardown"
-            loading={operations.bulkInFlight === "teardown"}
-            disabled={operations.bulkInFlight !== null}
-            onClick={() => operations.setConfirmTeardown(true)}
-          >
-            {t("event_detail.operations_bulk_teardown")}
-          </Button>
-        </SpaceBetween>
-      </Container>
-
-      <Container
-        header={<Header variant="h3">{t("event_detail.operations_deploy_progress_header")}</Header>}
-      >
-        {counts.totalDeployCount > 0 ? (
-          <DeployProgressPanel
-            allDoneCount={counts.allDoneCount}
-            completeCount={counts.completeCount}
-            failedCount={counts.failedCount}
-            inFlightCount={counts.inFlightCount}
-            manualRefreshInFlight={manualRefreshInFlight}
-            onManualRefresh={manualRefresh}
-            t={t}
-            totalDeployCount={counts.totalDeployCount}
-          />
-        ) : (
-          <Alert type="info">{t("event_detail.operations_deploy_progress_empty")}</Alert>
-        )}
-      </Container>
-
-      <Container
-        data-testid="operations-delete-section"
-        header={
-          <Header
-            variant="h3"
-            actions={
-              <Button
-                variant="primary"
-                data-testid="operations-delete-button"
-                loading={operations.bulkInFlight === "teardown"}
-                onClick={() => operations.setConfirmTeardown(true)}
-              >
-                {t("event_detail.operations_delete_button")}
-              </Button>
-            }
-          >
-            {t("event_detail.operations_delete_header")}
-          </Header>
-        }
-      >
-        <Alert type="warning">{t("event_detail.operations_delete_warning")}</Alert>
-      </Container>
-    </SpaceBetween>
   );
 }


### PR DESCRIPTION
## Summary

A SOLID decomposition of the repo's **worst high-coupling file** (#1418). `event-detail/tabs.tsx` bundled all 7 workflow tab components into one file, pulling **24 imports** (13 panels) — the file's dependency set was the union of every tab's needs (threshold is 16).

- Extracted the shared prop contract `EventTabContentProps` → `tab-content-props.ts`.
- Extracted the two **heavyweight, multi-panel** tabs into their own modules: `OverviewTab.tsx` (6 panels) and `OperationsTab.tsx` (Cloudscape primitives + panels + most of the JSX).
- The five remaining tabs are thin single/double-panel wrappers that stay co-located in `tabs.tsx`.
- `tabs.tsx` re-exports the extracted tabs, so the only consumer (`EventDetail.tsx`) imports unchanged.

**Result:** `tabs.tsx` imports drop **24 → 8** and it's off the high-coupling list; each new module depends only on the panels it renders (single responsibility, minimal coupling).

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook)
- `application-admin-console` typecheck passes; `EventDetail.tabs` + `EventDetail.wizard` tests (10) pass unchanged
- `make tech-debt` — `event-detail/tabs.tsx` no longer reported under high-coupling

## Regression analysis
- Pure structural move: the tab component bodies are **byte-identical**, only relocated; the barrel preserves the `./event-detail/tabs` public surface. No behavior change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Frontend source reorganization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)