### PR TITLE
test(participant-portal): cover TeamSetupPage to 100%

### DIFF
--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -55,6 +55,34 @@ export function formatTeamSetupSubmitError(err: unknown, validationMessage: stri
 }
 
 /**
+ * TopNavigation の言語切替 dropdown utility を組む。 component から切り出して onItemClick の
+ * 分岐 (= SUPPORTED_LOCALES に含まれる id のみ setLocale) を単体で検証できるようにした。
+ */
+export function buildLocaleUtility(
+  locale: LocaleCode,
+  t: (key: string) => string,
+  setLocale: (code: LocaleCode) => void,
+): TopNavigationProps.Utility {
+  return {
+    type: "menu-dropdown",
+    iconName: "globe",
+    ariaLabel: t("switcher.aria_label"),
+    text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
+    items: SUPPORTED_LOCALES.map((code) => ({
+      id: code,
+      // SUPPORTED_LOCALES は dict と同期済なので ?? 右辺は型安全用の不到達分岐。
+      /* v8 ignore next */
+      text: LOCALE_DICTIONARIES_NAME[code] ?? code,
+    })),
+    onItemClick: ({ detail }) => {
+      if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
+        setLocale(detail.id as LocaleCode);
+      }
+    },
+  };
+}
+
+/**
  * 競技者がログイン直後に通る team name 入力ページ。 `PATCH /portal/me` でサーバ側
  * `displayTeamName` を設定し、 AuthProvider のセッションを更新して `/` に戻る。
  *
@@ -86,6 +114,9 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
   });
 
   const handleSubmit = async () => {
+    // submit button は disabled={!canSubmit} なので canSubmit=false では呼ばれない。
+    // canSubmit は sessionToken を要求するので auth.session も非 null。 = 防御的な不到達分岐。
+    /* v8 ignore next */
     if (!canSubmit || !auth.session) return;
     setSubmitting(true);
     setError(null);
@@ -123,24 +154,10 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
     }
   };
 
