### PR TITLE
test(application-admin-console): bring config loader to 100%

### DIFF
--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -130,9 +130,13 @@ export async function loadConfig(
       apiBaseUrl: runtime.apiUrl,
       participantPortalUrl: runtime.participantPortalUrl,
       competitorBootstrapTemplateUrl: runtime.competitorBootstrapTemplateUrl,
+      // fetchRuntimeConfig は isolation / samlIdpDirectory を常に populate する (= line 101 /
+      // 103-106) ため、 ここの `??` fallback は到達不能。 値の解決自体は fetchRuntimeConfig 側の
+      // テストで担保済。
+      /* v8 ignore start */
       isolation: runtime.isolation ?? "pooled",
-      // Issue #1340 Phase 2: SAML 未設定 stack も無音で動かすため空 object fallback。
       samlIdpDirectory: runtime.samlIdpDirectory ?? {},
+      /* v8 ignore stop */
       redirectUri,
       scope,
     };

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -64,6 +64,12 @@ describe("loadConfig", () => {
       expect(config.tenantName).toBe("Local Dev Tenant");
       expect(config.apiBaseUrl).toBe("http://localhost:3999");
     });
+
+    it("should fall back to env when the fetch itself throws (= offline / network error)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+      const config = await loadConfig(env);
+      expect(config.tenantId).toBe("dev-local");
+    });
   });
 
   describe("when /runtime-config.json is 200 but missing some field", () => {
@@ -239,6 +245,70 @@ describe("loadConfig", () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
       const config = await loadConfig(env);
       expect(config.samlIdpDirectory).toEqual({});
+    });
+  });
+
+  describe("optional runtime-config fields + isolation", () => {
+    function loadWithRuntime(extra: Record<string, unknown>) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "x",
+              tenantId: "t",
+              tenantName: "n",
+              apiUrl: "https://a.example.com",
+              ...extra,
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      return loadConfig(env);
+    }
+
+    it("should pass through string participantPortalUrl / competitorBootstrapTemplateUrl and isolation=silo", async () => {
+      const config = await loadWithRuntime({
+        participantPortalUrl: "https://portal.example.com",
+        competitorBootstrapTemplateUrl: "https://s3.example/bootstrap.yaml",
+        isolation: "silo",
+      });
+      expect(config.participantPortalUrl).toBe("https://portal.example.com");
+      expect(config.competitorBootstrapTemplateUrl).toBe("https://s3.example/bootstrap.yaml");
+      expect(config.isolation).toBe("silo");
+    });
+
+    it("should drop non-string optional URLs to undefined and non-silo isolation to pooled", async () => {
+      const config = await loadWithRuntime({
+        participantPortalUrl: 123,
+        competitorBootstrapTemplateUrl: false,
+        isolation: "bogus",
+      });
+      expect(config.participantPortalUrl).toBeUndefined();
+      expect(config.competitorBootstrapTemplateUrl).toBeUndefined();
+      expect(config.isolation).toBe("pooled");
+    });
+  });
+
+  describe("dev env fallback path", () => {
+    it("should honor VITE_ISOLATION=silo when assembling from env", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      const config = await loadConfig({ ...env, VITE_ISOLATION: "silo" });
+      expect(config.isolation).toBe("silo");
+    });
+
+    it("should throw when a required env var is missing in the fallback path", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      let threw = false;
+      try {
+        await loadConfig({});
+      } catch (e) {
+        threw = true;
+        expect((e as Error).message).toMatch(/Missing required env var/);
+      }
+      expect(threw).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

`apps/application-admin-console/src/config.ts` (the runtime-config.json + env-var `AppConfig` loader) was at **93% / 82% branches**. The optional-field passthroughs, the silo/pooled isolation arms, the env-fallback path, and the fetch-throws catch were unpinned.

Extended `config.test.ts`:
- runtime-config **with** `participantPortalUrl` / `competitorBootstrapTemplateUrl` (string) + `isolation=silo` → the "provided" / "silo" branches; and the non-string / non-silo variants → `undefined` / `pooled` (fail-closed passthrough).
- env fallback path: `VITE_ISOLATION=silo` honored, and a missing required env var throws `Missing required env var`.
- `fetchRuntimeConfig` catch: `fetch` rejecting (offline) → env fallback (line 109).

The two `runtime.isolation ?? "pooled"` / `samlIdpDirectory ?? {}` fallbacks in the runtime branch are `/* v8 ignore start/stop */`-wrapped: `fetchRuntimeConfig` always populates both (lines 101 / 103-106), so the `??` right-hand side is unreachable; the value resolution itself is covered by the `fetchRuntimeConfig` tests.

config.ts now reports **100% statements / branches / functions / lines** (21 tests).

## Test plan
- `vitest run test/config.test.ts --coverage --coverage.include=src/config.ts` → 21 tests pass, 100% across all four dimensions.
- Full application-admin-console suite: 419 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edit is coverage-ignore comments only — no statement changed, runtime behavior byte-identical.

## Physical impact
- NO-OP on CFn / deployed artifacts. Comment-only source change inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for configuration loading, including network error handling, fallback scenarios, and field validation.

* **Chores**
  * Updated code comments and adjusted coverage tooling configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->