### PR TITLE
test(application-admin-console): cover event-report exporter empty states

### DIFF
--- a/apps/application-admin-console/test/event-report/html-export.test.ts
+++ b/apps/application-admin-console/test/event-report/html-export.test.ts
@@ -176,6 +176,18 @@ describe("buildEventReportHtml", () => {
   it("should use a serif font stack for print-readability parity with the page", () => {
     expect(buildEventReportHtml(makeExport())).toMatch(/font-family:[^;]*serif/i);
   });
+
+  it("should render the empty-state paragraph instead of a table when the scoreboard is empty", () => {
+    const html = buildEventReportHtml(makeExport({ scoreboard: [] }));
+    expect(html).toContain("No score events.");
+    // 空のときは scoreboard 行 (= "N pt" セル) を出さない。
+    expect(html).not.toContain(" pt</td>");
+  });
+
+  it("should render the empty-state paragraph instead of a table when the breakdown is empty", () => {
+    const html = buildEventReportHtml(makeExport({ breakdown: [] }));
+    expect(html).toContain("No problems.");
+  });
 });
 
 describe("escapeHtml", () => {

--- a/apps/application-admin-console/test/event-report/md-export.test.ts
+++ b/apps/application-admin-console/test/event-report/md-export.test.ts
@@ -150,6 +150,20 @@ describe("buildEventReportMarkdown", () => {
     );
     expect(md).toContain("| 1 | A \\| B | 0 pt | 0 |");
   });
+
+  it("should render the empty-state label instead of a table when the scoreboard is empty", () => {
+    const md = buildEventReportMarkdown(makeExport({ scoreboard: [] }));
+    expect(md).toContain("## Final scoreboard");
+    expect(md).toContain("No score events.");
+    // 空のときは GFM table の separator 行を出さない。
+    expect(md).not.toContain("| Rank | Team | Score | Problems solved |");
+  });
+
+  it("should render the empty-state label instead of a table when the breakdown is empty", () => {
+    const md = buildEventReportMarkdown(makeExport({ breakdown: [] }));
+    expect(md).toContain("## Per-problem breakdown");
+    expect(md).toContain("No problems.");
+  });
 });
 
 describe("escapeMarkdownCell", () => {


### PR DESCRIPTION
## Summary

The HTML and Markdown event-report exporters (operator post-event reports) were ~95% covered — the populated-table paths were tested, but the **empty-state branches** were not: empty scoreboard → "No score events.", empty per-problem breakdown → "No problems.".

Added the empty-state cases to both `md-export.test.ts` and `html-export.test.ts` using the existing `makeExport` fixture with `scoreboard: []` / `breakdown: []` overrides, asserting the empty-state label renders and the table rows do not. Both `html.ts` and `markdown.ts` now report **100% statements / branches / functions / lines**.

## Test plan
- `vitest run test/event-report/{md,html}-export.test.ts --coverage --coverage.include=…/exporters/html.ts --coverage.include=…/exporters/markdown.ts` → 25 tests pass, 100% across all four dimensions.
- Full application-admin-console suite: 426 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Existing exporter tests untouched (additive coverage only).

## Physical impact
- NO-OP on CFn / deployed artifacts. Test files only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)