### PR TITLE
test(participant-portal): cover the i18n provider to 100%

### DIFF
--- a/apps/participant-portal/src/i18n/index.tsx
+++ b/apps/participant-portal/src/i18n/index.tsx
@@ -110,6 +110,8 @@ export function I18nProvider({ children }: { children: ReactNode }) {
 
   // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
   useEffect(() => {
+    // SSR safety guard。 jsdom test 環境では document が常に存在するため到達不能。
+    /* v8 ignore next */
     if (typeof document === "undefined") return;
     document.documentElement.lang = locale;
   }, [locale]);
@@ -153,5 +155,12 @@ export function useLang(): LocaleCode {
   return useI18n().locale;
 }
 
-/** Tests / debug 用に dictionaries を露出。 portal 本体からは使わない。 */
-export const _testInternals = { LOCALE_DICTIONARIES, resolveKey, detectBrowserLocale, interpolate };
+/** Tests / debug 用に dictionaries / 内部 helper を露出。 portal 本体からは使わない。 */
+export const _testInternals = {
+  LOCALE_DICTIONARIES,
+  resolveKey,
+  detectBrowserLocale,
+  interpolate,
+  loadStoredLocale,
+  persistLocale,
+};

--- a/apps/participant-portal/test/i18n/i18n.test.tsx
+++ b/apps/participant-portal/test/i18n/i18n.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _testInternals,
+  I18nProvider,
+  SUPPORTED_LOCALES,
+  useI18n,
+  useLang,
+  useT,
+} from "../../src/i18n";
+
+/**
+ * Issue #583 i18n 基盤。 純 helper (detectBrowserLocale / loadStoredLocale / persistLocale /
+ * resolveKey / interpolate) を _testInternals 経由で全分岐 (= SSR guard / locale fallback /
+ * localStorage 例外) 走査し、 Provider + useT/useLang/useI18n/setLocale を renderHook で pin する。
+ */
+const { detectBrowserLocale, loadStoredLocale, persistLocale, resolveKey, interpolate } =
+  _testInternals;
+const STORAGE_KEY = "tenkacloud.portal.locale";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe("detectBrowserLocale", () => {
+  it("should narrow navigator.language and default to ja", () => {
+    vi.stubGlobal("navigator", { language: "ja-JP" });
+    expect(detectBrowserLocale()).toBe("ja");
+    vi.stubGlobal("navigator", { language: "en-US" });
+    expect(detectBrowserLocale()).toBe("en");
+    vi.stubGlobal("navigator", { language: "fr-FR" });
+    expect(detectBrowserLocale()).toBe("ja"); // no match
+    vi.stubGlobal("navigator", { language: "" });
+    expect(detectBrowserLocale()).toBe("ja"); // empty → "ja"
+    vi.stubGlobal("navigator", undefined);
+    expect(detectBrowserLocale()).toBe("ja"); // SSR guard
+  });
+});
+
+describe("loadStoredLocale", () => {
+  it("should return a valid stored locale, undefined otherwise / on error / without window", () => {
+    localStorage.setItem(STORAGE_KEY, "en");
+    expect(loadStoredLocale()).toBe("en");
+    localStorage.setItem(STORAGE_KEY, "klingon");
+    expect(loadStoredLocale()).toBeUndefined();
+    localStorage.removeItem(STORAGE_KEY);
+    expect(loadStoredLocale()).toBeUndefined();
+
+    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(loadStoredLocale()).toBeUndefined();
+    spy.mockRestore();
+
+    vi.stubGlobal("window", undefined);
+    expect(loadStoredLocale()).toBeUndefined(); // SSR guard
+  });
+});
+
+describe("persistLocale", () => {
+  it("should write, swallow errors, and no-op without window", () => {
+    persistLocale("en");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("en");
+
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => persistLocale("ja")).not.toThrow();
+    spy.mockRestore();
+
+    vi.stubGlobal("window", undefined);
+    expect(() => persistLocale("ja")).not.toThrow(); // SSR guard
+  });
+});
+
+describe("resolveKey", () => {
+  it("should resolve a leaf string, and return undefined for a non-string node / missing path", () => {
+    expect(resolveKey({ a: { b: "x" } }, "a.b")).toBe("x");
+    expect(resolveKey({ a: { b: "x" } }, "a")).toBeUndefined(); // node is an object
+    expect(resolveKey({ a: { b: "x" } }, "a.c.d")).toBeUndefined(); // missing
+  });
+});
+
+describe("interpolate", () => {
+  it("should leave the template untouched without params and substitute named placeholders", () => {
+    expect(interpolate("hi")).toBe("hi");
+    expect(interpolate("hi {name}", { name: "Al" })).toBe("hi Al");
+    // 未指定 placeholder はそのまま残す (= missing key debug 用)。
+    expect(interpolate("hi {name}", { other: "x" })).toBe("hi {name}");
+  });
+});
+
+describe("I18nProvider + hooks", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <I18nProvider>{children}</I18nProvider>
+  );
+
+  it("should translate a real key and fall back to the raw key when missing", () => {
+    const { result } = renderHook(() => useT(), { wrapper });
+    expect(result.current("definitely.not.a.real.key.zzz")).toBe("definitely.not.a.real.key.zzz");
+    // 実在 key (= app.loading) は raw key と異なる翻訳を返す。
+    expect(result.current("app.loading")).not.toBe("app.loading");
+  });
+
+  it("should expose the current locale via useLang", () => {
+    const { result } = renderHook(() => useLang(), { wrapper });
+    expect(SUPPORTED_LOCALES).toContain(result.current);
+  });
+
+  it("should update + persist the locale via setLocale", () => {
+    const { result } = renderHook(() => useI18n(), { wrapper });
+    act(() => result.current.setLocale("en"));
+    expect(result.current.locale).toBe("en");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("en");
+  });
+
+  it("should throw when used outside the provider", () => {
+    expect(() => renderHook(() => useI18n())).toThrow(/I18nProvider/);
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/i18n/index.tsx` (the homegrown i18n base) had **no test**. Added a comprehensive test driving all branches:

- `detectBrowserLocale`: ja / en narrowing, no-match + empty → ja default, and the navigator-undefined SSR guard (via `vi.stubGlobal`).
- `loadStoredLocale`: valid stored locale, invalid/missing → undefined, the localStorage-throws catch, and the window-undefined SSR guard.
- `persistLocale`: write, error-swallow, window-undefined no-op.
- `resolveKey`: leaf string, non-string node, missing path.
- `interpolate`: no-params passthrough, named substitution, missing-param kept.
- `I18nProvider` + hooks: `useT` (real key vs raw-key fallback), `useLang`, `setLocale` (updates + persists), and `useI18n` throwing outside the provider.

**Source edits:** `loadStoredLocale` / `persistLocale` added to the existing `_testInternals` export so the SSR/error branches are reachable directly, and the useEffect `typeof document === "undefined"` SSR guard (unreachable in jsdom) is `/* v8 ignore next */`. i18n/index.tsx now reports **100% statements / branches / functions / lines** (9 tests).

## Test plan
- `vitest run test/i18n/i18n.test.tsx --coverage --coverage.include=src/i18n/index.tsx` → 9 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 289 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edits expand a test-only export and add one coverage-ignore comment — no runtime behavior change. The stubbed globals are restored per test.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test-only export + comment inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)