### PR TITLE
test(saml-utils): reach 100% coverage; drop dead branch

### DIFF
--- a/packages/saml-utils/src/attribute-mapper.ts
+++ b/packages/saml-utils/src/attribute-mapper.ts
@@ -91,12 +91,13 @@ export function buildApplicationPlaneUserPk(
 
 function normalizeGroups(value: readonly string[] | string | undefined): readonly string[] {
   if (value === undefined) return [];
-  if (Array.isArray(value)) return value.filter((g): g is string => typeof g === "string");
   if (typeof value === "string") {
     return value
       .split(",")
       .map((g) => g.trim())
       .filter((g) => g.length > 0);
   }
-  return [];
+  // value is a (readonly) string[] here — the only remaining type, so this is the
+  // total final branch (no unreachable fallthrough).
+  return value.filter((g): g is string => typeof g === "string");
 }

--- a/packages/saml-utils/test/attribute-mapper.test.ts
+++ b/packages/saml-utils/test/attribute-mapper.test.ts
@@ -59,6 +59,18 @@ describe("buildIdentityClaim", () => {
     });
   });
 
+  it("should omit optional fields and default emailSnapshot to empty when absent", () => {
+    const claim = buildIdentityClaim(idp, { idpId: "okta", subjectId: "sub-1" });
+    expect(claim).toEqual({
+      idpId: "okta",
+      subjectId: "sub-1",
+      emailSnapshot: "",
+      roles: [],
+    });
+    expect(claim).not.toHaveProperty("tenantId");
+    expect(claim).not.toHaveProperty("displayName");
+  });
+
   it("should throw when subjectId is empty", () => {
     expect(() => buildIdentityClaim(idp, { idpId: "x", subjectId: "" })).toThrow();
   });

--- a/packages/saml-utils/test/metadata.test.ts
+++ b/packages/saml-utils/test/metadata.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { SAML_METADATA_MAX_BYTES, validateSamlMetadata } from "../src/metadata.js";
+import {
+  SAML_METADATA_MAX_BYTES,
+  toCognitoProviderDetails,
+  validateSamlMetadata,
+} from "../src/metadata.js";
 
 const OKTA_LIKE = `<?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/exk1tenant">
@@ -15,6 +19,14 @@ const OKTA_LIKE = `<?xml version="1.0" encoding="UTF-8"?>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.okta.com/app/sso/saml"/>
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>`;
+
+describe("toCognitoProviderDetails", () => {
+  it("should pin MetadataFile to the provided XML and return a frozen object", () => {
+    const details = toCognitoProviderDetails({ metadataXml: OKTA_LIKE });
+    expect(details.MetadataFile).toBe(OKTA_LIKE);
+    expect(Object.isFrozen(details)).toBe(true);
+  });
+});
 
 describe("validateSamlMetadata", () => {
   it("should accept a well-formed Okta-like metadata XML and extract the entityID", () => {


### PR DESCRIPTION
## Summary

Takes `saml-utils` from 96/90/90 to **100%** (55/55 stmts, 38/38 branches, 10/10 funcs) — part of goal #4. With `trust-bridge` (#1432) and `auth-client` (already 100%), the coverage-tracked **packages are all at 100%**.

- `buildIdentityClaim`: cover the absent-optional-fields path (no `tenantId`/`email`/`displayName`) — `emailSnapshot` defaults to `""`, optional keys omitted.
- `toCognitoProviderDetails`: was **entirely untested** — pin `MetadataFile` + frozen result.
- `normalizeGroups`: reordered to check string before array, so the array case is the total final return — **removing the previously-unreachable `return []` fallthrough** (dead code). 100% branches without a coverage-ignore.

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook); saml-utils typecheck passes
- `make test-coverage` → saml-utils 100% stmts/branches/funcs

## Regression analysis
- `normalizeGroups` is behavior-equivalent for all valid inputs (undefined/string/array); only the unreachable non-string-non-array fallthrough is removed.

## Physical impact
- **NO-OP** on CFn / deployed artifacts. Package source + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)