### PR TITLE
test(app-admin): cover deploy-client + useCompetitorAccountsLoader to 100%

### DIFF
--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -5,6 +5,7 @@ import {
   deleteDeployment,
   getDeployment,
   getStackProgress,
+  listAllDeployments,
   listDeployments,
   parseStackOutputs,
   startDeployment,
@@ -136,6 +137,8 @@ describe("parseStackOutputs", () => {
     expect(
       parseStackOutputs(
         JSON.stringify([
+          "not-an-object", // 非 object entry → skip (isObjectLike false)
+          null,
           { OutputKey: "FrontendUrl", OutputValue: "https://app.example.com" },
           { OutputKey: "IgnoredNumber", OutputValue: 123 },
           { OutputKey: 456, OutputValue: "ignored" },
@@ -162,6 +165,15 @@ describe("listDeployments", () => {
     const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
     await listDeployments(client, "p", { limit: 10, cursor: "abc" });
     expect(calls[0]?.path).toBe("/problems/p/deployments?limit=10&cursor=abc");
+  });
+});
+
+describe("listAllDeployments", () => {
+  it("should call GET /deployments tenant-wide (no problemId scope)", async () => {
+    const { client, calls } = fakeClient({ items: [], nextCursor: undefined });
+    await listAllDeployments(client, { limit: 50 });
+    expect(calls[0]?.path).toBe("/deployments?limit=50");
+    expect(calls[0]?.method).toBe("GET");
   });
 });
 

--- a/apps/application-admin-console/test/pages/event-create/useCompetitorAccountsLoader.test.ts
+++ b/apps/application-admin-console/test/pages/event-create/useCompetitorAccountsLoader.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../../src/config";
+
+/**
+ * Phase 2.2 (#459) / #671: useCompetitorAccountsLoader。 mount fetch (成功/失敗) /
+ * apiClient 不在の no-op / window focus 時の再取得 / unmount での listener 解除 を pin する。
+ * useApiClient / listCompetitorAccounts を mock、 formatCompetitorAccountsLoadError は実物。
+ */
+const { mockApiClient, mockList } = vi.hoisted(() => ({
+  mockApiClient: vi.fn(),
+  mockList: vi.fn(),
+}));
+vi.mock("../../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/api/client")>();
+  return { ...actual, useApiClient: mockApiClient };
+});
+vi.mock("../../../src/api/competitor-accounts-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/api/competitor-accounts-client")>();
+  return { ...actual, listCompetitorAccounts: mockList };
+});
+
+const { useCompetitorAccountsLoader } = await import(
+  "../../../src/pages/event-create/useCompetitorAccountsLoader"
+);
+const config = {} as AppConfig;
+
+beforeEach(() => {
+  mockApiClient.mockReturnValue({ get: vi.fn() });
+  mockList.mockReset().mockResolvedValue({ items: [{ awsAccountId: "1" }] });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("useCompetitorAccountsLoader", () => {
+  it("should fetch accounts on mount", async () => {
+    const { result } = renderHook(() => useCompetitorAccountsLoader(config));
+    await waitFor(() => expect(result.current.competitorAccounts).toEqual([{ awsAccountId: "1" }]));
+    expect(result.current.accountsLoadError).toBeNull();
+  });
+
+  it("should surface a load error", async () => {
+    mockList.mockRejectedValue(new Error("load boom"));
+    const { result } = renderHook(() => useCompetitorAccountsLoader(config));
+    await waitFor(() => expect(result.current.accountsLoadError).not.toBeNull());
+  });
+
+  it("should not fetch when the API client is unavailable", async () => {
+    mockApiClient.mockReturnValue(null);
+    const { result } = renderHook(() => useCompetitorAccountsLoader(config));
+    await Promise.resolve();
+    expect(mockList).not.toHaveBeenCalled();
+    expect(result.current.competitorAccounts).toBeNull();
+  });
+
+  it("should re-fetch on window focus", async () => {
+    renderHook(() => useCompetitorAccountsLoader(config));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+
+  it("should remove the focus listener on unmount without re-fetching", async () => {
+    const { unmount } = renderHook(() => useCompetitorAccountsLoader(config));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+    unmount();
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(mockList).toHaveBeenCalledTimes(1); // unmount 後は再取得しない
+  });
+});


### PR DESCRIPTION
## Summary

近-100% の 2 ファイルの残ギャップを閉じた:

- **deploy-client.ts**（97%）: `listAllDeployments`（tenant-wide `GET /deployments`）の未テスト経路と、`parseStackOutputs` の array-form で非 object entry を skip する分岐（`isObjectLike` false）
- **useCompetitorAccountsLoader.ts**（95% br、テスト無し）: mount fetch（成功/失敗）/ apiClient 不在の no-op / window focus 再取得 / unmount の listener 解除 を `renderHook` で網羅

`fakeClient` / `useApiClient` / `listCompetitorAccounts` を mock、`formatCompetitorAccountsLoadError` は実物。純テスト追加、source 変更なし。両ファイル 100%。

## Test plan
- `vitest run test/api/deploy-client.test.ts test/pages/event-create/useCompetitorAccountsLoader.test.ts --coverage` → 26 tests pass、両ファイル 100%
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加のみ。source 変更なし、実行時 behavior 不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)