### PR TITLE
test(admin-console): bring idp-client to 100% (76% → 100%)

### DIFF
--- a/apps/admin-console/test/idp-client.test.ts
+++ b/apps/admin-console/test/idp-client.test.ts
@@ -1,6 +1,15 @@
+import { StatusCodes } from "http-status-codes";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createIdpClient, describeIdpError, IdpApiError } from "../src/api/idp-client";
 import type { AppConfig } from "../src/config";
+
+const DETAIL = {
+  idpId: "okta-acme",
+  displayName: "Okta",
+  metadataXml: "<x/>",
+  attributeMapping: { email: "email" },
+  groupToRole: {},
+};
 
 const baseConfig: AppConfig = {
   cognitoDomain: "auth.example.com",
@@ -65,6 +74,89 @@ describe("createIdpClient", () => {
     const [calledUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(String(calledUrl)).toBe("https://control.example.com/admin/idp/okta%20acme");
   });
+
+  it("should append a trailing slash when apiBaseUrl lacks one", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [] }), { status: StatusCodes.OK }),
+    );
+    const client = createIdpClient(
+      { ...baseConfig, apiBaseUrl: "https://control.example.com" },
+      "id-token",
+    );
+    await client?.list();
+    const [calledUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toBe("https://control.example.com/admin/idp");
+  });
+
+  it("should leave errorCode undefined when the error body has a non-string error field", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 42 }), { status: StatusCodes.FORBIDDEN }),
+    );
+    const client = createIdpClient(baseConfig, "id-token");
+    await expect(client?.list()).rejects.toMatchObject({
+      status: StatusCodes.FORBIDDEN,
+      errorCode: undefined,
+    });
+  });
+
+  it("should GET a single IdP by (encoded) id", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify(DETAIL), { status: StatusCodes.OK }),
+    );
+    const client = createIdpClient(baseConfig, "id-token");
+    const detail = await client?.get("okta acme");
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toBe("https://control.example.com/admin/idp/okta%20acme");
+    expect((init as RequestInit).method).toBe("GET");
+    expect(detail).toEqual(DETAIL);
+  });
+
+  it("should POST create and return the detail on 201", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify(DETAIL), { status: StatusCodes.CREATED }),
+    );
+    const client = createIdpClient(baseConfig, "id-token");
+    const created = await client?.create({
+      idpId: "okta-acme",
+      displayName: "Okta",
+      metadataXml: "<x/>",
+      attributeMapping: { email: "email" },
+      groupToRole: {},
+    });
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toBe("https://control.example.com/admin/idp");
+    expect((init as RequestInit).method).toBe("POST");
+    expect(created).toEqual(DETAIL);
+  });
+
+  it("should throw unexpected_status when create returns 200 instead of 201", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify(DETAIL), { status: StatusCodes.OK }),
+    );
+    const client = createIdpClient(baseConfig, "id-token");
+    await expect(
+      client?.create({
+        idpId: "x",
+        displayName: "x",
+        metadataXml: "<x/>",
+        attributeMapping: { email: "email" },
+        groupToRole: {},
+      }),
+    ).rejects.toMatchObject({ status: StatusCodes.OK, errorCode: "unexpected_status" });
+  });
+
+  it("should PATCH update and return the detail", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify(DETAIL), { status: StatusCodes.OK }),
+    );
+    const client = createIdpClient(baseConfig, "id-token");
+    const updated = await client?.update("okta-acme", { displayName: "Renamed" });
+    const [calledUrl, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toBe("https://control.example.com/admin/idp/okta-acme");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ displayName: "Renamed" });
+    expect(updated).toEqual(DETAIL);
+  });
 });
 
 describe("describeIdpError", () => {
@@ -73,6 +165,26 @@ describe("describeIdpError", () => {
     expect(describeIdpError(new IdpApiError(404, "not_found"))).toContain("not found");
     expect(describeIdpError(new IdpApiError(409, "conflict"))).toContain("already exists");
     expect(describeIdpError(new IdpApiError(400, "invalid_metadata"))).toContain("metadata XML");
+  });
+
+  it("should distinguish a non-invalid_metadata 400 from the metadata case", () => {
+    expect(describeIdpError(new IdpApiError(StatusCodes.BAD_REQUEST, "bad_field"))).toContain(
+      "bad_field",
+    );
+    // errorCode 不在の 400 は validation_failed に倒す。
+    expect(describeIdpError(new IdpApiError(StatusCodes.BAD_REQUEST, undefined))).toContain(
+      "validation_failed",
+    );
+  });
+
+  it("should fall back to status + errorCode for other API statuses", () => {
+    expect(describeIdpError(new IdpApiError(StatusCodes.INTERNAL_SERVER_ERROR, "boom"))).toContain(
+      "500",
+    );
+    // default の errorCode 不在は unknown_error に倒す。
+    expect(
+      describeIdpError(new IdpApiError(StatusCodes.INTERNAL_SERVER_ERROR, undefined)),
+    ).toContain("unknown_error");
   });
 
   it("should fall back to Error.message for non-API errors", () => {


### PR DESCRIPTION
## Summary

The existing `admin-console/test/idp-client.test.ts` covered `list` / create-error / `remove`. The `get` / create-success / create-non-201 / `update` verbs, the base-without-trailing-slash normalization, the non-string `error`-field fallback, and the `describeIdpError` 400-other / default arms were unpinned.

Extended the test (using `StatusCodes.*` per the repo's no-magic-number rule for the new cases):

- `get()`: GET single IdP by encoded id, returns detail.
- `create()`: 201 → detail; **200 → throws `unexpected_status`** (strict status check).
- `update()`: PATCH body round-trip, returns detail.
- `createIdpClient`: appends a trailing slash when `apiBaseUrl` lacks one.
- `fetchOrThrow`: non-string `error` field → `errorCode` undefined.
- `describeIdpError`: non-`invalid_metadata` 400 (+ undefined → `validation_failed`) and the default arm (+ undefined → `unknown_error`).

idp-client.ts now reports **100% statements / branches / functions / lines** (14 tests).

## Test plan
- `vitest run test/idp-client.test.ts --coverage --coverage.include=src/api/idp-client.ts` → 14 tests pass, 100% across all four dimensions.
- Full admin-console suite: 151 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Existing cases untouched (additive coverage only). No open PR touches `idp-client.ts` (the `CreateIdpModal` extraction PRs #1438 touch the `IdentityProviders` component).

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)