### PR TITLE
test(participant-portal): cover App RequireAuth guard branches (100%)

### DIFF
--- a/apps/participant-portal/src/App.tsx
+++ b/apps/participant-portal/src/App.tsx
@@ -13,7 +13,7 @@ import { ScoreEventsPage } from "./pages/ScoreEvents";
 import { SsoCredentialsPage } from "./pages/SsoCredentials";
 import { TeamSetupPage } from "./pages/TeamSetup";
 
-function RequireAuth({
+export function RequireAuth({
   requireTeamName,
   children,
 }: {

--- a/apps/participant-portal/test/App.guards.test.tsx
+++ b/apps/participant-portal/test/App.guards.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * RequireAuth の guard 分岐 (auth 未 ready → null / 未ログイン → /login / チーム名未設定で
+ * requireTeamName → /setup / それ以外 → children) を pin する。 統合 routing は別ファイル
+ * (App.test.tsx) が実 AuthProvider で網羅するので、 ここは useAuth を mock して各状態を注入する。
+ */
+const { mockAuth } = vi.hoisted(() => ({ mockAuth: vi.fn() }));
+
+vi.mock("../src/auth/AuthProvider", () => ({
+  useAuth: mockAuth,
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+  };
+});
+
+const { RequireAuth } = await import("../src/App");
+
+const child = <div data-testid="child">protected</div>;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("RequireAuth", () => {
+  it("should render nothing while auth is not ready", () => {
+    mockAuth.mockReturnValue({ ready: false, session: null });
+    render(<RequireAuth requireTeamName>{child}</RequireAuth>);
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+  });
+
+  it("should redirect to /login when there is no session", () => {
+    mockAuth.mockReturnValue({ ready: true, session: null });
+    render(<RequireAuth requireTeamName>{child}</RequireAuth>);
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/login");
+  });
+
+  it("should redirect to /setup when the team name is not yet set", () => {
+    mockAuth.mockReturnValue({ ready: true, session: { teamNameSetByCompetitor: false } });
+    render(<RequireAuth requireTeamName>{child}</RequireAuth>);
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/setup");
+  });
+
+  it("should render children when authenticated with a team name set", () => {
+    mockAuth.mockReturnValue({ ready: true, session: { teamNameSetByCompetitor: true } });
+    render(<RequireAuth requireTeamName>{child}</RequireAuth>);
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("should render children without a team name when requireTeamName is false (/setup route)", () => {
+    mockAuth.mockReturnValue({ ready: true, session: { teamNameSetByCompetitor: false } });
+    render(<RequireAuth requireTeamName={false}>{child}</RequireAuth>);
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`App.tsx` was at ~80%. The existing integration spec (real `AuthProvider`, dev-mock) exercises login / redirect-to-login / re-login, but cannot reach the `!auth.ready` (renders null) and `requireTeamName && !teamNameSetByCompetitor` (redirect to `/setup`) guard branches, because dev-mock auth is always ready with the team name set. Export `RequireAuth` and add a focused unit spec that mocks `useAuth` + `Navigate` to inject each state. With the existing integration spec, `App.tsx` reaches **100% stmt/branch/func/line**.

## Test plan

- `RequireAuth`: not-ready → null, no session → `/login`, team-name-unset + `requireTeamName` → `/setup`, authenticated → children, `requireTeamName=false` → children.
- `make harness` ✅, `make before-commit` ✅, full participant-portal suite green.

## Regression analysis

- Source change is solely `export` on `RequireAuth`; no logic change.
- The new spec is **complementary** to `App.test.tsx` (guard-state units vs routing integration), not duplicate — it mocks `useAuth` precisely to drive states the real dev-mock provider never produces.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/participant-portal` source (export only) + test; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)