### PR TITLE
test(app-admin): cover DeployLogSection to 100%

### DIFF
--- a/apps/application-admin-console/src/pages/deployment-detail/DeployLogSection.tsx
+++ b/apps/application-admin-console/src/pages/deployment-detail/DeployLogSection.tsx
@@ -38,6 +38,8 @@ export function DeployLogSection({
 
   const scrollDeployLog = useCallback((direction: "top" | "bottom") => {
     const el = deployLogRef.current;
+    // ref は描画済 div を指すので button 押下時は常に non-null (= この guard は防御、不到達)。
+    /* v8 ignore next */
     if (!el) return;
     el.scrollIntoView({ block: direction === "top" ? "start" : "end", behavior: "smooth" });
   }, []);

--- a/apps/application-admin-console/test/pages/deployment-detail/DeployLogSection.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/DeployLogSection.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploymentSummary } from "../../../src/api/deploy-client";
+import type { DeployPhase } from "../../../src/lib/deploy-phases";
+import { DeployLogSection } from "../../../src/pages/deployment-detail/DeployLogSection";
+
+/**
+ * DeployLogSection: deploy log 区画 (scroll top/bottom / maximize button + PhaseRow 一覧)。
+ * scroll button → scrollIntoView(top/bottom)、 maximize → onMaximize、 非 terminal status での
+ * auto-refresh 説明文 vs terminal での非表示、 phases の PhaseRow 描画を pin する。
+ * PhaseRow は stub、 scrollIntoView は jsdom 未実装なので spy で stub。
+ */
+vi.mock("../../../src/pages/deployment-detail/PhaseRow", () => ({
+  PhaseRow: ({ phase }: { phase: DeployPhase }) => (
+    <div data-testid="phase-row">{(phase as { id: string }).id}</div>
+  ),
+}));
+
+const deployment = (status: string): DeploymentSummary =>
+  ({ jobId: "job-1", status }) as unknown as DeploymentSummary;
+const phases = [{ id: "validate" }, { id: "deploy" }] as unknown as DeployPhase[];
+
+const props = (over: Partial<Parameters<typeof DeployLogSection>[0]> = {}) => ({
+  deployment: deployment("IN_PROGRESS"),
+  phases,
+  stackProgress: null,
+  stackProgressError: null,
+  stackProgressPending: false,
+  onMaximize: vi.fn(),
+  t: (k: string) => k,
+  ...over,
+});
+
+let scrollSpy: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+  scrollSpy = vi.fn();
+  // jsdom は scrollIntoView 未実装なので prototype に生やす。
+  Element.prototype.scrollIntoView =
+    scrollSpy as unknown as typeof Element.prototype.scrollIntoView;
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("DeployLogSection", () => {
+  it("should render a PhaseRow per phase and the auto-refresh hint for non-terminal status", () => {
+    render(<DeployLogSection {...props()} />);
+    expect(screen.getAllByTestId("phase-row")).toHaveLength(2);
+    expect(screen.getByText(/deployment_detail\.log_auto_refresh/)).toBeInTheDocument();
+  });
+
+  it("should hide the auto-refresh hint for a terminal status", () => {
+    render(<DeployLogSection {...props({ deployment: deployment("COMPLETE") })} />);
+    expect(screen.queryByText(/deployment_detail\.log_auto_refresh/)).not.toBeInTheDocument();
+  });
+
+  it("should scroll to top and bottom from the scroll buttons", () => {
+    render(<DeployLogSection {...props()} />);
+    fireEvent.click(screen.getByRole("button", { name: "deployment_detail.log_scroll_top" }));
+    expect(scrollSpy).toHaveBeenCalledWith({ block: "start", behavior: "smooth" });
+    fireEvent.click(screen.getByRole("button", { name: "deployment_detail.log_scroll_bottom" }));
+    expect(scrollSpy).toHaveBeenCalledWith({ block: "end", behavior: "smooth" });
+  });
+
+  it("should invoke onMaximize from the maximize button", () => {
+    const onMaximize = vi.fn();
+    render(<DeployLogSection {...props({ onMaximize })} />);
+    fireEvent.click(screen.getByTestId("maximize-log"));
+    expect(onMaximize).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`DeployLogSection`（deploy log 区画: scroll top/bottom + maximize button + PhaseRow 一覧）はテストが無く coverage 44% だった。全分岐を pin して 100% にした。

カバー範囲:
- phases ごとの PhaseRow 描画
- 非 terminal status での auto-refresh 説明文 vs terminal status での非表示
- scroll top / bottom button の `scrollIntoView(start/end)`
- maximize button の `onMaximize`

`PhaseRow` は stub、jsdom 未実装の `scrollIntoView` は spy で stub。ref が常に描画済 div を指すため不到達な `if (!el) return` guard は `/* v8 ignore next */` + 理由コメントで明示。

## Test plan
- `vitest run test/pages/deployment-detail/DeployLogSection.test.tsx --coverage` → 4 tests pass、`DeployLogSection.tsx` 100%（stmts 8/8・branch 4/4・func 5/5・lines 8/8）
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加 + source への v8-ignore コメント 1 件のみ。実行時 behavior は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code coverage directives to deployment log component.

* **Tests**
  * Added test suite for deployment log section, verifying phase rendering, auto-refresh visibility based on deployment status, scroll button functionality, and maximize control behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->