### PR TITLE
test(participant-portal): cover LoginPage to 100%

### DIFF
--- a/apps/participant-portal/test/pages/Login.test.tsx
+++ b/apps/participant-portal/test/pages/Login.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * LoginPage の onSubmit エラー翻訳 (EMPTY_TEAM_LOGIN_KEY / BACKEND_UNREACHABLE / その他 /
+ * 非 Error) と、 backend モード (isMock=false) の info/field 出し分け、 既ログイン redirect を
+ * pin する。 useAuth / useIsMock / useNavigate / useT を mock し、 userEvent で入力→submit する。
+ */
+const { mockAuth, mockIsMock, mockNavigate, mockLogin } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockLogin: vi.fn(),
+}));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/i18n", () => ({ useT: () => (key: string) => key }));
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const { LoginPage } = await import("../../src/pages/Login");
+const config = { eventTitle: "Spring Cup" } as AppConfig;
+
+function renderLogin() {
+  return render(
+    <MemoryRouter>
+      <LoginPage config={config} />
+    </MemoryRouter>,
+  );
+}
+
+async function typeAndSubmit(key: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByRole("textbox"), key);
+  await user.click(screen.getByRole("button", { name: "login.submit" }));
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("LoginPage", () => {
+  it("should redirect home when already authenticated", () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ ready: true, session: { teamId: "t1" }, login: mockLogin });
+    renderLogin();
+    // Navigate redirect → ログインフォームは描画されない。
+    expect(screen.queryByRole("button", { name: "login.submit" })).not.toBeInTheDocument();
+  });
+
+  it("should render backend-mode info + password field when not in mock mode", () => {
+    mockIsMock.mockReturnValue(false);
+    mockAuth.mockReturnValue({ ready: true, session: null, login: mockLogin });
+    const { container } = renderLogin();
+    expect(container.textContent).toContain("login.info_header");
+    expect(container.textContent).toContain("login.info_body");
+    // backend モードは password 入力。
+    expect(container.querySelector('input[type="password"]')).not.toBeNull();
+  });
+
+  it("should log in and navigate home on success", async () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ ready: true, session: null, login: mockLogin });
+    mockLogin.mockResolvedValueOnce(undefined);
+    renderLogin();
+    await typeAndSubmit("TEAM-KEY");
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/"));
+  });
+
+  it("should translate known auth error codes and pass through others", async () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ ready: true, session: null, login: mockLogin });
+
+    for (const [thrown, expected] of [
+      [new Error("EMPTY_TEAM_LOGIN_KEY"), "home.auth_error_empty_key"],
+      [new Error("BACKEND_UNREACHABLE"), "home.auth_error_backend"],
+      [new Error("some other failure"), "some other failure"],
+      ["non-error-throwable", "login.failed_generic"],
+    ] as const) {
+      mockLogin.mockRejectedValueOnce(thrown);
+      const { unmount } = renderLogin();
+      await typeAndSubmit("KEY");
+      await waitFor(() => expect(screen.getByText(expected)).toBeInTheDocument());
+      unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/pages/Login.tsx` had no dedicated test (only indirect via `App.test` in dev-mock). Added an interaction test (mock `useAuth` / `useIsMock` / `useNavigate` / `useT`, `userEvent` for type + submit) covering:

- already-authenticated → redirect home (no form rendered).
- backend mode (`isMock=false`): `info_header` / `info_body` + password-type field.
- successful login → `navigate("/")`.
- `onSubmit` error translation: `EMPTY_TEAM_LOGIN_KEY` → empty-key message, `BACKEND_UNREACHABLE` → backend message, other `Error` → raw message, non-Error throwable → generic message (the error `Alert` renders each).

Login.tsx now reports **100% statements / branches / functions / lines** (4 tests).

## Test plan
- `vitest run test/pages/Login.test.tsx --coverage --coverage.include=src/pages/Login.tsx` → 4 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 284 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift. Hooks mocked file-scoped; `vi.clearAllMocks()` per test.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)