### PR TITLE
test(application-admin-console): bring friendly-error to 100%

### DIFF
--- a/apps/application-admin-console/src/lib/friendly-error.ts
+++ b/apps/application-admin-console/src/lib/friendly-error.ts
@@ -152,10 +152,11 @@ function extractBackendEnvelope(rawMessage: string): BackendErrorEnvelope | null
   if (!body.startsWith("{")) return null;
   try {
     const parsed = JSON.parse(body) as unknown;
-    if (parsed && typeof parsed === "object") {
-      return parsed as BackendErrorEnvelope;
-    }
-    return null;
+    // body は "{" 始まりに限定済 (上の guard) なので parse 成功時は必ず object。
+    // 非 object 分岐は到達不能な防御 guard。
+    /* v8 ignore next */
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as BackendErrorEnvelope;
   } catch {
     return null;
   }

--- a/apps/application-admin-console/test/lib/friendly-error.test.ts
+++ b/apps/application-admin-console/test/lib/friendly-error.test.ts
@@ -104,4 +104,50 @@ describe("toFriendlyError", () => {
     const fe = toFriendlyError(err);
     expect(fe.title).toMatch(/同 email/);
   });
+
+  it("should fall back to a status-only title when the body looks like JSON but is malformed", () => {
+    // `{` 始まりだが JSON として壊れている → extractBackendEnvelope の JSON.parse が throw →
+    // envelope=null → status だけの generic title + raw body を hint に残す。
+    const err = new ApiError(500, "{not: valid json");
+    const fe = toFriendlyError(err);
+    expect(fe.title).toBe("エラー (500)");
+    expect(fe.hint).toBe("{not: valid json");
+  });
+
+  it("should map a non-ApiError Error to its message and stringify unknown throwables", () => {
+    expect(toFriendlyError(new Error("network down")).title).toBe("network down");
+    expect(toFriendlyError("weird").title).toBe("weird");
+  });
+
+  it("should keep the raw error code + status when the code is unknown to the mapping", () => {
+    const fe = toFriendlyError(new ApiError(422, '{"error":"brand_new_code","message":"details"}'));
+    expect(fe.title).toBe("エラー (422) — brand_new_code");
+    expect(fe.hint).toBe("details");
+  });
+
+  it("should use the message when the error code is not a string", () => {
+    // error が非 string → code=null → message を title に併記、 hint は出さない。
+    const fe = toFriendlyError(new ApiError(422, '{"error":123,"message":"boom"}'));
+    expect(fe.title).toBe("エラー (422) — boom");
+    expect(fe.hint).toBeUndefined();
+  });
+
+  it("should show a status-only title when neither code nor message is present", () => {
+    const fe = toFriendlyError(new ApiError(500, '{"unrelated":"field"}'));
+    expect(fe.title).toBe("エラー (500)");
+    expect(fe.hint).toBeUndefined();
+  });
+
+  it("should fall back to the stripped raw message when the body is not JSON", () => {
+    // ApiError は `API <status>: <body>` を組むので、 body のみを渡す。
+    const fe = toFriendlyError(new ApiError(500, "plain failure text"));
+    expect(fe.title).toBe("エラー (500)");
+    expect(fe.hint).toBe("plain failure text");
+  });
+
+  it("should leave hint undefined when the non-JSON message is empty after stripping the prefix", () => {
+    const fe = toFriendlyError(new ApiError(500, ""));
+    expect(fe.title).toBe("エラー (500)");
+    expect(fe.hint).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

`apps/application-admin-console/src/lib/friendly-error.ts` (Issue #665 — converts backend `{ error: <code> }` JSON into readable operator messages) was at **94% statements / 78% branches**: the malformed-JSON `catch` and several error-formatting fallbacks were unpinned.

Extended `friendly-error.test.ts`:
- malformed JSON body (`{` start but unparseable) → status-only title + raw hint.
- non-string error code → message used in the title, hint suppressed.
- neither code nor message → status-only title.
- non-JSON message → stripped raw message as hint; empty-after-strip → no hint.
- non-`ApiError` `Error` → its message; unknown throwable → `String()`.

One genuinely-unreachable guard is marked `/* v8 ignore next */`: after the `body.startsWith("{")` filter a successful `JSON.parse` always yields an object, so the non-object branch cannot be hit. friendly-error.ts now reports **100% statements / branches / functions / lines** (21 tests).

## Test plan
- `vitest run test/lib/friendly-error.test.ts --coverage --coverage.include=src/lib/friendly-error.ts` → 21 tests pass, 100% across all four dimensions.
- Full application-admin-console suite: 418 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edit restructures the post-parse object check into an early-return guard (behavior-identical: returns the parsed object, else `null`) plus a coverage-ignore comment — no observable behavior change.
- Existing friendly-error tests untouched (additive coverage only).

## Physical impact
- NO-OP on CFn / deployed artifacts. Comment + early-return refactor inside a Lambda-free SPA module; bundle behavior identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)