### PR TITLE
test(app-admin): cover EventDetail orchestrator to 100%

### DIFF
--- a/apps/application-admin-console/src/pages/EventDetail.tsx
+++ b/apps/application-admin-console/src/pages/EventDetail.tsx
@@ -77,11 +77,15 @@ function summarizeDeployments(detail: EventDetail): DeploymentCounts {
  */
 function useTabFragmentSync(): readonly [EventTabId, (next: EventTabId) => void] {
   const [activeTab, setActiveTab] = useState<EventTabId>(() => {
+    // SSR guard: window は browser / test env では常に定義済みなので不到達。
+    /* v8 ignore next */
     if (typeof window === "undefined") return "overview";
     return readTabFromHash(window.location.hash);
   });
 
   useEffect(() => {
+    // SSR guard: 同上 (不到達)。
+    /* v8 ignore next */
     if (typeof window === "undefined") return;
     const onHashChange = () => setActiveTab(readTabFromHash(window.location.hash));
     window.addEventListener("hashchange", onHashChange);
@@ -90,6 +94,8 @@ function useTabFragmentSync(): readonly [EventTabId, (next: EventTabId) => void]
 
   const setTab = useCallback((next: EventTabId) => {
     setActiveTab(next);
+    // SSR guard: 同上 (不到達)。
+    /* v8 ignore next */
     if (typeof window === "undefined") return;
     // pathname + search を維持しつつ hash だけ書き換え。 overview は default なので hash を消す。
     const base = `${window.location.pathname}${window.location.search}`;
@@ -128,12 +134,13 @@ export function EventDetailPage({ config }: { config: AppConfig }) {
     return <Navigate to="/events" replace />;
   }
 
-  if (!detail && !error) {
-    // Issue #1366: 共有 LoadingState に切替 (DESIGN-SYSTEM 10 章)。
-    return <LoadingState label={t("event_detail.loading_spinner")} />;
-  }
-
   if (!detail) {
+    // detail 未取得時は loading (error なし) と error-only (取得失敗) の 2 経路に分かれる。
+    // ここで分岐すると error が string に narrow され、 error-only 側の冗長な guard が消える。
+    if (!error) {
+      // Issue #1366: 共有 LoadingState に切替 (DESIGN-SYSTEM 10 章)。
+      return <LoadingState label={t("event_detail.loading_spinner")} />;
+    }
     return (
       <EventDetailErrorOnly
         apiClient={apiClient}
@@ -174,7 +181,8 @@ function EventDetailErrorOnly({
   t,
 }: {
   readonly apiClient: ApiClient | null;
-  readonly error: string | null;
+  // error は呼び出し元 (EventDetailPage) で truthy に narrow 済み (loading 経路は分岐済み)。
+  readonly error: string;
   readonly eventId: string;
   readonly navigateBack: () => void;
   readonly operations: EventOperations;
@@ -207,10 +215,8 @@ function EventDetailErrorOnly({
       >
         {t("event_detail.loading_title")}
       </Header>
-      {error && (
-        // Issue #1366: error-only branch (= detail 取得失敗) を共有 ErrorState に統一。
-        <ErrorState title={t("event_detail.error_header")} hint={error} />
-      )}
+      {/* Issue #1366: error-only branch (= detail 取得失敗) を共有 ErrorState に統一。 */}
+      <ErrorState title={t("event_detail.error_header")} hint={error} />
     </SpaceBetween>
   );
 }

--- a/apps/application-admin-console/test/pages/EventDetail.wiring.test.tsx
+++ b/apps/application-admin-console/test/pages/EventDetail.wiring.test.tsx
@@ -1,0 +1,376 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventDetail } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * EventDetailPage の orchestration (= 配線) を対象にした wiring テスト。
+ *
+ * 既存の EventDetail.*.test.tsx は API 境界を mock した integration テストで、 child を
+ * 実物で描画するため inline callback (header actions / danger-zone の各 prop arrow) が
+ * 発火せず func coverage が 39% に留まっていた。 本テストは child (EventHeaderActions /
+ * EventDangerZone / 7 tab) と Cloudscape Tabs を stub し、 各 callback を 1 click で叩いて
+ * EventDetailPage 側の arrow → operations.* / navigate の配線を pin する。
+ *
+ * - 不正 / 欠落 eventId → /events への Navigate
+ * - loading (detail=null,error=null) / error-only (detail=null,error あり) の分岐
+ * - error-only header の各 action callback
+ * - loaded header + danger-zone + bulk-result dismiss + tab 切替 (既知 / 未知 id) + manual refresh
+ *
+ * useEventDetail / useEventOperations / useT / react-router は mock、 validateEndsAtInput /
+ * EVENT_ID_RE / computeEventWizardState / EVENT_TAB_IDS / readTabFromHash は実物。
+ */
+const h = vi.hoisted(() => ({
+  useParams: vi.fn(),
+  navigate: vi.fn(),
+  useEventDetail: vi.fn(),
+  useEventOperations: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useParams: () => h.useParams(),
+  useNavigate: () => h.navigate,
+  Navigate: ({ to, replace }: { to: string; replace?: boolean }) => (
+    <div data-testid="navigate" data-to={to} data-replace={String(replace)} />
+  ),
+}));
+vi.mock("../../src/api/client", () => ({ useApiClient: () => ({}) }));
+vi.mock("../../src/hooks/useEventDetail", () => ({ useEventDetail: h.useEventDetail }));
+vi.mock("../../src/hooks/useEventOperations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/hooks/useEventOperations")>();
+  return { ...actual, useEventOperations: h.useEventOperations };
+});
+vi.mock("../../src/i18n", () => ({ useT: () => (k: string) => k }));
+
+// EventHeaderActions stub: 各 action callback を 1 button で叩けるようにする。
+vi.mock("../../src/components/event-detail/EventHeaderActions", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  EventHeaderActions: (p: any) => (
+    <div data-testid="header-actions">
+      <button type="button" data-testid="hdr-back" onClick={p.onBack}>
+        back
+      </button>
+      <button type="button" data-testid="hdr-bulk-deploy" onClick={() => p.onBulkDeploy({})}>
+        bulk
+      </button>
+      <button type="button" data-testid="hdr-end" onClick={p.onEnd}>
+        end
+      </button>
+      <button type="button" data-testid="hdr-lock" onClick={p.onLockScoring}>
+        lock
+      </button>
+      <button type="button" data-testid="hdr-teardown" onClick={p.onTeardown}>
+        teardown
+      </button>
+      <button type="button" data-testid="hdr-unlock" onClick={p.onUnlockScoring}>
+        unlock
+      </button>
+    </div>
+  ),
+}));
+
+// EventDangerZone stub: 全 callback prop を 1 button ずつ。
+const DZ_CALLBACKS = [
+  "onBulkTeardown",
+  "onDismissEnd",
+  "onDismissEndsAt",
+  "onDismissForceArchive",
+  "onDismissNotification",
+  "onDismissNotificationSuccess",
+  "onDismissSchedule",
+  "onDismissTeardown",
+  "onEndEvent",
+  "onForceArchive",
+  "onNotificationSuccess",
+  "onScheduleEnd",
+  "onScheduledStart",
+] as const;
+vi.mock("../../src/components/event-detail/EventDangerZone", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  EventDangerZone: (p: any) => (
+    <div data-testid="danger-zone">
+      {DZ_CALLBACKS.map((cb) => (
+        <button key={cb} type="button" data-testid={`dz-${cb}`} onClick={p[cb]}>
+          {cb}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// tab component は stub (本テストは orchestrator 対象)。 EVENT_TAB_IDS / readTabFromHash は実物。
+vi.mock("../../src/pages/event-detail/tabs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/pages/event-detail/tabs")>();
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  const OverviewTab = (p: any) => (
+    <button type="button" data-testid="tab-manual-refresh" onClick={p.manualRefresh}>
+      refresh
+    </button>
+  );
+  const stub = (id: string) => () => <div data-testid={`tabstub-${id}`} />;
+  return {
+    ...actual,
+    OverviewTab,
+    ScheduleTab: stub("schedule"),
+    ProblemsTab: stub("problems"),
+    TeamsTab: stub("teams"),
+    ScoreboardTab: stub("scoreboard"),
+    NotificationsTab: stub("notifications"),
+    OperationsTab: stub("operations"),
+  };
+});
+
+// Cloudscape Tabs stub: onChange を既知 / 未知 id で叩け、 active content を描画する。
+vi.mock("@cloudscape-design/components/tabs", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: stub props。
+  default: (p: any) => (
+    <div data-testid="tabs">
+      {p.tabs.map((tab: { id: string; label: string; content: unknown }) => (
+        <button
+          key={tab.id}
+          type="button"
+          data-testid={`tabbtn-${tab.id}`}
+          onClick={() => p.onChange({ detail: { activeTabId: tab.id } })}
+        >
+          {tab.label}
+        </button>
+      ))}
+      <button
+        type="button"
+        data-testid="tabbtn-unknown"
+        onClick={() => p.onChange({ detail: { activeTabId: "___nope" } })}
+      >
+        unknown
+      </button>
+      <div data-testid="tab-active">
+        {p.tabs.find((tab: { id: string }) => tab.id === p.activeTabId)?.content}
+      </div>
+    </div>
+  ),
+}));
+
+const { EventDetailPage } = await import("../../src/pages/EventDetail");
+
+const VALID_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+const config = { tenantName: "Acme" } as AppConfig;
+
+const loadedDetail: EventDetail = {
+  eventId: VALID_ID,
+  name: "My Event",
+  status: "READY",
+  startsAt: "2026-06-01T00:00:00Z",
+  endsAt: "2026-06-02T00:00:00Z",
+  teams: [{ teamId: "t1" }],
+  problems: [{ problemId: "p1", defaultRegion: "ap-northeast-1" }],
+  deploymentsByProblem: {
+    p1: [
+      { jobId: "J1", teamId: "t1", status: "COMPLETE" },
+      { jobId: "J2", teamId: "t1", status: "FAILED" },
+      { jobId: "J3", teamId: "t1", status: "PENDING" },
+    ],
+  },
+} as unknown as EventDetail;
+
+// useEventOperations の返り値 fixture (全 handler / setter は spy、 state は default)。
+const makeOperations = () => ({
+  bulkInFlight: null,
+  bulkResult: null as { enqueued: number; skipped: number } | null,
+  confirmEnd: false,
+  confirmForceArchive: false,
+  confirmTeardown: false,
+  endInFlight: false,
+  endsAtDate: "",
+  endsAtInFlight: false,
+  endsAtModalOpen: false,
+  endsAtTime: "",
+  forceArchiveInFlight: false,
+  freezeMinutesInFlight: false,
+  freezeMinutesInput: "",
+  handleBulkDeploy: vi.fn(),
+  handleBulkTeardown: vi.fn(),
+  handleEndEvent: vi.fn(),
+  handleEndNowSchedule: vi.fn(),
+  handleForceArchive: vi.fn(),
+  handleLockScoring: vi.fn(),
+  handleSaveFreezeMinutes: vi.fn(),
+  handleScheduleEnd: vi.fn(),
+  handleScheduledStart: vi.fn(),
+  handleStartNow: vi.fn(),
+  handleUnlockScoring: vi.fn(),
+  notifyJustSent: false,
+  notifyModalOpen: false,
+  scheduleDate: "",
+  scheduleInFlight: null,
+  scheduleModalOpen: false,
+  scheduleTime: "",
+  scoringLockInFlight: null,
+  setBulkResult: vi.fn(),
+  setConfirmEnd: vi.fn(),
+  setConfirmForceArchive: vi.fn(),
+  setConfirmTeardown: vi.fn(),
+  setEndsAtDate: vi.fn(),
+  setEndsAtModalOpen: vi.fn(),
+  setEndsAtTime: vi.fn(),
+  setFreezeMinutesInput: vi.fn(),
+  setNotifyJustSent: vi.fn(),
+  setNotifyModalOpen: vi.fn(),
+  setScheduleDate: vi.fn(),
+  setScheduleModalOpen: vi.fn(),
+  setScheduleTime: vi.fn(),
+});
+type Ops = ReturnType<typeof makeOperations>;
+let ops: Ops;
+
+const detailHook = (over: Partial<ReturnType<typeof baseDetailHook>> = {}) => ({
+  ...baseDetailHook(),
+  ...over,
+});
+const baseDetailHook = () => ({
+  detail: null as EventDetail | null,
+  error: null as string | null,
+  manualRefresh: vi.fn(),
+  manualRefreshInFlight: false,
+  refresh: vi.fn(),
+  setError: vi.fn(),
+});
+
+beforeEach(() => {
+  ops = makeOperations();
+  h.useParams.mockReturnValue({ eventId: VALID_ID });
+  h.useEventOperations.mockReturnValue(ops);
+  h.useEventDetail.mockReturnValue(detailHook({ detail: loadedDetail }));
+  window.location.hash = "";
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  window.location.hash = "";
+});
+
+describe("EventDetailPage wiring", () => {
+  it("should redirect to /events for an invalid event id", () => {
+    h.useParams.mockReturnValue({ eventId: "not-a-ulid" });
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/events");
+  });
+
+  it("should redirect when the event id is missing", () => {
+    h.useParams.mockReturnValue({});
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/events");
+  });
+
+  it("should show the loading state when there is neither detail nor error", () => {
+    h.useEventDetail.mockReturnValue(detailHook({ detail: null, error: null }));
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByText("event_detail.loading_spinner")).toBeInTheDocument();
+  });
+
+  it("should render the error-only branch and wire its header actions", () => {
+    h.useEventDetail.mockReturnValue(detailHook({ detail: null, error: "load boom" }));
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByText("load boom")).toBeInTheDocument();
+    expect(screen.getByText("event_detail.loading_title")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("hdr-back"));
+    expect(h.navigate).toHaveBeenCalledWith("/events");
+    fireEvent.click(screen.getByTestId("hdr-bulk-deploy"));
+    expect(ops.handleBulkDeploy).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("hdr-end"));
+    expect(ops.setConfirmEnd).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByTestId("hdr-lock"));
+    expect(ops.handleLockScoring).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("hdr-teardown"));
+    expect(ops.setConfirmTeardown).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByTestId("hdr-unlock"));
+    expect(ops.handleUnlockScoring).toHaveBeenCalled();
+  });
+
+  it("should render loaded and wire header / danger-zone / bulk-result / tabs", () => {
+    ops.bulkResult = { enqueued: 3, skipped: 1 };
+    h.useEventDetail.mockReturnValue(
+      detailHook({ detail: loadedDetail, error: "operation failed" }),
+    );
+    render(<EventDetailPage config={config} />);
+
+    // header に detail.name、 error alert、 bulk-result alert が出る。
+    expect(screen.getByText("My Event")).toBeInTheDocument();
+    expect(screen.getByText("operation failed")).toBeInTheDocument();
+    expect(screen.getByText("event_detail.bulk_result_body")).toBeInTheDocument();
+
+    // header actions の各配線。
+    fireEvent.click(screen.getByTestId("hdr-back"));
+    expect(h.navigate).toHaveBeenCalledWith("/events");
+    fireEvent.click(screen.getByTestId("hdr-end"));
+    expect(ops.setConfirmEnd).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByTestId("hdr-lock"));
+    expect(ops.handleLockScoring).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("hdr-unlock"));
+    expect(ops.handleUnlockScoring).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("hdr-teardown"));
+    expect(ops.setConfirmTeardown).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByTestId("hdr-bulk-deploy"));
+    expect(ops.handleBulkDeploy).toHaveBeenCalled();
+
+    // bulk-result alert の dismiss → setBulkResult(null)。
+    fireEvent.click(document.querySelector('button[class*="dismiss-button"]') as HTMLButtonElement);
+    expect(ops.setBulkResult).toHaveBeenCalledWith(null);
+
+    // danger-zone の全 callback。
+    fireEvent.click(screen.getByTestId("dz-onBulkTeardown"));
+    expect(ops.handleBulkTeardown).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("dz-onDismissEnd"));
+    expect(ops.setConfirmEnd).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissEndsAt"));
+    expect(ops.setEndsAtModalOpen).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissForceArchive"));
+    expect(ops.setConfirmForceArchive).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissNotification"));
+    expect(ops.setNotifyModalOpen).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissNotificationSuccess"));
+    expect(ops.setNotifyJustSent).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissSchedule"));
+    expect(ops.setScheduleModalOpen).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onDismissTeardown"));
+    expect(ops.setConfirmTeardown).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId("dz-onEndEvent"));
+    expect(ops.handleEndEvent).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("dz-onForceArchive"));
+    expect(ops.handleForceArchive).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("dz-onScheduleEnd"));
+    expect(ops.handleScheduleEnd).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("dz-onScheduledStart"));
+    expect(ops.handleScheduledStart).toHaveBeenCalled();
+    // onNotificationSuccess は modal を閉じて just-sent を立てる (2 setter)。
+    fireEvent.click(screen.getByTestId("dz-onNotificationSuccess"));
+    expect(ops.setNotifyModalOpen).toHaveBeenCalledWith(false);
+    expect(ops.setNotifyJustSent).toHaveBeenCalledWith(true);
+
+    // 既定 active tab = overview の content (manual refresh) → manualRefresh 配線。
+    fireEvent.click(screen.getByTestId("tab-manual-refresh"));
+
+    // tab 切替: 既知 id (schedule → overview) と 未知 id (無反映)。
+    fireEvent.click(screen.getByTestId("tabbtn-schedule"));
+    expect(screen.getByTestId("tabstub-schedule")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("tabbtn-overview"));
+    expect(screen.getByTestId("tab-manual-refresh")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("tabbtn-unknown")); // 未知 id は無視 (active 維持)。
+    expect(screen.getByTestId("tab-manual-refresh")).toBeInTheDocument();
+  });
+
+  it("should compute the ends-at error text for an invalid ends-at input", () => {
+    // date+time が parse 不能 → validateEndsAtInput が errorKey を返し、 t(errorKey) 経路を通る。
+    ops.endsAtDate = "garbage";
+    ops.endsAtTime = "nope";
+    h.useEventDetail.mockReturnValue(detailHook({ detail: loadedDetail }));
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByTestId("danger-zone")).toBeInTheDocument();
+  });
+
+  it("should follow the URL hash on hashchange", () => {
+    render(<EventDetailPage config={config} />);
+    expect(screen.getByTestId("tab-manual-refresh")).toBeInTheDocument(); // 初期 = overview
+    window.location.hash = "#tab=teams";
+    fireEvent(window, new HashChangeEvent("hashchange"));
+    expect(screen.getByTestId("tabstub-teams")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`EventDetailPage` (the event-detail orchestrator) sat at ~67% lines / 39% funcs. The 10 existing `EventDetail.*.test.tsx` files are integration-style — they render the real children, so the inline callback arrows that wire the header / danger-zone props to `useEventOperations` were never invoked, and `EventDetailErrorOnly`, the `useTabFragmentSync` hash logic, and the invalid-id redirect were untested.

This adds **`EventDetail.wiring.test.tsx`**, a focused orchestration test that stubs `EventHeaderActions` / `EventDangerZone` / the 7 tab components / Cloudscape `Tabs` and fires each callback once, asserting the orchestrator arrow routes to the right `operations.*` / `navigate` call. It covers:

- invalid & missing `eventId` → `/events` redirect
- loading vs error-only split (`detail` null, with/without `error`)
- every header action callback (back / bulk-deploy / end / lock / teardown / unlock) in **both** the error-only and loaded headers
- every danger-zone callback (teardown, all dismisses, end, force-archive, notification-success, schedule)
- the bulk-result success-alert dismiss
- tab switching (known & unknown id), manual refresh, `hashchange` follow
- the ends-at error-text (`validateEndsAtInput` → `t(errorKey)`) path

Two small **behavior-preserving** source touches in `EventDetail.tsx`:

1. Co-locate the loading vs error-only split inside `if (!detail)` so TypeScript narrows `error` to `string` for `EventDetailErrorOnly`. That component now takes `error: string` and drops its now-dead `{error && …}` guard — `error` is always truthy when it mounts (the loading guard handles the null-error case first).
2. Mark the three `typeof window === "undefined"` SSR guards in `useTabFragmentSync` with `/* v8 ignore next */` (unreachable in the browser / jsdom test env), matching the repo convention (`DeploymentDetail.tsx:82`).

`EventDetail.tsx`: **100%** stmts (83/83), branches (37/37), funcs (41/41), lines (79/79).

## Test plan

- `vitest run test/pages/EventDetail.wiring.test.tsx` — 7 passed; `EventDetail.tsx` 100% on all four metrics
- full `application-admin-console` suite — 105 files / 862 tests pass (all 10 pre-existing EventDetail integration tests unchanged)
- `biome check`, `tsc --noEmit`, `make harness` all clean

## Regression analysis

- The loading/error-only refactor is behavior-identical: `detail` null + `error` null → `LoadingState`; `detail` null + `error` truthy → `EventDetailErrorOnly` with the same `ErrorState`; `detail` present → `EventDetailLoaded`. All 10 pre-existing EventDetail integration tests pass unchanged.
- `EventDetailErrorOnly`'s prop type narrowed from `string | null` to `string`; it is a module-local component with a single call site that now passes the narrowed value, so no caller breaks.
- The SSR-guard `/* v8 ignore next */` comments do not change runtime behavior; the guards still execute.

## Physical impact

- NO-OP on CFn / deployed artifacts. Source + test only; no `apps/*/dist` or `infrastructure` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive wiring tests for event detail page covering loading states, error handling, routing, modal interactions, and tab synchronization.

* **Bug Fixes**
  * Improved error state handling and server-side rendering compatibility for event detail pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->