-  const utilities = useMemo<TopNavigationProps.Utility[]>(() => {
-    const localeUtility: TopNavigationProps.Utility = {
-      type: "menu-dropdown",
-      iconName: "globe",
-      ariaLabel: t("switcher.aria_label"),
-      text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
-      items: SUPPORTED_LOCALES.map((code) => ({
-        id: code,
-        text: LOCALE_DICTIONARIES_NAME[code] ?? code,
-      })),
-      onItemClick: ({ detail }) => {
-        if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
-          setLocale(detail.id as LocaleCode);
-        }
-      },
-    };
-    return [localeUtility];
-  }, [locale, setLocale, t]);
+  const utilities = useMemo<TopNavigationProps.Utility[]>(
+    () => [buildLocaleUtility(locale, t, setLocale)],
+    [locale, setLocale, t],
+  );
 
   return (
     <>

--- a/apps/participant-portal/test/pages/TeamSetup.test.tsx
+++ b/apps/participant-portal/test/pages/TeamSetup.test.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PortalAuthError, PortalValidationError } from "../../src/api/portal-client";
+import type { AppConfig } from "../../src/config";
+import type { LocaleCode } from "../../src/i18n";
+
+/**
+ * TeamSetupPage の team name 入力 (新規 / edit mode / mock vs backend / 各 error) と純粋 helper
+ * (describeTeamNameDraft / canSubmitTeamName / formatTeamSetupSubmitError / buildLocaleUtility) を
+ * pin する。 hook と updateTeamName は mock、 Portal*Error は実物。
+ */
+const { mockNav, mockAuth, mockIsMock, mockLocale, mockSetLocale, mockUpdate } = vi.hoisted(() => ({
+  mockNav: vi.fn(),
+  mockAuth: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockLocale: { value: "en" as LocaleCode },
+  mockSetLocale: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return {
+    ...actual,
+    useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+      params ? `${key}|${JSON.stringify(params)}` : key,
+    useI18n: () => ({ locale: mockLocale.value, setLocale: mockSetLocale, t: (k: string) => k }),
+  };
+});
+vi.mock("../../src/api/portal-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/portal-client")>();
+  return { ...actual, updateTeamName: mockUpdate };
+});
+
+const {
+  TeamSetupPage,
+  describeTeamNameDraft,
+  canSubmitTeamName,
+  formatTeamSetupSubmitError,
+  buildLocaleUtility,
+} = await import("../../src/pages/TeamSetup");
+
+const config = { apiBaseUrl: "https://api.example.com", eventTitle: "Test event" } as AppConfig;
+const updateSession = vi.fn();
+const logout = vi.fn();
+
+function authValue(sessionOver: Record<string, unknown> | null = {}) {
+  return {
+    session:
+      sessionOver === null
+        ? null
+        : { sessionToken: "tok", teamName: "", teamNameSetByCompetitor: false, ...sessionOver },
+    updateSession,
+    logout,
+  };
+}
+
+const renderPage = () => render(<TeamSetupPage config={config} />);
+const submitButton = () =>
+  screen.getByRole("button", { name: /team_setup\.(edit_)?submit_button/ });
+const typeName = (value: string) =>
+  fireEvent.change(screen.getByRole("textbox"), { target: { value } });
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+beforeEach(() => {
+  mockAuth.mockReturnValue(authValue());
+  mockIsMock.mockReturnValue(false);
+  mockLocale.value = "en";
+  mockUpdate.mockReset();
+  mockNav.mockClear();
+  updateSession.mockClear();
+  logout.mockClear();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("pure helpers", () => {
+  it("should describe a team-name draft (trim + validity)", () => {
+    expect(describeTeamNameDraft("")).toEqual({ trimmed: "", invalid: false });
+    expect(describeTeamNameDraft("  Valid Name  ")).toEqual({
+      trimmed: "Valid Name",
+      invalid: false,
+    });
+    expect(describeTeamNameDraft("@@@").invalid).toBe(true);
+  });
+
+  it("should gate submission on token / non-empty / valid / not-submitting", () => {
+    const ok = { sessionToken: "t", trimmed: "Team", invalid: false, submitting: false };
+    expect(canSubmitTeamName(ok)).toBe(true);
+    expect(canSubmitTeamName({ ...ok, sessionToken: undefined })).toBe(false);
+    expect(canSubmitTeamName({ ...ok, trimmed: "" })).toBe(false);
+    expect(canSubmitTeamName({ ...ok, invalid: true })).toBe(false);
+    expect(canSubmitTeamName({ ...ok, submitting: true })).toBe(false);
+  });
+
+  it("should format submit errors by type", () => {
+    expect(formatTeamSetupSubmitError(new PortalValidationError("bad"), "invalid!")).toBe(
+      "invalid!",
+    );
+    expect(formatTeamSetupSubmitError(new Error("boom"), "x")).toBe("boom");
+    expect(formatTeamSetupSubmitError("plain", "x")).toBe("plain");
+  });
+
+  it("should build a locale utility that only switches to supported locales", () => {
+    const u = buildLocaleUtility("ja", (k) => k, mockSetLocale) as Extract<
+      ReturnType<typeof buildLocaleUtility>,
+      { type: "menu-dropdown" }
+    >;
+    expect(u.text).toBe("日本語");
+    expect(u.items?.map((i) => i.id)).toEqual(["ja", "en"]);
+    u.onItemClick?.({ detail: { id: "en" } } as never);
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+    u.onItemClick?.({ detail: { id: "bogus" } } as never);
+    expect(mockSetLocale).toHaveBeenCalledTimes(1); // bogus ignored
+    // 未知 locale → text は fallback で locale 文字列そのまま。
+    const unknown = buildLocaleUtility("zz" as LocaleCode, (k) => k, mockSetLocale) as Extract<
+      ReturnType<typeof buildLocaleUtility>,
+      { type: "menu-dropdown" }
+    >;
+    expect(unknown.text).toBe("zz");
+  });
+});
+
+describe("TeamSetupPage", () => {
+  it("should render the new-team form without a cancel button", () => {
+    renderPage();
+    expect(screen.getByText("team_setup.title")).toBeInTheDocument();
+    expect(submitButton()).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "team_setup.cancel_button" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should prefill and offer cancel in edit mode", () => {
+    mockAuth.mockReturnValue(authValue({ teamNameSetByCompetitor: true, teamName: "Existing" }));
+    renderPage();
+    expect(screen.getByText("team_setup.edit_title")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("Existing");
+    fireEvent.click(screen.getByRole("button", { name: "team_setup.cancel_button" }));
+    expect(mockNav).toHaveBeenCalledWith("/");
+  });
+
+  it("should start blank in edit mode when no team name is stored", () => {
+    mockAuth.mockReturnValue(authValue({ teamNameSetByCompetitor: true, teamName: undefined }));
+    renderPage();
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+
+  it("should show a format error and disable submit for an invalid name", () => {
+    renderPage();
+    typeName("@@@");
+    expect(screen.getByText("team_setup.field_invalid_format")).toBeInTheDocument();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it("should submit to the backend and update the session", async () => {
+    mockUpdate.mockResolvedValue({ team: { teamName: "My Team", teamNameSetByCompetitor: true } });
+    renderPage();
+    typeName("My Team");
+    fireEvent.click(submitButton());
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith("https://api.example.com", "tok", "My Team"),
+    );
+    expect(updateSession).toHaveBeenCalledWith({
+      teamName: "My Team",
+      teamNameSetByCompetitor: true,
+    });
+    expect(mockNav).toHaveBeenCalledWith("/");
+  });
+
+  it("should update the session locally without a backend call in mock mode", async () => {
+    mockIsMock.mockReturnValue(true);
+    renderPage();
+    typeName("Mock Team");
+    fireEvent.click(submitButton());
+    await waitFor(() =>
+      expect(updateSession).toHaveBeenCalledWith({
+        teamName: "Mock Team",
+        teamNameSetByCompetitor: true,
+      }),
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockNav).toHaveBeenCalledWith("/");
+  });
+
+  it("should log out and redirect on a PortalAuthError", async () => {
+    mockUpdate.mockRejectedValue(new PortalAuthError());
+    renderPage();
+    typeName("My Team");
+    fireEvent.click(submitButton());
+    await waitFor(() => expect(logout).toHaveBeenCalled());
+    expect(mockNav).toHaveBeenCalledWith("/login");
+  });
+
+  it("should surface a submit error alert on other failures", async () => {
+    mockUpdate.mockRejectedValue(new Error("server boom"));
+    renderPage();
+    typeName("My Team");
+    fireEvent.click(submitButton());
+    expect(await screen.findByText("server boom")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`TeamSetupPage` had only **23%** coverage. Add a page spec under `test/pages` (mock `useNavigate`/`useAuth`/`useIsMock`/`useI18n` + `updateTeamName`, keep the real `Portal*Error` classes). File reaches **100% stmt/branch/func/line**.

## Test plan

- **Render/flow**: new-team and edit-mode renders (prefill, blank-when-unset, cancel→`/`), invalid-name format error + disabled submit, backend submit + `updateSession` + nav, mock-mode local update (no backend call), `PortalAuthError` → logout + `/login`, generic submit-error alert.
- **Pure helpers** unit-tested directly: `describeTeamNameDraft` / `canSubmitTeamName` / `formatTeamSetupSubmitError`, plus the extracted `buildLocaleUtility` (text, items, `onItemClick` accept/reject, unknown-locale text fallback).
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- Source change is the `buildLocaleUtility` extraction only; the produced utility is identical to the prior inline object. No behavior change.
- Two genuinely-unreachable defensive spots are `v8-ignore`d with rationale: the items `?? code` fallback (`SUPPORTED_LOCALES` is in sync with the dictionary) and the `handleSubmit` guard (the submit button is `disabled={!canSubmit}`, and `canSubmit` requires a session).
- `updateTeamName` is mocked, real `Portal*Error` classes drive error mapping, `ResizeObserver` stubbed for `TopNavigation`.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/participant-portal` source + test only; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)