### PR TITLE
test(participant-portal): cover NotificationsPage to 100%

### DIFF
--- a/apps/participant-portal/src/pages/Notifications.tsx
+++ b/apps/participant-portal/src/pages/Notifications.tsx
@@ -38,7 +38,11 @@ export function NotificationsPage() {
   // markNotificationsSeen は巻き戻し防止 + 同値 skip なので no-op が連続しても害なし。
   useEffect(() => {
     if (items && items.length > 0) {
-      markNotificationsSeen(items[0]?.occurredAt ?? "");
+      // length>0 を確認済なので items[0] は必ず存在する (= ?. / ?? "" は noUncheckedIndexedAccess
+      // 用の防御で実行時には到達不能)。
+      /* v8 ignore next */
+      const latest = items[0]?.occurredAt ?? "";
+      markNotificationsSeen(latest);
     }
   }, [items, markNotificationsSeen]);
 

--- a/apps/participant-portal/test/pages/Notifications.test.tsx
+++ b/apps/participant-portal/test/pages/Notifications.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * NotificationsPage の render 分岐: error / no-event / loading spinner / empty / 一覧
+ * (info・warning severity badge + body + describeAgo)。 page を開いたら markNotificationsSeen
+ * が最新 occurredAt で呼ばれる (= 未読 badge 0 化) ことも pin する。共有 hook を mock する。
+ */
+const { mockTeamView, mockIsMock, mockSeen } = vi.hoisted(() => ({
+  mockTeamView: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockSeen: vi.fn(),
+}));
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/auth/TeamViewProvider", () => ({ useTeamView: mockTeamView }));
+
+const { NotificationsPage } = await import("../../src/pages/Notifications");
+
+const teamView = (over: Record<string, unknown>) => ({
+  notifications: undefined,
+  notificationsError: undefined,
+  notificationsNoEvent: undefined,
+  markNotificationsSeen: mockSeen,
+  ...over,
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("NotificationsPage", () => {
+  it("should show an error alert", () => {
+    mockIsMock.mockReturnValue(false);
+    mockTeamView.mockReturnValue(teamView({ notificationsError: "boom" }));
+    render(<NotificationsPage />);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("should show a no-event info alert", () => {
+    mockIsMock.mockReturnValue(false);
+    mockTeamView.mockReturnValue(teamView({ notificationsNoEvent: true }));
+    render(<NotificationsPage />);
+    expect(screen.getByText("notifications.no_event_header")).toBeInTheDocument();
+  });
+
+  it("should show a loading spinner in backend mode (and not in mock mode)", () => {
+    mockIsMock.mockReturnValue(false);
+    mockTeamView.mockReturnValue(teamView({}));
+    const a = render(<NotificationsPage />);
+    expect(a.getByText("notifications.loading")).toBeInTheDocument();
+    a.unmount();
+
+    mockIsMock.mockReturnValue(true);
+    mockTeamView.mockReturnValue(teamView({}));
+    const b = render(<NotificationsPage />);
+    expect(b.queryByText("notifications.loading")).not.toBeInTheDocument();
+  });
+
+  it("should show the empty state and not mark anything seen", () => {
+    mockIsMock.mockReturnValue(false);
+    mockTeamView.mockReturnValue(teamView({ notifications: { items: [] } }));
+    render(<NotificationsPage />);
+    expect(screen.getByText("notifications.empty_header")).toBeInTheDocument();
+    expect(mockSeen).not.toHaveBeenCalled();
+  });
+
+  it("should render notifications with severity badges and mark the latest as seen", () => {
+    mockIsMock.mockReturnValue(false);
+    mockTeamView.mockReturnValue(
+      teamView({
+        notifications: {
+          items: [
+            {
+              notificationId: "n1",
+              severity: "warning",
+              title: "Outage",
+              body: "DB is down",
+              occurredAt: "2026-05-21T10:00:00Z",
+            },
+            {
+              notificationId: "n2",
+              severity: "info",
+              title: "Welcome",
+              body: "Good luck",
+              occurredAt: "2026-05-21T09:00:00Z",
+            },
+          ],
+        },
+      }),
+    );
+    render(<NotificationsPage />);
+    expect(screen.getByText("Outage")).toBeInTheDocument();
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    expect(screen.getByText("notifications.severity_warning")).toBeInTheDocument();
+    expect(screen.getByText("notifications.severity_info")).toBeInTheDocument();
+    // 最新 (items[0]) の occurredAt で seen 化。
+    expect(mockSeen).toHaveBeenCalledWith("2026-05-21T10:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/pages/Notifications.tsx` was 0% covered (reads the shared `TeamViewProvider` state, no own polling). Added a render test mocking `useTeamView` / `useIsMock` / `useT`:

- error / no-event alerts; loading spinner in backend mode (and not in mock mode); empty state (and that `markNotificationsSeen` is NOT called).
- the notification list with info / warning severity badges + body, and that opening the page marks the latest `occurredAt` seen (= unread badge → 0).

One line is hoisted to a `/* v8 ignore next */` const: `items[0]?.occurredAt ?? ""` is a `noUncheckedIndexedAccess` defense unreachable at runtime (the `length > 0` guard guarantees `items[0]`). Behavior is identical. Notifications.tsx now reports **100% statements / branches / functions / lines** (5 tests).

## Test plan
- `vitest run test/pages/Notifications.test.tsx --coverage --coverage.include=src/pages/Notifications.tsx` → 5 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 289 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edit hoists the expression into a const + a coverage-ignore comment; the `markNotificationsSeen` call is unchanged. Mocks are file-scoped.

## Physical impact
- NO-OP on CFn / deployed artifacts. Local-variable hoist inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)