### PR TITLE
refactor(app-admin): extract usePollingList hook (DRY/SOLID)

### DIFF
--- a/apps/application-admin-console/src/hooks/usePollingList.ts
+++ b/apps/application-admin-console/src/hooks/usePollingList.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from "react";
+import { toErrorMessage } from "../lib/error-message";
+
+export interface PollingListState<T> {
+  /** 取得済の一覧。 初回 fetch 前 / fetcher 不在は null (= loading 判定に使う)。 */
+  readonly items: readonly T[] | null;
+  /** 直近 fetch のエラー文字列。 成功で null にリセット。 */
+  readonly error: string | null;
+  /** 手動再取得 (reload button 等)。 polling と同じ経路を 1 回実行する。 */
+  readonly refresh: () => Promise<void>;
+}
+
+/**
+ * 一覧を一定間隔で polling する共有 hook。
+ *
+ * Deployments / ProblemDetail の deployment 一覧で
+ * 「初回 fetch + setInterval polling + unmount 時の cancelled guard + error 文字列化 +
+ * 等価なら reference 据え置き」 が完全に copy-paste されていたのを 1 箇所へ集約する
+ * (DRY / 単一責務)。
+ *
+ * @param fetcher 一覧取得関数。 apiClient 不在などで取得できないときは null を渡す
+ *               (= fetch せず items=null のまま loading を維持)。
+ * @param intervalMs polling 間隔 (ms)。
+ * @param hasChanged 任意。 前回結果から変化が無ければ (= false) setItems を skip して同一
+ *             reference を保つ (Cloudscape Table の無駄な reconcile を防ぐ)。 省略時は毎回置換。
+ */
+export function usePollingList<T>(
+  fetcher: (() => Promise<readonly T[]>) | null,
+  intervalMs: number,
+  hasChanged?: (prev: readonly T[], next: readonly T[]) => boolean,
+): PollingListState<T> {
+  const [items, setItems] = useState<readonly T[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!fetcher) return;
+    try {
+      const next = await fetcher();
+      setItems((prev) => (prev && hasChanged && !hasChanged(prev, next) ? prev : next));
+      setError(null);
+    } catch (err) {
+      setError(toErrorMessage(err));
+    }
+  }, [fetcher, hasChanged]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      // unmount 時に clearInterval するので interval 経由の再 tick は来ない。 cancelled=true を
+      // 踏むのは teardown と既 queue の tick が競合する稀ケースのみ (= 防御的、不到達)。
+      /* v8 ignore next */
+      if (cancelled) return;
+      await refresh();
+    };
+    void tick();
+    const interval = setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [refresh, intervalMs]);
+
+  return { items, error, refresh };
+}

