### PR TITLE
test(application-admin-console): cover event-detail panels to 100%

### DIFF
--- a/apps/application-admin-console/src/components/event-detail/EventParticipantsPanel.tsx
+++ b/apps/application-admin-console/src/components/event-detail/EventParticipantsPanel.tsx
@@ -39,6 +39,9 @@ export function EventParticipantsPanel({
                   iconName="copy"
                   ariaLabel={t("event_detail.participants_copy_aria")}
                   onClick={() =>
+                    // この closure は participantPortalUrl truthy 時のみ render されるので
+                    // ?? "" の右辺は不到達 (property narrowing 用の型ガード)。
+                    /* v8 ignore next */
                     void navigator.clipboard?.writeText(config.participantPortalUrl ?? "")
                   }
                 >

--- a/apps/application-admin-console/src/components/event-detail/EventTeamsPanel.tsx
+++ b/apps/application-admin-console/src/components/event-detail/EventTeamsPanel.tsx
@@ -69,6 +69,8 @@ export function EventTeamsPanel({
                     ariaLabel={t("event_detail.teams_col_login_key_aria", {
                       slug: tr.internalSlug,
                     })}
+                    // teamLoginKey truthy の row だけ copy button を出すので ?? "" 右辺は不到達。
+                    /* v8 ignore next */
                     onClick={() => void navigator.clipboard?.writeText(tr.teamLoginKey ?? "")}
                   />
                 </SpaceBetween>

--- a/apps/application-admin-console/test/components/event-detail/EventNotificationsPanel.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/EventNotificationsPanel.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { EventDetail } from "../../../src/api/events-client";
+import { EventNotificationsPanel } from "../../../src/components/event-detail/EventNotificationsPanel";
+
+const t = (key: string) => key;
+const detail = (status: string) => ({ status, teams: [] }) as unknown as EventDetail;
+
+describe("EventNotificationsPanel", () => {
+  it("should enable the send button and fire onOpen for an active event", () => {
+    const onOpen = vi.fn();
+    render(<EventNotificationsPanel detail={detail("RUNNING")} onOpen={onOpen} t={t} />);
+    const btn = screen.getByRole("button", { name: "event_detail.notifications_send" });
+    expect(btn).toBeEnabled();
+    fireEvent.click(btn);
+    expect(onOpen).toHaveBeenCalled();
+    expect(screen.queryByText("event_detail.notifications_draft_disabled")).not.toBeInTheDocument();
+  });
+
+  it("should disable send and show the draft notice for a DRAFT event", () => {
+    render(<EventNotificationsPanel detail={detail("DRAFT")} onOpen={vi.fn()} t={t} />);
+    expect(screen.getByRole("button", { name: "event_detail.notifications_send" })).toBeDisabled();
+    expect(screen.getByText("event_detail.notifications_draft_disabled")).toBeInTheDocument();
+  });
+
+  it("should show the teardown notice for a TEARDOWN event", () => {
+    render(<EventNotificationsPanel detail={detail("TEARDOWN")} onOpen={vi.fn()} t={t} />);
+    expect(
+      screen.getByText("event_detail.notifications_teardown_disabled_teardown"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show the archived notice for an ARCHIVED event", () => {
+    render(<EventNotificationsPanel detail={detail("ARCHIVED")} onOpen={vi.fn()} t={t} />);
+    expect(
+      screen.getByText("event_detail.notifications_teardown_disabled_archived"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/application-admin-console/test/components/event-detail/EventParticipantsPanel.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/EventParticipantsPanel.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventDetail } from "../../../src/api/events-client";
+import { EventParticipantsPanel } from "../../../src/components/event-detail/EventParticipantsPanel";
+import type { AppConfig } from "../../../src/config";
+
+const t = (key: string) => key;
+const detail = (status: string) => ({ status, teams: [] }) as unknown as EventDetail;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("EventParticipantsPanel", () => {
+  it("should show the portal URL + copy button when configured (expanded for DRAFT)", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    render(
+      <EventParticipantsPanel
+        config={{ participantPortalUrl: "https://portal.example.com" } as AppConfig}
+        detail={detail("DRAFT")}
+        t={t}
+      />,
+    );
+    expect(screen.getByText("https://portal.example.com")).toBeInTheDocument();
+    expect(screen.getByText("event_detail.participants_steps_header")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "event_detail.participants_copy_aria" }));
+    expect(writeText).toHaveBeenCalledWith("https://portal.example.com");
+  });
+
+  it("should show the no-URL alert when the portal URL is absent (collapsed for RUNNING)", () => {
+    render(<EventParticipantsPanel config={{} as AppConfig} detail={detail("RUNNING")} t={t} />);
+    expect(screen.getByText("event_detail.participants_no_url_body")).toBeInTheDocument();
+  });
+});

--- a/apps/application-admin-console/test/components/event-detail/EventTeamsPanel.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/EventTeamsPanel.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventDetail } from "../../../src/api/events-client";
+import { EventTeamsPanel } from "../../../src/components/event-detail/EventTeamsPanel";
+
+const t = (key: string, params?: Readonly<Record<string, string | number>>) =>
+  params ? `${key}|${JSON.stringify(params)}` : key;
+// biome-ignore lint/suspicious/noExplicitAny: 最小 team fixture。
+const detail = (teams: any[], status = "DRAFT") => ({ status, teams }) as unknown as EventDetail;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("EventTeamsPanel", () => {
+  it("should render full team rows and copy the login key", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    render(
+      <EventTeamsPanel
+        detail={detail([
+          {
+            internalSlug: "team-a",
+            displayName: "Alpha",
+            awsAccountId: "111122223333",
+            teamLoginKey: "KEY-A",
+          },
+        ])}
+        t={t}
+      />,
+    );
+    expect(screen.getByText("team-a")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("111122223333")).toBeInTheDocument();
+    expect(screen.getByText("KEY-A")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: 'event_detail.teams_col_login_key_aria|{"slug":"team-a"}',
+      }),
+    );
+    expect(writeText).toHaveBeenCalledWith("KEY-A");
+  });
+
+  it("should show the unset / legacy fallbacks for missing fields (collapsed for RUNNING)", () => {
+    render(
+      <EventTeamsPanel
+        detail={detail([{ internalSlug: "team-b" }], "RUNNING")} // no displayName/account/key
+        t={t}
+      />,
+    );
+    expect(screen.getByText("event_detail.teams_col_display_name_unset")).toBeInTheDocument();
+    expect(screen.getByText("event_detail.teams_col_account_legacy")).toBeInTheDocument();
+    expect(screen.getByText("event_detail.teams_col_login_key_legacy")).toBeInTheDocument();
+  });
+
+  it("should render the empty state for an event with no teams", () => {
+    render(<EventTeamsPanel detail={detail([])} t={t} />);
+    expect(screen.getByText("event_detail.teams_empty")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`EventNotificationsPanel`, `EventParticipantsPanel`, and `EventTeamsPanel` (event-detail presentational panels) were at 0%. Add co-located specs (`t`/`config`/`detail` passed as props, no hooks). All three reach **100% stmt/branch/func/line**.

## Test plan

- **Notifications**: enabled send + `onOpen` for an active event; disabled + DRAFT / TEARDOWN / ARCHIVED notices.
- **Participants**: portal URL + copy button + steps when configured; no-URL alert otherwise.
- **Teams**: full team rows + login-key copy; the unset / legacy fallbacks for missing displayName / account / key; the empty state.
- `make harness` ✅, `make before-commit` ✅, full application-admin-console suite green.

## Regression analysis

- Source change is two `v8-ignore` comments on the unreachable `?? ""` fallbacks inside copy closures (the copy button only renders when the value is truthy). No logic change.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/application-admin-console` source (comments only) + tests; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)