### PR TITLE
test(participant-portal): cover PortalPluginSlots to 100%

### DIFF
--- a/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
@@ -135,9 +135,12 @@ class PluginErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
+      // getDerivedStateFromError は常に message を string で設定するため、 ?? fallback は到達不能。
+      /* v8 ignore next */
+      const message = this.state.message ?? "Unknown error";
       return (
         <Alert type="warning" header={`Plugin "${this.props.slotName}" failed to render`}>
-          {this.state.message ?? "Unknown error"}
+          {message}
         </Alert>
       );
     }

--- a/apps/participant-portal/test/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/test/plugins/PortalPluginSlots.test.tsx
@@ -1,0 +1,68 @@
+import { PORTAL_SLOT_NAMES } from "@tenkacloud/portal-plugin-sdk";
+import { render, screen, waitFor } from "@testing-library/react";
+import { lazy } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ADR-012 Phase 5 PortalPluginSlots wrapper。 loadPluginSlot を mock して slot 無し → null、
+ * pending lazy → Suspense fallback、 throw (Error / 非 Error) → PluginErrorBoundary の Alert
+ * (#1251 fail-loud console.error) を pin する。 props-builder は空に stub して catalog 非依存に。
+ */
+const { mockLoad } = vi.hoisted(() => ({ mockLoad: vi.fn() }));
+vi.mock("../../src/plugins/loader", () => ({ loadPluginSlot: mockLoad }));
+vi.mock("../../src/plugins/props-builder", () => ({
+  buildPortalPhases: () => [],
+  buildPortalDisruptions: () => [],
+  buildPortalEndpointsFromOutputs: () => [],
+  buildPortalTeam: (team: unknown) => team,
+}));
+
+const { PortalPluginSlots } = await import("../../src/plugins/PortalPluginSlots");
+
+const SLOT = PORTAL_SLOT_NAMES[0];
+const props = {
+  problemId: "p1",
+  jobId: "job-1",
+  score: 0,
+  team: { teamName: "Alpha" },
+  stackOutputs: {},
+};
+// 指定 slot だけ与えた lazy を返し、 他は undefined。
+const onlyFirst = (comp: ReturnType<typeof lazy>) => (_: string, slot: string) =>
+  slot === SLOT ? comp : undefined;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("PortalPluginSlots", () => {
+  it("should render nothing when no slot resolves", () => {
+    mockLoad.mockReturnValue(undefined);
+    const { container } = render(<PortalPluginSlots {...props} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("should show the Suspense loading fallback while a plugin chunk is pending", () => {
+    const pending = lazy(() => new Promise<{ default: () => null }>(() => {}));
+    mockLoad.mockImplementation(onlyFirst(pending));
+    render(<PortalPluginSlots {...props} />);
+    expect(screen.getByText(new RegExp(`Loading plugin: ${SLOT}`))).toBeInTheDocument();
+  });
+
+  it("should degrade to a warning Alert when a plugin throws an Error", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const boom = lazy(() => Promise.reject(new Error("plugin boom")));
+    mockLoad.mockImplementation(onlyFirst(boom));
+    render(<PortalPluginSlots {...props} />);
+    await waitFor(() => expect(screen.getByText("plugin boom")).toBeInTheDocument());
+    // #1251: crash を console.error に昇格。
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("crashed"))).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it("should stringify a non-Error plugin throwable in the Alert", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const boom = lazy(() => Promise.reject("plugin-string-failure"));
+    mockLoad.mockImplementation(onlyFirst(boom));
+    render(<PortalPluginSlots {...props} />);
+    await waitFor(() => expect(screen.getByText("plugin-string-failure")).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/plugins/PortalPluginSlots.tsx` (the plugin-slot render wrapper with Suspense + ErrorBoundary) had no test. Added a `.tsx` test mocking `loadPluginSlot` (controllable lazies) + stubbing `props-builder` to be catalog-free:

- no slot resolves → renders `null`.
- a pending lazy → the Suspense "Loading plugin: …" fallback.
- a plugin throwing an `Error` → the ErrorBoundary warning `Alert` + the **#1251 fail-loud** `console.error("… crashed")`.
- a non-Error plugin throwable → stringified in the `Alert` (`getDerivedStateFromError` `String(err)` branch).

One source line is hoisted out of JSX: the ErrorBoundary's `message ?? "Unknown error"` (`getDerivedStateFromError` always sets a string, so the fallback is unreachable) is moved to a JS const marked `/* v8 ignore next */`. Behavior is identical. PortalPluginSlots.tsx now reports **100% statements / branches / functions / lines** (4 tests).

## Test plan
- `vitest run test/plugins/PortalPluginSlots.test.tsx --coverage --coverage.include=src/plugins/PortalPluginSlots.tsx` → 4 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 281 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edit only hoists the message expression into a const + a coverage-ignore comment; the rendered `Alert` is identical. Mocks are file-scoped.

## Physical impact
- NO-OP on CFn / deployed artifacts. Local-variable hoist inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)