--- a/apps/application-admin-console/src/pages/Deployments.tsx
+++ b/apps/application-admin-console/src/pages/Deployments.tsx
@@ -7,7 +7,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { type NavigateFunction, useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
 import {
@@ -16,8 +16,8 @@ import {
   listAllDeployments,
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
+import { usePollingList } from "../hooks/usePollingList";
 import { useT } from "../i18n";
-import { toErrorMessage } from "../lib/error-message";
 import {
   DEPLOYMENT_LIST_PAGE_SIZE,
   DEPLOYMENT_LIST_POLL_INTERVAL_MS,
@@ -77,45 +77,32 @@ export function DeploymentsPage({ config }: { config: AppConfig }) {
   const apiClient = useApiClient(config);
   const navigate = useNavigate();
   const t = useT();
-  const [items, setItems] = useState<readonly DeploymentSummary[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [manualRefreshing, setManualRefreshing] = useState(false);
-
   const columnDefinitions = useMemo(() => buildColumnDefinitions(navigate, t), [navigate, t]);
 
-  const fetchOnce = useCallback(
-    async ({ showSpinner }: { showSpinner: boolean } = { showSpinner: false }) => {
-      if (!apiClient) return;
-      if (showSpinner) setManualRefreshing(true);
-      try {
-        const res = await listAllDeployments(apiClient, { limit: DEPLOYMENT_LIST_PAGE_SIZE });
-        setItems((prev) => (prev && !deploymentsChanged(prev, res.items) ? prev : res.items));
-        setError(null);
-      } catch (err) {
-        setError(toErrorMessage(err));
-      } finally {
-        if (showSpinner) setManualRefreshing(false);
-      }
-    },
+  const fetcher = useMemo(
+    () =>
+      apiClient
+        ? () =>
+            listAllDeployments(apiClient, { limit: DEPLOYMENT_LIST_PAGE_SIZE }).then((r) => r.items)
+        : null,
     [apiClient],
   );
+  const { items, error, refresh } = usePollingList(
+    fetcher,
+    DEPLOYMENT_LIST_POLL_INTERVAL_MS,
+    deploymentsChanged,
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      // unmount 時に clearInterval するので interval 経由の再 tick は来ない。 cancelled=true を
-      // 踏むのは teardown と既 queue の tick が競合する稀ケースのみ (= 防御的、不到達)。
-      /* v8 ignore next */
-      if (cancelled) return;
-      await fetchOnce();
-    };
-    void tick();
-    const interval = setInterval(tick, DEPLOYMENT_LIST_POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [fetchOnce]);
+  // reload button は polling と同じ refresh を spinner 付きで叩くだけ。
+  const [manualRefreshing, setManualRefreshing] = useState(false);
+  const onReload = useCallback(async () => {
+    setManualRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setManualRefreshing(false);
+    }
+  }, [refresh]);
 
   if (!items && !error) {
     return (
@@ -139,7 +126,7 @@ export function DeploymentsPage({ config }: { config: AppConfig }) {
         variant="h1"
         description={t("deployments.description")}
         actions={
-          <Button onClick={() => fetchOnce({ showSpinner: true })} loading={manualRefreshing}>
+          <Button onClick={onReload} loading={manualRefreshing}>
             {t("deployments.reload")}
           </Button>
         }

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -9,7 +9,7 @@ import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Navigate, type NavigateFunction, useNavigate, useParams } from "react-router";
 import { useApiClient } from "../api/client";
 import {
@@ -19,8 +19,8 @@ import {
 } from "../api/deploy-client";
 import type { AppConfig } from "../config";
 import { findProblem } from "../data/problems";
+import { usePollingList } from "../hooks/usePollingList";
 import { useT } from "../i18n";
-import { toErrorMessage } from "../lib/error-message";
 import {
   DEPLOYMENT_LIST_PAGE_SIZE,
   DEPLOYMENT_LIST_POLL_INTERVAL_MS,
@@ -177,38 +177,22 @@ function ProblemDeploymentsSection({
 }) {
   const apiClient = useApiClient(config);
   const navigate = useNavigate();
-  const [items, setItems] = useState<readonly DeploymentSummary[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
-  const fetchOnce = useCallback(async () => {
-    if (!apiClient) return;
-    try {
-      const res = await listDeployments(apiClient, problemId, {
-        limit: DEPLOYMENT_LIST_PAGE_SIZE,
-      });
-      setItems((prev) => (prev && !deploymentsChanged(prev, res.items) ? prev : res.items));
-      setError(null);
-    } catch (err) {
-      setError(toErrorMessage(err));
-    }
-  }, [apiClient, problemId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      // unmount 時に clearInterval するので interval 経由の再 tick は来ない。 cancelled=true を
-      // 踏むのは teardown と既 queue の tick が競合する稀ケースのみ (= 防御的、不到達)。
-      /* v8 ignore next */
-      if (cancelled) return;
-      await fetchOnce();
-    };
-    void tick();
-    const interval = setInterval(tick, DEPLOYMENT_LIST_POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [fetchOnce]);
+  const fetcher = useMemo(
+    () =>
+      apiClient
+        ? () =>
+            listDeployments(apiClient, problemId, { limit: DEPLOYMENT_LIST_PAGE_SIZE }).then(
+              (r) => r.items,
+            )
+        : null,
+    [apiClient, problemId],
+  );
+  const { items, error } = usePollingList(
+    fetcher,
+    DEPLOYMENT_LIST_POLL_INTERVAL_MS,
+    deploymentsChanged,
+  );
 
   const columns = useMemo(() => buildColumns(navigate, t), [navigate, t]);
 

--- a/apps/application-admin-console/test/hooks/usePollingList.test.ts
+++ b/apps/application-admin-console/test/hooks/usePollingList.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePollingList } from "../../src/hooks/usePollingList";
+
+/**
+ * usePollingList: 一覧 polling 共有 hook。 fetcher 不在の no-op / 初回取得 / 手動 refresh /
+ * hasChanged による reference 据え置き or 置換 / 省略時は毎回置換 / fetch 失敗の error 文字列化 /
+ * unmount cleanup を pin する。
+ */
+afterEach(() => vi.clearAllMocks());
+
+const INTERVAL = 1_000_000; // テスト中は interval を実質発火させない
+
+describe("usePollingList", () => {
+  it("should not fetch and stay null when the fetcher is null", () => {
+    const { result } = renderHook(() => usePollingList<number>(null, INTERVAL));
+    expect(result.current.items).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should fetch once on mount", async () => {
+    const fetcher = vi.fn().mockResolvedValue([1, 2]);
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    await waitFor(() => expect(result.current.items).toEqual([1, 2]));
+    expect(result.current.error).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("should re-fetch on manual refresh", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce([1]).mockResolvedValueOnce([1, 2]);
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    await waitFor(() => expect(result.current.items).toEqual([1]));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.items).toEqual([1, 2]));
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("should keep the same reference when hasChanged reports no change", async () => {
+    const a = [{ id: "x" }];
+    const b = [{ id: "x" }]; // 別 reference だが内容同一
+    const fetcher = vi.fn().mockResolvedValueOnce(a).mockResolvedValueOnce(b);
+    const hasChanged = () => false; // 「変化なし」
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL, hasChanged));
+    await waitFor(() => expect(result.current.items).toBe(a));
+    await result.current.refresh();
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(result.current.items).toBe(a); // 据え置き (b に置換されない)
+  });
+
+  it("should replace items when hasChanged reports a change", async () => {
+    const a = [{ id: "x" }];
+    const b = [{ id: "y" }];
+    const fetcher = vi.fn().mockResolvedValueOnce(a).mockResolvedValueOnce(b);
+    const hasChanged = () => true;
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL, hasChanged));
+    await waitFor(() => expect(result.current.items).toBe(a));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.items).toBe(b));
+  });
+
+  it("should always replace when hasChanged is omitted", async () => {
+    const a = [1];
+    const b = [2];
+    const fetcher = vi.fn().mockResolvedValueOnce(a).mockResolvedValueOnce(b);
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    await waitFor(() => expect(result.current.items).toBe(a));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.items).toBe(b));
+  });
+
+  it("should surface a fetch error as a string and reset it on success", async () => {
+    const fetcher = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce([9]);
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+    await result.current.refresh();
+    await waitFor(() => expect(result.current.items).toEqual([9]));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should stringify a non-Error rejection", async () => {
+    const fetcher = vi.fn().mockRejectedValue("string fail");
+    const { result } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    await waitFor(() => expect(result.current.error).toBe("string fail"));
+  });
+
+  it("should clear the interval on unmount without throwing", () => {
+    const fetcher = vi.fn().mockResolvedValue([]);
+    const { unmount } = renderHook(() => usePollingList(fetcher, INTERVAL));
+    expect(() => unmount()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`Deployments.tsx` と `ProblemDetail.tsx` の `ProblemDeploymentsSection` に、deployment 一覧の polling が**完全に copy-paste**されていた（初回 fetch + `setInterval` polling + unmount の cancelled guard + error 文字列化 + `deploymentsChanged` による reference 据え置き）。両者で同じ `/* v8 ignore next */` cancelled guard を貼っていたのが重複の証拠。これを `src/hooks/usePollingList.ts` の `usePollingList(fetcher, intervalMs, hasChanged?)` に集約した。

- **DRY**: polling lifecycle / cancelled guard / `catch(toErrorMessage)` / 等価据え置きが 1 箇所に。v8-ignore する防御 guard も 1 箇所だけに。
- **SOLID (SRP)**: polling の責務を hook が単独で持ち、page は fetcher 定義と描画に専念。
- **汎用性**: `hasChanged` は任意（省略時は毎回置換）。`fetcher` に null を渡すと fetch せず loading 維持。

`Deployments` の reload button は hook の `refresh()` を spinner state で包むだけに簡素化。`ProblemDetail` は reload 不要なので `items`/`error` のみ受け取る。純 behavior-preserving refactor で、両 page の既存テスト（100% 化済）は**無改変で緑** = 安全網が機能。hook 自体にも fetcher 不在 / 初回 / refresh / hasChanged 据え置き・置換・省略 / error(Error/非Error) / unmount cleanup を網羅する unit test を追加（100%）。

`EventList` の polling は archive error と polling error が同一 state に絡むため本 hook にはそのまま載せず据え置き（別途検討）。

## Test plan
- `vitest run test/hooks/usePollingList.test.ts test/pages/Deployments.test.tsx test/pages/ProblemDetail.test.tsx --coverage` → 27 tests pass、3 ファイルとも 100%
- app-admin 全 test suite green（725 tests、Deployments/ProblemDetail の既存テスト無改変で通過）
- `tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- 純 refactor。polling の外形（API 呼び出し / 間隔 / 等価判定 / error 表示）は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts. フロントエンド source の純 refactor + hook test 追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)