### PR TITLE
test(application-admin-console): cover AddAccountModal + SecretRevealModal to 100%

### DIFF
--- a/apps/application-admin-console/src/pages/competitor-accounts/AddAccountModal.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/AddAccountModal.tsx
@@ -48,6 +48,8 @@ export function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAc
   };
 
   const handleDismiss = () => {
+    // cancel button は disabled={inFlight} なので inFlight 中は呼ばれない (= 防御的不到達)。
+    /* v8 ignore next */
     if (inFlight) return;
     reset();
     onDismiss();
@@ -59,6 +61,8 @@ export function AddAccountModal({ config, visible, onDismiss, onSuccess }: AddAc
     !apiClient || inFlight || awsAccountId.length === 0 || awsAccountIdInvalid || aliasInvalid;
 
   const handleSubmit = async () => {
+    // submit button は disabled={submitDisabled} なので呼ばれるのは送信可能時のみ (= 防御的不到達)。
+    /* v8 ignore next */
     if (!apiClient || submitDisabled) return;
     setInFlight(true);
     setError(null);

--- a/apps/application-admin-console/test/pages/competitor-accounts/AddAccountModal.test.tsx
+++ b/apps/application-admin-console/test/pages/competitor-accounts/AddAccountModal.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../../src/config";
+import { AddAccountModal } from "../../../src/pages/competitor-accounts/AddAccountModal";
+
+/**
+ * AddAccountModal (#1314): account-id / alias validation + submit (createCompetitorAccount) +
+ * friendly error を pin する。 useApiClient / createCompetitorAccount / i18n は mock、
+ * FriendlyErrorAlert + toFriendlyError + defaultCompetitorRoleName は実物。
+ */
+const { mockUseApiClient, mockCreate } = vi.hoisted(() => ({
+  mockUseApiClient: vi.fn(),
+  mockCreate: vi.fn(),
+}));
+
+vi.mock("../../../src/api/client", async (importOriginal) => {
+  // ApiError は friendly-error が instanceof で使うので実物を残す (partial mock)。
+  const actual = await importOriginal<typeof import("../../../src/api/client")>();
+  return { ...actual, useApiClient: mockUseApiClient };
+});
+vi.mock("../../../src/api/competitor-accounts-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/api/competitor-accounts-client")>();
+  return { ...actual, createCompetitorAccount: mockCreate };
+});
+vi.mock("../../../src/i18n", () => {
+  const t = (key: string) => key;
+  return { useT: () => t };
+});
+
+const config = { tenantId: "tenant-1", apiBaseUrl: "https://api.example.com" } as AppConfig;
+const props = (over = {}) => ({
+  config,
+  visible: true,
+  onDismiss: vi.fn(),
+  onSuccess: vi.fn(),
+  ...over,
+});
+const accountInput = () => screen.getByPlaceholderText("123456789012");
+const submitBtn = () =>
+  screen.getByRole("button", { name: "competitor_accounts.add_modal_submit" });
+
+beforeEach(() => {
+  mockUseApiClient.mockReturnValue({ fetch: vi.fn() });
+  mockCreate.mockReset().mockResolvedValue({
+    tenkaCloudAccountId: "999988887777",
+    externalId: "ext-123",
+    competitorRoleName: "Role",
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("AddAccountModal", () => {
+  it("should keep submit disabled until a 12-digit account id is entered", () => {
+    render(<AddAccountModal {...props()} />);
+    expect(submitBtn()).toBeDisabled(); // empty
+    fireEvent.change(accountInput(), { target: { value: "123" } }); // invalid
+    expect(
+      screen.getByText("competitor_accounts.add_modal_account_id_invalid"),
+    ).toBeInTheDocument();
+    expect(submitBtn()).toBeDisabled();
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } }); // valid
+    expect(submitBtn()).toBeEnabled();
+  });
+
+  it("should disable submit when the alias exceeds the max length", () => {
+    render(<AddAccountModal {...props()} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    fireEvent.change(screen.getByPlaceholderText("Team Acme prod"), {
+      target: { value: "a".repeat(121) },
+    });
+    expect(submitBtn()).toBeDisabled();
+  });
+
+  it("should create the account with an alias and call onSuccess", async () => {
+    const onSuccess = vi.fn();
+    render(<AddAccountModal {...props({ onSuccess })} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    fireEvent.change(screen.getByPlaceholderText("Team Acme prod"), { target: { value: "Acme" } });
+    fireEvent.click(submitBtn());
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ awsAccountId: "123456789012", alias: "Acme" }),
+      ),
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("should omit the alias key when no alias is given", async () => {
+    render(<AddAccountModal {...props()} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    fireEvent.click(submitBtn());
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0]?.[1]).not.toHaveProperty("alias");
+  });
+
+  it("should show a friendly error when creation fails", async () => {
+    mockCreate.mockRejectedValue(new Error("account already linked"));
+    render(<AddAccountModal {...props()} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    fireEvent.click(submitBtn());
+    expect(await screen.findByText("account already linked")).toBeInTheDocument();
+  });
+
+  it("should reset and dismiss on cancel", () => {
+    const onDismiss = vi.fn();
+    render(<AddAccountModal {...props({ onDismiss })} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    fireEvent.click(screen.getByRole("button", { name: "competitor_accounts.add_modal_cancel" }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("should update the region and role inputs", () => {
+    render(<AddAccountModal {...props()} />);
+    const boxes = screen.getAllByRole("textbox"); // [account, alias, region, role]
+    fireEvent.change(boxes[2], { target: { value: "us-east-1" } });
+    fireEvent.change(boxes[3], { target: { value: "CustomRole" } });
+    expect(boxes[2]).toHaveValue("us-east-1");
+    expect(boxes[3]).toHaveValue("CustomRole");
+  });
+
+  it("should keep submit disabled when the API client is unavailable", () => {
+    mockUseApiClient.mockReturnValue(null);
+    render(<AddAccountModal {...props()} />);
+    fireEvent.change(accountInput(), { target: { value: "123456789012" } });
+    expect(submitBtn()).toBeDisabled();
+  });
+});

--- a/apps/application-admin-console/test/pages/competitor-accounts/SecretRevealModal.test.tsx
+++ b/apps/application-admin-console/test/pages/competitor-accounts/SecretRevealModal.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CreateCompetitorAccountResponse } from "../../../src/api/competitor-accounts-client";
+import { SecretRevealModal } from "../../../src/pages/competitor-accounts/SecretRevealModal";
+
+/**
+ * SecretRevealModal: secret null → 非表示、 secret あり → launch button / copy-all / manual
+ * (CopyableField) を描画。 copy-all で payload を clipboard へ + ✓ feedback → 2 秒で reset。
+ * templateUrl の有無で manual link を切替。 useT は安定 echo、 competitor-bootstrap lib は実物。
+ */
+vi.mock("../../../src/i18n", () => {
+  const t = (key: string) => key;
+  return { useT: () => t };
+});
+
+const secret: CreateCompetitorAccountResponse = {
+  tenkaCloudAccountId: "999988887777",
+  externalId: "ext-abc",
+  competitorRoleName: "TenkaCompetitorRole",
+} as CreateCompetitorAccountResponse;
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+  writeText.mockClear();
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("SecretRevealModal", () => {
+  it("should render nothing when secret is null", () => {
+    const { container } = render(<SecretRevealModal secret={null} onDismiss={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should reveal the secret fields, launch button, and dismiss", () => {
+    const onDismiss = vi.fn();
+    render(<SecretRevealModal secret={secret} onDismiss={onDismiss} />);
+    expect(screen.getByText("competitor_accounts.secret_modal_header")).toBeInTheDocument();
+    expect(screen.getByText("999988887777")).toBeInTheDocument(); // CopyableField value
+    expect(screen.getByText("ext-abc")).toBeInTheDocument();
+    // launch は href 付き Button = link role。
+    expect(
+      screen.getByRole("link", { name: "competitor_accounts.secret_modal_launch_button" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "competitor_accounts.secret_modal_close" }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("should copy the full payload and flip to the done state, then reset after 2s", async () => {
+    vi.useFakeTimers();
+    render(<SecretRevealModal secret={secret} onDismiss={vi.fn()} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "competitor_accounts.secret_modal_copy_all" }),
+    );
+    await act(async () => {
+      await Promise.resolve(); // flush onCopyAll → setAllCopied(true)
+    });
+    expect(writeText).toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "competitor_accounts.secret_modal_copy_done" }),
+    ).toBeInTheDocument();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000); // reset
+    });
+    expect(
+      screen.getByRole("button", { name: "competitor_accounts.secret_modal_copy_all" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should use the supplied templateUrl for the manual download link", () => {
+    render(
+      <SecretRevealModal
+        secret={secret}
+        onDismiss={vi.fn()}
+        templateUrl="https://custom.example.com/bootstrap.yaml"
+      />,
+    );
+    const link = screen.getByRole("link", { name: "competitor-bootstrap.yaml (raw)" });
+    expect(link).toHaveAttribute("href", "https://custom.example.com/bootstrap.yaml");
+  });
+});


### PR DESCRIPTION
## Summary

The remaining two competitor-accounts modals were at 0–7%. Add co-located specs; both reach **100% stmt/branch/func/line**.

## Test plan

- **AddAccountModal**: account-id validation (empty / invalid / valid), alias max-length gate, create-with-alias + `onSuccess`, alias-omitted submit, friendly error on failure, cancel/reset, region/role inputs, and the no-api-client disabled state. Mocks `useApiClient` (partial — keeps the real `ApiError` for `toFriendlyError`) + `createCompetitorAccount`; `FriendlyErrorAlert`/`toFriendlyError`/`defaultCompetitorRoleName` stay real.
- **SecretRevealModal**: null secret → renders nothing; reveal of the secret fields (`CopyableField`) + launch link + dismiss; copy-all → clipboard + ✓ done → 2s reset (fake timers); supplied `templateUrl` link.
- `make harness` ✅, `make before-commit` ✅, full application-admin-console suite green.

## Regression analysis

- Source change is two `v8-ignore` comments in `AddAccountModal` on the `handleDismiss`/`handleSubmit` guards (the cancel/submit buttons are `disabled` when those conditions hold, so the early returns are unreachable via the UI). No logic change.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `apps/application-admin-console` source (comments only) + tests; no infra change, no bundle-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)