### PR TITLE
test(application-admin-console): bring idp-resolution to 100%

### DIFF
--- a/apps/application-admin-console/test/auth/idp-resolution.test.ts
+++ b/apps/application-admin-console/test/auth/idp-resolution.test.ts
@@ -32,6 +32,12 @@ describe("distinctProviders (#1340)", () => {
     });
     expect(new Set(out)).toEqual(new Set(["corp-entra", "corp-okta"]));
   });
+
+  it("should skip blank / whitespace-only provider names (= directory hygiene)", () => {
+    expect(distinctProviders({ "a.com": ["", "  ", "corp-okta"] as unknown as string[] })).toEqual([
+      "corp-okta",
+    ]);
+  });
 });
 
 describe("resolveIdp (#1340)", () => {
@@ -39,6 +45,10 @@ describe("resolveIdp (#1340)", () => {
     expect(resolveIdp("alice@nope.com", { "example.com": ["corp-entra"] })).toEqual({
       kind: "local",
     });
+  });
+
+  it("should resolve `local` when the email has no domain at all (no @)", () => {
+    expect(resolveIdp("no-at-sign", { "example.com": ["corp-entra"] })).toEqual({ kind: "local" });
   });
 
   it("should auto-redirect when exactly one provider serves the domain", () => {


### PR DESCRIPTION
## Summary

`apps/application-admin-console/src/auth/idp-resolution.ts` (Issue #1340 Phase 2 — per-tenant SAML Home Realm Discovery) was at **96%** with two unpinned defensive branches:

- `distinctProviders` skipping a blank / whitespace-only provider name (directory hygiene).
- `resolveIdp` falling back to `local` when the email has **no domain at all** (no `@`) — distinct from the existing "domain present but not in directory" case.

Added both cases to `idp-resolution.test.ts`. The module now reports **100% statements / branches / functions / lines** (13 tests).

## Test plan
- `vitest run test/auth/idp-resolution.test.ts --coverage --coverage.include=src/auth/idp-resolution.ts` → 13 tests pass, 100% across all four dimensions.
- Full application-admin-console suite passes; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Pure HRD resolution logic; existing tests untouched (additive coverage only).

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)