### PR TITLE
test(app-admin): cover EmptyState href & no-alias account summary

### DIFF
--- a/apps/application-admin-console/test/components/design-system.test.tsx
+++ b/apps/application-admin-console/test/components/design-system.test.tsx
@@ -42,6 +42,16 @@ describe("EmptyState", () => {
     btn.click();
     expect(onClick).toHaveBeenCalled();
   });
+
+  it("should render the primary action as a same-tab link when href is given", () => {
+    // primaryAction.href が指定されると target="_self" (同タブ遷移) の link button になる。
+    render(
+      <EmptyState headline="No problems" primaryAction={{ label: "Browse", href: "/problems" }} />,
+    );
+    const link = screen.getByRole("link", { name: "Browse" });
+    expect(link).toHaveAttribute("href", "/problems");
+    expect(link).toHaveAttribute("target", "_self");
+  });
 });
 
 describe("ErrorState", () => {

--- a/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.verified-only.test.tsx
@@ -91,6 +91,8 @@ describe("EventCreatePage (Phase 2.2 verified-only)", () => {
     expect(option.labelTag).toBe("production-shared-account");
     expect(option.description).toContain("production-shared-account");
     expect(formatVerifiedAccountSummary(account)).toBe("111111111111 (production-shared-account)");
+    // alias が無い場合は account id だけを返す (no-alias 経路)。
+    expect(formatVerifiedAccountSummary({ ...account, alias: undefined })).toBe("111111111111");
   });
 
   it("should show Alert with link to Competitor Accounts when there are zero accounts", async () => {


### PR DESCRIPTION
## Summary

Two leftover branch gaps, both extended in **existing** test files (no new parallel specs):

- **EmptyState** — the `primaryAction.href` path (renders a `target="_self"` link button) was untested; only the `onClick` variant was. Adds an href case to `design-system.test.tsx`.
- **formatVerifiedAccountSummary** — only the with-alias branch was asserted; adds the no-alias branch (returns the bare account id) to `EventCreate.verified-only.test.tsx`.

`EmptyState.tsx` and `event-create/helpers.ts` are now **100%** on all four metrics (merged with the existing suite).

## Test plan

- `vitest run` the two extended specs; both target files 100% merged
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Test-only. No source touched; the new assertions lock existing behavior in as a regression guard. Full `application-admin-console` suite green.

## Physical impact

- NO-OP on CFn / deployed artifacts. Extends two existing Vitest specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)