### PR TITLE
test(admin-console): bring api/client to 100%

### DIFF
--- a/apps/admin-console/test/api-client.test.ts
+++ b/apps/admin-console/test/api-client.test.ts
@@ -1,6 +1,10 @@
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ApiError, createApiClient } from "../src/api/client";
+import { ApiError, createApiClient, useApiClient } from "../src/api/client";
 import type { AppConfig } from "../src/config";
+
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock("../src/auth/AuthProvider", () => ({ useAuth: mockUseAuth }));
 
 const config: AppConfig = {
   cognitoDomain: "https://example.com",
@@ -60,5 +64,59 @@ describe("createApiClient", () => {
       const api = createApiClient(config, "T");
       await expect(api.get("tenants")).rejects.toBeInstanceOf(ApiError);
     });
+
+    it("should fall back to statusText when the error body cannot be read", async () => {
+      // res.text() が reject → `.catch(() => "")` で空文字 → statusText を message に使う。
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+          text: () => Promise.reject(new Error("stream error")),
+        } as unknown as Response),
+      );
+      const api = createApiClient(config, "T");
+      await expect(api.get("tenants")).rejects.toMatchObject({
+        status: 503,
+        message: expect.stringContaining("Service Unavailable"),
+      });
+    });
+  });
+
+  it("should append a trailing slash to apiBaseUrl when it lacks one (already-slash kept)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = createApiClient({ ...config, apiBaseUrl: "https://api.example.com/prod/" }, "T");
+    await api.get("tenants");
+    const [url] = fetchMock.mock.calls[0] as [URL];
+    expect(url.toString()).toBe("https://api.example.com/prod/tenants");
+  });
+
+  it("should issue a DELETE for del() and resolve void", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = createApiClient(config, "T");
+    await expect(api.del("tenants/t-1")).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("https://api.example.com/prod/tenants/t-1");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("useApiClient", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("should return a client when auth tokens are present", () => {
+    mockUseAuth.mockReturnValue({ tokens: { idToken: "tok" } });
+    const { result } = renderHook(() => useApiClient(config));
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current?.get).toBe("function");
+  });
+
+  it("should return null when there are no auth tokens", () => {
+    mockUseAuth.mockReturnValue({ tokens: null });
+    const { result } = renderHook(() => useApiClient(config));
+    expect(result.current).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`apps/admin-console/src/api/client.ts` (the Control Plane API client) was at **72% / 56% branches**. The trailing-slash base normalization, `del()`, the error path's `text()`-rejects catch arrow + `statusText` fallback, and the `useApiClient` hook were unpinned.

Extended `api-client.test.ts`:
- trailing-slash `apiBaseUrl` normalization.
- `del()` → DELETE verb, resolves void.
- 4xx where `res.text()` rejects → `.catch(() => "")` arrow + `statusText` fallback.
- `useApiClient` (`renderHook` + mocked `useAuth`): client when `auth.tokens` present, `null` otherwise.

client.ts now reports **100% statements / branches / functions / lines** (8 tests). This completes the admin-console pure-logic (api / auth / lib) coverage.

## Test plan
- `vitest run test/api-client.test.ts --coverage --coverage.include=src/api/client.ts` → 8 tests pass, 100% across all four dimensions.
- Full admin-console suite: 154 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. The `statusText` test uses a `Response`-like stub whose `text()` rejects; the AuthProvider mock is file-scoped. Existing GET/POST/4xx tests untouched.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)