### PR TITLE
test(participant-portal): cover the untested portal-client API modules

### DIFF
--- a/apps/participant-portal/test/api/portal-client-leaderboard.test.ts
+++ b/apps/participant-portal/test/api/portal-client-leaderboard.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLeaderboard, getLeaderboardScoreEvents } from "../../src/api/portal-client";
+
+const KEY = "AbCdEfGhIjKlMnOpQrStUvWx";
+const API = "https://api.example.com";
+
+function mockFetch(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(status === 404 ? "" : JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("getLeaderboard", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("should GET /portal/leaderboard with a Bearer key and return the board", async () => {
+    const board = { entries: [{ rank: 1, teamName: "Alpha", isMyTeam: true }] };
+    const fetchMock = mockFetch(200, board);
+    const result = await getLeaderboard(API, KEY);
+    expect(result).toEqual(board);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/leaderboard");
+  });
+
+  it("should return undefined on 404 (legacy jobId deployment without an eventId)", async () => {
+    mockFetch(404, null);
+    expect(await getLeaderboard(API, KEY)).toBeUndefined();
+  });
+});
+
+describe("getLeaderboardScoreEvents", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("should GET /portal/leaderboard/score-events and return the response", async () => {
+    const data = { teams: [] };
+    const fetchMock = mockFetch(200, data);
+    const result = await getLeaderboardScoreEvents(API, KEY);
+    expect(result).toEqual(data);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/leaderboard/score-events");
+  });
+
+  it("should return undefined on 404", async () => {
+    mockFetch(404, null);
+    expect(await getLeaderboardScoreEvents(API, KEY)).toBeUndefined();
+  });
+});

--- a/apps/participant-portal/test/api/portal-client-modules.test.ts
+++ b/apps/participant-portal/test/api/portal-client-modules.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCliCredentials,
+  getConsoleSigninUrl,
+  getScoreEvents,
+  revealHint,
+  updateTeamName,
+} from "../../src/api/portal-client";
+
+const KEY = "AbCdEfGhIjKlMnOpQrStUvWx";
+const API = "https://api.example.com";
+
+function mockFetch(body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("revealHint", () => {
+  it("should POST the encoded hint-reveal endpoint and return the response", async () => {
+    const fetchMock = mockFetch({ hintText: "look at the IAM policy" });
+    const result = await revealHint(API, KEY, "prob 1", "hint/2");
+    expect(result).toEqual({ hintText: "look at the IAM policy" });
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/portal/me/problems/prob%201/hints/hint%2F2/reveal");
+    expect((init as RequestInit)?.method).toBe("POST");
+  });
+});
+
+describe("updateTeamName", () => {
+  it("should PATCH /portal/me with the new team name and return the view", async () => {
+    const view = { team: { teamName: "Beta", teamNameSetByCompetitor: true }, problems: [] };
+    const fetchMock = mockFetch(view);
+    const result = await updateTeamName(API, KEY, "Beta");
+    expect(result).toEqual(view);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/portal/me");
+    expect((init as RequestInit)?.method).toBe("PATCH");
+  });
+});
+
+describe("getScoreEvents", () => {
+  it("should GET /portal/me/score-events and return the response", async () => {
+    const data = { entries: [] };
+    const fetchMock = mockFetch(data);
+    const result = await getScoreEvents(API, KEY);
+    expect(result).toEqual(data);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/me/score-events");
+  });
+});
+
+describe("getConsoleSigninUrl", () => {
+  it("should return the loginUrl field (not the whole body) for the given jobId", async () => {
+    const fetchMock = mockFetch({ loginUrl: "https://console.aws.amazon.com/federated" });
+    const result = await getConsoleSigninUrl(API, KEY, "JOB1");
+    expect(result).toBe("https://console.aws.amazon.com/federated");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/me/console-signin-url");
+  });
+});
+
+describe("getCliCredentials", () => {
+  it("should return the credentials field (not the whole body) for the given jobId", async () => {
+    const creds = {
+      accessKeyId: "ASIA-test",
+      secretAccessKey: "secret",
+      sessionToken: "token",
+      expiration: 1_700_000_000,
+    };
+    const fetchMock = mockFetch({ credentials: creds });
+    const result = await getCliCredentials(API, KEY, "JOB1");
+    expect(result).toEqual(creds);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/me/cli-credentials");
+  });
+});

--- a/apps/participant-portal/test/api/portal-client-modules.test.ts
+++ b/apps/participant-portal/test/api/portal-client-modules.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getBattleAttacks,
   getCliCredentials,
   getConsoleSigninUrl,
   getScoreEvents,
@@ -77,5 +78,21 @@ describe("getCliCredentials", () => {
     const result = await getCliCredentials(API, KEY, "JOB1");
     expect(result).toEqual(creds);
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/me/cli-credentials");
+  });
+});
+
+describe("getBattleAttacks", () => {
+  it("should GET /portal/me/battle-attacks for the jobId and return the response", async () => {
+    const data = { attacks: [] };
+    const fetchMock = mockFetch(data);
+    const result = await getBattleAttacks(API, KEY, "JOB1");
+    expect(result).toEqual(data);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/portal/me/battle-attacks");
+  });
+
+  it("should include sinceMin in the query when provided", async () => {
+    const fetchMock = mockFetch({ attacks: [] });
+    await getBattleAttacks(API, KEY, "JOB1", 15);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("sinceMin=15");
   });
 });


### PR DESCRIPTION
## Summary

Covers the previously-untested participant-portal API-client modules (a bounded, render-free slice of the SPA coverage goal #4):

- **leaderboard.ts** (`getLeaderboard` / `getLeaderboardScoreEvents`) — endpoint + the **404 → undefined** legacy fall-back.
- **scoring.ts** (`revealHint`) — POST to the encoded hint-reveal endpoint.
- **team.ts** (`updateTeamName` / `getScoreEvents`) — PATCH `/portal/me`, GET score-events.
- **sso.ts** (`getConsoleSigninUrl` / `getCliCredentials`) — pins that each returns the **unwrapped field** (`loginUrl` / `credentials`), not the raw body.

All use the existing global-`fetch` mock pattern, so they exercise real `portalFetch` request-building + response handling. `leaderboard.ts` / `scoring.ts` / `team.ts` / `sso.ts` are now fully covered; `getBattleAttacks` (problems.ts) is the lone remaining wrapper (same pattern, follow-up).

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook); 9 new tests pass

## Regression analysis
- Test-only; no production change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)