### PR TITLE
test(participant-portal): cover SsoCredentialsPage to 100%

### DIFF
--- a/apps/participant-portal/test/pages/SsoCredentials.test.tsx
+++ b/apps/participant-portal/test/pages/SsoCredentials.test.tsx
@@ -1,0 +1,255 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PortalAssumeRoleError,
+  PortalAuthError,
+  PortalValidationError,
+} from "../../src/api/portal-client";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * SsoCredentialsPage の render 分岐 (error / loading / empty / problem 一覧 + awsAccountId
+ * filter) と AWS Console ワンクリック login (mock blocked / 成功 window.open / 各 error 種別
+ * = auth_logout・assume_role・validation・generic Error・非 Error) を pin する。共有 hook と
+ * getConsoleSigninUrl を mock し、 Portal*Error クラスと CliCredentialsPanel stub は実物/差し替え。
+ */
+const { mockAuth, mockTeamView, mockIsMock, mockSignin } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockTeamView: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockSignin: vi.fn(),
+}));
+
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+vi.mock("../../src/auth/TeamViewProvider", () => ({ useTeamView: mockTeamView }));
+vi.mock("../../src/api/portal-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/portal-client")>();
+  return { ...actual, getConsoleSigninUrl: mockSignin };
+});
+vi.mock("../../src/components/CliCredentialsPanel", () => ({
+  CliCredentialsPanel: ({ jobId }: { jobId: string }) => <div data-testid={`cli-${jobId}`} />,
+}));
+
+const { SsoCredentialsPage } = await import("../../src/pages/SsoCredentials");
+
+const config = {
+  apiBaseUrl: "https://api.example.com",
+  eventTitle: "Test event",
+  eventRegion: "ap-northeast-1",
+  mode: "backend",
+  cloudMode: "real",
+} as AppConfig;
+
+const logout = vi.fn();
+const auth = (sessionToken: string | null = "team-key") => ({
+  session: sessionToken ? { sessionToken } : null,
+  logout,
+});
+
+const problem = (over: Record<string, unknown> = {}) => ({
+  jobId: "job-1",
+  problemId: "hello-world",
+  awsAccountId: "111122223333",
+  region: "ap-northeast-1",
+  ...over,
+});
+
+const renderPage = () => render(<SsoCredentialsPage config={config} />);
+
+beforeEach(() => {
+  mockAuth.mockReturnValue(auth());
+  mockIsMock.mockReturnValue(false);
+  mockTeamView.mockReturnValue({ view: undefined, error: undefined });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("SsoCredentialsPage render branches", () => {
+  it("should always show the how-to alert", () => {
+    renderPage();
+    expect(screen.getByText("sso_credentials.howto_body")).toBeInTheDocument();
+  });
+
+  it("should show a team-view error alert", () => {
+    mockTeamView.mockReturnValue({ view: undefined, error: "boom" });
+    renderPage();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("should show the loading box in backend mode but not in mock mode", () => {
+    const a = renderPage();
+    expect(a.getByText("app.loading")).toBeInTheDocument();
+    a.unmount();
+
+    mockIsMock.mockReturnValue(true);
+    const b = renderPage();
+    expect(b.queryByText("app.loading")).not.toBeInTheDocument();
+  });
+
+  it("should show the empty state when there are no problems", () => {
+    mockTeamView.mockReturnValue({ view: { problems: [] }, error: undefined });
+    renderPage();
+    expect(screen.getByText("sso_credentials.empty_problems")).toBeInTheDocument();
+  });
+
+  it("should render only problems that have an awsAccountId", () => {
+    mockTeamView.mockReturnValue({
+      view: {
+        problems: [
+          problem({ jobId: "job-1", problemId: "with-account" }),
+          problem({ jobId: "job-2", problemId: "no-account", awsAccountId: undefined }),
+        ],
+      },
+      error: undefined,
+    });
+    renderPage();
+    expect(screen.getByText("with-account")).toBeInTheDocument();
+    expect(screen.queryByText("no-account")).not.toBeInTheDocument();
+    expect(screen.getByText("111122223333")).toBeInTheDocument();
+    expect(screen.getByTestId("cli-job-1")).toBeInTheDocument();
+  });
+
+  it("should not render the CLI panel when there is no session token", () => {
+    mockAuth.mockReturnValue(auth(null));
+    mockTeamView.mockReturnValue({ view: { problems: [problem()] }, error: undefined });
+    renderPage();
+    expect(screen.queryByTestId("cli-job-1")).not.toBeInTheDocument();
+  });
+});
+
+describe("SsoCredentialsPage open-console flow", () => {
+  const oneProblem = { view: { problems: [problem()] }, error: undefined };
+  const openButton = () =>
+    screen.getByRole("button", {
+      name: 'sso_credentials.open_console_aria|{"problemId":"hello-world"}',
+    });
+
+  it("should block opening the console in mock mode with an info alert", async () => {
+    const user = userEvent.setup();
+    mockIsMock.mockReturnValue(true);
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(screen.getByText("sso_credentials.mock_open_blocked")).toBeInTheDocument();
+    expect(screen.getByText("sso_credentials.mock_open_header")).toBeInTheDocument();
+    expect(mockSignin).not.toHaveBeenCalled();
+  });
+
+  it("should open the federation URL in a new tab on success", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    mockSignin.mockResolvedValue("https://signin.aws.amazon.com/federation?Action=login");
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://signin.aws.amazon.com/federation?Action=login",
+        "_blank",
+        "noopener,noreferrer",
+      ),
+    );
+    expect(mockSignin).toHaveBeenCalledWith("https://api.example.com", "team-key", "job-1");
+    openSpy.mockRestore();
+  });
+
+  it("should log out on a PortalAuthError without showing an alert", async () => {
+    const user = userEvent.setup();
+    mockSignin.mockRejectedValue(new PortalAuthError());
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    await waitFor(() => expect(logout).toHaveBeenCalled());
+    expect(screen.queryByText("sso_credentials.open_failed_header")).not.toBeInTheDocument();
+  });
+
+  it("should show a stage-aware message on a PortalAssumeRoleError", async () => {
+    const user = userEvent.setup();
+    mockSignin.mockRejectedValue(new PortalAssumeRoleError("participant_viewer", "denied"));
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(await screen.findByText(/sso_credentials\.cli\.assume_role_failed/)).toBeInTheDocument();
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it("should show a validation message on a PortalValidationError", async () => {
+    const user = userEvent.setup();
+    mockSignin.mockRejectedValue(new PortalValidationError("bad_input"));
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(await screen.findByText(/sso_credentials\.validation_error/)).toBeInTheDocument();
+  });
+
+  it("should surface a generic error message and allow dismissing it", async () => {
+    const user = userEvent.setup();
+    mockSignin.mockRejectedValue(new Error("network down"));
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(await screen.findByText("network down")).toBeInTheDocument();
+    // dismissible Alert の閉じるボタンは aria-label を持たないので class で引く → onDismiss 発火。
+    const dismiss = document.querySelector<HTMLButtonElement>('button[class*="dismiss-button"]');
+    expect(dismiss).not.toBeNull();
+    await user.click(dismiss as HTMLButtonElement);
+    await waitFor(() => expect(screen.queryByText("network down")).not.toBeInTheDocument());
+  });
+
+  it("should stringify a non-Error rejection", async () => {
+    const user = userEvent.setup();
+    mockSignin.mockRejectedValue("plain failure");
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(await screen.findByText("plain failure")).toBeInTheDocument();
+  });
+
+  it("should ignore clicks while there is no session token", async () => {
+    const user = userEvent.setup();
+    mockAuth.mockReturnValue(auth(null));
+    mockTeamView.mockReturnValue(oneProblem);
+    renderPage();
+    await user.click(openButton());
+    expect(mockSignin).not.toHaveBeenCalled();
+  });
+
+  it("should mark the active problem loading and disable the others while opening", async () => {
+    const user = userEvent.setup();
+    let resolveSignin: (url: string) => void = () => undefined;
+    mockSignin.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSignin = resolve;
+      }),
+    );
+    mockTeamView.mockReturnValue({
+      view: {
+        problems: [
+          problem({ jobId: "job-1", problemId: "p-a" }),
+          problem({ jobId: "job-2", problemId: "p-b" }),
+        ],
+      },
+      error: undefined,
+    });
+    renderPage();
+    const buttonA = screen.getByRole("button", {
+      name: 'sso_credentials.open_console_aria|{"problemId":"p-a"}',
+    });
+    const buttonB = screen.getByRole("button", {
+      name: 'sso_credentials.open_console_aria|{"problemId":"p-b"}',
+    });
+    await user.click(buttonA);
+    // pending="job-1" → 他の problem は disabled、 再 click しても二重起動しない。
+    await waitFor(() => expect(buttonB).toBeDisabled());
+    await user.click(buttonB);
+    expect(mockSignin).toHaveBeenCalledTimes(1);
+    resolveSignin("https://signin.example/x");
+    await waitFor(() => expect(buttonB).toBeEnabled());
+  });
+});


