### PR TITLE
test(participant-portal): cover TeamScorePanel to 100%

### DIFF
--- a/apps/participant-portal/src/pages/TeamScorePanel.tsx
+++ b/apps/participant-portal/src/pages/TeamScorePanel.tsx
@@ -24,7 +24,10 @@ export function TeamScorePanel({
   // rank / 全 team 数を出す。 entries が空 (= 凍結中 / event 未配線 / 自 team が落ちた)
   // のときは「—」 表示にして UI を壊さない。
   const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
-  const rankValue = myEntry ? `${myEntry.rank} / ${leaderboard?.entries.length ?? "—"}` : "—";
+  // myEntry が取れるのは leaderboard 非 null のときだけなので `&& leaderboard` で narrow し、
+  // 旧 `leaderboard?.entries.length ?? "—"` の不到達 fallback を消す。
+  const rankValue =
+    myEntry && leaderboard ? `${myEntry.rank} / ${leaderboard.entries.length}` : "—";
 
   return (
     <Container header={<Header variant="h2">{t("home.team_score_header")}</Header>}>

--- a/apps/participant-portal/test/pages/TeamScorePanel.test.tsx
+++ b/apps/participant-portal/test/pages/TeamScorePanel.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  LeaderboardResponse,
+  ParticipantProblemView,
+  ParticipantTeamView,
+} from "../../src/api/portal-client";
+
+/**
+ * TeamScorePanel (Home の累計スコア / 順位 / 問題数 / 正解数 サマリ) の集計と rank 表示
+ * (自チームが leaderboard にいる / いない・leaderboard 不在) を pin する。 useT は echo mock。
+ */
+vi.mock("../../src/i18n", () => ({
+  useT: () => (key: string) => key,
+}));
+
+const { TeamScorePanel } = await import("../../src/pages/TeamScorePanel");
+
+// biome-ignore lint/suspicious/noExplicitAny: テスト fixture を最小形で組む。
+const problem = (over: Record<string, any>): ParticipantProblemView =>
+  ({
+    jobId: "j",
+    problemId: "p",
+    region: "ap-northeast-1",
+    awsAccountId: "1",
+    status: "COMPLETE",
+    stackOutputs: {},
+    expiresAt: 0,
+    score: 0,
+    deployLog: { cursor: "", entries: [] },
+    ...over,
+  }) as ParticipantProblemView;
+
+const view = (problems: ParticipantProblemView[]): ParticipantTeamView =>
+  ({ problems }) as unknown as ParticipantTeamView;
+
+const problems = [
+  problem({ score: 100, scoring: { kind: "flag", flagSubmitted: true } }), // cleared (flag)
+  problem({ score: 0, scoring: { kind: "flag", flagSubmitted: false } }), // not cleared
+  problem({ score: 60, scoring: { kind: "uptime" } }), // cleared (score>0)
+  problem({ score: 0, scoring: { kind: "uptime" } }), // not cleared
+];
+
+describe("TeamScorePanel", () => {
+  it("should sum the score and count problems and cleared (flag-submitted or score>0)", () => {
+    render(<TeamScorePanel view={view(problems)} leaderboard={null} />);
+    expect(screen.getByText("160 pt")).toBeInTheDocument(); // total 100+0+60+0
+    expect(screen.getByText("4")).toBeInTheDocument(); // problem count
+    expect(screen.getByText("2")).toBeInTheDocument(); // cleared: flag-submitted + uptime score>0
+  });
+
+  it("should show the rank when the team is on the leaderboard", () => {
+    const leaderboard = {
+      entries: [
+        { rank: 1, isMyTeam: false, teamName: "A", score: 200 },
+        { rank: 2, isMyTeam: true, teamName: "Me", score: 160 },
+        { rank: 3, isMyTeam: false, teamName: "C", score: 50 },
+      ],
+    } as unknown as LeaderboardResponse;
+    render(<TeamScorePanel view={view(problems)} leaderboard={leaderboard} />);
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("should fall back to a dash when the team is not on the leaderboard", () => {
+    const leaderboard = {
+      entries: [{ rank: 1, isMyTeam: false, teamName: "A", score: 200 }],
+    } as unknown as LeaderboardResponse;
+    render(<TeamScorePanel view={view(problems)} leaderboard={leaderboard} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("should fall back to a dash when there is no leaderboard at all", () => {
+    render(<TeamScorePanel view={view([])} leaderboard={null} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`TeamScorePanel` (Home's total-score / rank / problem-count / cleared-count summary) had ~67% branch coverage and no test. Add a co-located page spec (useT echoed). File reaches **100% stmt/branch/func/line**.

## Test plan

- score sum, problem count, cleared count (flag-submitted OR non-flag `score>0` vs not).
- rank display: team on the leaderboard → `"rank / total"`, team absent → `"—"`, no leaderboard → `"—"`.
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Source tidy (behavior-equivalent)

Rank used `leaderboard?.entries.length ?? "—"` inside the `myEntry ? ...` branch, but `myEntry` can only be truthy when `leaderboard` is non-null, so that `?? "—"` was dead. Narrow with `myEntry && leaderboard` so the length access is non-optional and the dead fallback is removed.

## Regression analysis

- `myEntry && leaderboard` is equivalent to the old `myEntry` guard (`myEntry` is found within `leaderboard.entries`, so it implies a non-null leaderboard); the rendered rank string is identical. No behavior change.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/participant-portal` source + test only; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team rank display logic to consistently show "—" when team rank information is unavailable.

* **Tests**
  * Added comprehensive test coverage for team score panel, verifying points calculation, problem status tracking, and rank display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->