### PR TITLE
test(participant-portal): cover CelebrationOverlay to 100%

### DIFF
--- a/apps/participant-portal/src/components/CelebrationOverlay.tsx
+++ b/apps/participant-portal/src/components/CelebrationOverlay.tsx
@@ -32,12 +32,15 @@ function buildParticles(seed: number): readonly Particle[] {
   for (let i = 0; i < PARTICLE_COUNT; i++) {
     const r = ((Math.sin(seed * 9301 + i * 49297) + 1) / 2 + 0.001) % 1;
     const r2 = ((Math.sin(seed * 233 + i * 7919) + 1) / 2 + 0.001) % 1;
+    // i % COLORS.length は常に有効 index なので ?? は noUncheckedIndexedAccess 用の到達不能防御。
+    /* v8 ignore next */
+    const color = COLORS[i % COLORS.length] ?? "#fc4d75";
     out.push({
       id: i,
       left: r * 100,
       delay: r2 * 500,
       duration: 1800 + r * 1000,
-      color: COLORS[i % COLORS.length] ?? "#fc4d75",
+      color,
       rotate: r * 360,
       size: 6 + r2 * 8,
     });

--- a/apps/participant-portal/test/components/CelebrationOverlay.test.tsx
+++ b/apps/participant-portal/test/components/CelebrationOverlay.test.tsx
@@ -1,0 +1,35 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CelebrationOverlay } from "../../src/components/CelebrationOverlay";
+
+/**
+ * audit table #6: 正解時の confetti 演出。 visible=false は null、 visible=true で 60 粒 +
+ * keyframes を描画、 3 秒後に fade-out (null) する 1-shot 挙動を pin する。 外部 lib なしの
+ * 自前 CSS animation なので render + fake timer だけで完結する。
+ */
+afterEach(() => vi.useRealTimers());
+
+describe("CelebrationOverlay", () => {
+  it("should render nothing when not visible", () => {
+    const { container } = render(<CelebrationOverlay visible={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render 60 confetti particles + the fall keyframes when visible", () => {
+    const { container } = render(<CelebrationOverlay visible />);
+    expect(container.querySelectorAll("span")).toHaveLength(60);
+    expect(container.querySelector("style")?.textContent).toContain("tc-celebrate-fall");
+    // 装飾なので a11y tree からは隠す。
+    expect(container.querySelector("[aria-hidden]")).not.toBeNull();
+  });
+
+  it("should fade out (render null) after the 3s duration", () => {
+    vi.useFakeTimers();
+    const { container } = render(<CelebrationOverlay visible />);
+    expect(container.querySelectorAll("span")).toHaveLength(60);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`apps/participant-portal/src/components/CelebrationOverlay.tsx` (audit #6 correct-answer confetti) had no test. Added a render test (no deps — self-contained CSS animation):

- `visible=false` → renders `null`.
- `visible=true` → 60 confetti particles + the `tc-celebrate-fall` keyframes, and the decorative overlay is `aria-hidden`.
- fake timers: after the 3s duration the overlay fades out to `null` (1-shot).

The `COLORS[i % COLORS.length] ?? "#fc4d75"` is hoisted to a `/* v8 ignore next */` const — `i % length` is always a valid index, so the `??` is a `noUncheckedIndexedAccess` defense unreachable at runtime. Behavior is identical. CelebrationOverlay.tsx now reports **100% statements / branches / functions / lines** (3 tests).

## Test plan
- `vitest run test/components/CelebrationOverlay.test.tsx --coverage --coverage.include=src/components/CelebrationOverlay.tsx` → 3 tests pass, 100% across all four dimensions.
- Full participant-portal suite: 282 tests pass; `tsc --noEmit` clean; biome clean; `make harness` no findings; pre-commit `before-commit` gate green.

## Regression analysis
- The source edit hoists the color expression into a const + a coverage-ignore comment; the particle output is unchanged.

## Physical impact
- NO-OP on CFn / deployed artifacts. Local-variable hoist inside a Lambda-free SPA module; test additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)