### PR TITLE
refactor(application-admin-console): extract CreateIdpModal from IdentityProviders

### DIFF
--- a/apps/application-admin-console/src/pages/CreateIdpModal.tsx
+++ b/apps/application-admin-console/src/pages/CreateIdpModal.tsx
@@ -1,0 +1,97 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import FormField from "@cloudscape-design/components/form-field";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Textarea from "@cloudscape-design/components/textarea";
+import { useCallback, useState } from "react";
+import { describeTenantIdpError, type TenantIdpClient } from "../api/idp-client";
+
+interface CreateIdpModalProps {
+  readonly client: TenantIdpClient | null;
+  readonly onClose: () => void;
+  readonly onCreated: () => Promise<void>;
+  readonly busy: boolean;
+  readonly setBusy: (b: boolean) => void;
+}
+
+/**
+ * Tenant SAML IdP 登録モーダル。 `IdentityProvidersPage` から切り出し、 Modal / FormField /
+ * Input / Textarea 依存をこの module に閉じ込めた (= ページの高結合を解消)。
+ */
+export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
+  const [idpId, setIdpId] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [metadataXml, setMetadataXml] = useState("");
+  const [emailAttr, setEmailAttr] = useState(
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = useCallback(async () => {
+    if (!client) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await client.create({
+        idpId,
+        displayName,
+        ...(description ? { description } : {}),
+        metadataXml,
+        attributeMapping: { email: emailAttr },
+        groupToRole: {},
+      });
+      await onCreated();
+    } catch (err) {
+      setError(describeTenantIdpError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [client, idpId, displayName, description, metadataXml, emailAttr, onCreated, setBusy]);
+
+  return (
+    <Modal
+      visible
+      onDismiss={onClose}
+      header="Register SAML IdP"
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={onSubmit} loading={busy}>
+              Register
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        {error ? <Alert type="error">{error}</Alert> : null}
+        <FormField label="IdP ID" description="Cognito ProviderName. 3–32 chars, [A-Za-z0-9_-].">
+          <Input value={idpId} onChange={(e) => setIdpId(e.detail.value)} />
+        </FormField>
+        <FormField label="Display name">
+          <Input value={displayName} onChange={(e) => setDisplayName(e.detail.value)} />
+        </FormField>
+        <FormField label="Description (optional)">
+          <Input value={description} onChange={(e) => setDescription(e.detail.value)} />
+        </FormField>
+        <FormField label="Email attribute (SAML)">
+          <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
+        </FormField>
+        <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
+          <Textarea
+            value={metadataXml}
+            onChange={(e) => setMetadataXml(e.detail.value)}
+            rows={10}
+          />
+        </FormField>
+      </SpaceBetween>
+    </Modal>
+  );
+}

--- a/apps/application-admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/application-admin-console/src/pages/IdentityProviders.tsx
@@ -2,14 +2,10 @@ import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
-import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Icon from "@cloudscape-design/components/icon";
-import Input from "@cloudscape-design/components/input";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import Textarea from "@cloudscape-design/components/textarea";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createTenantIdpClient,
@@ -21,6 +17,7 @@ import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useLang } from "../i18n";
 import { formatRelativeTime } from "../lib/format";
+import { CreateIdpModal } from "./CreateIdpModal";
 
 /**
  * Issue #1294: Tenant Admin → list / add / edit / delete SAML IdPs attached
@@ -227,88 +224,5 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
         />
       ) : null}
     </SpaceBetween>
-  );
-}
-
-interface CreateIdpModalProps {
-  readonly client: TenantIdpClient | null;
-  readonly onClose: () => void;
-  readonly onCreated: () => Promise<void>;
-  readonly busy: boolean;
-  readonly setBusy: (b: boolean) => void;
-}
-
-function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
-  const [idpId, setIdpId] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [description, setDescription] = useState("");
-  const [metadataXml, setMetadataXml] = useState("");
-  const [emailAttr, setEmailAttr] = useState(
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const onSubmit = useCallback(async () => {
-    if (!client) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await client.create({
-        idpId,
-        displayName,
-        ...(description ? { description } : {}),
-        metadataXml,
-        attributeMapping: { email: emailAttr },
-        groupToRole: {},
-      });
-      await onCreated();
-    } catch (err) {
-      setError(describeTenantIdpError(err));
-    } finally {
-      setBusy(false);
-    }
-  }, [client, idpId, displayName, description, metadataXml, emailAttr, onCreated, setBusy]);
-
-  return (
-    <Modal
-      visible
-      onDismiss={onClose}
-      header="Register SAML IdP"
-      footer={
-        <Box float="right">
-          <SpaceBetween direction="horizontal" size="xs">
-            <Button onClick={onClose} disabled={busy}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={onSubmit} loading={busy}>
-              Register
-            </Button>
-          </SpaceBetween>
-        </Box>
-      }
-    >
-      <SpaceBetween size="m">
-        {error ? <Alert type="error">{error}</Alert> : null}
-        <FormField label="IdP ID" description="Cognito ProviderName. 3–32 chars, [A-Za-z0-9_-].">
-          <Input value={idpId} onChange={(e) => setIdpId(e.detail.value)} />
-        </FormField>
-        <FormField label="Display name">
-          <Input value={displayName} onChange={(e) => setDisplayName(e.detail.value)} />
-        </FormField>
-        <FormField label="Description (optional)">
-          <Input value={description} onChange={(e) => setDescription(e.detail.value)} />
-        </FormField>
-        <FormField label="Email attribute (SAML)">
-          <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
-        </FormField>
-        <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
-          <Textarea
-            value={metadataXml}
-            onChange={(e) => setMetadataXml(e.detail.value)}
-            rows={10}
-          />
-        </FormField>
-      </SpaceBetween>
-    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

Mirror of #1438 (admin-console). `IdentityProviders.tsx` held the IdP list page plus a self-contained `CreateIdpModal`, pulling **17 imports** (over the threshold of 16). Extracting the modal drops the page to **15 imports** (off the high-coupling list).

With both apps' modals now isolated, the **genuine cross-app duplication is explicit and ready to dedup**: this `CreateIdpModal` and the admin-console one are **~95% identical**, differing only in the injected client type (`TenantIdpClient` vs `IdpClient`) and error helper — a clean follow-up to extract into a shared, client-parameterized component.

This **completes the high-coupling cleanup** for every cleanly-splittable page (tabs / Home / ScoreEvents / AuditLog / IdentityProviders ×2).

## Test plan
- `make harness` — clean
- application-admin-console typecheck passes; all **407** tests pass unchanged
- `make tech-debt` — application-admin-console `IdentityProviders.tsx` no longer reported under high-coupling

## Regression analysis
- Pure structural move: byte-identical modal body + props, imported back. `describeTenantIdpError` stays used by the page. No behavior change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Frontend source reorganization only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)