### PR TITLE
test(application-admin-console): close the lib/util branch-coverage long-tail

### DIFF
--- a/apps/application-admin-console/test/auth/jwt.test.ts
+++ b/apps/application-admin-console/test/auth/jwt.test.ts
@@ -38,6 +38,16 @@ describe("decodeIdToken", () => {
     });
   });
 
+  describe("when payload has no (string) email", () => {
+    it("should return undefined email but still resolve tenantId", () => {
+      // email field 不在 のとき email を undefined に倒す防御分岐。
+      const token = buildToken({ "custom:tenantId": "tenant-123" });
+      const claims = decodeIdToken(token);
+      expect(claims?.email).toBeUndefined();
+      expect(claims?.tenantId).toBe("tenant-123");
+    });
+  });
+
   describe("when JWT does not have 3 segments", () => {
     it("should return null", () => {
       expect(decodeIdToken("header.body")).toBeNull();

--- a/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
+++ b/apps/application-admin-console/test/lib/competitor-bootstrap.test.ts
@@ -37,6 +37,17 @@ describe("buildLaunchStackUrl", () => {
     expect(url).toContain("https://us-east-1.console.aws.amazon.com/");
     expect(url).toContain("region=us-east-1");
   });
+
+  it("should prefer an injected templateUrl over the dev fallback when provided", () => {
+    // runtime-config 由来の S3 URL が注入された production 経路 (= resolveTemplateUrl の
+    // 「templateUrl あり」 分岐)。 fallback の GitHub raw URL は使わない。
+    const injected = "https://tc-templates.s3.amazonaws.com/competitor-bootstrap.yaml";
+    const decoded = decodeURIComponent(
+      buildLaunchStackUrl({ ...baseInput, templateUrl: injected }),
+    );
+    expect(decoded).toContain(injected);
+    expect(decoded).not.toContain(COMPETITOR_BOOTSTRAP_TEMPLATE_URL);
+  });
 });
 
 describe("buildShareablePayload", () => {

--- a/apps/application-admin-console/test/lib/event-wizard.test.ts
+++ b/apps/application-admin-console/test/lib/event-wizard.test.ts
@@ -35,6 +35,14 @@ describe("computeEventWizardState", () => {
     expect(out.alertType).toBe("success");
   });
 
+  it("should omit the N/M progress tail when DEPLOYING with no deployments yet", () => {
+    // deploymentsByProblem 未提供 (= bulk deploy 直後で集計対象 0) のとき、 deploymentProgress
+    // が {0,0,0} を返し total===0 → CTA の進捗 tail を出さない防御分岐。
+    const out = computeEventWizardState({ status: "DEPLOYING" }, NOW_MS);
+    expect(out.step).toBe("deploying");
+    expect(out.cta).not.toMatch(/完了/);
+  });
+
   it("should set primary=start and prompt to 'set the start time' when READY without startsAt", () => {
     const out = computeEventWizardState({ status: "READY" }, NOW_MS);
     expect(out.step).toBe("ready_unscheduled");

--- a/apps/application-admin-console/test/lib/resource-naming.test.ts
+++ b/apps/application-admin-console/test/lib/resource-naming.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildStackPrefix, slugify } from "../../src/lib/resource-naming";
+import {
+  buildStackPrefix,
+  defaultCompetitorRoleName,
+  slugify,
+} from "../../src/lib/resource-naming";
 
 describe("slugify", () => {
   it("should replace non-alphanumeric characters with hyphens", () => {
@@ -41,5 +45,28 @@ describe("buildStackPrefix", () => {
 
   it("should still produce a prefix when team is empty (validation is the caller's responsibility)", () => {
     expect(buildStackPrefix("p1", "")).toBe("tc-p1-");
+  });
+});
+
+describe("defaultCompetitorRoleName", () => {
+  it("should build TenkaCloud-{tenant}-{namespace}-Role with the default namespace", () => {
+    expect(defaultCompetitorRoleName({ tenantId: "acme" })).toBe("TenkaCloud-acme-deploy-Role");
+    expect(defaultCompetitorRoleName({ tenantId: "acme", namespace: "scoring" })).toBe(
+      "TenkaCloud-acme-scoring-Role",
+    );
+  });
+
+  it("should fall back to 'tenant' / 'deploy' when the segments sanitize to empty", () => {
+    // `#` は IAM 許可文字集合外 → sanitize 後が空 → fallback segment に倒す防御分岐。
+    expect(defaultCompetitorRoleName({ tenantId: "###", namespace: "###" })).toBe(
+      "TenkaCloud-tenant-deploy-Role",
+    );
+  });
+
+  it("should truncate an over-long tenant id to keep the role name within the 64-char IAM limit", () => {
+    const name = defaultCompetitorRoleName({ tenantId: "a".repeat(80) });
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.startsWith("TenkaCloud-")).toBe(true);
+    expect(name.endsWith("-deploy-Role")).toBe(true);
   });
 });

--- a/apps/application-admin-console/test/utils/deployments.test.ts
+++ b/apps/application-admin-console/test/utils/deployments.test.ts
@@ -93,6 +93,13 @@ describe("deploymentsChanged", () => {
       ),
     ).toBe(false);
   });
+
+  it("配列に hole (undefined 要素) があれば true (= 防御 guard)", () => {
+    // 長さは同じだが要素が欠落している異常系。 index 比較で a / b が undefined になる
+    // 防御 guard を抜けて 「変化あり」 に倒す (= 安全側)。
+    const hole = [undefined] as unknown as DeploymentSummary[];
+    expect(deploymentsChanged(hole, hole)).toBe(true);
+  });
 });
 
 describe("constants", () => {


### PR DESCRIPTION
## Summary

Pinned the last cluster of unreached defensive / tiebreaker branches across **five** pure-logic modules so each reaches 100% branches (measured with the full suite):

- **`utils/deployments.ts`** — the `!a || !b` hole guard in `deploymentsChanged` (a length-matched array with an `undefined` element → treated as changed, fail-safe).
- **`auth/jwt.ts`** — `decodeIdToken` with a payload that has no (string) `email` → `email` undefined while `tenantId` still resolves.
- **`lib/competitor-bootstrap.ts`** — `buildLaunchStackUrl` with an injected `templateUrl` (the `resolveTemplateUrl` "provided" branch) preferring it over the dev fallback.
- **`lib/resource-naming.ts`** — `defaultCompetitorRoleName`: the `|| "tenant"` / `|| "deploy"` fallbacks when segments sanitize to empty, plus the 64-char IAM-limit truncation path (the function previously had **no test at all**).
- **`lib/event-wizard.ts`** — `computeEventWizardState` in `DEPLOYING` with no `deploymentsByProblem` → `deploymentProgress`'s undefined guard + the `total === 0` "omit progress tail" branch.

All five modules now report **100% statements / branches / functions / lines**.

## Test plan
- Per-file `vitest run --coverage --coverage.include=…` (full suite) → 100% across all four dimensions for each of the five files.
- Full application-admin-console suite: 414 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Each addition is additive; existing tests untouched. The deployments hole-guard test passes a cast `[undefined]` purely to exercise the defensive branch.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test files only; not bundled into any Lambda or SPA dist.

> Batched as a single "long-tail" unit because each change is a 1–2 line branch pin sharing one theme (last-mile branch coverage); shipping five separate PRs would add gate overhead without aiding review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)