### PR TITLE
test(participant-portal): bring AuthProvider to 100%

### DIFF
--- a/apps/participant-portal/src/auth/AuthProvider.tsx
+++ b/apps/participant-portal/src/auth/AuthProvider.tsx
@@ -49,7 +49,10 @@ async function exchangeKeyForSession(
       view = await getPortalMe(config.apiBaseUrl, trimmed);
     } catch (err) {
       if (err instanceof PortalAuthError) throw err;
-      throw new Error(err instanceof Error ? err.message : "BACKEND_UNREACHABLE");
+      // getPortalMe は network / parse 失敗時も Error を throw するため、 非 Error fallback は到達不能。
+      /* v8 ignore next */
+      const message = err instanceof Error ? err.message : "BACKEND_UNREACHABLE";
+      throw new Error(message);
     }
     const now = Date.now();
     // Phase 2c: teamLoginKey で引いた view は team scope。teamId / eventId は team から、
@@ -144,6 +147,8 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
       window.addEventListener(evt, resetTimer, { passive: true });
     }
     return () => {
+      // resetTimer が必ず先に走り idleTimerRef を set 済なので、 cleanup 時の null 分岐は到達不能。
+      /* v8 ignore next */
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       for (const evt of IDLE_EVENTS) {
         window.removeEventListener(evt, resetTimer);

--- a/apps/participant-portal/test/auth/AuthProvider.test.tsx
+++ b/apps/participant-portal/test/auth/AuthProvider.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider, useAuth } from "../../src/auth/AuthProvider";
 import type { AppConfig } from "../../src/config";
@@ -29,6 +29,8 @@ describe("AuthProvider", () => {
     localStorage.clear();
     sessionStorage.clear();
     vi.restoreAllMocks();
+    // ?demo=1 等の query が他 test に漏れないよう URL を戻す。
+    window.history.replaceState({}, "", "/");
   });
 
   it("should be ready=true with no session in initial state", () => {
@@ -132,6 +134,65 @@ describe("AuthProvider", () => {
 
   it("should throw an error when useAuth() is called outside the Provider", () => {
     expect(() => renderHook(() => useAuth())).toThrow(/AuthProvider/);
+  });
+
+  it("backend mode: should wrap a non-auth getPortalMe failure as a login error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    const { result } = renderAuth(prodConfig);
+    await act(async () => {
+      await expect(result.current.login("AbCdEfGhIjKlMnOpQrStUvWx")).rejects.toBeInstanceOf(Error);
+    });
+    expect(result.current.session).toBeNull();
+  });
+
+  it("backend mode: should fall back to placeholders + default TTL when team/problem fields are absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ team: { teamName: "Alpha" }, problems: [] }), {
+          status: 200,
+        }),
+      ),
+    );
+    const { result } = renderAuth(prodConfig);
+    await act(async () => {
+      await result.current.login("AbCdEfGhIjKlMnOpQrStUvWx");
+    });
+    expect(result.current.session?.teamId).toBe("(unknown)");
+    expect(result.current.session?.eventId).toBe("(unknown)");
+    // expiresAt が default TTL (= 起動時刻 + 4h 付近) で 0 ではない。
+    expect(result.current.session?.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("dev-mock + ?demo=1: should auto-login a fixed demo team", async () => {
+    window.history.replaceState({}, "", "/?demo=1");
+    const { result } = renderAuth(devConfig);
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    expect(result.current.session?.teamId).toMatch(/^team-/);
+  });
+
+  describe("updateSession", () => {
+    it("should patch teamName and/or teamNameSetByCompetitor and persist", async () => {
+      const { result } = renderAuth(devConfig);
+      await act(async () => {
+        await result.current.login("abc-123-team");
+      });
+      act(() =>
+        result.current.updateSession({ teamName: "Renamed", teamNameSetByCompetitor: true }),
+      );
+      expect(result.current.session?.teamName).toBe("Renamed");
+      // 片方だけの patch も通る (= 各 spread 分岐)。
+      act(() => result.current.updateSession({ teamName: "Again" }));
+      expect(result.current.session?.teamName).toBe("Again");
+      act(() => result.current.updateSession({ teamNameSetByCompetitor: false }));
+      expect(result.current.session?.teamNameSetByCompetitor).toBe(false);
+    });
+
+    it("should be a no-op when there is no session", () => {
+      const { result } = renderAuth(devConfig);
+      act(() => result.current.updateSession({ teamName: "X" }));
+      expect(result.current.session).toBeNull();
+    });
   });
 
   describe("Issue #859: idle timeout (6 hours)", () => {


### PR DESCRIPTION
## Summary

The existing `AuthProvider` test covered dev/backend login, 401, logout, and the 6h idle timer. Extended it for the remaining branches:

- backend login where `getPortalMe` fails with a non-auth error → wrapped login error.
- backend view lacking `teamId` / `eventId` / problems → `"(unknown)"` placeholders + default-TTL `expiresAt`.
- dev-mock + `?demo=1` query → auto-login of the fixed demo team.
- `updateSession`: patch `teamName` and/or `teamNameSetByCompetitor` (each spread branch) + persist; no-op when there is no session.

Two genuinely-unreachable defensive branches are `/* v8 ignore next */`-annotated: the `BACKEND_UNREACHABLE` non-Error fallback (`getPortalMe` only throws `Error`s) and the idle-timer cleanup's null-guard (`resetTimer` always sets the ref first). The ternary is hoisted to a const for a clean ignore; behavior is identical. AuthProvider.tsx now reports **100% statements / branches / functions / lines** (16 tests).

## Test plan
- `vitest run test/auth/AuthProvider.test.tsx --coverage --coverage.include=src/auth/AuthProvider.tsx` → 16 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 283 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edits are a variable hoist + two coverage-ignore comments — no observable behavior change. Tests restore globals / history per test.

## Physical impact
- NO-OP on CFn / deployed artifacts. Comment + hoist inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)