### PR TITLE
test(participant-portal): cover format + notifications-storage lib gaps

### DIFF
--- a/apps/participant-portal/test/lib/format.test.ts
+++ b/apps/participant-portal/test/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { describeAgo, formatRelativeTime } from "../../src/lib/format";
+import { describeAgo, formatOccurredAtTooltip, formatRelativeTime } from "../../src/lib/format";
 
 /**
  * `describeAgo` は score 停滞時間の人間可読フォーマット。
@@ -92,5 +92,31 @@ describe("formatRelativeTime", () => {
 
   it("should treat future timestamps as 「今」 (= clock skew defense)", () => {
     expect(formatRelativeTime("2026-05-05T11:00:00.000Z", "ja", NOW_DATE)).toBe("今");
+  });
+});
+
+/**
+ * Issue #548: `formatOccurredAtTooltip` は score events cell の hover tooltip 用に
+ * 「UTC ISO + ローカル時刻 (TZ)」を併記する。一次情報は相対時刻で十分なので絶対時刻は
+ * tooltip に逃がす設計。未採点 / invalid ISO は防御的に固定文字列を返す。
+ */
+describe("formatOccurredAtTooltip", () => {
+  it("should return 「未採点」 for undefined", () => {
+    expect(formatOccurredAtTooltip(undefined)).toBe("未採点");
+  });
+
+  it("should return 「?」 for an invalid ISO string (= 防御的 fallback)", () => {
+    expect(formatOccurredAtTooltip("not-a-date")).toBe("?");
+  });
+
+  it("should pair the UTC ISO with a local-time line and its IANA TZ", () => {
+    const iso = "2026-05-05T10:00:00.000Z";
+    const out = formatOccurredAtTooltip(iso);
+    // 1 行目に元の UTC ISO をそのまま残す (= UTC 基準で機械照合できる)。
+    expect(out.startsWith(`${iso}\n`)).toBe(true);
+    // 2 行目はブラウザ環境の解決済み IANA TZ を括弧書きで併記する。
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    expect(out).toContain(`(${tz})`);
+    expect(out.split("\n")).toHaveLength(2);
   });
 });

--- a/apps/participant-portal/test/lib/notifications-storage.test.ts
+++ b/apps/participant-portal/test/lib/notifications-storage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { countUnread, loadLastSeenAt, saveLastSeenAt } from "../../src/lib/notifications-storage";
 
 const KEY_PREFIX = "TenkaCloud.participant.lastSeenNotificationAt";
@@ -38,6 +38,19 @@ describe("notifications-storage", () => {
       saveLastSeenAt(EV_B, "2026-05-09T10:00:00.000Z");
       expect(loadLastSeenAt(EV_A)).toBe("2026-05-10T14:00:00.000Z");
       expect(loadLastSeenAt(EV_B)).toBe("2026-05-09T10:00:00.000Z");
+    });
+
+    it("should return null (not throw) when localStorage access is blocked (= private window)", () => {
+      // Safari private mode 等では getItem 自体が SecurityError を投げる。 unread badge の
+      // ために portal 全体を落とさず、 既読時刻不明 = null に倒すのが正しい防御挙動。
+      const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("SecurityError: localStorage is disabled");
+      });
+      try {
+        expect(loadLastSeenAt(EV_A)).toBeNull();
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Two pure-logic helpers in `apps/participant-portal/src/lib/` were below 100% coverage with no behavioral test pinning their defensive branches:

- **`format.ts` — `formatOccurredAtTooltip`** (#548 score-cell hover tooltip): entirely uncovered (80% stmts / 66% funcs). It pairs the UTC ISO with a local-time line + resolved IANA TZ, and falls back to fixed strings on undefined / invalid ISO.
- **`notifications-storage.ts` — `loadLastSeenAt` catch** (line 29): the private-window / blocked-`localStorage` defense was uncovered (95.8% stmts).

Added unit tests in the existing `should …` style:
- `formatOccurredAtTooltip`: `undefined → 「未採点」`, invalid ISO `→ 「?」`, and a valid ISO whose first line is the verbatim UTC ISO and whose second line carries `(<IANA TZ>)`.
- `loadLastSeenAt`: spy `Storage.prototype.getItem` to throw a SecurityError (Safari private mode) and assert it returns `null` rather than throwing — the spy is restored in a `finally`.

Both modules now report **100% statements / branches / functions / lines**.

## Test plan
- `vitest run test/lib/format.test.ts test/lib/notifications-storage.test.ts --coverage` → 29 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 278 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change, so no runtime / CFn behavior shifts. The `getItem` spy is restored in `finally`, so it cannot leak into sibling tests.
- Existing `format` / `notifications-storage` tests are untouched and still pass.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test files only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)