### PR TITLE
refactor(admin-console): extract AuditLogTable from AuditLog.tsx

### DIFF
--- a/apps/admin-console/src/pages/AuditLog.tsx
+++ b/apps/admin-console/src/pages/AuditLog.tsx
@@ -1,14 +1,10 @@
 import Alert from "@cloudscape-design/components/alert";
-import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import Icon from "@cloudscape-design/components/icon";
 import Input from "@cloudscape-design/components/input";
 import Select from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import StatusIndicator from "@cloudscape-design/components/status-indicator";
-import Table from "@cloudscape-design/components/table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   AuditApiError,
@@ -20,8 +16,8 @@ import {
 } from "../api/audit-client";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
-import { useLang, useT } from "../i18n";
-import { formatRelativeTime } from "../lib/format";
+import { useT } from "../i18n";
+import { AuditLogTable } from "./AuditLogTable";
 
 const AUDIT_PAGE_LIMIT = 50;
 
@@ -118,7 +114,6 @@ function triggerCsvDownload(blob: Blob, filename: string): void {
 export function AuditLogPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const t = useT();
-  const lang = useLang();
   const client: AuditClient | null = useMemo(
     () => (auth.tokens ? createAuditClient(config, auth.tokens.idToken) : null),
     [auth.tokens, config],
@@ -201,15 +196,6 @@ export function AuditLogPage({ config }: { config: AppConfig }) {
         </Alert>
       </Container>
     );
-  }
-
-  function outcomeIndicator(outcome: string) {
-    if (outcome === "success") return <StatusIndicator type="success">success</StatusIndicator>;
-    if (outcome === "forbidden") return <StatusIndicator type="error">forbidden</StatusIndicator>;
-    if (outcome === "not_found") return <StatusIndicator type="warning">not_found</StatusIndicator>;
-    if (outcome === "conflict") return <StatusIndicator type="warning">conflict</StatusIndicator>;
-    if (outcome === "error") return <StatusIndicator type="error">error</StatusIndicator>;
-    return <span>{outcome}</span>;
   }
 
   const scopeOptions = [
@@ -297,60 +283,7 @@ export function AuditLogPage({ config }: { config: AppConfig }) {
         </Alert>
       )}
 
-      <Table
-        loading={loading}
-        loadingText={t("audit_log.loading_text")}
-        items={items}
-        columnDefinitions={[
-          {
-            id: "occurredAt",
-            header: t("audit_log.col_occurred_at"),
-            // Issue #1362: ISO 生値ではなく 「N 分前」 表示 + hover で絶対時刻 tooltip。
-            cell: (i) => <span title={i.occurredAt}>{formatRelativeTime(i.occurredAt, lang)}</span>,
-          },
-          {
-            id: "actor",
-            header: t("audit_log.col_actor"),
-            cell: (i) => i.actorUsername ?? i.actor,
-          },
-          {
-            id: "action",
-            header: t("audit_log.col_action"),
-            cell: (i) => i.action,
-          },
-          {
-            id: "outcome",
-            header: t("audit_log.col_result"),
-            cell: (i) => outcomeIndicator(i.outcome),
-          },
-          {
-            id: "target",
-            header: t("audit_log.col_target"),
-            cell: (i) => i.target ?? "-",
-          },
-          {
-            id: "tenantId",
-            header: t("audit_log.col_tenant"),
-            cell: (i) => i.tenantId,
-          },
-          {
-            id: "ipAddress",
-            header: t("audit_log.col_ip"),
-            cell: (i) => i.ipAddress ?? "-",
-          },
-        ]}
-        empty={
-          // Issue #1362: アイコン + 強調 + 行動誘導の 3 段で empty state を friendly に。
-          <Box textAlign="center" padding="l">
-            <SpaceBetween size="xs">
-              <Box variant="strong" color="text-status-inactive">
-                <Icon name="file" size="big" variant="subtle" /> {t("audit_log.empty_header")}
-              </Box>
-              <Box color="text-body-secondary">{t("audit_log.empty_hint_filter")}</Box>
-            </SpaceBetween>
-          </Box>
-        }
-      />
+      <AuditLogTable items={items} loading={loading} />
 
       {nextCursor && (
         <Button

--- a/apps/admin-console/src/pages/AuditLogTable.tsx
+++ b/apps/admin-console/src/pages/AuditLogTable.tsx
@@ -1,0 +1,88 @@
+import Box from "@cloudscape-design/components/box";
+import Icon from "@cloudscape-design/components/icon";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import type { AuditItem } from "../api/audit-client";
+import { useLang, useT } from "../i18n";
+import { formatRelativeTime } from "../lib/format";
+
+function outcomeIndicator(outcome: string) {
+  if (outcome === "success") return <StatusIndicator type="success">success</StatusIndicator>;
+  if (outcome === "forbidden") return <StatusIndicator type="error">forbidden</StatusIndicator>;
+  if (outcome === "not_found") return <StatusIndicator type="warning">not_found</StatusIndicator>;
+  if (outcome === "conflict") return <StatusIndicator type="warning">conflict</StatusIndicator>;
+  if (outcome === "error") return <StatusIndicator type="error">error</StatusIndicator>;
+  return <span>{outcome}</span>;
+}
+
+/**
+ * SystemAdmin 監査ログの結果テーブル。 `AuditLogPage` から切り出し、 Table / 時刻フォーマット /
+ * outcome バッジ (StatusIndicator) 依存をこの module に閉じ込めた (= ページの高結合を解消)。
+ */
+export function AuditLogTable({
+  items,
+  loading,
+}: {
+  items: readonly AuditItem[];
+  loading: boolean;
+}) {
+  const t = useT();
+  const lang = useLang();
+  return (
+    <Table
+      loading={loading}
+      loadingText={t("audit_log.loading_text")}
+      items={[...items]}
+      columnDefinitions={[
+        {
+          id: "occurredAt",
+          header: t("audit_log.col_occurred_at"),
+          // Issue #1362: ISO 生値ではなく 「N 分前」 表示 + hover で絶対時刻 tooltip。
+          cell: (i) => <span title={i.occurredAt}>{formatRelativeTime(i.occurredAt, lang)}</span>,
+        },
+        {
+          id: "actor",
+          header: t("audit_log.col_actor"),
+          cell: (i) => i.actorUsername ?? i.actor,
+        },
+        {
+          id: "action",
+          header: t("audit_log.col_action"),
+          cell: (i) => i.action,
+        },
+        {
+          id: "outcome",
+          header: t("audit_log.col_result"),
+          cell: (i) => outcomeIndicator(i.outcome),
+        },
+        {
+          id: "target",
+          header: t("audit_log.col_target"),
+          cell: (i) => i.target ?? "-",
+        },
+        {
+          id: "tenantId",
+          header: t("audit_log.col_tenant"),
+          cell: (i) => i.tenantId,
+        },
+        {
+          id: "ipAddress",
+          header: t("audit_log.col_ip"),
+          cell: (i) => i.ipAddress ?? "-",
+        },
+      ]}
+      empty={
+        // Issue #1362: アイコン + 強調 + 行動誘導の 3 段で empty state を friendly に。
+        <Box textAlign="center" padding="l">
+          <SpaceBetween size="xs">
+            <Box variant="strong" color="text-status-inactive">
+              <Icon name="file" size="big" variant="subtle" /> {t("audit_log.empty_header")}
+            </Box>
+            <Box color="text-body-secondary">{t("audit_log.empty_hint_filter")}</Box>
+          </SpaceBetween>
+        </Box>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary

SOLID extraction (#1418). `AuditLog.tsx` rendered the filter form and the results table in one 367-line page, pulling **17 imports** (over the high-coupling threshold of 16). The results table owned the only `Table`/`StatusIndicator`/`Icon`/`Box` uses + `formatRelativeTime` + the `outcomeIndicator` badge logic — extracting it to `AuditLogTable.tsx` drops `AuditLog.tsx` to **13 imports** (off the high-coupling list).

## Test plan
- `make harness` — clean
- admin-console typecheck passes; all **143** tests pass unchanged
- `make tech-debt` — `AuditLog.tsx` no longer reported under high-coupling

## Regression analysis
- Pure structural move: the table JSX + `outcomeIndicator` are byte-identical, rendered via `<AuditLogTable items={items} loading={loading} />`. No behavior change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Frontend source reorganization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured audit log table into a dedicated component for improved code maintainability and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->