### PR TITLE
refactor(participant-portal): extract TeamScorePanel from Home.tsx

### DIFF
--- a/apps/participant-portal/src/pages/Home.tsx
+++ b/apps/participant-portal/src/pages/Home.tsx
@@ -2,10 +2,8 @@ import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useNavigate } from "react-router";
-import type { LeaderboardResponse, ParticipantTeamView } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
 import { useTeamView } from "../auth/TeamViewProvider";
 import { EmptyState, ErrorState, LoadingState } from "../components/design-system";
@@ -14,6 +12,7 @@ import { ScoreTimelineChart } from "../components/ScoreTimelineChart";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
+import { TeamScorePanel } from "./TeamScorePanel";
 
 /**
  * Audit table #11: 超長 username (= Cognito sub-derived 名等) が header 全幅を占有して
@@ -94,61 +93,5 @@ export function HomePage({ config }: { config: AppConfig }) {
         </Container>
       )}
     </SpaceBetween>
-  );
-}
-
-function TeamScorePanel({
-  view,
-  leaderboard,
-}: {
-  view: ParticipantTeamView;
-  leaderboard: LeaderboardResponse | null;
-}) {
-  const t = useT();
-  const totalScore = view.problems.reduce((sum, p) => sum + p.score, 0);
-
-  // Issue #1038 P1 #5: 順位 (Rank) を表示。 leaderboard.entries から isMyTeam を引き、
-  // rank / 全 team 数を出す。 entries が空 (= 凍結中 / event 未配線 / 自 team が落ちた)
-  // のときは「—」 表示にして UI を壊さない。
-  const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
-  const rankValue = myEntry ? `${myEntry.rank} / ${leaderboard?.entries.length ?? "—"}` : "—";
-
-  return (
-    <Container header={<Header variant="h2">{t("home.team_score_header")}</Header>}>
-      <KeyValuePairs
-        columns={4}
-        items={[
-          {
-            label: t("home.score_total"),
-            value: (
-              <Box variant="awsui-value-large" color="text-status-success">
-                {totalScore} pt
-              </Box>
-            ),
-          },
-          {
-            label: t("home.rank_label"),
-            value: (
-              <Box variant="awsui-value-large" color="text-status-info">
-                {rankValue}
-              </Box>
-            ),
-          },
-          { label: t("home.score_problem_count"), value: String(view.problems.length) },
-          {
-            // Issue #821 / #822: 旧 \"deploy COMPLETE\" カウントから 「正解した問題数」 に
-            // 変更する。 flag 問題は flagSubmitted=true、 非 flag (Battle) は score>0 を
-            // 「解いた」 と扱う (= スコアを稼げてれば貢献あり)。
-            label: t("home.score_completed_count"),
-            value: String(
-              view.problems.filter((p) => {
-                if (p.scoring?.kind === "flag") return p.scoring.flagSubmitted === true;
-                return p.score > 0;
-              }).length,
-            ),
-          },
-        ]}
-      />
-    </Container>
   );
 }

--- a/apps/participant-portal/src/pages/TeamScorePanel.tsx
+++ b/apps/participant-portal/src/pages/TeamScorePanel.tsx
@@ -1,0 +1,67 @@
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import type { LeaderboardResponse, ParticipantTeamView } from "../api/portal-client";
+import { useT } from "../i18n";
+
+/**
+ * Home dashboard の「累計スコア / 順位 / 問題数 / 正解数」サマリーカード。
+ * `HomePage` から切り出して、 各ページが描画する component だけに依存するようにした
+ * (= 旧 Home.tsx の高結合を解消)。
+ */
+export function TeamScorePanel({
+  view,
+  leaderboard,
+}: {
+  view: ParticipantTeamView;
+  leaderboard: LeaderboardResponse | null;
+}) {
+  const t = useT();
+  const totalScore = view.problems.reduce((sum, p) => sum + p.score, 0);
+
+  // Issue #1038 P1 #5: 順位 (Rank) を表示。 leaderboard.entries から isMyTeam を引き、
+  // rank / 全 team 数を出す。 entries が空 (= 凍結中 / event 未配線 / 自 team が落ちた)
+  // のときは「—」 表示にして UI を壊さない。
+  const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
+  const rankValue = myEntry ? `${myEntry.rank} / ${leaderboard?.entries.length ?? "—"}` : "—";
+
+  return (
+    <Container header={<Header variant="h2">{t("home.team_score_header")}</Header>}>
+      <KeyValuePairs
+        columns={4}
+        items={[
+          {
+            label: t("home.score_total"),
+            value: (
+              <Box variant="awsui-value-large" color="text-status-success">
+                {totalScore} pt
+              </Box>
+            ),
+          },
+          {
+            label: t("home.rank_label"),
+            value: (
+              <Box variant="awsui-value-large" color="text-status-info">
+                {rankValue}
+              </Box>
+            ),
+          },
+          { label: t("home.score_problem_count"), value: String(view.problems.length) },
+          {
+            // Issue #821 / #822: 旧 \"deploy COMPLETE\" カウントから 「正解した問題数」 に
+            // 変更する。 flag 問題は flagSubmitted=true、 非 flag (Battle) は score>0 を
+            // 「解いた」 と扱う (= スコアを稼げてれば貢献あり)。
+            label: t("home.score_completed_count"),
+            value: String(
+              view.problems.filter((p) => {
+                if (p.scoring?.kind === "flag") return p.scoring.flagSubmitted === true;
+                return p.score > 0;
+              }).length,
+            ),
+          },
+        ]}
+      />
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

A bounded SOLID extraction (#1418). `Home.tsx` held both the `HomePage` dashboard and an inlined `TeamScorePanel` (score / rank / problem-count / solved summary), at the **16-import high-coupling threshold**. `TeamScorePanel` owned the only `KeyValuePairs` use and the two `portal-client` API types, so extracting it to its own module:

- drops `Home.tsx` to **15 imports** (off the high-coupling list),
- gives each module a single responsibility.

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook); participant-portal typecheck passes
- All **274** participant-portal tests pass unchanged
- `make tech-debt` — `Home.tsx` no longer reported under high-coupling

## Regression analysis
- Pure structural move: `TeamScorePanel`'s body is byte-identical, only relocated and imported back. No behavior change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Frontend source reorganization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)