### PR TITLE
refactor(admin-console): extract CreateIdpModal from IdentityProviders.tsx

### DIFF
--- a/apps/admin-console/src/pages/CreateIdpModal.tsx
+++ b/apps/admin-console/src/pages/CreateIdpModal.tsx
@@ -1,0 +1,97 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import FormField from "@cloudscape-design/components/form-field";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Textarea from "@cloudscape-design/components/textarea";
+import { useCallback, useState } from "react";
+import { describeIdpError, type IdpClient } from "../api/idp-client";
+
+interface CreateIdpModalProps {
+  readonly client: IdpClient | null;
+  readonly onClose: () => void;
+  readonly onCreated: () => Promise<void>;
+  readonly busy: boolean;
+  readonly setBusy: (b: boolean) => void;
+}
+
+/**
+ * SAML IdP 登録モーダル。 `IdentityProvidersPage` から切り出し、 Modal / FormField / Input /
+ * Textarea 依存をこの module に閉じ込めた (= ページの高結合を解消)。
+ */
+export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
+  const [idpId, setIdpId] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [metadataXml, setMetadataXml] = useState("");
+  const [emailAttr, setEmailAttr] = useState(
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = useCallback(async () => {
+    if (!client) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await client.create({
+        idpId,
+        displayName,
+        ...(description ? { description } : {}),
+        metadataXml,
+        attributeMapping: { email: emailAttr },
+        groupToRole: {},
+      });
+      await onCreated();
+    } catch (err) {
+      setError(describeIdpError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [client, idpId, displayName, description, metadataXml, emailAttr, onCreated, setBusy]);
+
+  return (
+    <Modal
+      visible
+      onDismiss={onClose}
+      header="Register SAML IdP"
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={onSubmit} loading={busy}>
+              Register
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        {error ? <Alert type="error">{error}</Alert> : null}
+        <FormField label="IdP ID" description="Cognito ProviderName. 3–32 chars, [A-Za-z0-9_-].">
+          <Input value={idpId} onChange={(e) => setIdpId(e.detail.value)} />
+        </FormField>
+        <FormField label="Display name">
+          <Input value={displayName} onChange={(e) => setDisplayName(e.detail.value)} />
+        </FormField>
+        <FormField label="Description (optional)">
+          <Input value={description} onChange={(e) => setDescription(e.detail.value)} />
+        </FormField>
+        <FormField label="Email attribute (SAML)">
+          <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
+        </FormField>
+        <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
+          <Textarea
+            value={metadataXml}
+            onChange={(e) => setMetadataXml(e.detail.value)}
+            rows={10}
+          />
+        </FormField>
+      </SpaceBetween>
+    </Modal>
+  );
+}

--- a/apps/admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/admin-console/src/pages/IdentityProviders.tsx
@@ -2,14 +2,10 @@ import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
-import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Icon from "@cloudscape-design/components/icon";
-import Input from "@cloudscape-design/components/input";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import Textarea from "@cloudscape-design/components/textarea";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createIdpClient,
@@ -21,6 +17,7 @@ import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useLang } from "../i18n";
 import { formatRelativeTime } from "../lib/format";
+import { CreateIdpModal } from "./CreateIdpModal";
 
 /**
  * Issue #1293: System Admin → list / add / edit / delete SAML IdPs attached to
@@ -213,88 +210,5 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
         />
       ) : null}
     </SpaceBetween>
-  );
-}
-
-interface CreateIdpModalProps {
-  readonly client: IdpClient | null;
-  readonly onClose: () => void;
-  readonly onCreated: () => Promise<void>;
-  readonly busy: boolean;
-  readonly setBusy: (b: boolean) => void;
-}
-
-function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
-  const [idpId, setIdpId] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [description, setDescription] = useState("");
-  const [metadataXml, setMetadataXml] = useState("");
-  const [emailAttr, setEmailAttr] = useState(
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const onSubmit = useCallback(async () => {
-    if (!client) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await client.create({
-        idpId,
-        displayName,
-        ...(description ? { description } : {}),
-        metadataXml,
-        attributeMapping: { email: emailAttr },
-        groupToRole: {},
-      });
-      await onCreated();
-    } catch (err) {
-      setError(describeIdpError(err));
-    } finally {
-      setBusy(false);
-    }
-  }, [client, idpId, displayName, description, metadataXml, emailAttr, onCreated, setBusy]);
-
-  return (
-    <Modal
-      visible
-      onDismiss={onClose}
-      header="Register SAML IdP"
-      footer={
-        <Box float="right">
-          <SpaceBetween direction="horizontal" size="xs">
-            <Button onClick={onClose} disabled={busy}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={onSubmit} loading={busy}>
-              Register
-            </Button>
-          </SpaceBetween>
-        </Box>
-      }
-    >
-      <SpaceBetween size="m">
-        {error ? <Alert type="error">{error}</Alert> : null}
-        <FormField label="IdP ID" description="Cognito ProviderName. 3–32 chars, [A-Za-z0-9_-].">
-          <Input value={idpId} onChange={(e) => setIdpId(e.detail.value)} />
-        </FormField>
-        <FormField label="Display name">
-          <Input value={displayName} onChange={(e) => setDisplayName(e.detail.value)} />
-        </FormField>
-        <FormField label="Description (optional)">
-          <Input value={description} onChange={(e) => setDescription(e.detail.value)} />
-        </FormField>
-        <FormField label="Email attribute (SAML)">
-          <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
-        </FormField>
-        <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
-          <Textarea
-            value={metadataXml}
-            onChange={(e) => setMetadataXml(e.detail.value)}
-            rows={10}
-          />
-        </FormField>
-      </SpaceBetween>
-    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

SOLID extraction (#1418) of the last single-app high-coupling page. `IdentityProviders.tsx` held both the IdP list page and a self-contained `CreateIdpModal` (SAML registration form), pulling **17 imports** (over the threshold of 16). The modal owned the only `Modal`/`FormField`/`Input`/`Textarea` uses — extracting it to `CreateIdpModal.tsx` drops the page to **15 imports** (off the high-coupling list).

It also **sets up the cross-app dedup**: `application-admin-console` has a near-identical IdentityProviders page + modal; isolating both modals makes the shared-package extraction a mechanical follow-up.

## Test plan
- `make harness` — clean
- admin-console typecheck passes; all **143** tests pass unchanged
- `make tech-debt` — admin-console `IdentityProviders.tsx` no longer reported under high-coupling

## Regression analysis
- Pure structural move: `CreateIdpModal`'s body + props are byte-identical, imported back. `describeIdpError` stays used by the page's load/delete paths. No behavior change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Frontend source reorganization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)