### PR TITLE
test(app-admin): cover ProblemDetailPage to 100%

### DIFF
--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -195,6 +195,9 @@ function ProblemDeploymentsSection({
   useEffect(() => {
     let cancelled = false;
     const tick = async () => {
+      // unmount 時に clearInterval するので interval 経由の再 tick は来ない。 cancelled=true を
+      // 踏むのは teardown と既 queue の tick が競合する稀ケースのみ (= 防御的、不到達)。
+      /* v8 ignore next */
       if (cancelled) return;
       await fetchOnce();
     };

--- a/apps/application-admin-console/test/pages/ProblemDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/ProblemDetail.test.tsx
@@ -1,0 +1,189 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploymentSummary } from "../../src/api/deploy-client";
+import type { AppConfig } from "../../src/config";
+import type { ProblemDetail } from "../../src/data/problems";
+
+/**
+ * ProblemDetailPage: catalog から problem を引き、 overview / description / learning goals /
+ * endpoints / tags を描画し、 末尾に ProblemDeploymentsSection (polling) を載せる。
+ * problemId 欠落の redirect / not-found / Battle+ready vs Challenge+draft の badge 分岐 /
+ * deployments section の loading・成功行 (team link navigate)・error・empty を pin する。
+ * react-router / useT / findProblem / useApiClient / listDeployments を mock、
+ * DEPLOYMENT_STATUS_INDICATOR と deploymentsChanged は実物。
+ */
+const { mockParams, mockNav, mockFind, mockApiClient, mockList } = vi.hoisted(() => ({
+  mockParams: vi.fn(),
+  mockNav: vi.fn(),
+  mockFind: vi.fn(),
+  mockApiClient: vi.fn(),
+  mockList: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useParams: () => mockParams(),
+  useNavigate: () => mockNav,
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+vi.mock("../../src/i18n", () => ({
+  useT: () => (k: string, p?: Readonly<Record<string, string | number>>) =>
+    p ? `${k}|${JSON.stringify(p)}` : k,
+}));
+vi.mock("../../src/data/problems", () => ({ findProblem: mockFind }));
+vi.mock("../../src/api/client", () => ({ useApiClient: mockApiClient }));
+vi.mock("../../src/api/deploy-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/deploy-client")>();
+  return { ...actual, listDeployments: mockList };
+});
+
+const { ProblemDetailPage } = await import("../../src/pages/ProblemDetail");
+
+const config = {} as AppConfig;
+const problem = (over: Partial<ProblemDetail> = {}): ProblemDetail =>
+  ({
+    id: "p1",
+    name: "SQLi Battle",
+    category: "Battle",
+    status: "ready",
+    shortDescription: "short summary",
+    difficulty: 3,
+    estimatedDuration: "45m",
+    tags: ["web", "sqli"],
+    description: "long\ndescription",
+    exposedPorts: [{ name: "web", port: 8080 }],
+    learningGoals: ["goal-a", "goal-b"],
+    ...over,
+  }) as ProblemDetail;
+const dep = (over: Partial<DeploymentSummary> = {}): DeploymentSummary =>
+  ({
+    jobId: "job-1",
+    problemId: "p1",
+    tenantId: "t",
+    awsAccountId: "1",
+    region: "r",
+    teamName: "slug-a",
+    namePrefix: "pre-a",
+    status: "COMPLETE",
+    createdAt: "2026-05-20T10:00:00Z",
+    ...over,
+  }) as DeploymentSummary;
+const renderPage = () => render(<ProblemDetailPage config={config} />);
+
+beforeEach(() => {
+  mockParams.mockReturnValue({ problemId: "p1" });
+  mockNav.mockClear();
+  mockFind.mockReturnValue(problem());
+  mockApiClient.mockReturnValue(null); // default: deployments section stays in loading
+  mockList.mockReset().mockResolvedValue({ items: [] });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("ProblemDetailPage", () => {
+  it("should redirect to the problem list when no problemId is in the URL", () => {
+    mockParams.mockReturnValue({});
+    renderPage();
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/problems");
+  });
+
+  it("should show a not-found view and route back when the problem is unknown", () => {
+    mockParams.mockReturnValue({ problemId: "ghost" });
+    mockFind.mockReturnValue(undefined);
+    renderPage();
+    expect(screen.getByText("problem_detail.not_found_header")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "problem_detail.back_to_list" }));
+    expect(mockNav).toHaveBeenCalledWith("/problems");
+  });
+
+  it("should render the full detail for a Battle/ready problem", () => {
+    renderPage();
+    expect(screen.getByText("SQLi Battle")).toBeInTheDocument();
+    expect(screen.getByText("short summary")).toBeInTheDocument();
+    expect(screen.getByText("Battle")).toBeInTheDocument(); // category badge (red branch)
+    expect(screen.getByText("ready")).toBeInTheDocument(); // status badge (green branch)
+    expect(screen.getByText("problem_detail.difficulty_3")).toBeInTheDocument();
+    expect(screen.getByText("45m")).toBeInTheDocument();
+    expect(screen.getByText("goal-a")).toBeInTheDocument();
+    expect(screen.getByText("goal-b")).toBeInTheDocument();
+    expect(screen.getByText(/web \(port 8080\)/)).toBeInTheDocument();
+    expect(screen.getByText("sqli")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "problem_detail.back_short" }));
+    expect(mockNav).toHaveBeenCalledWith("/problems");
+  });
+
+  it("should render the alternate badge branches for a Challenge/draft problem", () => {
+    mockFind.mockReturnValue(problem({ category: "Challenge", status: "draft" }));
+    renderPage();
+    expect(screen.getByText("Challenge")).toBeInTheDocument(); // blue branch
+    expect(screen.getByText("draft")).toBeInTheDocument(); // blue branch
+  });
+
+  it("should show the deployments table loading state when the API client is unavailable", () => {
+    renderPage();
+    expect(screen.getByText("problem_detail.deployments_loading_text")).toBeInTheDocument();
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("should render a deployment row and navigate on the team link", async () => {
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    mockList.mockResolvedValue({ items: [dep({ displayTeamName: "Alpha", status: "COMPLETE" })] });
+    renderPage();
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("COMPLETE")).toBeInTheDocument();
+    expect(screen.getByText("pre-a")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Alpha"));
+    expect(mockNav).toHaveBeenCalledWith("/deployments/job-1");
+  });
+
+  it("should fall back to the internal team slug when no display name is set", async () => {
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    mockList.mockResolvedValue({
+      items: [dep({ teamName: "slug-b", displayTeamName: undefined })],
+    });
+    renderPage();
+    expect(await screen.findByText("slug-b")).toBeInTheDocument();
+  });
+
+  it("should surface a deployments fetch error", async () => {
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    mockList.mockRejectedValue(new Error("deploy list boom"));
+    renderPage();
+    expect(await screen.findByText("deploy list boom")).toBeInTheDocument();
+  });
+
+  it("should render the empty state when the problem has no deployments", async () => {
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    mockList.mockResolvedValue({ items: [] });
+    renderPage();
+    expect(await screen.findByText("problem_detail.deployments_empty")).toBeInTheDocument();
+  });
+
+  it("should keep items on an unchanged refetch and replace them on change", async () => {
+    // problemId を rerender で差し替えると fetchOnce が再生成され useEffect が再 fetch する。
+    // prev (= 既存 items) は state として残るので deploymentsChanged の prev/res 両分岐を踏める。
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    const sameItems = [dep({ jobId: "job-1", displayTeamName: "Alpha" })];
+    mockList
+      .mockResolvedValueOnce({ items: sameItems }) // p1 mount → prev null → res
+      .mockResolvedValueOnce({ items: sameItems }) // p2 同一参照 → !changed → prev
+      .mockResolvedValueOnce({ items: [dep({ jobId: "job-2", displayTeamName: "Beta" })] }); // p3 changed → res
+    mockFind.mockReturnValue(problem({ id: "p1" }));
+    const { rerender } = renderPage();
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+
+    mockFind.mockReturnValue(problem({ id: "p2" }));
+    rerender(<ProblemDetailPage config={config} />);
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Alpha")).toBeInTheDocument(); // prev 保持
+
+    mockFind.mockReturnValue(problem({ id: "p3" }));
+    rerender(<ProblemDetailPage config={config} />);
+    expect(await screen.findByText("Beta")).toBeInTheDocument(); // res で置換
+  });
+
+  it("should stringify a non-Error deployments rejection", async () => {
+    mockApiClient.mockReturnValue({ fetch: vi.fn() });
+    mockList.mockRejectedValue("string deploy fail");
+    renderPage();
+    expect(await screen.findByText("string deploy fail")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`ProblemDetailPage`（catalog から problem を引き overview / description / learning goals / endpoints / tags を描画し、末尾に `ProblemDeploymentsSection` の polling table を載せる page）はテストが無く coverage 0% だった。全 render 分岐と polling ロジックを pin して statements/branches/functions/lines をすべて 100% にした。

カバーした分岐:
- `problemId` 欠落 → `/problems` redirect
- not-found view（back button → `navigate("/problems")`)
- overview badge 両分岐: Battle+ready（red/green）と Challenge+draft（blue/blue）
- overview meta / learning goals / exposed ports / tags
- deployments section: apiClient 不在の loading（fetch skip）/ 成功行（team link navigate + `displayTeamName ?? teamName` fallback + status indicator）/ fetch error alert / empty state
- **polling の `deploymentsChanged` updater**（prev null→res / 同一→prev 保持 / 変化→res 置換）を `problemId` の rerender で `fetchOnce` 再生成→再 fetch を起こし prev state を保持したまま全分岐到達
- catch の `String(err)` 分岐（非 Error reject）

残る polling `cancelled` guard のみ（unmount で `clearInterval` 済みのため不到達）`Deployments.tsx` と同じく `/* v8 ignore next */` + 理由コメントで明示。

`react-router` / `useT` / `findProblem` / `useApiClient` / `listDeployments` を mock、`DEPLOYMENT_STATUS_INDICATOR` と `deploymentsChanged` は実物。

## Test plan
- `vitest run test/pages/ProblemDetail.test.tsx --coverage` → 11 tests pass、`ProblemDetail.tsx` 100%（stmts 47/47・branch 24/24・func 20/20・lines 43/43）
- app-admin 全 79 test files / 631 tests green
- `tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加 + source への v8-ignore コメント 1 件のみ。実行時 behavior は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts. フロントエンド source のコメント追加 + テスト追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)