### PR TITLE
test(participant-portal): cover NextActionHero render branches (100%)

### DIFF
--- a/apps/participant-portal/test/components/NextActionHero.render.test.tsx
+++ b/apps/participant-portal/test/components/NextActionHero.render.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LeaderboardResponse, ParticipantTeamView } from "../../src/api/portal-client";
+
+/**
+ * Issue #1349: NextActionHero の render 4 状態 (not_started / ended / all_cleared / running) と
+ * 「次の問題を開く」 button → navigate を pin する。 pure 戦術関数 (pickNextProblem 等) は別 test
+ * で網羅済。 useT は key echo、 useNavigate は spy に差し替える。
+ */
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+
+const { NextActionHero } = await import("../../src/components/NextActionHero");
+
+const view = (over: Partial<ParticipantTeamView>): ParticipantTeamView =>
+  ({ eventGate: undefined, problems: [], ...over }) as unknown as ParticipantTeamView;
+const board = (over: Partial<LeaderboardResponse>): LeaderboardResponse =>
+  ({ entries: [], ...over }) as unknown as LeaderboardResponse;
+
+const UNSOLVED = {
+  problemId: "p1",
+  jobId: "job-1",
+  status: "COMPLETE",
+  score: 0,
+  scoring: { kind: "flag", flagSubmitted: false },
+};
+const SOLVED = {
+  problemId: "p2",
+  jobId: "job-2",
+  status: "COMPLETE",
+  score: 100,
+  scoring: { kind: "flag", flagSubmitted: true },
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe("NextActionHero (render)", () => {
+  it("should render nothing when there is no team view", () => {
+    const { container } = render(<NextActionHero view={null} leaderboard={null} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("should show the not-started countdown (with and without a startsAt)", () => {
+    const withStart = render(
+      <NextActionHero
+        view={view({
+          eventGate: { kind: "scoring_not_started", startsAt: "2999-01-01T00:00:00Z" },
+        })}
+        leaderboard={null}
+      />,
+    );
+    expect(withStart.container.textContent).toContain("next_action.not_started_starts_at");
+    withStart.unmount();
+
+    const noStart = render(
+      <NextActionHero
+        view={view({ eventGate: { kind: "scoring_not_started" } })}
+        leaderboard={null}
+      />,
+    );
+    expect(noStart.container.textContent).toContain("next_action.not_started_unknown");
+  });
+
+  it("should show the ended summary with a final rank and without one", () => {
+    const withRank = render(
+      <NextActionHero
+        view={view({ eventGate: { kind: "scoring_ended" } })}
+        leaderboard={board({ entries: [{ isMyTeam: true, rank: 3 }] as never })}
+      />,
+    );
+    expect(withRank.container.textContent).toContain("next_action.ended_with_rank");
+    withRank.unmount();
+
+    const noRank = render(
+      <NextActionHero view={view({ eventGate: { kind: "scoring_ended" } })} leaderboard={null} />,
+    );
+    expect(noRank.container.textContent).toContain("next_action.ended_no_rank");
+  });
+
+  it("should show all-cleared when every problem is solved", () => {
+    const { container } = render(
+      <NextActionHero view={view({ problems: [SOLVED] as never })} leaderboard={null} />,
+    );
+    expect(container.textContent).toContain("next_action.all_cleared");
+  });
+
+  it("should suggest the next problem and navigate to it on click", () => {
+    render(<NextActionHero view={view({ problems: [UNSOLVED] as never })} leaderboard={null} />);
+    expect(screen.getByText(/next_action\.running_pick/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "next_action.running_open_button" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/problems/job-1");
+  });
+
+  it("should fall back to a non-COMPLETE unsolved problem when none are deploy-ready", () => {
+    // ready (= COMPLETE) が 0 件 → pickNextProblem は unsolved pool をそのまま使う分岐。
+    const inProgress = {
+      problemId: "p3",
+      jobId: "job-3",
+      status: "IN_PROGRESS",
+      score: 0,
+      scoring: { kind: "uptime" },
+    };
+    render(<NextActionHero view={view({ problems: [inProgress] as never })} leaderboard={null} />);
+    expect(screen.getByText(/next_action\.running_pick/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "next_action.running_open_button" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/problems/job-3");
+  });
+
+  it("should show the no-ready-problem running state when there is nothing to open", () => {
+    // problems が空 → running 状態だが nextProblem 無し → button を出さず no_ready ラベル。
+    const { container } = render(
+      <NextActionHero view={view({ problems: [] })} leaderboard={null} />,
+    );
+    expect(container.textContent).toContain("next_action.running_no_ready");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/components/NextActionHero.tsx`'s pure tactical helpers (`pickNextProblem` / `isProblemUnsolved` / `computeNextActionState`) were tested, but the **component render branches** were not. Added a `.tsx` render test (mock `useT` to echo keys, `useNavigate` to a spy):

- renders nothing without a team view.
- not_started countdown (with `startsAt` → starts-at label, without → unknown).
- ended summary (with a final rank, and without one).
- all_cleared when every problem is solved.
- running: suggests the next problem and **navigates to `/problems/:jobId` on click**; the non-COMPLETE fallback (no deploy-ready problem → use the unsolved pool); and the no-ready-problem state (empty problems → label, no button).

NextActionHero.tsx now reports **100% statements / branches / functions / lines** (20 tests incl. the existing pure-function suite).

## Test plan
- `vitest run …/NextActionHero.render.test.tsx …/NextActionHero.test.ts --coverage --coverage.include=…` → 20 tests pass, 100% across all four dimensions.
- Full participant-portal suite passes; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. `useT` / `useNavigate` mocks are file-scoped; `vi.clearAllMocks()` per test.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)