### PR TITLE
test(participant-portal): cover ProblemPanel scoring-gate helpers to 100%

### DIFF
--- a/apps/participant-portal/src/components/ProblemPanel.helpers.test.ts
+++ b/apps/participant-portal/src/components/ProblemPanel.helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  PortalScoringGateError,
+  PortalValidationError,
+  type SubmitFlagOutcome,
+} from "../api/portal-client";
+import {
+  formatProblemPanelActionError,
+  shouldRefreshAfterFlagSubmit,
+} from "./ProblemPanel.helpers";
+
+// `t` echoes the key (+ params) so each branch is identifiable by its returned key.
+const t = (key: string, params?: Readonly<Record<string, string | number>>) =>
+  params ? `${key}|${JSON.stringify(params)}` : key;
+
+const VKEY = "problem_panel.validation_error" as const;
+const fmt = (err: unknown) => formatProblemPanelActionError(t, err, VKEY);
+
+describe("formatProblemPanelActionError — scoring gate", () => {
+  it("should describe scoring_not_started without an ETA", () => {
+    expect(fmt(new PortalScoringGateError("scoring_not_started"))).toBe(
+      "problem_panel.scoring_gate_not_started_no_eta",
+    );
+  });
+
+  it("should describe scoring_not_started with an unparseable startsAt", () => {
+    expect(fmt(new PortalScoringGateError("scoring_not_started", "not-a-date"))).toBe(
+      "problem_panel.scoring_gate_not_started_unknown",
+    );
+  });
+
+  it("should describe scoring_not_started whose startsAt has already passed", () => {
+    expect(
+      fmt(new PortalScoringGateError("scoring_not_started", "2020-01-01T00:00:00.000Z")),
+    ).toContain("problem_panel.scoring_gate_not_started_passed");
+  });
+
+  it("should describe scoring_not_started with remaining minutes when startsAt is in the future", () => {
+    const out = fmt(new PortalScoringGateError("scoring_not_started", "2999-01-01T00:00:00.000Z"));
+    expect(out).toContain("problem_panel.scoring_gate_not_started_remaining");
+    expect(out).toContain("minutes");
+  });
+
+  it("should describe scoring_ended (no / invalid / valid endsAt)", () => {
+    expect(fmt(new PortalScoringGateError("scoring_ended"))).toBe(
+      "problem_panel.scoring_gate_ended_no_eta",
+    );
+    expect(fmt(new PortalScoringGateError("scoring_ended", undefined, "nope"))).toBe(
+      "problem_panel.scoring_gate_ended_unknown",
+    );
+    expect(
+      fmt(new PortalScoringGateError("scoring_ended", undefined, "2026-05-15T00:00:00.000Z")),
+    ).toContain("problem_panel.scoring_gate_ended_at");
+  });
+
+  it("should describe a locked gate as paused", () => {
+    expect(fmt(new PortalScoringGateError("scoring_locked"))).toBe(
+      "problem_panel.scoring_gate_paused",
+    );
+  });
+});
+
+describe("formatProblemPanelActionError — non-gate errors", () => {
+  it("should map a PortalValidationError to the validation key with its errorCode", () => {
+    expect(fmt(new PortalValidationError("flag_too_long"))).toContain(VKEY);
+  });
+
+  it("should fall back to the Error message, then String() for unknowns", () => {
+    expect(fmt(new Error("boom"))).toBe("boom");
+    expect(fmt("weird")).toBe("weird");
+  });
+});
+
+describe("shouldRefreshAfterFlagSubmit", () => {
+  it("should refresh on ok / already_scored and not otherwise", () => {
+    expect(shouldRefreshAfterFlagSubmit({ kind: "ok" } as SubmitFlagOutcome)).toBe(true);
+    expect(shouldRefreshAfterFlagSubmit({ kind: "already_scored" } as SubmitFlagOutcome)).toBe(
+      true,
+    );
+    expect(shouldRefreshAfterFlagSubmit({ kind: "wrong" } as SubmitFlagOutcome)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`ProblemPanel.helpers.ts` (`formatProblemPanelActionError` / `describeScoringGate` / `shouldRefreshAfterFlagSubmit`) had **no test (37%)**. Adds a unit test covering **every** scoring-gate branch — not-started (no ETA / unparseable / already-passed / remaining-minutes), ended (no ETA / unparseable / valid), locked→paused — plus the validation / `Error` / `String` fallbacks and the refresh-after-submit predicate.

`ProblemPanel.helpers.ts`: **37% → 100%** (27/27 stmts, 23/23 branches, 3/3 funcs). Real user-facing logic (the "competition starts in N minutes" / "ended at <time>" messaging), not coverage theater.

## Test plan
- `make harness` — clean
- `make before-commit` — green (pre-commit hook); 9 new tests pass
- Focused coverage run: `ProblemPanel.helpers.ts` 100% stmts/branches/funcs

## Regression analysis
- Test-only; no production change.

## Physical impact
- **NO-OP** on CloudFormation / deployed artifacts. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)