### PR TITLE
test(participant-portal): cover ScoreEvents page + simplify chart domain

### DIFF
--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -52,6 +52,9 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
   const [error, setError] = useState<string | null>(null);
 
   const tick = useCallback(async () => {
+    // 呼び出し元の useEffect が同条件を gate 済み。 ここは getScoreEvents に渡す
+    // sessionToken を string へ narrow するための型ガードで、 true 分岐は不到達。
+    /* v8 ignore next */
     if (isMock || !sessionToken) return;
     try {
       const next = await getScoreEvents(config.apiBaseUrl, sessionToken);
@@ -68,17 +71,9 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
 
   useEffect(() => {
     if (isMock || !sessionToken) return;
-    let cancelled = false;
-    const run = async () => {
-      if (cancelled) return;
-      await tick();
-    };
-    void run();
-    const interval = setInterval(run, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
+    void tick();
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
   }, [isMock, sessionToken, tick]);
 
   // LP 「モックで試す」 動線: dev-mock mode では backend を叩かないので、 fixture を
@@ -91,6 +86,13 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
   }, [isMock, sessionToken, data]);
 
   const series = useMemo(() => (data ? buildCumulativeSeries(data.entries) : []), [data]);
+  // chart x 軸 domain。 series が空なら undefined (= LineChart は empty 表示)。 旧実装の
+  // `series[0]?.x ?? new Date()` は系列欠損時に「現在時刻」を軸端に捏造する silent fallback
+  // だったので、 明示的に undefined を返すよう改めた (no-silent-fallback)。
+  const firstPoint = series[0];
+  const lastPoint = series[series.length - 1];
+  const xDomain: [Date, Date] | undefined =
+    firstPoint && lastPoint ? [firstPoint.x, lastPoint.x] : undefined;
 
   return (
     <SpaceBetween size="l">
@@ -122,11 +124,7 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
                 data: series.map((p) => ({ x: p.x, y: p.y })),
               },
             ]}
-            xDomain={
-              series.length > 0
-                ? [series[0]?.x ?? new Date(), series[series.length - 1]?.x ?? new Date()]
-                : undefined
-            }
+            xDomain={xDomain}
             xScaleType="time"
             xTitle={t("score_events.chart_x_title")}
             yTitle={t("score_events.chart_y_title")}

