### PR TITLE
test(app-admin): cover ProblemsPage to 100%

### DIFF
--- a/apps/application-admin-console/test/pages/Problems.test.tsx
+++ b/apps/application-admin-console/test/pages/Problems.test.tsx
@@ -1,0 +1,178 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProblemSummary } from "../../src/data/problems";
+
+/**
+ * Issue #834 / #835: ProblemsPage (Cards + search / category segment / difficulty &
+ * tag multi-select / tag badge toggle / clear filter)。 検索 / category 切替 / tag badge
+ * の active 切替 / card header navigate / counter / empty (filtered vs none) / difficulty
+ * & tag multiselect onChange (Number/string parse + tagMatchMode toggle) を pin する。
+ * useNavigate / listProblemSummaries / useT を mock、 problem-filter ロジックと interpolate
+ * は実物。
+ */
+const { mockNav, mockList } = vi.hoisted(() => ({ mockNav: vi.fn(), mockList: vi.fn() }));
+
+vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
+vi.mock("../../src/data/problems", () => ({ listProblemSummaries: mockList }));
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return { ...actual, useT: () => (key: string) => key };
+});
+
+const { ProblemsPage } = await import("../../src/pages/Problems");
+
+const summary = (over: Partial<ProblemSummary> = {}): ProblemSummary =>
+  ({
+    id: "a",
+    name: "Alpha",
+    category: "Battle",
+    status: "ready",
+    shortDescription: "alpha desc",
+    difficulty: 1,
+    estimatedDuration: "30m",
+    tags: ["web", "sqli"],
+    ...over,
+  }) as ProblemSummary;
+const CATALOG: ProblemSummary[] = [
+  summary({ id: "a", name: "Alpha", category: "Battle", difficulty: 1, tags: ["web", "sqli"] }),
+  summary({
+    id: "b",
+    name: "Bravo",
+    category: "Challenge",
+    status: "draft",
+    difficulty: 5,
+    tags: ["web", "crypto"],
+    shortDescription: "bravo desc",
+  }),
+];
+
+const renderPage = () => render(<ProblemsPage />);
+const searchBox = () => screen.getByPlaceholderText("problems.search_placeholder");
+
+beforeEach(() => {
+  mockNav.mockClear();
+  mockList.mockReturnValue(CATALOG);
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("ProblemsPage", () => {
+  it("should render every problem card and a plain total counter when no filter is active", () => {
+    renderPage();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(screen.getByText("(2)")).toBeInTheDocument(); // counter no filter
+    // category badge 両色: Alpha=Battle(red), Bravo=Challenge(blue)。
+    expect(
+      screen.getAllByText("Battle").some((e) => e.closest(".awsui_badge, [class*=badge]")),
+    ).toBe(true);
+  });
+
+  it("should filter by search text and show a filtered counter + clear button", () => {
+    renderPage();
+    fireEvent.change(searchBox(), { target: { value: "bravo" } });
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+    expect(screen.getByText("(1 / 2)")).toBeInTheDocument();
+    // clear filter (header action)
+    fireEvent.click(screen.getAllByRole("button", { name: "problems.clear_filter" })[0]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("(2)")).toBeInTheDocument();
+  });
+
+  it("should filter by category via the segmented control", () => {
+    renderPage();
+    const battleSeg = screen
+      .getAllByText("Battle")
+      .map((e) => e.closest("button"))
+      .find((b): b is HTMLButtonElement => b !== null);
+    fireEvent.click(battleSeg as HTMLButtonElement);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Bravo")).not.toBeInTheDocument();
+    // back to "all"
+    fireEvent.click(screen.getByText("problems.all"));
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("should toggle a tag filter on and off via a card tag badge", () => {
+    renderPage();
+    // "sqli" は Alpha だけが持つので、 click すると Bravo が消える。
+    fireEvent.click(screen.getByText("sqli"));
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Bravo")).not.toBeInTheDocument();
+    // active になった "sqli" card badge (= 一意な active aria) を再 click → toggle off。
+    fireEvent.click(screen.getByRole("button", { name: "problems.tag_active_aria" }));
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("should navigate to the problem detail when a card header link is clicked", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("Alpha"));
+    expect(mockNav).toHaveBeenCalledWith("/problems/a");
+  });
+
+  it("should show the filtered-empty state with a clear button when nothing matches", () => {
+    renderPage();
+    fireEvent.change(searchBox(), { target: { value: "no-such-problem" } });
+    expect(screen.getByText("problems.empty_filtered")).toBeInTheDocument();
+    // clear button は header と empty-state の 2 つ。 ここでは empty-state 側 (= 末尾) を click。
+    const clears = screen.getAllByRole("button", { name: "problems.clear_filter" });
+    fireEvent.click(clears[clears.length - 1]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
+
+  it("should show the plain empty state when the catalog itself is empty", () => {
+    mockList.mockReturnValue([]);
+    renderPage();
+    expect(screen.getByText("problems.empty")).toBeInTheDocument();
+    expect(screen.getByText("(0)")).toBeInTheDocument();
+  });
+
+  // Cloudscape Multiselect は role="option" の素朴な click では onChange が発火しないため、
+  // 公式 test-utils (createWrapper → openDropdown → selectOptionByValue) で駆動する。
+  // findAllMultiselects() は DOM 順 = [difficulty, tag]。
+  it("should filter by difficulty via the difficulty multiselect", () => {
+    const { container } = renderPage();
+    const difficultyMs = createWrapper(container).findAllMultiselects()[0];
+    difficultyMs.openDropdown();
+    difficultyMs.selectOptionByValue("1"); // difficulty 1 → Alpha のみ (Bravo は 5)
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Bravo")).not.toBeInTheDocument();
+  });
+
+  it("should select multiple tags, reveal the match-mode toggle, and switch or→and", () => {
+    const { container } = renderPage();
+    const tagMs = createWrapper(container).findAllMultiselects()[1];
+    tagMs.openDropdown();
+    tagMs.selectOptionByValue("web"); // tags=[web] (A,B 両方が持つ)
+    // Multiselect は選択後も dropdown が開いたままなので再 open は不要 (= toggle で閉じてしまう)。
+    tagMs.selectOptionByValue("crypto"); // tags=[web, crypto] → length 2
+    // length>1 で match-mode toggle button が出現 (初期 mode "or")。
+    fireEvent.click(screen.getByRole("button", { name: "problems.tag_match_or_button" })); // or→and
+    expect(
+      screen.getByRole("button", { name: "problems.tag_match_and_button" }),
+    ).toBeInTheDocument();
+    // mode "and" で web AND crypto を両方持つ問題 → Bravo のみ (Alpha は crypto を持たない)。
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+
+    // and→or に戻す (ternary 反対分岐)。 OR では web|crypto を持つ → 両方表示。
+    fireEvent.click(screen.getByRole("button", { name: "problems.tag_match_and_button" }));
+    expect(
+      screen.getByRole("button", { name: "problems.tag_match_or_button" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Issue #834 / #835 の `ProblemsPage`（Cards カタログ + search / category segment / difficulty & tag multiselect / tag badge toggle / clear filter）はテストが無く coverage 0% だった。**source は変更せず**、全 render 分岐と filter wiring を pin する unit test を追加して statements/branches/functions/lines をすべて 100% にした。

カバー範囲:
- 全 card 描画 + counter（filter 無し total / filter 中 `filtered / total`）
- search 絞り込み + header clear button
- category `SegmentedControl`（Battle 絞り → all 戻し）
- tag badge の toggle on/off（active/inactive aria + variant 両分岐）
- card header link → `navigate`
- empty: filtered-empty（empty-state 側 clear button）と catalog-empty
- difficulty multiselect onChange（Number/filter parse）
- tag multiselect で複数 tag 選択 → `tagMatchMode` toggle button 出現 → or↔and 往復（placeholder と button label の and/or 両分岐 + ternary 両側）

Cloudscape `Multiselect` は素朴な `role="option"` click では onChange が発火しないため、**公式 test-utils**（`createWrapper` → `openDropdown` → `selectOptionByValue`）で駆動した。`useNavigate` / `listProblemSummaries` / `useT` を mock、`problem-filter` ロジックと `interpolate` は実物。

## Test plan
- `vitest run test/pages/Problems.test.tsx --coverage` → 9 tests pass、`Problems.tsx` 100%（stmts 50/50・branch 24/24・func 35/35・lines 38/38）
- app-admin 全 test suite green（640 tests）
- `tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加のみ。source 変更なし、実行時 behavior 不変。
- Cloudscape 公式 test-utils を本 repo で初採用（= 既存の素朴 DOM 駆動が効かない Multiselect / Select 系の今後の test に転用可能）。

## Physical impact
- NO-OP on CFn / deployed artifacts. テスト追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)