### PR TITLE
test(participant-portal): cover plugins/props-builder.ts to 100%

### DIFF
--- a/apps/participant-portal/src/plugins/props-builder.ts
+++ b/apps/participant-portal/src/plugins/props-builder.ts
@@ -49,8 +49,13 @@ export function buildPortalEndpointsFromOutputs(
       try {
         defaultUrl = joinUrl(base, ep.default.appendPath);
       } catch (e) {
+        // `new URL()` は不正入力に対して必ず TypeError (= instanceof Error) を投げるため、
+        // String(e) 側は到達不能な防御 fallback。 分岐 coverage 上ノイズになるので ignore。
+        /* v8 ignore start */
+        const detail = e instanceof Error ? e.message : String(e);
+        /* v8 ignore stop */
         throw new Error(
-          `Failed to build endpoint URL for problemId=${problemId} slot=${ep.slot} key=${ep.default.key}: ${e instanceof Error ? e.message : String(e)}`,
+          `Failed to build endpoint URL for problemId=${problemId} slot=${ep.slot} key=${ep.default.key}: ${detail}`,
           { cause: e },
         );
       }

--- a/apps/participant-portal/test/plugins/props-builder.test.ts
+++ b/apps/participant-portal/test/plugins/props-builder.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProblemCatalogEntry } from "../../src/data/problems";
+import {
+  buildPortalDisruptions,
+  buildPortalEndpointsFromOutputs,
+  buildPortalPhases,
+  buildPortalTeam,
+} from "../../src/plugins/props-builder";
+
+/**
+ * ADR-012 Phase 5: props-builder は build-time catalog (`findProblemMetadata`) を消費して
+ * SDK の PortalSlotProps shape に marshal する純関数群。 catalog 実データに依存させず
+ * `findProblemMetadata` を mock して各分岐 (= endpoint URL 結合 / fail-closed publicHint
+ * filter / 不正 URL の context-rethrow / optional field の narrow) を決定論的に pin する。
+ */
+const { findProblemMetadata } = vi.hoisted(() => ({ findProblemMetadata: vi.fn() }));
+vi.mock("../../src/data/problems", () => ({ findProblemMetadata }));
+
+// props-builder が読む field (endpoints / phases / disruptions) のみ詰めた最小 entry。
+function entry(overrides: Partial<ProblemCatalogEntry>): ProblemCatalogEntry {
+  return {
+    endpoints: [],
+    phases: [],
+    disruptions: [],
+    ...overrides,
+  } as unknown as ProblemCatalogEntry;
+}
+
+beforeEach(() => findProblemMetadata.mockReset());
+
+describe("buildPortalEndpointsFromOutputs", () => {
+  it("should return [] when the problem has no metadata", () => {
+    findProblemMetadata.mockReturnValue(undefined);
+    expect(buildPortalEndpointsFromOutputs("missing", {})).toEqual([]);
+  });
+
+  it("should return [] when the metadata declares no endpoints", () => {
+    findProblemMetadata.mockReturnValue(entry({ endpoints: [] }));
+    expect(buildPortalEndpointsFromOutputs("p", { BaseUrl: "https://api.example.com" })).toEqual(
+      [],
+    );
+  });
+
+  it("should join base + appendPath into default/effective URLs from stack outputs", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          {
+            slot: "users",
+            overridable: true,
+            default: { from: "cfn-output", key: "BaseUrl", appendPath: "/users" },
+          },
+        ],
+      }),
+    );
+    const out = buildPortalEndpointsFromOutputs("p", { BaseUrl: "https://api.example.com" });
+    expect(out).toEqual([
+      {
+        slot: "users",
+        overridable: true,
+        defaultUrl: "https://api.example.com/users",
+        effectiveUrl: "https://api.example.com/users",
+      },
+    ]);
+  });
+
+  it("should not double the slash when the base already ends with '/'", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          {
+            slot: "users",
+            overridable: true,
+            default: { from: "cfn-output", key: "BaseUrl", appendPath: "users" },
+          },
+        ],
+      }),
+    );
+    const out = buildPortalEndpointsFromOutputs("p", { BaseUrl: "https://api.example.com/" });
+    expect(out[0]?.defaultUrl).toBe("https://api.example.com/users");
+  });
+
+  it("should use the bare base URL when no appendPath is declared", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          { slot: "api", overridable: false, default: { from: "cfn-output", key: "Url" } },
+        ],
+      }),
+    );
+    const out = buildPortalEndpointsFromOutputs("p", { Url: "https://h.example/path" });
+    expect(out[0]?.defaultUrl).toBe("https://h.example/path");
+    expect(out[0]?.effectiveUrl).toBe("https://h.example/path");
+    expect(out[0]?.overridable).toBe(false);
+  });
+
+  it("should carry optional label / description through to the endpoint", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          {
+            slot: "api",
+            overridable: true,
+            label: "Users API",
+            description: "The users microservice",
+            default: { from: "cfn-output", key: "Url" },
+          },
+        ],
+      }),
+    );
+    const out = buildPortalEndpointsFromOutputs("p", { Url: "https://e.example" });
+    expect(out[0]?.label).toBe("Users API");
+    expect(out[0]?.description).toBe("The users microservice");
+  });
+
+  it("should omit URLs when the stack output for the key is absent (not yet deployed)", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          { slot: "api", overridable: true, default: { from: "cfn-output", key: "Missing" } },
+        ],
+      }),
+    );
+    const out = buildPortalEndpointsFromOutputs("p", {});
+    expect(out).toEqual([{ slot: "api", overridable: true }]);
+    expect(out[0]?.defaultUrl).toBeUndefined();
+  });
+
+  it("should rethrow a malformed base URL with problemId / slot / key context (no silent skip)", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        endpoints: [
+          {
+            slot: "users",
+            overridable: true,
+            default: { from: "cfn-output", key: "BaseUrl", appendPath: "/users" },
+          },
+        ],
+      }),
+    );
+    expect(() =>
+      buildPortalEndpointsFromOutputs("battle-x", { BaseUrl: "not-a-valid-base" }),
+    ).toThrow(/Failed to build endpoint URL for problemId=battle-x slot=users key=BaseUrl/);
+  });
+});
+
+describe("buildPortalPhases (fairness contract: publicHint fail-closed)", () => {
+  it("should return [] when the problem has no metadata", () => {
+    findProblemMetadata.mockReturnValue(undefined);
+    expect(buildPortalPhases("missing")).toEqual([]);
+  });
+
+  it("should keep only phases explicitly flagged publicHint: true", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        phases: [
+          { name: "reveal", afterMinutes: 5, publicHint: true },
+          { name: "hidden", afterMinutes: 10, publicHint: false },
+          { name: "default-hidden", afterMinutes: 15 },
+        ],
+      }),
+    );
+    expect(buildPortalPhases("p")).toEqual([{ name: "reveal", afterMinutes: 5, publicHint: true }]);
+  });
+});
+
+describe("buildPortalDisruptions (fairness contract: publicHint fail-closed)", () => {
+  it("should return [] when the problem has no metadata", () => {
+    findProblemMetadata.mockReturnValue(undefined);
+    expect(buildPortalDisruptions("missing")).toEqual([]);
+  });
+
+  it("should keep only disruptions explicitly flagged publicHint: true", () => {
+    findProblemMetadata.mockReturnValue(
+      entry({
+        disruptions: [
+          { id: "d1", name: "Announced", publicHint: true },
+          { id: "d2", name: "Surprise", publicHint: false },
+        ],
+      }),
+    );
+    expect(buildPortalDisruptions("p")).toEqual([
+      { id: "d1", name: "Announced", publicHint: true },
+    ]);
+  });
+});
+
+describe("buildPortalTeam (narrow undefined optionals for exactOptionalPropertyTypes)", () => {
+  it("should keep only teamName when teamId / eventId are absent", () => {
+    expect(buildPortalTeam({ teamName: "Alpha" })).toEqual({ teamName: "Alpha" });
+  });
+
+  it("should include teamId / eventId when present", () => {
+    expect(buildPortalTeam({ teamName: "Alpha", teamId: "t1", eventId: "e1" })).toEqual({
+      teamName: "Alpha",
+      teamId: "t1",
+      eventId: "e1",
+    });
+  });
+
+  it("should include teamId but drop an absent eventId", () => {
+    expect(buildPortalTeam({ teamName: "Alpha", teamId: "t1" })).toEqual({
+      teamName: "Alpha",
+      teamId: "t1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/plugins/props-builder.ts` (ADR-012 Phase 5 — marshals the build-time catalog into the SDK `PortalSlotProps` shape) had **no dedicated test**; it was only incidentally exercised by component tests. Added a focused unit suite that mocks `findProblemMetadata`, making every branch deterministic instead of dependent on the live problem catalog:

- **`buildPortalEndpointsFromOutputs`**: no-metadata → `[]`, no-endpoints → `[]`, base + appendPath join, base already-trailing-slash (no double slash), bare base (no appendPath), optional `label`/`description` passthrough, missing stack output → URL omitted, and a malformed base URL **rethrown with `problemId`/`slot`/`key` context** (fail-loud, no silent skip — the security-relevant fairness behavior).
- **`buildPortalPhases` / `buildPortalDisruptions`**: the fairness-contract `publicHint` fail-closed filter — keeps only `publicHint: true`, drops `false`/`undefined`, `[]` when no metadata.
- **`buildPortalTeam`**: `exactOptionalPropertyTypes` narrowing of `teamId` / `eventId`.

The only remaining branch was the `String(e)` fallback in the joinUrl `catch` — unreachable because `new URL()` always throws a `TypeError` (`instanceof Error`). Extracted it to a `detail` const wrapped in `/* v8 ignore start/stop */`, matching the repo's convention for unreachable defensive code. **props-builder.ts now reports 100% statements / branches / functions / lines** (15 tests).

## Test plan
- `vitest run test/plugins/props-builder.test.ts --coverage --coverage.include=src/plugins/props-builder.ts` → 15 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 289 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source change is behavior-preserving: `detail` holds the exact same ternary value previously inlined into the throw template; the thrown message and `{ cause: e }` are byte-identical. Test 7 still asserts the context prefix.
- New tests only; existing tests untouched and still pass.

## Physical impact
- NO-OP on CFn / deployed artifacts. The source edit is a local-variable extraction + coverage-ignore comment inside an existing Lambda-free SPA module; bundle output is semantically identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)