--- a/apps/participant-portal/test/pages/ScoreEvents.test.tsx
+++ b/apps/participant-portal/test/pages/ScoreEvents.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PortalAuthError, type ScoreEventView } from "../../src/api/portal-client";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * ScoreEventsPage (累積スコア LineChart + 履歴 Table) の render 分岐と polling tick の
+ * 結果ハンドリング (loading / error / PortalAuthError→logout / 成功 / mock seed / 空) を pin
+ * する。 ScoreEventsTable は stub せず実物で render し、 source badge / points 正負 / 空状態を
+ * 同時に網羅する。 buildCumulativeSeries の sort・同値・無効 timestamp skip も同経路で踏む。
+ */
+const { mockAuth, mockIsMock, mockGet } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockGet: vi.fn(),
+}));
+
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+vi.mock("../../src/api/portal-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/portal-client")>();
+  return { ...actual, getScoreEvents: mockGet };
+});
+
+const { ScoreEventsPage } = await import("../../src/pages/ScoreEvents");
+
+const config = { apiBaseUrl: "https://api.example.com" } as AppConfig;
+const logout = vi.fn();
+const renderPage = () => render(<ScoreEventsPage config={config} />);
+
+const ev = (over: Partial<ScoreEventView>): ScoreEventView => ({
+  jobId: "job-1",
+  problemId: "p",
+  source: "flag",
+  points: 10,
+  result: "ok",
+  occurredAt: "2026-05-22T13:00:00Z",
+  ...over,
+});
+
+beforeAll(() => {
+  // Cloudscape LineChart は ResizeObserver を使うので jsdom 用に最小 stub を与える。
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+beforeEach(() => {
+  mockAuth.mockReturnValue({ session: { sessionToken: "team-key" }, logout });
+  mockIsMock.mockReturnValue(false);
+  mockGet.mockReset();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("ScoreEventsPage", () => {
+  it("should show the loading spinner before the first tick resolves", () => {
+    mockGet.mockReturnValue(new Promise<never>(() => undefined)); // never resolves
+    renderPage();
+    expect(screen.getByText("app.loading")).toBeInTheDocument();
+  });
+
+  it("should surface a fetch error", async () => {
+    mockGet.mockRejectedValue(new Error("network down"));
+    renderPage();
+    expect(await screen.findByText("network down")).toBeInTheDocument();
+  });
+
+  it("should stringify a non-Error fetch rejection", async () => {
+    mockGet.mockRejectedValue("plain failure");
+    renderPage();
+    expect(await screen.findByText("plain failure")).toBeInTheDocument();
+  });
+
+  it("should log out on a PortalAuthError without showing an error alert", async () => {
+    mockGet.mockRejectedValue(new PortalAuthError());
+    renderPage();
+    await waitFor(() => expect(logout).toHaveBeenCalled());
+    expect(screen.queryByText("app.fetch_status_failed")).not.toBeInTheDocument();
+  });
+
+  it("should render the cumulative chart and history table for all source/point kinds", async () => {
+    mockGet.mockResolvedValue({
+      entries: [
+        ev({
+          problemId: "p-flag",
+          source: "flag",
+          points: 100,
+          occurredAt: "2026-05-22T13:00:00Z",
+        }),
+        ev({ problemId: "p-up", source: "uptime", points: 60, occurredAt: "2026-05-22T12:00:00Z" }),
+        // p-flag と同一 timestamp → sort comparator の === 0 経路。
+        ev({
+          problemId: "p-wrong",
+          source: "flag-wrong",
+          points: -10,
+          occurredAt: "2026-05-22T13:00:00Z",
+        }),
+        ev({ problemId: "p-hint", source: "hint", points: -5, occurredAt: "2026-05-22T14:00:00Z" }),
+        // 無効 timestamp → buildCumulativeSeries の !Number.isFinite continue。
+        ev({ problemId: "p-bad", source: "uptime", points: 5, occurredAt: "not-a-date" }),
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("score_events.cumulative_header")).toBeInTheDocument();
+    expect(screen.getByText('score_events.history_header|{"count":5}')).toBeInTheDocument();
+    // table rows
+    expect(screen.getByText("p-flag")).toBeInTheDocument();
+    expect(screen.getByText("p-hint")).toBeInTheDocument();
+    // source badge: 全 4 種 (uptime は 2 件)
+    expect(screen.getByText("score_events.source_flag")).toBeInTheDocument();
+    expect(screen.getByText("score_events.source_flag_wrong")).toBeInTheDocument();
+    expect(screen.getByText("score_events.source_hint")).toBeInTheDocument();
+    expect(screen.getAllByText("score_events.source_uptime")).toHaveLength(2);
+    // points 正負の両分岐
+    expect(screen.getByText("+100 pt")).toBeInTheDocument();
+    expect(screen.getByText("-10 pt")).toBeInTheDocument();
+  });
+
+  it("should render the empty table and no chart when there are no entries", async () => {
+    mockGet.mockResolvedValue({ entries: [] });
+    renderPage();
+    expect(await screen.findByText("score_events.empty_header")).toBeInTheDocument();
+    expect(screen.queryByText("score_events.cumulative_header")).not.toBeInTheDocument();
+  });
+
+  it("should seed dev-mock fixtures without calling the backend in mock mode", async () => {
+    mockIsMock.mockReturnValue(true);
+    renderPage();
+    expect(await screen.findByText("score_events.cumulative_header")).toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("should not poll and stay on the spinner without a session token", () => {
+    mockAuth.mockReturnValue({ session: null, logout });
+    renderPage();
+    expect(screen.getByText("app.loading")).toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("should not seed dev-mock fixtures in mock mode without a session token", () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ session: null, logout });
+    renderPage();
+    // mock mode かつ session 無し → seed されないので chart も table も出ない。
+    expect(screen.queryByText("score_events.cumulative_header")).not.toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`ScoreEventsPage` + `ScoreEventsTable` had **no test** (0% coverage). Add a page spec under `test/pages` (mock `useAuth` / `useIsMock` / `useT` / `getScoreEvents`, keep the real `PortalAuthError` + dev-mock fixture, render the **real** `ScoreEventsTable`). Both files reach **100% stmt/branch/func/line**.

Two small source cleanups made the page honestly coverable rather than masked with v8-ignores:
- **Hoist the `LineChart` xDomain** to an explicit `[Date, Date] | undefined` const. The old inline `series[0]?.x ?? new Date()` was a **silent fallback** that would fabricate "now" as an axis bound on a missing point (prohibited by the no-silent-fallback rule); it now returns `undefined` (LineChart shows its empty state) when the series is empty.
- **Drop the `cancelled`/`run` wrapper** in the polling effect. Its guard sat *before* `await tick()` and ran synchronously, so it never observed `cancelled=true` and did not actually prevent `tick`'s post-unmount `setState` — `clearInterval` already handles teardown. Pass `tick` straight to `setInterval`.

## Test plan

- Covers loading spinner / fetch error / non-`Error` stringify / `PortalAuthError` → `logout` / success chart+table / empty / mock-seed / no-session / mock-mode-without-session.
- The success path also exercises `buildCumulativeSeries` (sort, equal-timestamp `=== 0`, invalid-timestamp skip) and every `ScoreEventsTable` source badge (uptime/flag/flag-wrong/hint) + the `+`/`-` points branches.
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- xDomain change is behavior-equivalent for the only reachable case (non-empty series → same `[first, last]`); the empty case yields `undefined` instead of a fabricated `[now, now]` and only occurs when the chart is not rendered anyway.
- Polling simplification is behavior-equivalent: the removed `cancelled` flag never fired (guard precedes the await); teardown still clears the interval. The in-flight-tick-after-unmount `setState` was already unguarded and is harmless under React 18.
- `tick` keeps its `!sessionToken` guard for type-narrowing (true-branch unreachable since the effect gates the same condition) — marked `v8-ignore`.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/participant-portal` source + test only; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)