### PR TITLE
test(admin): cover i18n / AuthProvider / EmptyState copies to 100%

### DIFF
--- a/apps/admin-console/src/auth/AuthProvider.tsx
+++ b/apps/admin-console/src/auth/AuthProvider.tsx
@@ -81,6 +81,9 @@ export function AuthProvider({ config, children }: { config: AppConfig; children
       window.addEventListener(evt, resetTimer, { passive: true });
     }
     return () => {
+      // cleanup 時は直前の resetTimer() で必ず timer が set 済 (この effect は tokens truthy
+      // のときだけ cleanup を登録し、 その run は必ず resetTimer() を呼ぶ)。 null 経路は不到達。
+      /* v8 ignore next */
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       for (const evt of IDLE_EVENTS) {
         window.removeEventListener(evt, resetTimer);

--- a/apps/admin-console/src/i18n/i18n.test.tsx
+++ b/apps/admin-console/src/i18n/i18n.test.tsx
@@ -1,6 +1,14 @@
 import { act, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _testInternals, I18nProvider, interpolate, type LocaleCode, useI18n, useT } from "./index";
+import {
+  _testInternals,
+  I18nProvider,
+  interpolate,
+  type LocaleCode,
+  useI18n,
+  useLang,
+  useT,
+} from "./index";
 
 /**
  * Issue #583 i18n Phase 1.B: admin-console の自前 i18n の pin。
@@ -132,5 +140,51 @@ describe("interpolate (#655)", () => {
 
   it("should return a template without placeholders unchanged", () => {
     expect(interpolate("no placeholder", { a: "X" })).toBe("no placeholder");
+  });
+});
+
+describe("detectBrowserLocale", () => {
+  const setLanguage = (value: string) =>
+    Object.defineProperty(navigator, "language", { value, configurable: true });
+  const original = navigator.language;
+  afterEach(() => setLanguage(original));
+
+  it("should map en-* / ja-* and fall back to ja for unsupported / empty languages", () => {
+    const { detectBrowserLocale } = _testInternals;
+    setLanguage("en-US");
+    expect(detectBrowserLocale()).toBe("en");
+    setLanguage("ja-JP");
+    expect(detectBrowserLocale()).toBe("ja");
+    setLanguage("fr-FR"); // 非対応 → ja
+    expect(detectBrowserLocale()).toBe("ja");
+    setLanguage(""); // navigator.language が空 → `|| "ja"` の RHS
+    expect(detectBrowserLocale()).toBe("ja");
+  });
+});
+
+describe("resolveKey", () => {
+  it("should resolve nested strings and return undefined for non-string / non-object descents", () => {
+    const { resolveKey } = _testInternals;
+    expect(resolveKey({ a: { b: "hit" } }, "a.b")).toBe("hit");
+    expect(resolveKey({ a: { b: "hit" } }, "a")).toBeUndefined(); // node が object → undefined
+    expect(resolveKey({ a: "leaf" }, "a.b.c")).toBeUndefined(); // string を descend → undefined
+  });
+});
+
+describe("t with params / useLang", () => {
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return <I18nProvider>{children}</I18nProvider>;
+  }
+
+  it("should interpolate params passed to t()", () => {
+    const { result } = renderHook(() => useT(), { wrapper });
+    // 既知 key が無くても raw key (= template) に param を埋め込む経路を通す。
+    expect(result.current("greeting {who}", { who: "World" })).toBe("greeting World");
+  });
+
+  it("should expose the active locale via useLang", () => {
+    const { result } = renderHook(() => ({ i18n: useI18n(), lang: useLang() }), { wrapper });
+    act(() => result.current.i18n.setLocale("en"));
+    expect(result.current.lang).toBe("en");
   });
 });

--- a/apps/admin-console/src/i18n/index.tsx
+++ b/apps/admin-console/src/i18n/index.tsx
@@ -40,6 +40,8 @@ const LOCAL_STORAGE_KEY = "tenkacloud.admin.locale";
  * 一致なければ "ja" を default にする (= 既存 UI を維持)。
  */
 function detectBrowserLocale(): LocaleCode {
+  // SSR guard: navigator は browser / jsdom では常に定義済みなので不到達。
+  /* v8 ignore next */
   if (typeof navigator === "undefined") return "ja";
   const raw = (navigator.language || "ja").toLowerCase();
   for (const code of SUPPORTED_LOCALES) {
@@ -49,6 +51,8 @@ function detectBrowserLocale(): LocaleCode {
 }
 
 function loadStoredLocale(): LocaleCode | undefined {
+  // SSR guard: window は browser / jsdom では常に定義済みなので不到達。
+  /* v8 ignore next */
   if (typeof window === "undefined") return undefined;
   try {
     const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
@@ -62,6 +66,8 @@ function loadStoredLocale(): LocaleCode | undefined {
 }
 
 function persistLocale(code: LocaleCode): void {
+  // SSR guard: 同上 (不到達)。
+  /* v8 ignore next */
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
@@ -98,6 +104,8 @@ export function I18nProvider({ children }: { children: ReactNode }) {
 
   // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
   useEffect(() => {
+    // SSR guard: document は browser / jsdom では常に定義済みなので不到達。
+    /* v8 ignore next */
     if (typeof document === "undefined") return;
     document.documentElement.lang = locale;
   }, [locale]);

--- a/apps/admin-console/test/AuthProvider.test.tsx
+++ b/apps/admin-console/test/AuthProvider.test.tsx
@@ -165,3 +165,16 @@ describe("AuthProvider idle timeout (#859)", () => {
     expect(beginLogoutMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("useAuth guard", () => {
+  it("should throw when used outside an AuthProvider", () => {
+    const Bare = () => {
+      useAuth();
+      return null;
+    };
+    // provider 外で useAuth → context null → 明示 error を投げる (誤用の早期検知)。
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Bare />)).toThrow("useAuth must be used inside <AuthProvider>");
+    spy.mockRestore();
+  });
+});

--- a/apps/admin-console/test/components/design-system.test.tsx
+++ b/apps/admin-console/test/components/design-system.test.tsx
@@ -42,6 +42,16 @@ describe("EmptyState", () => {
     btn.click();
     expect(onClick).toHaveBeenCalled();
   });
+
+  it("should render the primary action as a same-tab link when href is given", () => {
+    // primaryAction.href が指定されると target="_self" (同タブ遷移) の link button になる。
+    render(
+      <EmptyState headline="No problems" primaryAction={{ label: "Browse", href: "/problems" }} />,
+    );
+    const link = screen.getByRole("link", { name: "Browse" });
+    expect(link).toHaveAttribute("href", "/problems");
+    expect(link).toHaveAttribute("target", "_self");
+  });
 });
 
 describe("ErrorState", () => {


### PR DESCRIPTION
## Summary

admin-console keeps copy-paste copies of the shared **i18n / AuthProvider / EmptyState** components (the "3 SPA 同型維持" pattern), and its copies had the same branch gaps already closed in `application-admin-console`:

- **i18n** — add `detectBrowserLocale` (en / ja / unsupported / empty-language), `resolveKey` (non-string / non-object descent), t-with-params, and `useLang` tests; mark the four `typeof navigator|window|document === "undefined"` SSR guards `/* v8 ignore next */`.
- **AuthProvider** — add the `useAuth`-outside-provider throw test; mark the unreachable idle-timer cleanup guard `/* v8 ignore next */`.
- **EmptyState** — add the `primaryAction.href` (same-tab link) test.

All three files now **100%** on all four metrics (merged with the suite).

## Test plan

- `vitest run` the three affected specs — 33 pass; merged coverage 100% for all three files
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Source changes are comment-only `v8-ignore` markers (runtime NO-OP). New tests assert existing behavior.

## Physical impact

- NO-OP on CFn / deployed artifacts. Source comments + test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)