### PR TITLE
test(app-admin): cover deployment-detail branch gaps to 100%

### DIFF
--- a/apps/application-admin-console/test/pages/deployment-detail/BasicInfoSection.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/BasicInfoSection.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { DeploymentSummary } from "../../../src/api/deploy-client";
+import { BasicInfoSection } from "../../../src/pages/deployment-detail/BasicInfoSection";
+
+const t = (k: string) => k;
+const base = {
+  problemId: "hello-world",
+  displayTeamName: "Alpha",
+  teamName: "team-alpha",
+  awsAccountId: "111111111111",
+  region: "ap-northeast-1",
+  namePrefix: "tc-hello",
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T01:00:00Z",
+};
+
+/**
+ * BasicInfoSection の stackId 有無 (assigned ↔ unassigned) と displayTeamName の fallback。
+ */
+describe("BasicInfoSection", () => {
+  it("should show the stack id as code when it is assigned", () => {
+    const item = { ...base, stackId: "arn:aws:cloudformation:stack/abc" } as DeploymentSummary;
+    render(<BasicInfoSection item={item} t={t} />);
+    expect(screen.getByText("arn:aws:cloudformation:stack/abc")).toBeInTheDocument();
+  });
+
+  it("should fall back to the unassigned label and unset team name when missing", () => {
+    const item = { ...base, displayTeamName: undefined, stackId: undefined } as DeploymentSummary;
+    render(<BasicInfoSection item={item} t={t} />);
+    expect(screen.getByText("deployment_detail.value_unassigned")).toBeInTheDocument();
+    expect(screen.getByText("deployment_detail.value_unset")).toBeInTheDocument();
+  });
+});

--- a/apps/application-admin-console/test/pages/deployment-detail/PhaseRow.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/PhaseRow.test.tsx
@@ -1,0 +1,48 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { DeploymentSummary, StackProgress } from "../../../src/api/deploy-client";
+import type { DeployPhase } from "../../../src/lib/deploy-phases";
+import { PhaseRow } from "../../../src/pages/deployment-detail/PhaseRow";
+
+const t = (k: string) => k;
+const deployment = {
+  createdAt: "2026-06-01T00:00:00Z",
+  tenantId: "tenant-1",
+  problemId: "hello-world",
+  displayTeamName: "Alpha",
+  teamName: "team-alpha",
+} as unknown as DeploymentSummary;
+const buildingPhase: DeployPhase = { id: "building", name: "Building", status: "in-progress" };
+
+const renderPhase = (stackProgress: StackProgress | null) => {
+  const { container } = render(
+    <PhaseRow
+      phase={buildingPhase}
+      deployment={deployment}
+      stackProgress={stackProgress}
+      stackProgressError={null}
+      stackProgressPending={false}
+      t={t}
+    />,
+  );
+  // ExpandableSection を開いて body (= building case) を描画させる。
+  createWrapper(container).findExpandableSection()?.findExpandButton()?.click();
+  return container;
+};
+
+/**
+ * PhaseRow の building phase body: console URL があれば Link、 無ければ「準備中」Box。
+ */
+describe("PhaseRow building phase", () => {
+  it("should render the console link when a console URL is present", () => {
+    const container = renderPhase({ consoleUrl: "https://console.aws.example/x" } as StackProgress);
+    const link = container.querySelector('a[href="https://console.aws.example/x"]');
+    expect(link).not.toBeNull();
+  });
+
+  it("should render the url-unavailable note when no console URL is present", () => {
+    const container = renderPhase(null);
+    expect(container.textContent).toContain("deployment_detail.phase_building_url_unavailable");
+  });
+});

--- a/apps/application-admin-console/test/pages/deployment-detail/TerminalLogView.test.tsx
+++ b/apps/application-admin-console/test/pages/deployment-detail/TerminalLogView.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LogLine } from "../../../src/lib/deploy-phases";
+import { TerminalLogView } from "../../../src/pages/deployment-detail/TerminalLogView";
+
+/**
+ * TerminalLogView の行 key 生成。 同一 (timestamp|header|text) が 2 回現れたとき、
+ * 2 行目以降は `#1` suffix を付けて key を一意化する (dup>0 経路)。
+ */
+describe("TerminalLogView", () => {
+  it("should render every line including exact duplicates with unique keys", () => {
+    const dup: LogLine = { header: false, timestamp: "2026-06-01T00:00:00Z", text: "same line" };
+    const lines: readonly LogLine[] = [
+      { header: true, timestamp: "2026-06-01T00:00:00Z", text: "section" },
+      dup,
+      dup, // 完全重複 → key は `...#1` に分岐 (dup>0)。
+    ];
+    render(<TerminalLogView lines={lines} />);
+    expect(screen.getByTestId("terminal-log")).toBeInTheDocument();
+    // 重複行も両方描画される (行番号 002 / 003)。
+    expect(screen.getAllByText("same line")).toHaveLength(2);
+  });
+
+  it("should render a line that has no timestamp", () => {
+    render(<TerminalLogView lines={[{ header: false, text: "no ts" }]} />);
+    expect(screen.getByText("no ts")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Three presentational `deployment-detail` components were only exercised indirectly by `DeploymentDetail.test.tsx`, leaving one branch each uncovered. This adds focused unit tests:

- **TerminalLogView** — the duplicate-line key path (`dup > 0` → `${base}#${dup}`) via two identical `LogLine`s, plus a no-timestamp line.
- **BasicInfoSection** — the `stackId`-assigned (`<code>`) path, plus the unassigned / unset-team-name fallback.
- **PhaseRow** — the building-phase body both **with** a console URL (renders `Link`) and **without** (renders the url-unavailable note), expanding the `ExpandableSection` via Cloudscape test-utils.

The `deployment-detail` trio is now **100%** on all four metrics (merged with the existing suite).

## Test plan

- `vitest run` the three new specs — 6 passed
- merged coverage for the three files — 100% stmts/branches/funcs/lines
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Test-only. No source touched, so no runtime behavior can change; the tests lock in existing rendering as a regression guard. Full `application-admin-console` suite stays green.

## Physical impact

- NO-OP on CFn / deployed artifacts. Adds three Vitest specs under `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)