### PR DESCRIPTION
## Summary

`SsoCredentialsPage` (AWS Console one-click login) had **no test** (0% coverage). Add a page spec under `test/pages` following the repo convention — mock the shared hooks (`useAuth` / `useTeamView` / `useIsMock` / `useT`), partial-mock `portal-client` to keep the real `Portal*Error` classes while mocking `getConsoleSigninUrl`, and stub `CliCredentialsPanel`.

## Test plan

Covers every render branch and the full open-console flow:
- **Render**: how-to alert, team-view error, backend loading vs mock-mode, empty problems, the `awsAccountId` filter (problem without an account is dropped), and the session-gated CLI panel.
- **Open console**: mock-mode block (info alert), success `window.open(url, "_blank", "noopener,noreferrer")`, and each `describeOpenConsoleError` branch — `PortalAuthError` → `logout`, `PortalAssumeRoleError` → stage-aware message, `PortalValidationError`, generic `Error` message (+ dismiss), and a non-`Error` rejection stringified — plus the no-session early return and the pending loading/disabled gating.
- `SsoCredentials.tsx` reaches **100% stmt / branch / func / line**.
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- Test-only change; no production code touched, so no runtime behavior can change. The spec pins existing `SsoCredentialsPage` behavior as a regression guard.
- Shared hooks and `getConsoleSigninUrl` are mocked; the real `Portal*Error` classes drive the error-mapping assertions, so `describeOpenConsoleError` is exercised against genuine instances.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. Adds one test file under `apps/participant-portal/test/pages`; no source or bundle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)