### PR TITLE
test(participant-portal): cover config + auth/storage defensive branches

### DIFF
--- a/apps/participant-portal/test/auth/storage.test.ts
+++ b/apps/participant-portal/test/auth/storage.test.ts
@@ -76,6 +76,15 @@ describe("storage", () => {
       expect(loadSession()).toBeNull();
     });
 
+    it("should return null (not throw) when localStorage access is blocked (= private window)", () => {
+      // Safari private mode 等では getItem 自体が SecurityError を投げる。 session 復元の
+      // ために portal を落とさず 「未ログイン扱い」 = null に倒すのが正しい防御挙動。
+      vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("SecurityError: localStorage is disabled");
+      });
+      expect(loadSession()).toBeNull();
+    });
+
     it("should be stored in `localStorage` and survive closing the tab (= even when sessionStorage is empty)", () => {
       saveSession(sample());
       sessionStorage.clear(); // tab を閉じた相当

--- a/apps/participant-portal/test/config.test.ts
+++ b/apps/participant-portal/test/config.test.ts
@@ -116,4 +116,63 @@ describe("loadConfig", () => {
     expect(cfg.mode).toBe("dev-mock");
     expect(cfg.cloudMode).toBe("mock");
   });
+
+  it("Issue #871: should fall back when apiBaseUrl is an unparseable URL in backend mode", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        // `http://` 検査以前に `new URL()` 自体が throw する不正値。 HTTPS 強制ガードが
+        // 例外を握り潰して 「HTTPS でない」 = fallback に倒すこと (= fail closed) を確認。
+        apiBaseUrl: "not-a-valid-url",
+        mode: "backend",
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.apiBaseUrl).toContain("dev-mock");
+    expect(cfg.mode).toBe("dev-mock");
+  });
+
+  it("should drop an unparseable localstackEndpoint (= new URL throws) to undefined", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        mode: "backend",
+        cloudMode: "localstack",
+        // host 検査以前に `new URL()` が throw する不正値 → undefined に倒す (= fail closed)。
+        localstackEndpoint: "http://",
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.cloudMode).toBe("localstack");
+    expect(cfg.localstackEndpoint).toBeUndefined();
+  });
+
+  it("should leave localstackEndpoint undefined when cloudMode=localstack but the key is omitted", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        mode: "backend",
+        cloudMode: "localstack",
+        // localstackEndpoint 未指定 (= 非 string) → normalizeLocalstackEndpoint 早期 return。
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.cloudMode).toBe("localstack");
+    expect(cfg.localstackEndpoint).toBeUndefined();
+  });
+
+  it("should fall back apiBaseUrl to the dev default when the key is omitted (dev-mock mode)", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      // apiBaseUrl を省いた dev-mock 配信 → `?? DEV_FALLBACK.apiBaseUrl` で既定値を採用。
+      json: async () => ({ eventTitle: "No-API Event" }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.apiBaseUrl).toBe("http://localhost:3199/dev-mock");
+    expect(cfg.mode).toBe("dev-mock");
+    expect(cfg.eventTitle).toBe("No-API Event");
+  });
 });


### PR DESCRIPTION
## Summary

Two fail-closed defensive branches in `apps/participant-portal/src/` had no test pinning them — both are security-relevant (they prevent leaking the team bearer key or crashing the portal):

- **`config.ts` `isHttpsUrl` catch**: the existing #871 test feeds an `http://` URL, which is rejected by the *protocol comparison* and never throws. An **unparseable** URL throws inside `new URL()`; that catch (→ `false` → fall back to dev-mock, never sending `teamLoginKey` to a malformed attacker origin) was uncovered. Added a `not-a-valid-url` backend-mode case.
- **`config.ts` `normalizeLocalstackEndpoint` catch**: the existing test uses a well-formed non-localhost URL (rejected by the host allow-list). An **unparseable** endpoint throws in `new URL()` → dropped to `undefined`. Added `http://` (unparseable) + the non-string early-return + the `apiBaseUrl ?? DEV_FALLBACK` fallback so `config.ts` is **self-sufficiently 100%**.
- **`auth/storage.ts` `loadSession` catch**: `localStorage.getItem` throwing a SecurityError (Safari private window) must yield `null`, not crash the portal. Added a `Storage.prototype.getItem` spy.

`config.ts` and `auth/storage.ts` now report **100% statements / branches / functions / lines** (24 focused tests).

## Test plan
- `vitest run test/config.test.ts test/auth/storage.test.ts --coverage --coverage.include=src/config.ts --coverage.include=src/auth/storage.ts` → 24 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 279 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. The `getItem` spy is restored by the storage suite's existing `vi.restoreAllMocks()` afterEach. Existing config / storage tests untouched and still pass.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test files only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)