### PR TITLE
test(app-admin): cover DeploymentDetail to 100%

### DIFF
--- a/apps/application-admin-console/src/pages/DeploymentDetail.tsx
+++ b/apps/application-admin-console/src/pages/DeploymentDetail.tsx
@@ -77,6 +77,9 @@ export function DeploymentDetailPage({ config }: { config: AppConfig }) {
     );
   }
 
+  // 上の loading (!item && !error) / error (error && !item) guard を抜けた時点で item は必ず
+  // non-null (型 narrowing 用の防御 guard、 return は不到達)。
+  /* v8 ignore next */
   if (!item) return null;
 
   const outputs = parseStackOutputs(item.stackOutputs);

--- a/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
+++ b/apps/application-admin-console/test/pages/DeploymentDetail.test.tsx
@@ -261,4 +261,67 @@ describe("DeploymentDetailPage (Netlify-style phase + log view)", () => {
     // Building phase body 内の link を text で拾う。
     expect(screen.getByText(/Open CodeBuild \/ CloudFormation logs/)).toBeInTheDocument();
   });
+
+  it("should show an invalid-job-id alert for a malformed jobId (no fetch)", () => {
+    render(
+      <I18nProvider>
+        <MemoryRouter initialEntries={["/deployments/bad"]}>
+          <Routes>
+            <Route path="/deployments/:jobId" element={<DeploymentDetailPage config={config} />} />
+          </Routes>
+        </MemoryRouter>
+      </I18nProvider>,
+    );
+    expect(screen.getByText("不正な Job ID です。")).toBeInTheDocument();
+    expect(mocks.getDeployment).not.toHaveBeenCalled();
+  });
+
+  it("should show a fetch-failed alert when loading the deployment errors", async () => {
+    mocks.getDeployment.mockRejectedValue(new Error("fetch boom"));
+    renderPage();
+    expect(await screen.findByText("ジョブの取得に失敗しました")).toBeInTheDocument();
+    expect(screen.getByText("fetch boom")).toBeInTheDocument();
+  });
+
+  it("should render failure-reason, hand-off, and CFn outputs sections when present", async () => {
+    mocks.getDeployment.mockResolvedValue({
+      ...baseDeployment,
+      status: "FAILED",
+      failureReason: "CFn rollback",
+      teamLoginKey: "KEY-123",
+      stackOutputs: JSON.stringify({ FrontendUrl: "https://app.example.com" }),
+    });
+    mocks.getStackProgress.mockResolvedValue(emptyProgress);
+    renderPage();
+    expect(await screen.findByText("失敗理由")).toBeInTheDocument(); // failure_reason_header
+    expect(screen.getAllByText("CFn rollback").length).toBeGreaterThan(0); // alert + guidance
+    expect(screen.getByText("競技者 hand-off")).toBeInTheDocument(); // handoff_header
+    expect(screen.getByText("https://app.example.com")).toBeInTheDocument(); // CfnOutputsSection
+  });
+
+  it("should fall back to the internal team name in the header when displayTeamName is absent", async () => {
+    mocks.getDeployment.mockResolvedValue({
+      ...baseDeployment,
+      displayTeamName: undefined,
+      status: "COMPLETE",
+    });
+    mocks.getStackProgress.mockResolvedValue(emptyProgress);
+    renderPage();
+    // header description = problemId · (displayTeamName ?? teamName) · Job ... → teamName。
+    expect(await screen.findByText(/· team-alpha · Job/)).toBeInTheDocument();
+  });
+
+  it("should close the maximize-log modal on dismiss", async () => {
+    mocks.getDeployment.mockResolvedValue({ ...baseDeployment, status: "IN_PROGRESS" });
+    mocks.getStackProgress.mockResolvedValue(emptyProgress);
+    renderPage();
+    fireEvent.click(await screen.findByTestId("maximize-log"));
+    await screen.findByTestId("terminal-log");
+    // Modal の X (dismiss-control) → onDismiss → setLogModalOpen(false)。
+    fireEvent.click(
+      document.querySelector('button[class*="dismiss-control"]') as HTMLButtonElement,
+    );
+    // close 後も page 本体 (reload button) は残る。
+    expect(screen.getByRole("button", { name: "再読み込み" })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

`DeploymentDetailPage` は既存テストで phase 描画系を被覆済だったが、不正 jobId / fetch error / failure-reason・hand-off・CFn outputs の各 section / displayTeamName 不在の teamName fallback / maximize log modal の dismiss が未網羅で coverage 85% だった。これらを追加して 100% にした。

loading/error guard 通過後に item が必ず non-null になる `if (!item) return null`（型 narrowing 用の防御 guard、不到達）は `/* v8 ignore next */` + 理由コメントで明示。`useDeploymentDetail` は `getDeployment`/`getStackProgress` mock 越しに実物を使い、`MemoryRouter` で jobId を与える既存パターンを踏襲。

## Test plan
- `vitest run test/pages/DeploymentDetail.test.tsx --coverage` → 12 tests pass、`DeploymentDetail.tsx` 100%（stmts 20/20・branch 27/27・func 5/5・lines 20/20）
- app-admin 全 test suite green、`tsc --noEmit` clean、`biome check` clean、`make harness` no findings

## Regression analysis
- テスト追加 + source への v8-ignore コメント 1 件のみ。実行時 behavior は不変。

## Physical impact
- NO-OP on CFn / deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)