### PR TITLE
test(participant-portal): close EmptyState href-action branch (100%)

### DIFF
--- a/apps/participant-portal/test/components/design-system.test.tsx
+++ b/apps/participant-portal/test/components/design-system.test.tsx
@@ -42,6 +42,15 @@ describe("EmptyState", () => {
     btn.click();
     expect(onClick).toHaveBeenCalled();
   });
+
+  it("should render the primary action as an href link with target _self", () => {
+    render(
+      <EmptyState headline="Browse" primaryAction={{ label: "Open catalog", href: "/catalog" }} />,
+    );
+    const link = screen.getByRole("link", { name: "Open catalog" });
+    expect(link).toHaveAttribute("href", "/catalog");
+    expect(link).toHaveAttribute("target", "_self");
+  });
 });
 
 describe("ErrorState", () => {


### PR DESCRIPTION
## Summary

The design-system spec covered `EmptyState`'s headline-only and `onClick`-action cases but not the **href-action** branch (`target="_self"`), leaving it at ~83% branch. Add one test rendering the primary action with an `href` and asserting the anchor's `href` + `target`. `EmptyState` reaches **100% stmt/branch/func/line**.

## Test plan

- New test: primary action with `href` → anchor with `href="/catalog"` and `target="_self"`.
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- Test-only change; no production code touched. Extends the existing design-system suite with the previously-missing href-action branch.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. Test-only change under `apps/participant-portal/test/components`; no source or bundle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)