### PR TITLE
test(app-admin): cover ShellLayout (AppLayout) to 100%

### DIFF
--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -47,6 +47,8 @@ export function ShellLayout({ children }: { children: ReactNode }) {
           },
         ],
         onItemClick: ({ detail }) => {
+          // user menu の item は signout のみなので detail.id は常に "signout" (= 偽は不到達)。
+          /* v8 ignore next */
           if (detail.id === "signout") {
             auth.logout();
             navigate("/login");
@@ -59,9 +61,15 @@ export function ShellLayout({ children }: { children: ReactNode }) {
     type: "menu-dropdown",
     iconName: "globe",
     ariaLabel: t("nav.locale_switcher_aria"),
+    // locale / code は SUPPORTED_LOCALES = LOCALE_NAME の key と一致するので ?? の右辺は不到達
+    // (= noUncheckedIndexedAccess 下で型を満たすための防御的フォールバック)。
+    /* v8 ignore next */
     text: LOCALE_NAME[locale] ?? locale,
+    /* v8 ignore next */
     items: SUPPORTED_LOCALES.map((code) => ({ id: code, text: LOCALE_NAME[code] ?? code })),
     onItemClick: ({ detail }) => {
+      // items は SUPPORTED_LOCALES のみなので detail.id は常に既知 locale (= includes 偽は不到達)。
+      /* v8 ignore next */
       if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
         setLocale(detail.id as LocaleCode);
       }
@@ -111,6 +119,8 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/identity-providers", text: "Identity providers" },
             ]}
             onFollow={(e) => {
+              // SideNavigation の link は全て internal (external:true なし) なので偽は不到達。
+              /* v8 ignore next */
               if (!e.detail.external) {
                 e.preventDefault();
                 navigate(e.detail.href);

--- a/apps/application-admin-console/test/components/AppLayout.test.tsx
+++ b/apps/application-admin-console/test/components/AppLayout.test.tsx
@@ -1,0 +1,116 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ShellLayout: TopNavigation (locale switcher + sign-in user menu / sign-out button) +
+ * SideNavigation の shell。 未 sign-in (locale のみ) / sign-in+email (locale + user menu →
+ * signout) / sign-in+no-email (locale + signout button) の 3 utility 状態、 locale 切替、
+ * SideNavigation の link navigate を pin する。 useAuth / decodeIdToken / useI18n /
+ * react-router を mock、 SUPPORTED_LOCALES は実物。 Cloudscape は test-utils で駆動。
+ */
+const { mockAuth, mockDecode, mockNav, mockSetLocale } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockDecode: vi.fn(),
+  mockNav: vi.fn(),
+  mockSetLocale: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useLocation: () => ({ pathname: "/" }),
+  useNavigate: () => mockNav,
+}));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+vi.mock("../../src/auth/claims", () => ({ decodeIdToken: mockDecode }));
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({ locale: "ja", setLocale: mockSetLocale, t: (k: string) => k }),
+  };
+});
+
+const { ShellLayout } = await import("../../src/components/AppLayout");
+
+/** test-utils の finder は null を返しうるので、 見つからなければ即 fail させて型を狭める。 */
+function must<T>(value: T | null | undefined, what: string): T {
+  if (!value) throw new Error(`expected ${what} to exist`);
+  return value;
+}
+
+const logout = vi.fn();
+const renderShell = () => render(<ShellLayout>child-content</ShellLayout>);
+const topNav = (container: HTMLElement) =>
+  must(createWrapper(container).findTopNavigation(), "top navigation");
+
+beforeEach(() => {
+  mockAuth.mockReturnValue({ tokens: null, logout });
+  mockDecode.mockReturnValue(null);
+  mockNav.mockClear();
+  mockSetLocale.mockClear();
+  logout.mockClear();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("ShellLayout", () => {
+  it("should render only the locale switcher when signed out and switch the locale", () => {
+    const { container } = renderShell();
+    const localeMenu = must(
+      must(topNav(container).findUtility(1), "utility 1").findMenuDropdownType(),
+      "locale menu",
+    );
+    localeMenu.openDropdown();
+    must(localeMenu.findItemById("en"), "en item").click();
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+  });
+
+  it("should navigate via a side navigation link", () => {
+    const { container } = renderShell();
+    const link = must(
+      must(createWrapper(container).findSideNavigation(), "side nav").findLinkByHref("/problems"),
+      "problems link",
+    );
+    link.click();
+    expect(mockNav).toHaveBeenCalledWith("/problems");
+  });
+
+  it("should show the user menu and sign out when an email claim is present", () => {
+    mockAuth.mockReturnValue({ tokens: { idToken: "tok" }, logout });
+    mockDecode.mockReturnValue({ email: "user@example.com" });
+    const { container } = renderShell();
+    // utilities = [locale(1), userMenu(2)]
+    const userMenu = must(
+      must(topNav(container).findUtility(2), "utility 2").findMenuDropdownType(),
+      "user menu",
+    );
+    userMenu.openDropdown();
+    must(userMenu.findItemById("signout"), "signout item").click();
+    expect(logout).toHaveBeenCalled();
+    expect(mockNav).toHaveBeenCalledWith("/login");
+  });
+
+  it("should show a plain sign-out button when signed in without an email claim", () => {
+    mockAuth.mockReturnValue({ tokens: { idToken: "tok" }, logout });
+    mockDecode.mockReturnValue(null); // no email → userMenuUtility undefined
+    const { container } = renderShell();
+    // utilities = [locale(1), signout-button(2)]
+    const signout = must(
+      must(topNav(container).findUtility(2), "utility 2").findButtonLinkType(),
+      "signout button",
+    );
+    signout.click();
+    expect(logout).toHaveBeenCalled();
+    expect(mockNav).toHaveBeenCalledWith("/login");
+  });
+});


### PR DESCRIPTION
## Summary

`ShellLayout`（application-admin-console の shell: TopNavigation の locale switcher + sign-in user menu / sign-out button、SideNavigation）は coverage 52% だった。Cloudscape 公式 test-utils で全 utility 状態と handler を駆動して statements/branches/functions/lines をすべて 100% にした。

カバー範囲:
- 3 つの utility 状態: 未 sign-in（locale のみ）/ sign-in+email（locale + user menu → signout）/ sign-in+no-email（locale + signout button）
- locale 切替（`setLocale`）
- SideNavigation link → `navigate`
- user menu / signout button からの `logout` + `navigate("/login")`

driving は test-utils（`findTopNavigation` → `findUtility(i)` → `findMenuDropdownType` / `findButtonLinkType`、`findSideNavigation` → `findLinkByHref`）。

UI 経路では発生し得ない防御分岐は `/* v8 ignore next */` + 理由コメントで明示:
- locale / user-menu の `onItemClick` の id 検証（items は固定なので偽は不到達）
- SideNavigation `onFollow` の `external` 判定（link は全て internal）
- `LOCALE_NAME[x] ?? x` の右辺（`noUncheckedIndexedAccess` 下で型を満たす fallback、`locale ∈ SUPPORTED_LOCALES = LOCALE_NAME` key なので右辺不到達）

`useAuth` / `decodeIdToken` / `useI18n` / `react-router` を mock、`SUPPORTED_LOCALES` は実物。test-utils finder の nullable は `must()` helper で狭め、non-null assertion (`!`) を使わず biome warning 0。

## Test plan
- `vitest run test/components/AppLayout.test.tsx --coverage` → 4 tests pass、`AppLayout.tsx` 100%（stmts 12/12・branch 8/8・func 5/5・lines 12/12）
- app-admin 全 test suite green（655 tests）
- `tsc --noEmit` clean、`biome check` warning/error 0、`make harness` no findings

## Regression analysis
- テスト追加 + source への v8-ignore コメント 3 件のみ。実行時 behavior は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts. フロントエンド source のコメント追加 + テスト追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the application layout component, including tests for locale switching, navigation, user authentication, and sign-out functionality.

* **Chores**
  * Enhanced code coverage annotations to improve test reliability tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->