### PR TITLE
test(participant-portal): cover plugins/loader to 100%

### DIFF
--- a/apps/participant-portal/src/plugins/loader.ts
+++ b/apps/participant-portal/src/plugins/loader.ts
@@ -25,6 +25,9 @@ import { findProblemMetadata, type ProblemDashboardSlots } from "../data/problem
  * `eager: false` で各 file を別 chunk に分け、 必要時のみ fetch される。
  * 戻り値 key の例: "../../../../problems/battles/microservice-migration-battle/portal/StatusPanel.tsx"
  */
+// glob pattern は Vite が build/HMR 時に解決する compile-time directive。 引数の path literal は
+// ランタイムでは実行されず coverage instrument 対象として到達不能なので ignore する。
+/* v8 ignore next 3 */
 const pluginModules = import.meta.glob<{ default: PortalSlotComponent }>(
   "../../../../problems/*/*/portal/*.tsx",
 );
@@ -42,10 +45,14 @@ const PLUGIN_ENTRY_BY_NEEDLE: ReadonlyMap<string, () => Promise<{ default: Porta
     for (const [key, loader] of Object.entries(pluginModules)) {
       // key = "../../../../problems/<category>/<problemId>/portal/<file>.tsx"
       const segments = key.split("/");
+      // glob は常に上記 6+ segment の portal path を返すため、 segment 数不足 / 非 portal の
+      // skip 分岐は valid な glob 結果では到達不能な防御ガード。
+      /* v8 ignore next */
       if (segments.length < 3) continue;
       const fileName = segments[segments.length - 1];
       const portalSegment = segments[segments.length - 2];
       const problemId = segments[segments.length - 3];
+      /* v8 ignore next */
       if (!fileName || !problemId || portalSegment !== "portal") continue;
       map.set(`${problemId}/portal/${fileName}`, loader);
     }

--- a/apps/participant-portal/test/plugins/loader.test.tsx
+++ b/apps/participant-portal/test/plugins/loader.test.tsx
@@ -1,0 +1,109 @@
+import type { PortalSlotName } from "@tenkacloud/portal-plugin-sdk";
+import { render, screen, waitFor } from "@testing-library/react";
+import { Component, type ComponentType, type ReactNode, Suspense } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ADR-012 Phase 5 plugin loader。 findProblemMetadata を mock して dashboard slot の
+ * 宣言有無 / glob 解決可否を制御し、 (1) slot 未宣言 → undefined、 (2) glob 解決済 →
+ * memoize された React.lazy、 (3) 宣言済だが file 不在 → erroring lazy (= #1251 fail-loud)
+ * を pin する。 erroring lazy は ErrorBoundary 経由で render し console.error を確認する。
+ */
+const { mockFind } = vi.hoisted(() => ({ mockFind: vi.fn() }));
+vi.mock("../../src/data/problems", () => ({ findProblemMetadata: mockFind }));
+
+const { loadPluginSlot, _listDiscoveredPluginKeys, _clearSlotComponentCache } = await import(
+  "../../src/plugins/loader"
+);
+
+const STATUS = "StatusPanel" as PortalSlotName;
+
+class ErrorBoundary extends Component<{ children: ReactNode }, { errored: boolean }> {
+  state = { errored: false };
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+  render() {
+    return this.state.errored ? <div>errored</div> : this.props.children;
+  }
+}
+
+beforeEach(() => {
+  mockFind.mockReset();
+  _clearSlotComponentCache();
+});
+
+describe("loadPluginSlot", () => {
+  it("should return undefined for missing metadata / missing slots / undeclared slot", () => {
+    mockFind.mockReturnValueOnce(undefined);
+    expect(loadPluginSlot("nope", STATUS)).toBeUndefined();
+    mockFind.mockReturnValueOnce({});
+    expect(loadPluginSlot("nope", STATUS)).toBeUndefined();
+    mockFind.mockReturnValueOnce({ dashboardSlots: {} });
+    expect(loadPluginSlot("nope", STATUS)).toBeUndefined();
+  });
+
+  it("should return a memoized lazy component for a glob-resolved slot", () => {
+    mockFind.mockReturnValue({ dashboardSlots: { StatusPanel: "portal/StatusPanel.tsx" } });
+    const a = loadPluginSlot("microservice-migration-battle", STATUS);
+    const b = loadPluginSlot("microservice-migration-battle", STATUS);
+    expect(a).toBeDefined();
+    // same (problemId, slot) → 同一 component identity (Suspense flash 抑止の cache)。
+    expect(a).toBe(b);
+  });
+
+  it("should return an erroring lazy for a declared-but-unresolved slot and fail loud on render", async () => {
+    mockFind.mockReturnValue({ dashboardSlots: { StatusPanel: "portal/DoesNotExist.tsx" } });
+    const Comp = loadPluginSlot("ghost-problem", STATUS);
+    expect(Comp).toBeDefined();
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const C = Comp as unknown as ComponentType;
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <C />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+    await waitFor(() => expect(screen.getByText("errored")).toBeInTheDocument());
+    expect(errSpy.mock.calls.some((call) => String(call[0]).includes("unresolved slot"))).toBe(
+      true,
+    );
+    errSpy.mockRestore();
+  });
+
+  it("should import the real plugin chunk when the slot resolves (covers the glob loader)", async () => {
+    mockFind.mockReturnValue({ dashboardSlots: { StatusPanel: "portal/StatusPanel.tsx" } });
+    const Comp = loadPluginSlot("microservice-migration-battle", STATUS);
+    expect(Comp).toBeDefined();
+    // suppress any render-time warnings from the real component.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const C = Comp as unknown as ComponentType<Record<string, unknown>>;
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading-real</div>}>
+          <C />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+    // import が解決 (= glob loader 実行) すると fallback が消える (rendered or errored)。
+    await waitFor(() => expect(screen.queryByText("loading-real")).not.toBeInTheDocument());
+    vi.restoreAllMocks();
+  });
+
+  it("should expose the discovered glob keys and a cache reset for tests", () => {
+    const keys = _listDiscoveredPluginKeys();
+    expect(Array.isArray(keys)).toBe(true);
+    expect(keys.some((k) => k.endsWith("/portal/StatusPanel.tsx"))).toBe(true);
+
+    // cache reset 後は同 (problemId, slot) でも新しい component identity が返る。
+    mockFind.mockReturnValue({ dashboardSlots: { StatusPanel: "portal/StatusPanel.tsx" } });
+    const first = loadPluginSlot("microservice-migration-battle", STATUS);
+    _clearSlotComponentCache();
+    const second = loadPluginSlot("microservice-migration-battle", STATUS);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/plugins/loader.ts` (ADR-012 Phase 5 plugin loader) was at ~92% with no dedicated test (covered only incidentally). Added `test/plugins/loader.test.tsx` that mocks `findProblemMetadata` to control slot declaration / glob resolution:

- `undefined` for missing metadata / missing `dashboardSlots` / undeclared slot.
- a memoized `React.lazy` for a glob-resolved slot (same identity on repeat call).
- an **erroring lazy** for a declared-but-unresolved slot, rendered through a Suspense + ErrorBoundary to verify the **#1251 fail-loud** `console.error` (no silent skip of a deploy/typo).
- rendering the resolved slot imports the real plugin chunk (covers the glob-generated loader function).
- the `_listDiscoveredPluginKeys` / `_clearSlotComponentCache` test utilities.

Two source edits are `/* v8 ignore */` annotations with a rationale: the `import.meta.glob(...)` path literal (a Vite compile-time directive, not runtime code) and the index-builder's segment-count / non-portal `continue` guards (unreachable for the 6+-segment portal paths the glob always yields). loader.ts now reports **100% statements / branches / functions / lines** (5 tests). This completes participant-portal pure-logic coverage.

## Test plan
- `vitest run test/plugins/loader.test.tsx --coverage --coverage.include=src/plugins/loader.ts` → 5 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 279 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edits are coverage-ignore comments only — no statement changed, so runtime behavior is byte-identical. The defensive guards remain in place.

## Physical impact
- NO-OP on CFn / deployed artifacts. Comment-only source change inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)