### PR TITLE
test(application-admin-console): cover CompetitorAccountsPage to 100%

### DIFF
--- a/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * CompetitorAccountsPage: useCompetitorAccounts の state を受けて header/table/modals を配線する
+ * orchestration page。 hook は mock、 子 (Table / AddAccountModal / SecretRevealModal /
+ * DeleteModal) は callback を expose する stub に差し替えて wiring を pin。 loading / bootstrap
+ * 警告 / error / add→secret→reload / request-delete→confirm(remove) / 空 target guard を網羅。
+ */
+const { mockHook } = vi.hoisted(() => ({ mockHook: vi.fn() }));
+
+vi.mock("../../src/i18n", () => {
+  const t = (key: string) => key;
+  return { useT: () => t };
+});
+vi.mock("../../src/pages/competitor-accounts/useCompetitorAccounts", () => ({
+  useCompetitorAccounts: mockHook,
+}));
+vi.mock("../../src/pages/competitor-accounts/CompetitorAccountsTable", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  CompetitorAccountsTable: ({ onVerify, onRequestDelete }: any) => (
+    <div data-testid="accounts-table">
+      <button type="button" onClick={() => onVerify("acct-1")}>
+        stub-verify
+      </button>
+      <button type="button" onClick={() => onRequestDelete({ awsAccountId: "acct-1" })}>
+        stub-request-delete
+      </button>
+    </div>
+  ),
+}));
+vi.mock("../../src/pages/competitor-accounts/AddAccountModal", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  AddAccountModal: ({ visible, onSuccess, onDismiss }: any) =>
+    visible ? (
+      <div data-testid="add-modal">
+        <button type="button" onClick={() => onSuccess({ tenkaCloudAccountId: "x" })}>
+          stub-add-success
+        </button>
+        <button type="button" onClick={onDismiss}>
+          stub-add-dismiss
+        </button>
+      </div>
+    ) : null,
+}));
+vi.mock("../../src/pages/competitor-accounts/SecretRevealModal", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  SecretRevealModal: ({ secret, onDismiss }: any) =>
+    secret ? (
+      <div data-testid="secret-modal">
+        <button type="button" onClick={onDismiss}>
+          stub-secret-dismiss
+        </button>
+      </div>
+    ) : null,
+}));
+vi.mock("../../src/pages/competitor-accounts/CompetitorAccountDeleteModal", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  CompetitorAccountDeleteModal: ({ target, onConfirm, onDismiss }: any) => (
+    <div>
+      <span data-testid="delete-target">{target?.awsAccountId ?? "no-target"}</span>
+      <button type="button" onClick={onConfirm}>
+        stub-confirm-delete
+      </button>
+      <button type="button" onClick={onDismiss}>
+        stub-delete-dismiss
+      </button>
+    </div>
+  ),
+}));
+
+const { CompetitorAccountsPage } = await import("../../src/pages/CompetitorAccounts");
+
+const remove = vi.fn().mockResolvedValue(undefined);
+const verify = vi.fn();
+const reload = vi.fn().mockResolvedValue(undefined);
+const hookState = (over: Record<string, unknown> = {}) => ({
+  items: [],
+  error: null,
+  verifyInFlight: null,
+  deleteInFlight: false,
+  reload,
+  verify,
+  remove,
+  ...over,
+});
+const config = (over: Partial<AppConfig> = {}) =>
+  ({ competitorBootstrapTemplateUrl: "https://x/bootstrap.yaml", ...over }) as AppConfig;
+const renderPage = (cfg = config()) => render(<CompetitorAccountsPage config={cfg} />);
+
+beforeEach(() => {
+  mockHook.mockReturnValue(hookState());
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("CompetitorAccountsPage", () => {
+  it("should show a spinner while loading (no items, no error)", () => {
+    mockHook.mockReturnValue(hookState({ items: undefined, error: null }));
+    renderPage();
+    expect(screen.getByText("competitor_accounts.loading_spinner")).toBeInTheDocument();
+  });
+
+  it("should render the table and the bootstrap warning when the template URL is missing", () => {
+    renderPage(config({ competitorBootstrapTemplateUrl: "" }));
+    expect(screen.getByTestId("accounts-table")).toBeInTheDocument();
+    expect(screen.getByText("competitor_accounts.bootstrap_url_missing_body")).toBeInTheDocument();
+  });
+
+  it("should hide the bootstrap warning when the template URL is set", () => {
+    renderPage();
+    expect(
+      screen.queryByText("competitor_accounts.bootstrap_url_missing_body"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show a friendly error alert (items undefined → table gets [])", () => {
+    // items undefined + error → loading は抜けて table に items ?? [] の [] が渡る。
+    mockHook.mockReturnValue(hookState({ items: undefined, error: { title: "load boom" } }));
+    renderPage();
+    expect(screen.getByText("load boom")).toBeInTheDocument();
+    expect(screen.getByTestId("accounts-table")).toBeInTheDocument();
+  });
+
+  it("should verify an account via the table callback", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("stub-verify"));
+    expect(verify).toHaveBeenCalledWith("acct-1");
+  });
+
+  it("should open the add modal, reveal the secret on success, and reload", () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "competitor_accounts.add_button" }));
+    fireEvent.click(screen.getByText("stub-add-success"));
+    expect(screen.getByTestId("secret-modal")).toBeInTheDocument();
+    expect(reload).toHaveBeenCalled();
+    // secret modal dismiss → 閉じる。
+    fireEvent.click(screen.getByText("stub-secret-dismiss"));
+    expect(screen.queryByTestId("secret-modal")).not.toBeInTheDocument();
+  });
+
+  it("should close the add modal on dismiss", () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "competitor_accounts.add_button" }));
+    expect(screen.getByTestId("add-modal")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("stub-add-dismiss"));
+    expect(screen.queryByTestId("add-modal")).not.toBeInTheDocument();
+  });
+
+  it("should set the delete target then remove it on confirm", async () => {
+    renderPage();
+    fireEvent.click(screen.getByText("stub-request-delete"));
+    expect(screen.getByTestId("delete-target")).toHaveTextContent("acct-1");
+    fireEvent.click(screen.getByText("stub-confirm-delete"));
+    await waitFor(() => expect(remove).toHaveBeenCalledWith("acct-1"));
+    expect(screen.getByTestId("delete-target")).toHaveTextContent("no-target");
+  });
+
+  it("should clear the delete target on dismiss", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("stub-request-delete"));
+    expect(screen.getByTestId("delete-target")).toHaveTextContent("acct-1");
+    fireEvent.click(screen.getByText("stub-delete-dismiss"));
+    expect(screen.getByTestId("delete-target")).toHaveTextContent("no-target");
+  });
+
+  it("should no-op confirm when there is no delete target", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("stub-confirm-delete")); // target null
+    expect(remove).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The competitor-accounts orchestration page was at 0%. Add a co-located spec that mocks `useCompetitorAccounts` and stubs the (separately-tested) child components to pin the page wiring. File reaches **100% stmt/branch/func/line**.

## Test plan

- Loading spinner, bootstrap-url-missing warning (on/off), friendly error (items undefined → table gets `[]`), verify via table callback, add → reveal-secret → reload, add/secret/delete dismiss, request-delete → confirm (remove), and the empty-target confirm no-op.
- `make harness` ✅, `make before-commit` ✅, full application-admin-console suite green.

## Regression analysis

- Test-only change; no production code touched. Children + hook are stubbed/mocked (covered by their own suites). Verified via local `node_modules/.bin/vitest` + `.bin/biome` (no `bunx`).

## Physical impact

- **NO-OP** on CFn / deployed artifacts. Adds one test file under `apps/application-admin-console/test/pages`; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)