### PR TITLE
test(app-admin): cover ProductLoginShell to 100%

### DIFF
--- a/apps/application-admin-console/test/components/ProductLoginShell.test.tsx
+++ b/apps/application-admin-console/test/components/ProductLoginShell.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProductLoginShell } from "../../src/components/ProductLoginShell";
+
+/**
+ * Issue #1329: ProductLoginShell (Cognito redirect 前のログイン shell)。 idle (sign-in button) vs
+ * signing-in (spinner) / error alert 有無 / locale switcher (ja active・en inactive + click で
+ * setLocale) / sign-in button の onSignIn を pin する。 useI18n / useT を mock、 SUPPORTED_LOCALES
+ * は実物。
+ */
+const { mockSetLocale } = vi.hoisted(() => ({ mockSetLocale: vi.fn() }));
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return {
+    ...actual,
+    useT: () => (k: string) => k,
+    useI18n: () => ({ locale: "ja", setLocale: mockSetLocale, t: (k: string) => k }),
+  };
+});
+
+const props = (over: Partial<Parameters<typeof ProductLoginShell>[0]> = {}) => ({
+  title: "Login Title",
+  subtitle: "Login Subtitle",
+  signInLabel: "Sign in",
+  signingInLabel: "Redirecting…",
+  signingIn: false,
+  errorMessage: undefined,
+  onSignIn: vi.fn(),
+  ...over,
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("ProductLoginShell", () => {
+  it("should render the sign-in button (idle), fire onSignIn, and switch locale", () => {
+    const p = props({ errorMessage: "boom" });
+    render(<ProductLoginShell {...p} />);
+    expect(screen.getByText("Login Title")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument(); // error alert
+    // locale switcher: ja active / en inactive。
+    expect(screen.getByRole("button", { name: "日本語" })).toHaveAttribute("aria-pressed", "true");
+    const en = screen.getByRole("button", { name: "English" });
+    expect(en).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(en);
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(p.onSignIn).toHaveBeenCalled();
+  });
+
+  it("should show the spinner (no sign-in button / no error) while signing in", () => {
+    render(<ProductLoginShell {...props({ signingIn: true })} />);
+    expect(screen.getByText("Redirecting…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sign in" })).not.toBeInTheDocument();
+    expect(screen.queryByText("login.error_header")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`ProductLoginShell`（Issue #1329、Cognito redirect 前のログイン shell）は LoginPage 越しの間接被覆のみで coverage 87.5% だった。直接 render して 100% にした。

カバー範囲:
- idle（sign-in button + `onSignIn`）vs signing-in（spinner、button/alert 非表示）
- error alert 有無
- locale switcher（ja active・en inactive + click で `setLocale("en")`）

`useI18n` / `useT` を mock、`SUPPORTED_LOCALES` は実物。純テスト追加、source 変更なし。

## Test plan
- `vitest run test/components/ProductLoginShell.test.tsx --coverage` → 2 tests pass、`ProductLoginShell.tsx` 100%（stmts 8/8・branch 12/12・func 5/5・lines 8/8）
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加のみ。source 変更なし、実行時 behavior 不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)