### PR TITLE
test(application-admin-console): cover deployment-detail Cfn/Handoff sections (100%)

### DIFF
--- a/apps/application-admin-console/test/pages/deployment-detail/CfnOutputsSection.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/CfnOutputsSection.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CfnOutputsSection } from "../../../src/pages/deployment-detail/CfnOutputsSection";
+
+const t = (key: string) => key;
+
+describe("CfnOutputsSection", () => {
+  it("should render each CFn output as a label/value pair", () => {
+    render(
+      <CfnOutputsSection
+        outputs={{ SiteUrl: "https://x", RoleArn: "arn:aws:iam::1:role/x" }}
+        t={t}
+      />,
+    );
+    expect(screen.getByText("deployment_detail.cfn_outputs_header")).toBeInTheDocument();
+    expect(screen.getByText("SiteUrl")).toBeInTheDocument();
+    expect(screen.getByText("https://x")).toBeInTheDocument();
+    expect(screen.getByText("arn:aws:iam::1:role/x")).toBeInTheDocument();
+  });
+
+  it("should render no pairs for empty outputs", () => {
+    render(<CfnOutputsSection outputs={{}} t={t} />);
+    expect(screen.getByText("deployment_detail.cfn_outputs_header")).toBeInTheDocument();
+  });
+});

--- a/apps/application-admin-console/test/pages/deployment-detail/HandoffSection.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/HandoffSection.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HandoffSection } from "../../../src/pages/deployment-detail/HandoffSection";
+
+const t = (key: string) => key;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("HandoffSection", () => {
+  it("should render the team login key and copy it to the clipboard", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    render(<HandoffSection teamLoginKey="LOGIN-KEY-123" t={t} />);
+    expect(screen.getByText("LOGIN-KEY-123")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "deployment_detail.copy_login_key_aria" }));
+    expect(writeText).toHaveBeenCalledWith("LOGIN-KEY-123");
+  });
+
+  it("should not throw when the clipboard API is unavailable", () => {
+    // navigator.clipboard を undefined にして optional-chain の short-circuit を踏む。
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+    render(<HandoffSection teamLoginKey="LOGIN-KEY-123" t={t} />);
+    fireEvent.click(screen.getByRole("button", { name: "deployment_detail.copy_login_key_aria" }));
+    expect(screen.getByText("LOGIN-KEY-123")).toBeInTheDocument(); // no crash
+  });
+});


### PR DESCRIPTION
## Summary

`CfnOutputsSection` and `HandoffSection` (deployment-detail) were at 0% statements. Add co-located specs; both reach **100% stmt/branch/func/line**.

## Test plan

- **CfnOutputsSection**: renders each CFn output as a label/value pair, plus the empty case.
- **HandoffSection**: renders the team login key, copies it to the clipboard on click, and no-ops safely when the clipboard API is unavailable (the optional-chain short-circuit).
- `t` is passed as a prop (no hook); `navigator.clipboard` stubbed (present + undefined).
- `make harness` ✅, `make before-commit` ✅, full application-admin-console suite green.

## Regression analysis

- Test-only change; no production code touched. Pins existing behavior.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. Adds two test files under `apps/application-admin-console/test/pages/deployment-detail`; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)