### PR TITLE
fix(ci): run CI on push to main so Codecov has a BASE coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ permissions:
   actions: read
 
 on:
+  # main への push (= PR merge 後) でも CI を回し coverage を Codecov に upload する。
+  # これが無いと Codecov に BASE (main) の report が無く、 PR で「Please upload report for
+  # BASE」 警告 + diff 不能 (base が "?") になる。 Issue #993 の延長。
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

The codecov bot warns on every PR: **"Please upload report for BASE (main@…)"**, and the coverage diff shows `?` for the base — because the `ci` workflow only triggers on `pull_request` / `workflow_dispatch`, so it never runs on a push to `main` (after a merge). Codecov therefore never receives a coverage report for the base commit.

Add a `push: branches: [main]` trigger so the same job — which already uploads each workspace's `lcov.info` via `codecov-action` — runs on main and seeds the BASE report. The PR warning disappears and the coverage delta becomes computable. Extends #993 (which fixed per-workspace coverage upload).

## Regression analysis

- CI-config only; the job body is unchanged and now additionally runs on main pushes.
- The Codecov upload already sets `fail_ci_if_error: false`, so a Codecov outage cannot break main.
- Cost: one extra CI run per merge to main — which is exactly what produces the base coverage report.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. `.github/workflows/ci.yml` trigger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)