### PR TITLE
refactor(app-admin): share deployment table cell renderers (DRY)

### DIFF
--- a/apps/application-admin-console/src/components/deployment-columns.tsx
+++ b/apps/application-admin-console/src/components/deployment-columns.tsx
@@ -1,0 +1,38 @@
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import type { NavigateFunction } from "react-router";
+import { DEPLOYMENT_STATUS_INDICATOR, type DeploymentSummary } from "../api/deploy-client";
+
+/**
+ * Deployments / ProblemDetail の deployment 一覧 table で完全に重複していた cell renderer を
+ * 共有する (DRY)。 列の `header` (i18n key) は page ごとに違うので各 page 側で持ち、 cell の
+ * 描画ロジックだけをここへ集約する。
+ */
+
+/** team 列: 表示名 (displayTeamName ?? teamName) を deployment 詳細への internal link にする。 */
+export function deploymentTeamCell(navigate: NavigateFunction) {
+  return (item: DeploymentSummary) => (
+    <Link
+      fontSize="body-m"
+      href={`/deployments/${encodeURIComponent(item.jobId)}`}
+      onFollow={(e) => {
+        e.preventDefault();
+        navigate(`/deployments/${encodeURIComponent(item.jobId)}`);
+      }}
+    >
+      {item.displayTeamName ?? item.teamName}
+    </Link>
+  );
+}
+
+/** status 列: deployment status を Cloudscape の StatusIndicator にマップする。 */
+export function deploymentStatusCell(item: DeploymentSummary) {
+  return (
+    <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>{item.status}</StatusIndicator>
+  );
+}
+
+/** stack name 列: CFn StackName prefix を code 表記する。 */
+export function deploymentStackNameCell(item: DeploymentSummary) {
+  return <code>{item.namePrefix}</code>;
+}

--- a/apps/application-admin-console/src/pages/Deployments.tsx
+++ b/apps/application-admin-console/src/pages/Deployments.tsx
@@ -2,19 +2,18 @@ import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Header from "@cloudscape-design/components/header";
-import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
-import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
 import { useCallback, useMemo, useState } from "react";
 import { type NavigateFunction, useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
+import { type DeploymentSummary, listAllDeployments } from "../api/deploy-client";
 import {
-  DEPLOYMENT_STATUS_INDICATOR,
-  type DeploymentSummary,
-  listAllDeployments,
-} from "../api/deploy-client";
+  deploymentStackNameCell,
+  deploymentStatusCell,
+  deploymentTeamCell,
+} from "../components/deployment-columns";
 import type { AppConfig } from "../config";
 import { usePollingList } from "../hooks/usePollingList";
 import { useT } from "../i18n";
@@ -33,18 +32,7 @@ function buildColumnDefinitions(
     {
       id: "team",
       header: t("deployments.col_team"),
-      cell: (item) => (
-        <Link
-          fontSize="body-m"
-          href={`/deployments/${encodeURIComponent(item.jobId)}`}
-          onFollow={(e) => {
-            e.preventDefault();
-            navigate(`/deployments/${encodeURIComponent(item.jobId)}`);
-          }}
-        >
-          {item.displayTeamName ?? item.teamName}
-        </Link>
-      ),
+      cell: deploymentTeamCell(navigate),
     },
     {
       id: "problemId",
@@ -54,16 +42,12 @@ function buildColumnDefinitions(
     {
       id: "status",
       header: t("deployments.col_status"),
-      cell: (item) => (
-        <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>
-          {item.status}
-        </StatusIndicator>
-      ),
+      cell: deploymentStatusCell,
     },
     {
       id: "namePrefix",
       header: t("deployments.col_stack_name"),
-      cell: (item) => <code>{item.namePrefix}</code>,
+      cell: deploymentStackNameCell,
     },
     {
       id: "createdAt",

--- a/apps/application-admin-console/src/pages/ProblemDetail.tsx
+++ b/apps/application-admin-console/src/pages/ProblemDetail.tsx
@@ -5,18 +5,17 @@ import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
 import { useMemo } from "react";
 import { Navigate, type NavigateFunction, useNavigate, useParams } from "react-router";
 import { useApiClient } from "../api/client";
+import { type DeploymentSummary, listDeployments } from "../api/deploy-client";
 import {
-  DEPLOYMENT_STATUS_INDICATOR,
-  type DeploymentSummary,
-  listDeployments,
-} from "../api/deploy-client";
+  deploymentStackNameCell,
+  deploymentStatusCell,
+  deploymentTeamCell,
+} from "../components/deployment-columns";
 import type { AppConfig } from "../config";
 import { findProblem } from "../data/problems";
 import { usePollingList } from "../hooks/usePollingList";
@@ -131,32 +130,17 @@ function buildColumns(
     {
       id: "team",
       header: t("problem_detail.col_team"),
-      cell: (item) => (
-        <Link
-          fontSize="body-m"
-          href={`/deployments/${encodeURIComponent(item.jobId)}`}
-          onFollow={(e) => {
-            e.preventDefault();
-            navigate(`/deployments/${encodeURIComponent(item.jobId)}`);
-          }}
-        >
-          {item.displayTeamName ?? item.teamName}
-        </Link>
-      ),
+      cell: deploymentTeamCell(navigate),
     },
     {
       id: "status",
       header: t("problem_detail.col_status_header"),
-      cell: (item) => (
-        <StatusIndicator type={DEPLOYMENT_STATUS_INDICATOR[item.status]}>
-          {item.status}
-        </StatusIndicator>
-      ),
+      cell: deploymentStatusCell,
     },
     {
       id: "namePrefix",
       header: t("problem_detail.col_stack_name"),
-      cell: (item) => <code>{item.namePrefix}</code>,
+      cell: deploymentStackNameCell,
     },
     {
       id: "createdAt",


### PR DESCRIPTION
## Summary

`Deployments.tsx` と `ProblemDetail.tsx` の deployment 一覧 table で、team（詳細への internal link + `displayTeamName ?? teamName`）/ status（`StatusIndicator`）/ stack name（`code`）の **cell renderer が完全に重複**していた（列 `header` の i18n key だけが page ごとに異なる）。cell の描画ロジックを `src/components/deployment-columns.tsx` の `deploymentTeamCell` / `deploymentStatusCell` / `deploymentStackNameCell` に集約し、各 page は header + 共有 cell を組み立てるだけにした。

team link の挙動や status マッピングを変えるとき 1 箇所で済む。純 behavior-preserving refactor で、両 page の既存テスト（100% 化済）は**無改変で緑**。共有 cell は両 page の table 描画（team link click→navigate / status / stack name）で網羅され 100% を維持。`usePollingList`（PR-1516）に続く deployment-list 重複解消の 2 つ目。

## Test plan
- `vitest run test/pages/Deployments.test.tsx test/pages/ProblemDetail.test.tsx --coverage` → 18 tests pass、deployment-columns / Deployments / ProblemDetail とも 100%
- app-admin 全 test suite green（733 tests、既存テスト無改変で通過）、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- 純 refactor。cell の DOM 出力は不変（同一 JSX を関数に移しただけ）。

## Physical impact
- NO-OP on CFn / deployed artifacts. フロントエンド source の純 refactor のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)