### PR TITLE
test(participant-portal): cover QuestsPage to 100% + fix dead Cards loading

### DIFF
--- a/apps/participant-portal/src/pages/Quests.tsx
+++ b/apps/participant-portal/src/pages/Quests.tsx
@@ -205,22 +205,20 @@ export function QuestsPage() {
         label={t("quests.filter_label")}
       />
 
-      {/* Issue #1000: 未解決 section を常時 expand で先頭に並べる */}
+      {/* Issue #1000: 未解決 section を常時 expand で先頭に並べる。 Cards 自身の
+       *   loading / empty slot に委ねる (= 旧 ternary は loading 中も emptyUnsolved を
+       *   出してしまい spinner が死んでいた)。 */}
       <Container
         header={<Header counter={`(${unsolved.length})`}>{t("quests.section_unsolved")}</Header>}
       >
-        {unsolved.length > 0 ? (
-          <Cards<ParticipantProblemView>
-            items={unsolved}
-            loading={!isMock && !view && !error}
-            loadingText={t("quests.loading_text")}
-            cardDefinition={renderCard}
-            cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}
-            empty={emptyUnsolved}
-          />
-        ) : (
-          emptyUnsolved
-        )}
+        <Cards<ParticipantProblemView>
+          items={unsolved}
+          loading={!isMock && !view && !error}
+          loadingText={t("quests.loading_text")}
+          cardDefinition={renderCard}
+          cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}
+          empty={emptyUnsolved}
+        />
       </Container>
 
       {/* Issue #1000: 解決済み section は collapsible、 初期 collapsed (= 視線を未解決に集中) */}
@@ -229,17 +227,16 @@ export function QuestsPage() {
         variant="container"
         defaultExpanded={false}
       >
-        {cleared.length > 0 ? (
-          <Cards<ParticipantProblemView>
-            items={cleared}
-            cardDefinition={renderCard}
-            cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}
-          />
-        ) : (
-          <Box textAlign="center" padding="m" color="text-status-inactive">
-            {t("quests.empty_cleared")}
-          </Box>
-        )}
+        <Cards<ParticipantProblemView>
+          items={cleared}
+          cardDefinition={renderCard}
+          cardsPerRow={[{ cards: 1 }, { minWidth: 600, cards: 2 }]}
+          empty={
+            <Box textAlign="center" padding="m" color="text-status-inactive">
+              {t("quests.empty_cleared")}
+            </Box>
+          }
+        />
       </ExpandableSection>
     </SpaceBetween>
   );

--- a/apps/participant-portal/test/pages/Quests.test.tsx
+++ b/apps/participant-portal/test/pages/Quests.test.tsx
@@ -1,12 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParticipantProblemView } from "../../src/api/portal-client";
-import { renderSubmissionState } from "../../src/pages/Quests";
 
 /**
- * Issue #1349 — scoring badge per-status pin。 `renderSubmissionState` の 4 状態
- * (= 未着手 / Deploy 中 / 着手中 / 解答済) を unit test し、 解答済 時に
- * `+Npt` (points) が末尾に出ることを確認する。
+ * Quests: pure helper `renderSubmissionState` の全 status 分岐と、 QuestsPage component の
+ * render (error / loading / category filter + counts / 未解決・解決済 section split / card の
+ * category・difficulty badge + Link navigate) を pin する。 共有 hook と findProblemMetadata は
+ * mock、 categoryOf (lib/category) は実物。
  */
