### PR TITLE
refactor(app-admin): extract isTerminalEventStatus (DRY)

### DIFF
--- a/apps/application-admin-console/src/components/event-detail/EventHeaderActions.tsx
+++ b/apps/application-admin-console/src/components/event-detail/EventHeaderActions.tsx
@@ -3,6 +3,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useNavigate } from "react-router";
 import type { ApiClient } from "../../api/client";
 import type { BulkDeployBody, EventDetail } from "../../api/events-client";
+import { isTerminalEventStatus } from "../../lib/effective-event-status";
 import { isReportReady } from "../../lib/event-report-stats";
 import type { WizardState } from "../../lib/event-wizard";
 
@@ -52,9 +53,7 @@ export function EventHeaderActions({
           !detail ||
           detail.problems.length === 0 ||
           detail.teams.length === 0 ||
-          detail.status === "ENDED" ||
-          detail.status === "TEARDOWN" ||
-          detail.status === "ARCHIVED"
+          isTerminalEventStatus(detail.status)
         }
         onClick={() => onBulkDeploy()}
       >
@@ -63,13 +62,7 @@ export function EventHeaderActions({
       {failedCount > 0 && (
         <Button
           loading={bulkInFlight === "retry-failed"}
-          disabled={
-            !detail ||
-            detail.status === "ENDED" ||
-            detail.status === "TEARDOWN" ||
-            detail.status === "ARCHIVED" ||
-            bulkInFlight !== null
-          }
+          disabled={!detail || isTerminalEventStatus(detail.status) || bulkInFlight !== null}
           iconName="refresh"
           onClick={() => onBulkDeploy({ retryFailedOnly: true })}
         >
@@ -79,13 +72,7 @@ export function EventHeaderActions({
       {completeCount > 0 && (
         <Button
           loading={bulkInFlight === "redeploy"}
-          disabled={
-            !detail ||
-            detail.status === "ENDED" ||
-            detail.status === "TEARDOWN" ||
-            detail.status === "ARCHIVED" ||
-            bulkInFlight !== null
-          }
+          disabled={!detail || isTerminalEventStatus(detail.status) || bulkInFlight !== null}
           iconName="refresh"
           onClick={() => onBulkDeploy({ forceRedeploy: true })}
         >

--- a/apps/application-admin-console/src/components/event-detail/shared.tsx
+++ b/apps/application-admin-console/src/components/event-detail/shared.tsx
@@ -8,7 +8,11 @@ import type {
   EventDetail,
   EventStatus,
 } from "../../api/events-client";
-import { computeEffectiveStatus, type EffectiveStatus } from "../../lib/effective-event-status";
+import {
+  computeEffectiveStatus,
+  type EffectiveStatus,
+  isTerminalEventStatus,
+} from "../../lib/effective-event-status";
 
 type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
@@ -141,7 +145,7 @@ export function scoringBadge(
 ) {
   if (detail.scoringLocked === true)
     return <Badge color="red">{t("event_detail.scoring_badge_locked")}</Badge>;
-  if (detail.status === "ENDED" || detail.status === "ARCHIVED" || detail.status === "TEARDOWN") {
+  if (isTerminalEventStatus(detail.status)) {
     return <Badge color="grey">{t("event_detail.scoring_badge_ended")}</Badge>;
   }
   if (!detail.startsAt)

--- a/apps/application-admin-console/src/lib/effective-event-status.ts
+++ b/apps/application-admin-console/src/lib/effective-event-status.ts
@@ -49,7 +49,7 @@ export function computeEffectiveStatus(
   now: Date = new Date(),
 ): EffectiveStatus {
   // 1. terminal status は時刻無関係 (= 運営者が明示的に倒した状態を尊重)
-  if (event.status === "ARCHIVED" || event.status === "TEARDOWN" || event.status === "ENDED") {
+  if (isTerminalEventStatus(event.status)) {
     return event.status;
   }
   // 2. deploy 前後の status は時刻に意味がない (= 競技開始時刻を過ぎていても deploy 未完了は RUNNING ではない)
@@ -68,4 +68,20 @@ export function computeEffectiveStatus(
 
   // 5. それ以外 (= READY + startsAt 未来 or startsAt なし)
   return event.status;
+}
+
+/**
+ * これ以上 deploy / 編集できない終端 status (= 運営者が明示終了させた状態) かを判定する。
+ * `status === "ENDED" || "TEARDOWN" || "ARCHIVED"` が EventHeaderActions (×3) / OperationsTab /
+ * scoringBadge / computeEffectiveStatus に 6 箇所コピペされていたのを集約する。
+ * (EventPhaseBanner は raw status ではなく EffectiveStatus = RUNNING を含む別ドメインなので対象外。)
+ */
+const TERMINAL_EVENT_STATUSES: ReadonlySet<EventStatus> = new Set<EventStatus>([
+  "ENDED",
+  "TEARDOWN",
+  "ARCHIVED",
+]);
+
+export function isTerminalEventStatus(status: EventStatus): boolean {
+  return TERMINAL_EVENT_STATUSES.has(status);
 }

--- a/apps/application-admin-console/src/pages/event-detail/OperationsTab.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/OperationsTab.tsx
@@ -5,6 +5,7 @@ import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { DeployProgressPanel } from "../../components/event-detail/DeployProgressPanel";
 import { EventRescuePanel } from "../../components/event-detail/EventWizardPanel";
+import { isTerminalEventStatus } from "../../lib/effective-event-status";
 import type { EventTabContentProps } from "./tab-content-props";
 
 /**
@@ -30,8 +31,7 @@ export function OperationsTab({
   operations,
   t,
 }: EventTabContentProps) {
-  const bulkDisabled =
-    detail.status === "ENDED" || detail.status === "TEARDOWN" || detail.status === "ARCHIVED";
+  const bulkDisabled = isTerminalEventStatus(detail.status);
   return (
     <SpaceBetween size="l">
       <Header variant="h2">{t("event_detail.operations_header")}</Header>

--- a/apps/application-admin-console/test/lib/effective-event-status.test.ts
+++ b/apps/application-admin-console/test/lib/effective-event-status.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { computeEffectiveStatus } from "../../src/lib/effective-event-status";
+import type { EventStatus } from "../../src/api/events-client";
+import {
+  computeEffectiveStatus,
+  isTerminalEventStatus,
+} from "../../src/lib/effective-event-status";
 
 const PAST = "2026-05-01T00:00:00Z";
 const FUTURE = "2099-01-01T00:00:00Z";
@@ -94,5 +98,23 @@ describe("computeEffectiveStatus", () => {
   it("should default the `now` argument to current time when omitted", () => {
     // PAST < Date.now() なので RUNNING になるはず。
     expect(computeEffectiveStatus({ status: "READY", startsAt: PAST })).toBe("RUNNING");
+  });
+});
+
+describe("isTerminalEventStatus", () => {
+  it.each<EventStatus>([
+    "ENDED",
+    "TEARDOWN",
+    "ARCHIVED",
+  ])("should be true for terminal status %s", (status) => {
+    expect(isTerminalEventStatus(status)).toBe(true);
+  });
+
+  it.each<EventStatus>([
+    "DRAFT",
+    "DEPLOYING",
+    "READY",
+  ])("should be false for non-terminal status %s", (status) => {
+    expect(isTerminalEventStatus(status)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`status === "ENDED" || "TEARDOWN" || "ARCHIVED"` の終端 status 判定が **6 箇所**にコピペされていた（EventHeaderActions の deploy/retry/redeploy disabled ×3 / OperationsTab の `bulkDisabled` / `shared.tsx` の `scoringBadge` / `effective-event-status.ts` の `computeEffectiveStatus`）。`effective-event-status.ts` に `isTerminalEventStatus(status: EventStatus): boolean`（Set ベース）を追加して集約した。

`EventPhaseBanner.effectiveStatusToPhase` は raw `EventStatus` ではなく `EffectiveStatus`（RUNNING を含む別ドメイン）を扱うため対象外（型・意味が異なる）。

純 behavior-preserving refactor。影響先は全て 100% 化済で既存テストは**無改変で緑**。helper には terminal 3 値 / non-terminal 3 値を網羅する unit test を追加。

## Test plan
- `vitest run`（effective-event-status / EventHeaderActions / shared / OperationsTab）→ 56 tests pass、4 ファイルとも 100%
- app-admin 全 test suite green（既存テスト無改変で通過）、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- 純 refactor。`Set.has` は元の `=== A || B || C` と 3 値とも同値。振る舞い不変。

## Physical impact
- NO-OP on CFn / deployed artifacts. フロントエンド source の純 refactor + helper test 追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)