### PR TITLE
test(admin-console): close idp-resolution / format / insight coverage gaps

### DIFF
--- a/apps/admin-console/test/idp-resolution.test.ts
+++ b/apps/admin-console/test/idp-resolution.test.ts
@@ -31,9 +31,19 @@ describe("distinctProviders (#1335)", () => {
     });
     expect(new Set(out)).toEqual(new Set(["corp-entra", "corp-okta"]));
   });
+
+  it("should skip blank / whitespace-only provider names (= directory hygiene)", () => {
+    expect(distinctProviders({ "a.com": ["", "  ", "corp-okta"] as unknown as string[] })).toEqual([
+      "corp-okta",
+    ]);
+  });
 });
 
 describe("resolveIdp (#1335)", () => {
+  it("should resolve `local` when the email has no domain at all (no @)", () => {
+    expect(resolveIdp("no-at-sign", { "example.com": ["corp-entra"] })).toEqual({ kind: "local" });
+  });
+
   it("should resolve `local` when the email has no matching domain", () => {
     expect(resolveIdp("alice@nope.com", { "example.com": ["corp-entra"] })).toEqual({
       kind: "local",

--- a/apps/admin-console/test/insight.test.ts
+++ b/apps/admin-console/test/insight.test.ts
@@ -81,6 +81,36 @@ describe("fetchTenantsInsightSummary", () => {
       { message: expect.stringContaining("500") },
     );
   });
+
+  it("should fall back to statusText when the error body cannot be read", async () => {
+    // res.text() が reject するケース → `.catch(() => "")` で空文字に倒し、 statusText を使う。
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: () => Promise.reject(new Error("stream error")),
+    } as unknown as Response);
+    await expect(fetchTenantsInsightSummary(baseConfig, "id-token", ["t-1"])).rejects.toMatchObject(
+      {
+        message: expect.stringContaining("Bad Gateway"),
+      },
+    );
+  });
+
+  it("should normalize a base URL that already ends with '/'", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [] }), { status: 200 }),
+    );
+    await fetchTenantsInsightSummary(
+      { ...baseConfig, adminInsightApiUrl: "https://insight.example.com/" },
+      "id-token",
+      ["t-1"],
+    );
+    const [calledUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(calledUrl)).toBe(
+      "https://insight.example.com/admin/insight/tenants/summary?tenantIds=t-1",
+    );
+  });
 });
 
 describe("indexSummaryByTenantId", () => {

--- a/apps/admin-console/test/lib/format.test.ts
+++ b/apps/admin-console/test/lib/format.test.ts
@@ -14,6 +14,10 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime("", "ja", NOW)).toBe("—");
   });
 
+  it("should return em-dash for an unparseable (non-empty) ISO string", () => {
+    expect(formatRelativeTime("not-a-date", "ja", NOW)).toBe("—");
+  });
+
   it("should render under 30 seconds as 「今」 in ja and 'just now' in en", () => {
     expect(formatRelativeTime("2026-05-05T10:00:00.000Z", "ja", NOW)).toBe("今");
     expect(formatRelativeTime("2026-05-05T10:00:00.000Z", "en", NOW)).toBe("just now");
@@ -23,6 +27,12 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime("2026-05-05T09:59:00.000Z", "ja", NOW)).toBe("1 分前");
     expect(formatRelativeTime("2026-05-05T09:00:00.000Z", "ja", NOW)).toBe("1 時間前");
     expect(formatRelativeTime("2026-05-04T10:00:00.000Z", "ja", NOW)).toBe("1 日前");
+  });
+
+  it("should render the minute / hour / day buckets in English too", () => {
+    expect(formatRelativeTime("2026-05-05T09:59:00.000Z", "en", NOW)).toBe("1 min ago");
+    expect(formatRelativeTime("2026-05-05T09:00:00.000Z", "en", NOW)).toBe("1 h ago");
+    expect(formatRelativeTime("2026-05-04T10:00:00.000Z", "en", NOW)).toBe("1 d ago");
   });
 
   it("should fall back to YYYY-MM-DD beyond 30 days", () => {


### PR DESCRIPTION
## Summary

Pinned the remaining unreached branches across three admin-console pure-logic modules to **100%**:

- **`auth/idp-resolution.ts`** — `distinctProviders` skipping a blank provider name, and `resolveIdp` falling back to `local` when the email has no domain (no `@`).
- **`lib/format.ts`** — `formatRelativeTime` for an unparseable (non-empty) ISO → em-dash, and the English minute / hour / day buckets (only `ja` was pinned).
- **`api/insight.ts`** — trailing-slash `adminInsightApiUrl` normalization, and the error path's `.catch(() => "")` arrow + `statusText` fallback when `res.text()` rejects (the existing 500 test reads the body successfully, so the catch arrow was unreached).

All three modules now report **100% statements / branches / functions / lines**.

## Test plan
- `vitest run test/idp-resolution.test.ts test/lib/format.test.ts test/insight.test.ts --coverage --coverage.include=…` → 31 tests pass, 100% across all four dimensions.
- Full admin-console suite: 149 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Each addition is additive; existing tests untouched. The insight `statusText` test uses a `Response`-like stub whose `text()` rejects to exercise the catch arrow.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test files only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)