+const { mockTeamView, mockNav, mockIsMock, mockFindMeta } = vi.hoisted(() => ({
+  mockTeamView: vi.fn(),
+  mockNav: vi.fn(),
+  mockIsMock: vi.fn(),
+  mockFindMeta: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
+vi.mock("../../src/auth/TeamViewProvider", () => ({ useTeamView: mockTeamView }));
+vi.mock("../../src/config-context", () => ({ useIsMock: mockIsMock }));
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key,
+}));
+vi.mock("../../src/data/problems", () => ({ findProblemMetadata: mockFindMeta }));
+
+const { renderSubmissionState, QuestsPage } = await import("../../src/pages/Quests");
+
 function problem(partial: Partial<ParticipantProblemView>): ParticipantProblemView {
   return {
     jobId: "job-x",
@@ -36,9 +55,20 @@ describe("renderSubmissionState scoring badge", () => {
     expect(s.label).toBe("[quests.submission_failed]");
   });
 
-  it("should show in-progress type while the deploy is still PENDING / IN_PROGRESS", () => {
+  it("should show warning for EXPIRED and stopped for DELETED / AUTO_DELETED", () => {
+    expect(renderSubmissionState(problem({ status: "EXPIRED" }), pseudoT).type).toBe("warning");
+    expect(renderSubmissionState(problem({ status: "DELETED" }), pseudoT).type).toBe("stopped");
+    expect(renderSubmissionState(problem({ status: "AUTO_DELETED" }), pseudoT).type).toBe(
+      "stopped",
+    );
+  });
+
+  it("should show in-progress type while the deploy is PENDING / IN_PROGRESS / DELETING", () => {
     expect(renderSubmissionState(problem({ status: "PENDING" }), pseudoT).type).toBe("in-progress");
     expect(renderSubmissionState(problem({ status: "IN_PROGRESS" }), pseudoT).type).toBe(
+      "in-progress",
+    );
+    expect(renderSubmissionState(problem({ status: "DELETING" }), pseudoT).type).toBe(
       "in-progress",
     );
   });
@@ -54,10 +84,7 @@ describe("renderSubmissionState scoring badge", () => {
 
   it("should include points (+Npt) when flag is submitted and scoring.points is known", () => {
     const s = renderSubmissionState(
-      problem({
-        status: "COMPLETE",
-        scoring: { kind: "flag", flagSubmitted: true, points: 100 },
-      }),
+      problem({ status: "COMPLETE", scoring: { kind: "flag", flagSubmitted: true, points: 100 } }),
       pseudoT,
     );
     expect(s.type).toBe("success");
@@ -66,10 +93,7 @@ describe("renderSubmissionState scoring badge", () => {
 
   it("should fall back to plain cleared label when points is missing", () => {
     const s = renderSubmissionState(
-      problem({
-        status: "COMPLETE",
-        scoring: { kind: "flag", flagSubmitted: true },
-      }),
+      problem({ status: "COMPLETE", scoring: { kind: "flag", flagSubmitted: true } }),
       pseudoT,
     );
     expect(s.label).toBe("[quests.submission_cleared]");
@@ -82,5 +106,121 @@ describe("renderSubmissionState scoring badge", () => {
     );
     expect(s.type).toBe("info");
     expect(s.label).toBe("[quests.submission_in_progress]");
+  });
+});
+
+const flagUnsolved = problem({
+  problemId: "ctf-unsolved",
+  jobId: "job-1",
+  scoring: { kind: "flag", flagSubmitted: false },
+});
+const flagCleared = problem({
+  problemId: "ctf-cleared",
+  jobId: "job-2",
+  scoring: { kind: "flag", flagSubmitted: true, points: 50 },
+});
+const battle = problem({
+  problemId: "uptime-battle",
+  jobId: "job-3",
+  scoring: { kind: "uptime" },
+});
+const uncategorized = problem({ problemId: "legacy", jobId: "job-4", scoring: undefined });
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+beforeEach(() => {
+  mockIsMock.mockReturnValue(false);
+  mockNav.mockClear();
+  mockFindMeta.mockReset();
+  // difficulty badge: 既知 problem は metadata あり、 それ以外は undefined (= badge 無し)。
+  mockFindMeta.mockImplementation((id: string) =>
+    id === "ctf-unsolved" ? { difficulty: 3 } : undefined,
+  );
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("QuestsPage", () => {
+  it("should show a loading spinner while the view is undefined", () => {
+    mockTeamView.mockReturnValue({ view: undefined, error: null });
+    render(<QuestsPage />);
+    expect(screen.getByText("quests.loading_text")).toBeInTheDocument();
+  });
+
+  it("should show an error alert (and not the loading spinner)", () => {
+    mockTeamView.mockReturnValue({ view: undefined, error: "boom" });
+    render(<QuestsPage />);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.queryByText("quests.loading_text")).not.toBeInTheDocument();
+  });
+
+  it("should not show a spinner in mock mode even without a view", () => {
+    mockIsMock.mockReturnValue(true);
+    mockTeamView.mockReturnValue({ view: undefined, error: null });
+    render(<QuestsPage />);
+    expect(screen.queryByText("quests.loading_text")).not.toBeInTheDocument();
+    // unsolved も cleared も空 → 両 empty state。
+    expect(screen.getByText("quests.empty_unsolved")).toBeInTheDocument();
+  });
+
+  it("should split unsolved vs cleared and render category + difficulty badges", () => {
+    mockTeamView.mockReturnValue({
+      view: { problems: [flagUnsolved, flagCleared, battle, uncategorized] },
+      error: null,
+    });
+    render(<QuestsPage />);
+    // unsolved card (challenge badge + difficulty badge)。 Challenge は flagUnsolved と
+    // flagCleared の 2 枚に出る (cleared section は collapsed でも DOM 上にある)。
+    expect(screen.getByText("ctf-unsolved")).toBeInTheDocument();
+    expect(screen.getAllByText("Challenge")).toHaveLength(2);
+    expect(screen.getByText(/quests\.difficulty_label/)).toBeInTheDocument();
+    // battle category badge + uncategorized badge
+    expect(screen.getByText("Battle")).toBeInTheDocument();
+    expect(screen.getByText("quests.category_uncategorized")).toBeInTheDocument();
+    // counts in the segmented control: all=4, battle=1, challenge=2
+    // (SegmentedControl は segment + responsive select の 2 箇所に text を出す)
+    expect(screen.getAllByText(/quests\.filter_all \(4\)/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/quests\.filter_battle \(1\)/).length).toBeGreaterThan(0);
+  });
+
+  it("should navigate to the problem detail when a card link is followed", () => {
+    mockTeamView.mockReturnValue({ view: { problems: [flagUnsolved] }, error: null });
+    render(<QuestsPage />);
+    fireEvent.click(screen.getByText("ctf-unsolved"));
+    expect(mockNav).toHaveBeenCalledWith("/problems/job-1");
+  });
+
+  it("should filter to a single category via the segmented control", () => {
+    mockTeamView.mockReturnValue({ view: { problems: [flagUnsolved, battle] }, error: null });
+    render(<QuestsPage />);
+    expect(screen.getByText("uptime-battle")).toBeInTheDocument();
+    // battle filter を選ぶと challenge の ctf-unsolved が消える (segment button = 先頭要素)。
+    fireEvent.click(screen.getAllByText(/quests\.filter_battle \(1\)/)[0]);
+    expect(screen.getByText("uptime-battle")).toBeInTheDocument();
+    expect(screen.queryByText("ctf-unsolved")).not.toBeInTheDocument();
+  });
+
+  it("should show the empty-cleared box when there are no cleared problems", () => {
+    mockTeamView.mockReturnValue({ view: { problems: [flagUnsolved] }, error: null });
+    render(<QuestsPage />);
+    expect(screen.getByText("quests.empty_cleared")).toBeInTheDocument();
+  });
+
+  it("should render a cleared problem in the cleared section", () => {
+    mockTeamView.mockReturnValue({ view: { problems: [flagCleared] }, error: null });
+    render(<QuestsPage />);
+    // 未解決は空。
+    expect(screen.getByText("quests.empty_unsolved")).toBeInTheDocument();
+    // 解決済 section に cleared card。
+    expect(screen.getByText("ctf-cleared")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

The existing Quests spec only covered the `renderSubmissionState` helper (~40%); `QuestsPage` itself was untested. Add component tests (mock `useTeamView`/`useNavigate`/`useT`/`useIsMock` + `findProblemMetadata`, keep `categoryOf` real) and extend the helper tests with the previously-missing **EXPIRED / DELETED / AUTO_DELETED / DELETING** statuses. Both `QuestsPage` and `renderSubmissionState` reach **100% stmt/branch/func/line**.

## Source fix (behavior improvement)

The unsolved/cleared sections wrapped `Cards` in `items.length > 0 ? <Cards/> : <empty>` ternaries, which made the `Cards` `loading` prop **dead** — during the load window (`view` undefined) the list is empty, so the misleading empty state showed instead of the spinner. Render `Cards` unconditionally and delegate to its own `loading` / `empty` slots (idiomatic Cloudscape), removing both redundant ternaries.

## Test plan

- **QuestsPage**: loading spinner, error alert, mock-mode, unsolved-vs-cleared split, category + difficulty badges, card `Link` → navigate, `SegmentedControl` category filtering, both empty states.
- **renderSubmissionState**: all status branches (now including EXPIRED/DELETED/AUTO_DELETED/DELETING).
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- Empty-state output is unchanged (`Cards` `empty` renders the same nodes when the list is empty and not loading). The only behavior change: the unsolved section now shows the loading spinner during the initial fetch instead of a premature "no unsolved problems" — strictly more correct.
- `renderSubmissionState` is untouched; `categoryOf` stays real so battle/challenge mapping is genuinely exercised.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/participant-portal` source + test only; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)