### PR TITLE
test(app-admin): cover i18n module to 100%

### DIFF
--- a/apps/application-admin-console/src/i18n/index.tsx
+++ b/apps/application-admin-console/src/i18n/index.tsx
@@ -40,6 +40,8 @@ const LOCAL_STORAGE_KEY = "tenkacloud.application-admin.locale";
  * 一致なければ "ja" を default にする (= 既存 UI を維持)。
  */
 function detectBrowserLocale(): LocaleCode {
+  // SSR guard: navigator は browser / jsdom では常に定義済みなので不到達。
+  /* v8 ignore next */
   if (typeof navigator === "undefined") return "ja";
   const raw = (navigator.language || "ja").toLowerCase();
   for (const code of SUPPORTED_LOCALES) {
@@ -49,6 +51,8 @@ function detectBrowserLocale(): LocaleCode {
 }
 
 function loadStoredLocale(): LocaleCode | undefined {
+  // SSR guard: window は browser / jsdom では常に定義済みなので不到達。
+  /* v8 ignore next */
   if (typeof window === "undefined") return undefined;
   try {
     const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
@@ -62,6 +66,8 @@ function loadStoredLocale(): LocaleCode | undefined {
 }
 
 function persistLocale(code: LocaleCode): void {
+  // SSR guard: 同上 (不到達)。
+  /* v8 ignore next */
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
@@ -109,6 +115,8 @@ export function I18nProvider({ children }: { children: ReactNode }) {
 
   // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
   useEffect(() => {
+    // SSR guard: document は browser / jsdom では常に定義済みなので不到達。
+    /* v8 ignore next */
     if (typeof document === "undefined") return;
     document.documentElement.lang = locale;
   }, [locale]);

--- a/apps/application-admin-console/test/i18n.test.tsx
+++ b/apps/application-admin-console/test/i18n.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { _testInternals, interpolate } from "../src/i18n";
+
+/**
+ * i18n の純関数 (detectBrowserLocale / resolveKey / interpolate) の枝を pin する。
+ * Provider 側 (t fallback / setLocale / useI18n) はアプリ全体の render で既に網羅済みのため、
+ * ここでは branch gap の残り (navigator.language fallback / 非一致 locale / 非 string 解決 /
+ * 欠落 placeholder) を直接突く。
+ */
+const { detectBrowserLocale, resolveKey } = _testInternals;
+
+const setLanguage = (value: string) => {
+  Object.defineProperty(navigator, "language", { value, configurable: true });
+};
+const originalLanguage = navigator.language;
+afterEach(() => setLanguage(originalLanguage));
+
+describe("detectBrowserLocale", () => {
+  it("should return en for an en-* browser language", () => {
+    setLanguage("en-US");
+    expect(detectBrowserLocale()).toBe("en");
+  });
+
+  it("should return ja for a ja-* browser language", () => {
+    setLanguage("ja-JP");
+    expect(detectBrowserLocale()).toBe("ja");
+  });
+
+  it("should fall back to ja for an unsupported browser language", () => {
+    setLanguage("fr-FR");
+    expect(detectBrowserLocale()).toBe("ja");
+  });
+
+  it("should fall back to ja when navigator.language is empty", () => {
+    // `navigator.language || "ja"` の RHS 経路。
+    setLanguage("");
+    expect(detectBrowserLocale()).toBe("ja");
+  });
+});
+
+describe("resolveKey", () => {
+  it("should resolve a nested string key", () => {
+    expect(resolveKey({ a: { b: "hello" } }, "a.b")).toBe("hello");
+  });
+
+  it("should return undefined when the resolved node is not a string", () => {
+    // a は object → typeof node === "string" が false → undefined。
+    expect(resolveKey({ a: { b: "hello" } }, "a")).toBeUndefined();
+  });
+
+  it("should return undefined when descending past a non-object node", () => {
+    expect(resolveKey({ a: "leaf" }, "a.b.c")).toBeUndefined();
+  });
+});
+
+describe("interpolate", () => {
+  it("should return the template unchanged when there are no params", () => {
+    expect(interpolate("plain text")).toBe("plain text");
+  });
+
+  it("should substitute provided params", () => {
+    expect(interpolate("Hello {name}", { name: "Bob" })).toBe("Hello Bob");
+  });
+
+  it("should leave an unmatched placeholder verbatim", () => {
+    // params に該当 key が無い → match (= "{missing}") をそのまま残す。
+    expect(interpolate("Hi {missing}", { other: "x" })).toBe("Hi {missing}");
+  });
+});


### PR DESCRIPTION
## Summary

`src/i18n/index.tsx` sat at ~79% branch. Adds a focused unit test for the pure functions exposed via `_testInternals` / the exported `interpolate`, covering the previously-missed branches:

- **detectBrowserLocale** — en-* / ja-* matches, the unsupported-language fallback (`return "ja"`), and the `navigator.language || "ja"` RHS (empty language string).
- **resolveKey** — nested-string hit, the non-string-node → `undefined` branch, and descending past a non-object node.
- **interpolate** — no-params passthrough, substitution, and the unmatched placeholder (params missing the key → keep the literal).

The four `typeof navigator|window|document === "undefined"` SSR guards (`detectBrowserLocale` / `loadStoredLocale` / `persistLocale` / lang effect) are unreachable in the browser / jsdom env, so they are marked `/* v8 ignore next */` with reasons (repo convention).

`src/i18n/index.tsx` now **100%** on all four metrics (merged with the suite). With this + the other in-flight PRs, the whole `application-admin-console` reaches 100%.

## Test plan

- `vitest run --coverage` for `src/i18n/index.tsx` — 100% all metrics
- full suite green; `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- The `v8-ignore` comments are runtime NO-OPs; the guards still execute. The new test only asserts existing pure-function behavior.

## Physical impact

- NO-OP on CFn / deployed artifacts. Source comments + one new test spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)