### PR TITLE
test(app-admin): cover AuthProvider useAuth guard to 100%

### DIFF
--- a/apps/application-admin-console/src/auth/AuthProvider.tsx
+++ b/apps/application-admin-console/src/auth/AuthProvider.tsx
@@ -78,6 +78,9 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
       window.addEventListener(evt, resetTimer, { passive: true });
     }
     return () => {
+      // cleanup 時は直前の resetTimer() で必ず timer が set 済 (この effect は tokens truthy
+      // のときだけ cleanup を登録し、 その run は必ず resetTimer() を呼ぶ)。 null 経路は不到達。
+      /* v8 ignore next */
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       for (const evt of IDLE_EVENTS) {
         window.removeEventListener(evt, resetTimer);

--- a/apps/application-admin-console/test/AuthProvider.test.tsx
+++ b/apps/application-admin-console/test/AuthProvider.test.tsx
@@ -155,3 +155,16 @@ describe("AuthProvider idle timeout (#859)", () => {
     expect(beginLogoutMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("useAuth guard", () => {
+  it("should throw when used outside an AuthProvider", () => {
+    const Bare = () => {
+      useAuth();
+      return null;
+    };
+    // provider 外で useAuth → context null → 明示 error を投げる (誤用の早期検知)。
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Bare />)).toThrow("useAuth must be used inside <AuthProvider>");
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Two branch gaps in `AuthProvider`:

- `useAuth()` **outside** an `<AuthProvider>` throws — that guard was never exercised. Adds a test rendering a bare consumer and asserting the throw (`console.error` spied to keep output clean).
- The idle-timer cleanup `if (idleTimerRef.current) clearTimeout(...)` has an **unreachable false branch**: this effect only registers a cleanup when `tokens` are truthy, and that run always calls `resetTimer()` first, so the ref is always set by cleanup time. Marked `/* v8 ignore next */` with a reason (repo convention, `DeploymentDetail.tsx:82`).

`AuthProvider.tsx` now **100%** on all four metrics (merged with the suite).

## Test plan

- `vitest run test/AuthProvider.test.tsx` — guard test passes
- merged `AuthProvider.tsx` coverage — 100% all metrics
- full `application-admin-console` suite — 869 tests pass
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- The useAuth guard test only asserts existing throw behavior. The `v8-ignore` comment is a runtime NO-OP (the `clearTimeout` still runs).

## Physical impact

- NO-OP on CFn / deployed artifacts. Source comment + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)