### PR TITLE
test(application-admin-console): cover auth/claims JWT decode (0% → 100%)

### DIFF
--- a/apps/application-admin-console/test/claims.test.ts
+++ b/apps/application-admin-console/test/claims.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { decodeIdToken } from "../src/auth/claims";
+
+/**
+ * Cognito id_token payload デコード util。 署名検証は API GW authorizer 側なので
+ * frontend は base64url + UTF-8 デコードのみ。 不正 token (= part 数違い / base64 不正 /
+ * 非 JSON) は throw せず null に倒す (= 画面を壊さない) ことを pin する。
+ */
+function b64url(value: object | string): string {
+  const json = typeof value === "string" ? value : JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function makeJwt(payload: object): string {
+  return `${b64url({ alg: "RS256", typ: "JWT" })}.${b64url(payload)}.signature`;
+}
+
+describe("decodeIdToken", () => {
+  it("should decode the standard + custom Cognito claims, including multi-byte names", () => {
+    const token = makeJwt({
+      sub: "user-1",
+      email: "tenant-admin@acme.example",
+      "custom:tenantId": "01HXTENANT00000000000000AB",
+      "custom:userRole": "TenantAdmin",
+      "custom:tenantTier": "PLATINUM",
+      // UTF-8 multi-byte を TextDecoder 経路が正しく復号できることを確認する。
+      "custom:tenantName": "天下クラウド株式会社",
+    });
+    const claims = decodeIdToken(token);
+    expect(claims).not.toBeNull();
+    expect(claims?.sub).toBe("user-1");
+    expect(claims?.email).toBe("tenant-admin@acme.example");
+    expect(claims?.["custom:tenantId"]).toBe("01HXTENANT00000000000000AB");
+    expect(claims?.["custom:userRole"]).toBe("TenantAdmin");
+    expect(claims?.["custom:tenantTier"]).toBe("PLATINUM");
+    expect(claims?.["custom:tenantName"]).toBe("天下クラウド株式会社");
+  });
+
+  it("should return null when the token is not a 3-part JWT", () => {
+    expect(decodeIdToken("only.two")).toBeNull();
+    expect(decodeIdToken("a.b.c.d")).toBeNull();
+    expect(decodeIdToken("")).toBeNull();
+  });
+
+  it("should return null when the payload segment is not valid base64", () => {
+    // `***` は base64 に存在しない文字 → atob が throw → catch → null。
+    expect(decodeIdToken("header.***.signature")).toBeNull();
+  });
+
+  it("should return null when the decoded payload is not JSON", () => {
+    // 有効な base64 だが中身は素のテキスト → JSON.parse が throw → null。
+    expect(decodeIdToken(`header.${b64url("not-json-payload")}.signature`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`apps/application-admin-console/src/auth/claims.ts` (the Cognito `id_token` payload decoder used to surface tenant/role for display) had **no test**. Added `test/claims.test.ts` covering:

- a standard + custom claim set, including a multi-byte (Japanese) `custom:tenantName` to exercise the `base64url → atob → Uint8Array → TextDecoder` UTF-8 decode path.
- non-3-part tokens → `null` (2 parts / 4 parts / empty).
- an invalid-base64 payload segment → `atob` throws → `null`.
- a valid-base64 but non-JSON payload → `JSON.parse` throws → `null`.

claims.ts now reports **100% statements / branches / functions / lines** (4 tests).

## Test plan
- `vitest run test/claims.test.ts --coverage --coverage.include=src/auth/claims.ts` → 4 tests pass, 100% across all four dimensions.
- Full application-admin-console suite passes; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Pure decode util with no shared state; isolated from the rest of the suite.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)