### PR TITLE
test(app-admin): cover EventDangerZone to 100%

### DIFF
--- a/apps/application-admin-console/test/components/event-detail/EventDangerZone.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/EventDangerZone.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventDetail } from "../../../src/api/events-client";
+import { EventDangerZone } from "../../../src/components/event-detail/EventDangerZone";
+import type { AppConfig } from "../../../src/config";
+import type { EndsAtValidation } from "../../../src/hooks/useEventOperations";
+
+/**
+ * Issue #1350: EventDangerZone (end / force-archive / teardown / schedule-start / ends-at /
+ * notification の確認 modal 群)。 各 modal の confirm/cancel callback、 teardown 確認入力
+ * (DELETE で活性化)、 schedule・ends-at の DatePicker/TimeInput onChange、 notification success
+ * alert を pin する。 子 SendNotificationModal は stub、 props は fixture、 t は echo。
+ */
+vi.mock("../../../src/components/SendNotificationModal", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  SendNotificationModal: (p: any) =>
+    p.visible ? (
+      <div data-testid="send-notification-modal">
+        <button type="button" onClick={p.onSuccess}>
+          stub-notify-success
+        </button>
+        <button type="button" onClick={p.onDismiss}>
+          stub-notify-dismiss
+        </button>
+      </div>
+    ) : null,
+}));
+
+type Props = Parameters<typeof EventDangerZone>[0];
+const props = (over: Partial<Props> = {}): Props =>
+  ({
+    config: {} as AppConfig,
+    confirmEnd: false,
+    confirmForceArchive: false,
+    confirmTeardown: false,
+    detail: {
+      teams: [{}],
+      problems: [{}],
+      startsAt: "2026-06-01T00:00:00Z",
+    } as unknown as EventDetail,
+    endsAtDate: "",
+    endsAtErrorText: undefined,
+    endsAtInFlight: false,
+    endsAtInvalid: false,
+    endsAtModalOpen: false,
+    endsAtTime: "",
+    endsAtValidation: { canSubmit: true } as EndsAtValidation,
+    eventId: "e1",
+    forceArchiveInFlight: false,
+    notifyJustSent: false,
+    notifyModalOpen: false,
+    onBulkTeardown: vi.fn(),
+    onDismissEnd: vi.fn(),
+    onDismissEndsAt: vi.fn(),
+    onDismissForceArchive: vi.fn(),
+    onDismissNotification: vi.fn(),
+    onDismissNotificationSuccess: vi.fn(),
+    onDismissSchedule: vi.fn(),
+    onDismissTeardown: vi.fn(),
+    onEndEvent: vi.fn(),
+    onForceArchive: vi.fn(),
+    onNotificationSuccess: vi.fn(),
+    onScheduleEnd: vi.fn(),
+    onScheduledStart: vi.fn(),
+    scheduleDate: "",
+    scheduleInFlight: null,
+    scheduleModalOpen: false,
+    scheduleTime: "",
+    setEndsAtDate: vi.fn(),
+    setEndsAtTime: vi.fn(),
+    setScheduleDate: vi.fn(),
+    setScheduleTime: vi.fn(),
+    t: (k: string) => k,
+    ...over,
+  }) as Props;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("EventDangerZone", () => {
+  it("should confirm end / force-archive / teardown (DELETE-gated) and cancel each", () => {
+    const p = props({ confirmEnd: true, confirmForceArchive: true, confirmTeardown: true });
+    render(<EventDangerZone {...p} />);
+    // teardown blast-radius は teams/problems 件数を出す。
+    expect(screen.getByText("event_detail.modal_teardown_blast_radius_body")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "event_detail.modal_end_event_confirm" }));
+    expect(p.onEndEvent).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("force-archive-confirm"));
+    expect(p.onForceArchive).toHaveBeenCalled();
+
+    // teardown confirm は DELETE 入力まで disabled。
+    const teardownBtn = screen.getByTestId("modal-teardown-confirm");
+    expect(teardownBtn).toBeDisabled();
+    const input = screen.getByTestId("modal-teardown-confirm-input").querySelector("input");
+    fireEvent.change(input as HTMLInputElement, { target: { value: "DELETE" } });
+    expect(screen.getByTestId("modal-teardown-confirm")).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId("modal-teardown-confirm"));
+    expect(p.onBulkTeardown).toHaveBeenCalled();
+
+    // 各 modal の cancel (modal_cancel) → end / force-archive / teardown の順。
+    const cancels = screen.getAllByRole("button", { name: "event_detail.modal_cancel" });
+    fireEvent.click(cancels[0] as HTMLElement);
+    fireEvent.click(cancels[1] as HTMLElement);
+    fireEvent.click(cancels[2] as HTMLElement);
+    expect(p.onDismissEnd).toHaveBeenCalled();
+    expect(p.onDismissForceArchive).toHaveBeenCalled();
+    expect(p.onDismissTeardown).toHaveBeenCalled();
+  });
+
+  it("should drive the schedule-start and ends-at date/time inputs and confirms", () => {
+    const p = props({ scheduleModalOpen: true, endsAtModalOpen: true });
+    render(<EventDangerZone {...p} />);
+    expect(screen.getByText(/event_detail\.modal_endsat_starts_at_hint/)).toBeInTheDocument(); // detail.startsAt hint
+
+    // Cloudscape DatePicker/TimeInput は入力値を正規化するので、 onChange が発火したことだけ pin。
+    const dates = screen.getAllByPlaceholderText("YYYY/MM/DD"); // [0]=schedule, [1]=ends-at
+    fireEvent.change(dates[0] as HTMLElement, { target: { value: "2026/06/01" } });
+    expect(p.setScheduleDate).toHaveBeenCalled();
+    fireEvent.change(dates[1] as HTMLElement, { target: { value: "2026/06/02" } });
+    expect(p.setEndsAtDate).toHaveBeenCalled();
+
+    const times = screen.getAllByPlaceholderText("hh:mm");
+    fireEvent.change(times[0] as HTMLElement, { target: { value: "10:00" } });
+    expect(p.setScheduleTime).toHaveBeenCalled();
+    fireEvent.change(times[1] as HTMLElement, { target: { value: "18:00" } });
+    expect(p.setEndsAtTime).toHaveBeenCalled();
+
+    // 両 modal の confirm (modal_schedule_confirm_label) → schedule-start / ends-at の順。
+    const confirms = screen.getAllByRole("button", {
+      name: "event_detail.modal_schedule_confirm_label",
+    });
+    fireEvent.click(confirms[0] as HTMLElement);
+    expect(p.onScheduledStart).toHaveBeenCalled();
+    fireEvent.click(confirms[1] as HTMLElement);
+    expect(p.onScheduleEnd).toHaveBeenCalled();
+  });
+
+  it("should render the teardown blast-radius with zero counts when detail is null", () => {
+    render(<EventDangerZone {...props({ confirmTeardown: true, detail: null })} />);
+    // detail?.teams.length ?? 0 / detail?.problems.length ?? 0 の null 経路。
+    expect(screen.getByText("event_detail.modal_teardown_blast_radius_body")).toBeInTheDocument();
+  });
+
+  it("should wire the notification modal and dismiss the just-sent success alert", () => {
+    const p = props({ notifyModalOpen: true, notifyJustSent: true });
+    render(<EventDangerZone {...p} />);
+    fireEvent.click(screen.getByText("stub-notify-success"));
+    expect(p.onNotificationSuccess).toHaveBeenCalled();
+    fireEvent.click(screen.getByText("stub-notify-dismiss"));
+    expect(p.onDismissNotification).toHaveBeenCalled();
+    // notifyJustSent → success alert + dismiss。
+    expect(screen.getByText("event_detail.notification_sent_body")).toBeInTheDocument();
+    fireEvent.click(document.querySelector('button[class*="dismiss-button"]') as HTMLButtonElement);
+    expect(p.onDismissNotificationSuccess).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`EventDangerZone` — the end / force-archive / teardown / schedule-start / ends-at / notification confirmation-modal cluster used by `EventDetail` — had no direct test. This adds a behavior-level Vitest suite (test-only; source untouched) that drives:

- each modal's confirm + cancel callback (end / force-archive / teardown)
- the DELETE-gated teardown confirm input (disabled until `DELETE` is typed)
- the schedule-start + ends-at `DatePicker` / `TimeInput` `onChange` wiring (asserting the setters fire; Cloudscape normalizes the value)
- both schedule confirms (`onScheduledStart` / `onScheduleEnd`)
- the `detail === null` blast-radius zero path (`detail?.teams.length ?? 0`)
- the `notifyJustSent` success alert + its dismiss

`SendNotificationModal` is stubbed, props come from a fixture, `t` is an echo.

Coverage for `src/components/event-detail/EventDangerZone.tsx`: **100%** stmts (13/13), branches (12/12), funcs (8/8), lines (12/12).

## Test plan

- `vitest run test/components/event-detail/EventDangerZone.test.tsx` — 4 passed
- full `application-admin-console` suite green
- `biome check`, `tsc --noEmit`, `make harness` all clean

## Regression analysis

- Test-only addition. No source file touched, so no runtime behavior can change. The suite asserts existing wiring (callbacks fired on the right buttons, DELETE gate, date/time `onChange`), locking current behavior in as a regression guard rather than altering it.

## Physical impact

- NO-OP on CFn / deployed artifacts. No `apps/*/dist` or `infrastructure` change; adds a single Vitest spec under `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)