### PR TITLE
test(app-admin): cover api/client to 100%

### DIFF
--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -1,6 +1,10 @@
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ApiError, createApiClient } from "../../src/api/client";
+import { ApiError, createApiClient, useApiClient } from "../../src/api/client";
 import type { AppConfig } from "../../src/config";
+
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockUseAuth }));
 
 const config: AppConfig = {
   cognitoDomain: "https://example.com",
@@ -84,5 +88,94 @@ describe("createApiClient", () => {
       const url2 = (fetchMock.mock.calls[1] as [URL, RequestInit])[0].toString();
       expect(url1).toBe(url2);
     });
+  });
+
+  describe("PATCH / DELETE verbs", () => {
+    it("should send PATCH with a JSON body", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      await createApiClient(config.apiBaseUrl, "T").patch("apps/1", { name: "y" });
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+      expect(init.method).toBe("PATCH");
+      expect(init.body).toBe('{"name":"y"}');
+    });
+
+    it("should send DELETE returning void (del) and JSON (delJson)", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ removed: 3 }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      const api = createApiClient(config.apiBaseUrl, "T");
+      await expect(api.del("apps/1")).resolves.toBeUndefined();
+      await expect(api.delJson<{ removed: number }>("apps/1")).resolves.toEqual({ removed: 3 });
+      expect((fetchMock.mock.calls[0] as [URL, RequestInit])[1].method).toBe("DELETE");
+    });
+  });
+
+  describe("network failure", () => {
+    it("should normalize a thrown fetch (TypeError) into an ApiError with status 0", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+      const api = createApiClient(config.apiBaseUrl, "T");
+      await expect(api.post("apps", {})).rejects.toMatchObject({
+        status: 0,
+        message: expect.stringMatching(/Network error: Failed to fetch.*method: POST/),
+      });
+      // GET は init.method 未指定 → メッセージは "GET" に fallback (?? 分岐)。
+      await expect(api.get("apps")).rejects.toMatchObject({
+        status: 0,
+        message: expect.stringMatching(/method: GET/),
+      });
+    });
+  });
+
+  describe("error body fallback", () => {
+    it("should fall back to statusText when the error body is empty", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve(new Response("", { status: 502, statusText: "Bad Gateway" })),
+          ),
+      );
+      const api = createApiClient(config.apiBaseUrl, "T");
+      await expect(api.get("apps")).rejects.toMatchObject({
+        message: expect.stringMatching(/502.*Bad Gateway/),
+      });
+    });
+
+    it("should fall back to statusText when reading the error body throws", async () => {
+      // res.text() が reject するケース → `.catch(() => "")` 経由で空文字 → statusText。
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          text: () => Promise.reject(new Error("stream broken")),
+        }),
+      );
+      const api = createApiClient(config.apiBaseUrl, "T");
+      await expect(api.get("apps")).rejects.toMatchObject({
+        message: expect.stringMatching(/500.*Server Error/),
+      });
+    });
+  });
+});
+
+describe("useApiClient", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("should return a client when auth tokens are present", () => {
+    mockUseAuth.mockReturnValue({ tokens: { idToken: "TOKEN" } });
+    const { result } = renderHook(() => useApiClient(config));
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current?.get).toBe("function");
+  });
+
+  it("should return null when there are no auth tokens", () => {
+    mockUseAuth.mockReturnValue({ tokens: null });
+    const { result } = renderHook(() => useApiClient(config));
+    expect(result.current).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`api/client.ts`（tenant API 用の最小 HTTP client）は既存テストが GET/POST/4xx/trailing-slash のみで coverage 63% だった。残りの経路を pin して 100% にした。

追加カバー範囲:
- PATCH / DELETE(`del` void) / `delJson`(JSON)
- fetch が throw する network failure → `ApiError(status=0)` 正規化（method 付き message、GET の `?? "GET"` fallback 含む）
- error body 空時の `statusText` fallback
- `res.text()` が reject したときの `.catch(() => "")` 経由 fallback
- `useApiClient` hook（tokens 有→client / 無→null）

fetch を stub、`useAuth` を mock。純テスト追加、source 変更なし。

## Test plan
- `vitest run test/api/client.test.ts --coverage` → 11 tests pass、`client.ts` 100%（stmts 23/23・branch 11/11・func 11/11・lines 22/22）
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加のみ。source 変更なし、実行時 behavior 不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)