### PR TITLE
test(application-admin-console): bring deploy-phases to 100%

### DIFF
--- a/apps/application-admin-console/src/lib/deploy-phases.ts
+++ b/apps/application-admin-console/src/lib/deploy-phases.ts
@@ -67,6 +67,9 @@ function stackStatusToPhaseStatus(stackStatus: string | undefined): PhaseStatus 
  * 返していた。
  */
 function eventsToPhaseStatus(events: readonly StackProgressEvent[]): PhaseStatus {
+  // 唯一の caller (deriveCfnDeployStatus) が events.length===0 を先に弾くため、ここは
+  // 到達不能な防御 guard。 branch coverage のノイズになるので ignore。
+  /* v8 ignore next */
   if (events.length === 0) return "pending";
   const latestByLogicalId = new Map<string, StackProgressEvent>();
   for (const e of events) {
@@ -148,6 +151,9 @@ const FINAL_STATUS_FROM_DEPLOYMENT: Partial<Record<DeploymentStatus, PhaseStatus
 export function deriveFinalStatus(status: DeploymentStatus): PhaseStatus {
   const direct = FINAL_STATUS_FROM_DEPLOYMENT[status];
   if (direct !== undefined) return direct;
+  // COMPLETE_STATUSES のメンバーは全て FINAL_STATUS_FROM_DEPLOYMENT のキーでもあるため、
+  // map miss 時に has() が true になることはない (= 到達不能な防御 fallback)。
+  /* v8 ignore next */
   if (COMPLETE_STATUSES.has(status)) return "complete";
   return "pending";
 }

--- a/apps/application-admin-console/test/lib/deploy-phases.test.ts
+++ b/apps/application-admin-console/test/lib/deploy-phases.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import type { DeploymentSummary, StackProgress } from "../../src/api/deploy-client";
+import type {
+  DeploymentStatus,
+  DeploymentSummary,
+  StackProgress,
+} from "../../src/api/deploy-client";
 import {
   buildTerminalLog,
   type DeployPhase,
   deploySummaryTitle,
+  deriveCfnDeployStatus,
+  deriveFinalStatus,
   derivePhases,
+  formatLogTimestamp,
   type PhaseId,
 } from "../../src/lib/deploy-phases";
 
@@ -235,6 +242,135 @@ describe("deploySummaryTitle", () => {
     expect(deploySummaryTitle({ ...baseDeployment, status: "AUTO_DELETED" })).toMatch(
       /auto-deleted/,
     );
+  });
+});
+
+describe("deriveCfnDeployStatus — stackStatus authority (#818)", () => {
+  const withStatus = (stackStatus: string): StackProgress => ({
+    ...emptyProgress,
+    stackStatus,
+    events: [],
+  });
+
+  it("should map every *_COMPLETE stack status to complete", () => {
+    for (const s of ["UPDATE_COMPLETE", "IMPORT_COMPLETE"]) {
+      expect(deriveCfnDeployStatus("IN_PROGRESS", withStatus(s))).toBe("complete");
+    }
+  });
+
+  it("should map *_FAILED and the rollback-complete variants to failed", () => {
+    for (const s of ["CREATE_FAILED", "UPDATE_ROLLBACK_COMPLETE", "IMPORT_ROLLBACK_COMPLETE"]) {
+      expect(deriveCfnDeployStatus("FAILED", withStatus(s))).toBe("failed");
+    }
+  });
+
+  it("should map any DELETE_* stack status to skipped", () => {
+    expect(deriveCfnDeployStatus("DELETING", withStatus("DELETE_IN_PROGRESS"))).toBe("skipped");
+  });
+
+  it("should fall through to status-only inference for an unrecognized stack status", () => {
+    // 未知 stackStatus → undefined → events 空 → status=COMPLETE 由来で complete。
+    expect(deriveCfnDeployStatus("COMPLETE", withStatus("UNKNOWN_STATE"))).toBe("complete");
+  });
+
+  it("should keep the latest event per LogicalId even when a later array entry is older", () => {
+    // stackStatus 無し → event history fallback。 配列後方に **古い** timestamp が来ても
+    // cur (= 新しい COMPLETE) を維持する (= cur.timestamp < e.timestamp が false の分岐)。
+    const outOfOrder: StackProgress = {
+      ...emptyProgress,
+      events: [
+        {
+          timestamp: "2026-05-11T01:09:10.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_COMPLETE",
+        },
+        {
+          timestamp: "2026-05-11T01:09:00.000Z",
+          logicalResourceId: "MyBucket",
+          resourceType: "AWS::S3::Bucket",
+          resourceStatus: "CREATE_IN_PROGRESS",
+        },
+      ],
+    };
+    expect(deriveCfnDeployStatus("IN_PROGRESS", outOfOrder)).toBe("complete");
+  });
+});
+
+describe("deriveFinalStatus", () => {
+  it("should map each deployment status to its final phase status", () => {
+    expect(deriveFinalStatus("COMPLETE")).toBe("complete");
+    expect(deriveFinalStatus("FAILED")).toBe("failed");
+    expect(deriveFinalStatus("DELETING")).toBe("in-progress");
+    expect(deriveFinalStatus("DELETED")).toBe("skipped");
+    expect(deriveFinalStatus("EXPIRED")).toBe("failed");
+    expect(deriveFinalStatus("AUTO_DELETED")).toBe("skipped");
+  });
+
+  it("should default to pending for a non-terminal status (PENDING / IN_PROGRESS)", () => {
+    expect(deriveFinalStatus("PENDING")).toBe("pending");
+    expect(deriveFinalStatus("IN_PROGRESS")).toBe("pending");
+  });
+});
+
+describe("deploySummaryTitle — remaining statuses", () => {
+  it("should produce a label for in-progress / queued / teardown / removed statuses", () => {
+    expect(deploySummaryTitle({ ...baseDeployment, status: "IN_PROGRESS" })).toMatch(/in progress/);
+    expect(deploySummaryTitle({ ...baseDeployment, status: "PENDING" })).toMatch(/queued/);
+    expect(deploySummaryTitle({ ...baseDeployment, status: "DELETING" })).toMatch(/Tearing down/);
+    expect(deploySummaryTitle({ ...baseDeployment, status: "DELETED" })).toMatch(/removed/);
+  });
+
+  it("should fall back to a generic label for an unknown status", () => {
+    expect(deploySummaryTitle({ ...baseDeployment, status: "WAT" as DeploymentStatus })).toBe(
+      "Deploy for Alpha Team",
+    );
+  });
+
+  it("should use the raw teamName when displayTeamName is absent", () => {
+    expect(
+      deploySummaryTitle({ ...baseDeployment, status: "COMPLETE", displayTeamName: undefined }),
+    ).toBe("Deploy succeeded for team-alpha");
+  });
+});
+
+describe("formatLogTimestamp", () => {
+  it("should format a valid ISO timestamp as a 12-hour en-US time", () => {
+    expect(formatLogTimestamp("2026-05-11T01:09:00.000Z")).toMatch(/\d{1,2}:\d{2}:\d{2}\s?[AP]M/);
+  });
+
+  it("should return the raw string when the timestamp is unparseable", () => {
+    expect(formatLogTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("buildTerminalLog — branch coverage", () => {
+  it("should note missing console URL and no CFn events when stackProgress is null", () => {
+    const deployment = { ...baseDeployment, status: "PENDING" as DeploymentStatus };
+    const phases = derivePhases(deployment, null);
+    const lines = buildTerminalLog(deployment, null, phases);
+    expect(lines.some((l) => l.text.includes("CodeBuild console URL not yet available"))).toBe(
+      true,
+    );
+    expect(lines.some((l) => l.text.includes("No CloudFormation events observed yet."))).toBe(true);
+  });
+
+  it("should append the resourceStatusReason to a failed CFn event line", () => {
+    const deployment = { ...baseDeployment, status: "FAILED" as DeploymentStatus };
+    const phases = derivePhases(deployment, progressWithFailed);
+    const lines = buildTerminalLog(deployment, progressWithFailed, phases);
+    expect(lines.some((l) => l.text.includes("— Bucket name already exists"))).toBe(true);
+  });
+
+  it("should emit a Failure reason line when the deployment carries one", () => {
+    const deployment = {
+      ...baseDeployment,
+      status: "FAILED" as DeploymentStatus,
+      failureReason: "AssumeRole denied",
+    };
+    const phases = derivePhases(deployment, emptyProgress);
+    const lines = buildTerminalLog(deployment, emptyProgress, phases);
+    expect(lines.some((l) => l.text === "Failure reason: AssumeRole denied")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`apps/application-admin-console/src/lib/deploy-phases.ts` (the frontend-only 4-phase derivation powering the DeploymentDetail terminal view) was at **84% statements / 74% branches**. The Issue #818 stackStatus→phase authority mapping, the `deploySummaryTitle` status arms, the status-only CFn inference, the invalid-timestamp guard, and the terminal-log builders were only partially pinned.

Extended `deploy-phases.test.ts`:

- `deriveCfnDeployStatus`: every `*_COMPLETE` / `*_FAILED` / rollback-complete / `DELETE_*` / unrecognized stackStatus arm (#818), plus the event-history fallback keeping the latest event per `LogicalId` when a later array entry is older (the `cur.timestamp < e.timestamp` false branch).
- `deriveFinalStatus`: all status → phase mappings + the non-terminal default.
- `deploySummaryTitle`: in-progress / queued / teardown / removed / unknown-default, and the raw-`teamName` fallback when `displayTeamName` is absent.
- `formatLogTimestamp`: valid 12-hour format + the unparseable passthrough.
- `buildTerminalLog`: null `stackProgress` (no console URL / no CFn events), `resourceStatusReason` append, and the Failure-reason line.

Two genuinely-unreachable defensive guards are marked `/* v8 ignore next */` with a rationale comment: `eventsToPhaseStatus`'s empty-events check (its only caller pre-filters empty) and `deriveFinalStatus`'s `COMPLETE_STATUSES` fallback (every member is also a `FINAL_STATUS_FROM_DEPLOYMENT` key). deploy-phases.ts now reports **100% statements / branches / functions / lines** (33 tests).

## Test plan
- `vitest run test/lib/deploy-phases.test.ts --coverage --coverage.include=src/lib/deploy-phases.ts` → 33 tests pass, 100% across all four dimensions.
- Full application-admin-console suite: 422 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The two source edits are coverage-ignore comments only — no statement changed, so runtime behavior is byte-identical. The dead guards remain in place as documented safety nets.
- Existing deploy-phases tests untouched (additive coverage only).

## Physical impact
- NO-OP on CFn / deployed artifacts. Comment-only source change inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)