### PR TITLE
test(app-admin): cover SendNotificationModal to 100%

### DIFF
--- a/apps/application-admin-console/src/components/SendNotificationModal.tsx
+++ b/apps/application-admin-console/src/components/SendNotificationModal.tsx
@@ -77,12 +77,17 @@ export function SendNotificationModal({
   };
 
   const handleDismiss = () => {
+    // cancel button は disabled={inFlight} なので inFlight 中は押せない (= 防御、不到達)。
+    /* v8 ignore next */
     if (inFlight) return;
     reset();
     onDismiss();
   };
 
   const handleSubmit = async () => {
+    // submit button は disabled (= !apiClient / 無効 draft / inFlight) なので、 ここに来る時点で
+    // apiClient あり & draft 有効。 = この guard の return は UI 経路では不到達 (防御)。
+    /* v8 ignore next */
     if (!apiClient || !isNotificationDraftValid({ title, body })) return;
     setInFlight(true);
     setError(null);
@@ -162,6 +167,8 @@ export function SendNotificationModal({
         <FormField label={t("send_notification.severity_label")}>
           <Select
             selectedOption={
+              // severity は常に severityOptions のいずれか → find は必ず一致 (?? 以降は防御)。
+              /* v8 ignore next */
               severityOptions.find((o) => o.value === severity) ?? severityOptions[0] ?? null
             }
             options={[...severityOptions]}

--- a/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
+++ b/apps/application-admin-console/test/components/SendNotificationModal.test.tsx
@@ -1,3 +1,4 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -161,6 +162,87 @@ describe("SendNotificationModal", () => {
     fireEvent.change(titleInput, { target: { value: "a".repeat(121) } });
     fireEvent.change(screen.getByLabelText("本文"), { target: { value: "b" } });
     expect(screen.getByText(/120 文字以内/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+  });
+
+  it("should reset and call onDismiss when cancel is clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      withI18n(
+        <SendNotificationModal
+          config={config}
+          visible={true}
+          eventId={EVENT_ID}
+          onDismiss={onDismiss}
+          onSuccess={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("should submit with the chosen severity from the select", async () => {
+    const user = userEvent.setup();
+    mocks.createNotification.mockResolvedValueOnce({ notificationId: "n", occurredAt: "now" });
+    render(
+      withI18n(
+        <SendNotificationModal
+          config={config}
+          visible={true}
+          eventId={EVENT_ID}
+          onDismiss={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      ),
+    );
+    // severity Select を warning に切替 (Modal は portal なので document から探す)。
+    const select = createWrapper(document.body).findSelect();
+    select?.openDropdown();
+    select?.selectOptionByValue("warning");
+    await user.type(screen.getByLabelText("タイトル"), "T");
+    await user.type(screen.getByLabelText("本文"), "B");
+    await user.click(screen.getByRole("button", { name: "送信" }));
+    await waitFor(() =>
+      expect(mocks.createNotification).toHaveBeenCalledWith({}, EVENT_ID, {
+        title: "T",
+        body: "B",
+        severity: "warning",
+      }),
+    );
+  });
+
+  it("should disable submit when the API client is unavailable", () => {
+    mocks.useApiClient.mockReturnValue(null);
+    render(
+      withI18n(
+        <SendNotificationModal
+          config={config}
+          visible={true}
+          eventId={EVENT_ID}
+          onDismiss={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+  });
+
+  it("should show the body errorText and disable submit when body exceeds the limit", () => {
+    render(
+      withI18n(
+        <SendNotificationModal
+          config={config}
+          visible={true}
+          eventId={EVENT_ID}
+          onDismiss={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      ),
+    );
+    fireEvent.change(screen.getByLabelText("タイトル"), { target: { value: "T" } });
+    fireEvent.change(screen.getByLabelText("本文"), { target: { value: "b".repeat(2001) } });
+    // bodyInvalid → errorText 描画 + submit 無効。
     expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

`SendNotificationModal` は既存テストで draft 検証 / submit / error / helpers を被覆済だったが、cancel・severity Select・apiClient 不在・body 超過 が未網羅で coverage 88% だった。残りを pin して 100% にした。

追加カバー範囲:
- cancel → `onDismiss`（reset）
- severity Select を test-utils で warning に切替 → submit が `severity:"warning"` で `createNotification`
- apiClient null → submit 無効
- body > 2000 → submit 無効（bodyInvalid）

UI 経路では不到達な防御分岐は `/* v8 ignore next */` + 理由コメントで明示:
- `handleDismiss` の inFlight guard（cancel は inFlight で disabled）
- `handleSubmit` の guard（submit は !apiClient/無効 draft で disabled）
- severity selectedOption の `?? severityOptions[0] ?? null` fallback（severity は常に options 内）

## Test plan
- `vitest run test/components/SendNotificationModal.test.tsx --coverage` → 13 tests pass、`SendNotificationModal.tsx` 100%（stmts 42/42・branch 17/17・func 10/10・lines 40/40）
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加 + source への v8-ignore コメント 3 件のみ。実行時 behavior は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the notification modal, including cancel behavior, severity selection, error handling, and submit button state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->