### PR TITLE
test(participant-portal): cover config-context to 100%

### DIFF
--- a/apps/participant-portal/test/config-context.test.tsx
+++ b/apps/participant-portal/test/config-context.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import type { AppConfig } from "../src/config";
+import { AppConfigProvider, useAppConfig, useIsMock } from "../src/config-context";
+
+/**
+ * AppConfig context: provider 内で config を返す / provider 外で throw / useIsMock の
+ * mode !== "backend" 派生を pin する。
+ */
+const cfg = (mode: string) => ({ mode }) as AppConfig;
+const wrapWith = (config: AppConfig) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <AppConfigProvider config={config}>{children}</AppConfigProvider>;
+  };
+
+describe("config-context", () => {
+  it("should return the config from inside the provider", () => {
+    const config = cfg("backend");
+    const { result } = renderHook(() => useAppConfig(), { wrapper: wrapWith(config) });
+    expect(result.current).toBe(config);
+  });
+
+  it("should throw when useAppConfig is called outside the provider", () => {
+    expect(() => renderHook(() => useAppConfig())).toThrow(/AppConfigProvider/);
+  });
+
+  it("should derive useIsMock from mode !== backend", () => {
+    expect(
+      renderHook(() => useIsMock(), { wrapper: wrapWith(cfg("backend")) }).result.current,
+    ).toBe(false);
+    expect(
+      renderHook(() => useIsMock(), { wrapper: wrapWith(cfg("dev-mock")) }).result.current,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/config-context.tsx` (the AppConfig context + `useIsMock` derived hook) had no dedicated test; the `useAppConfig` out-of-provider throw was uncovered. Added a `renderHook` test: returns the config inside the provider, throws outside it, and `useIsMock` derives `mode !== "backend"` (both sides).

config-context.tsx now reports **100% statements / branches / functions / lines** (3 tests).

## Test plan
- `vitest run test/config-context.test.tsx --coverage --coverage.include=src/config-context.tsx` → 3 tests pass, 100% across all four dimensions.
- Full participant-portal suite passes; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- Test-only. No `src/**` change → no runtime / CFn behavior shift.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test file only; not bundled into any Lambda or SPA dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)