### PR TITLE
feat(problems): make validate-problems multi-cloud runtime-aware

### DIFF
--- a/infrastructure/test/scripts/validate-problems-runtime.test.ts
+++ b/infrastructure/test/scripts/validate-problems-runtime.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { checkCrossRefs, checkRuntimeSupport } from "../../../scripts/validate-problems";
+
+/**
+ * ADR-026 / ADR-027: validate-problems.ts の multi-cloud runtime 対応。
+ *
+ * - CFn Outputs 構文を前提にした cross-ref (scoring.flagOutputKey / endpoints[].key) は
+ *   executable な aws/cloudformation のときだけ走る。 予約済み (sakura/azure/gcp) は
+ *   出力 binding 機構が provider 固有 + まだ deploy 不可なので skip し、 spurious error にしない。
+ * - executable でも予約済みでもない provider/engine は typo guard で reject。
+ * - runtime object が壊れている (provider/engine/entry が string でない) なら reject。
+ */
+
+describe("checkRuntimeSupport", () => {
+  it("should accept the executable aws/cloudformation runtime", () => {
+    expect(
+      checkRuntimeSupport({ provider: "aws", engine: "cloudformation", entry: "template.yaml" }),
+    ).toEqual([]);
+  });
+
+  it.each([
+    { provider: "sakura", engine: "apprun" },
+    { provider: "azure", engine: "bicep" },
+    { provider: "gcp", engine: "infra-manager" },
+  ])("should accept the reserved runtime $provider/$engine", (rt) => {
+    expect(checkRuntimeSupport({ ...rt, entry: "x" })).toEqual([]);
+  });
+
+  it("should reject an unknown provider/engine as a likely typo", () => {
+    const errs = checkRuntimeSupport({ provider: "aws", engine: "cfn", entry: "x" });
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("typo");
+    expect(errs[0]).toContain("sakura/apprun"); // 予約済み一覧を案内する
+  });
+});
+
+describe("checkCrossRefs runtime awareness", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "tc-validate-runtime-"));
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  const writeProblem = (
+    sub: string,
+    meta: Record<string, unknown>,
+    template: { name: string; body: string },
+  ): { metaPath: string; meta: Record<string, unknown> } => {
+    const pdir = join(dir, sub);
+    mkdirSync(pdir, { recursive: true });
+    writeFileSync(join(pdir, template.name), template.body);
+    const metaPath = join(pdir, "metadata.json");
+    writeFileSync(metaPath, JSON.stringify(meta));
+    return { metaPath, meta };
+  };
+
+  it("should skip CFn output cross-refs for a reserved azure/bicep runtime", () => {
+    // scoring.flagOutputKey / endpoints[].key は CFn Outputs 構文を持たない bicep file を指すが、
+    // executable でないので CFn check は走らず spurious error にならない。
+    const { metaPath, meta } = writeProblem(
+      "azure-problem",
+      {
+        runtime: { provider: "azure", engine: "bicep", entry: "main.bicep" },
+        scoring: { kind: "flag", flagOutputKey: "FlagValue" },
+        endpoints: [{ slot: "web", default: { from: "cfn-output", key: "ServiceUrl" } }],
+      },
+      { name: "main.bicep", body: "// bicep template, no CFn Outputs here\n" },
+    );
+    expect(checkCrossRefs(metaPath, meta)).toEqual([]);
+  });
+
+  it("should still run CFn output cross-refs for the executable aws/cloudformation runtime", () => {
+    const { metaPath, meta } = writeProblem(
+      "aws-problem",
+      {
+        runtime: { provider: "aws", engine: "cloudformation", entry: "template.yaml" },
+        scoring: { kind: "flag", flagOutputKey: "FlagValue" },
+      },
+      { name: "template.yaml", body: "Outputs:\n  SomethingElse:\n    Value: x\n" },
+    );
+    const errors = checkCrossRefs(metaPath, meta);
+    expect(errors.some((e) => e.includes("FlagValue"))).toBe(true);
+  });
+
+  it("should reject an unknown runtime via checkCrossRefs (typo guard)", () => {
+    const { metaPath, meta } = writeProblem(
+      "typo-problem",
+      { runtime: { provider: "aws", engine: "cfn", entry: "template.yaml" } },
+      { name: "template.yaml", body: "Outputs: {}\n" },
+    );
+    const errors = checkCrossRefs(metaPath, meta);
+    expect(errors.some((e) => e.includes("typo"))).toBe(true);
+  });
+
+  it("should reject a malformed runtime object", () => {
+    const { metaPath, meta } = writeProblem(
+      "malformed-problem",
+      { runtime: { provider: 123, engine: "bicep", entry: "main.bicep" } },
+      { name: "main.bicep", body: "x\n" },
+    );
+    expect(checkCrossRefs(metaPath, meta)).toEqual([
+      "runtime object が不正です (provider / engine / entry はすべて string 必須)",
+    ]);
+  });
+
+  it("should report when the runtime entry file is missing", () => {
+    const pdir = join(dir, "missing-entry");
+    mkdirSync(pdir, { recursive: true });
+    const metaPath = join(pdir, "metadata.json");
+    const meta = { runtime: { provider: "gcp", engine: "infra-manager", entry: "main.tf" } };
+    writeFileSync(metaPath, JSON.stringify(meta));
+    const errors = checkCrossRefs(metaPath, meta);
+    expect(errors).toEqual(['runtime entry file "main.tf" not found']);
+  });
+
+  it("should default to template.yaml for a legacy problem with no runtime declared", () => {
+    const { metaPath, meta } = writeProblem(
+      "legacy-problem",
+      { scoring: { kind: "flag", flagOutputKey: "FlagValue" } },
+      { name: "template.yaml", body: "Outputs:\n  FlagValue:\n    Value: x\n" },
+    );
+    // legacy = aws/cloudformation 既定 → CFn check が走り、 FlagValue は Outputs にあるので OK。
+    expect(checkCrossRefs(metaPath, meta)).toEqual([]);
+  });
+});

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -13,6 +13,14 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
+import {
+  classifyRuntimeSupport,
+  isExecutableRuntime,
+  normalizeRuntime,
+  RESERVED_RUNTIMES,
+  type RuntimeDescriptor,
+  type RuntimeMetadataInput,
+} from "@tenkacloud/problem-runtime";
 import Ajv2020 from "ajv";
 import addFormats from "ajv-formats";
 
@@ -51,11 +59,19 @@ function findMetadataFiles(dir: string): string[] {
  * 実 deploy で CFn が CREATE_COMPLETE しても、 これらの参照が解決できないと
  * scoring engine / portal が壊れるので、 ここで先に止める。
  */
-function resolveTemplatePath(meta: Metadata): string {
-  // [ADR-023] Prefer `runtime.entry` when declared; fall back to legacy `cfnTemplate`; finally default.
-  const runtime = meta.runtime as Record<string, unknown> | undefined;
-  if (runtime && typeof runtime.entry === "string") return runtime.entry;
-  return typeof meta.cfnTemplate === "string" ? meta.cfnTemplate : "template.yaml";
+/**
+ * [ADR-023 / ADR-026 / ADR-027] runtime の provider/engine が、 実行可能な
+ * `aws/cloudformation` でも、 ロードマップ予約済み (sakura/apprun・azure/bicep・
+ * gcp/infra-manager) でもないとき = typo の可能性が高いので止める。 予約済み runtime は
+ * まだ deploy できないが、 problem author が先行して書けるよう validation は通す。
+ */
+export function checkRuntimeSupport(runtime: RuntimeDescriptor): ValidationError[] {
+  if (classifyRuntimeSupport(runtime) !== "unknown") return [];
+  const reserved = RESERVED_RUNTIMES.map((r) => `${r.provider}/${r.engine}`).join(", ");
+  return [
+    `runtime "${runtime.provider}/${runtime.engine}" は実行可能 (aws/cloudformation) でも` +
+      ` 予約済みでもありません (typo の可能性)。 予約済み: ${reserved}`,
+  ];
 }
 
 function checkRuntimeConsistency(meta: Metadata): ValidationError[] {
@@ -72,22 +88,36 @@ function checkRuntimeConsistency(meta: Metadata): ValidationError[] {
   return [];
 }
 
-function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
+export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationError[] {
   const dir = dirname(metaPath);
-  const cfnTemplate = resolveTemplatePath(meta);
-  const templatePath = join(dir, cfnTemplate);
-
-  if (!existsSync(templatePath)) {
-    return [`cfnTemplate file "${cfnTemplate}" not found`];
+  // [ADR-023] 正本の正規化ロジック (problem-runtime) を共有して provider/engine/entry を解決。
+  const runtime = normalizeRuntime(meta as RuntimeMetadataInput);
+  if (!runtime) {
+    return ["runtime object が不正です (provider / engine / entry はすべて string 必須)"];
   }
-  const yaml = readFileSync(templatePath, "utf8");
-  return [
+  const templatePath = join(dir, runtime.entry);
+  if (!existsSync(templatePath)) {
+    return [`runtime entry file "${runtime.entry}" not found`];
+  }
+
+  const errors = [
+    ...checkRuntimeSupport(runtime),
     ...checkRuntimeConsistency(meta),
-    ...checkScoringOutputRefs(meta, yaml, cfnTemplate),
-    ...checkEndpointOutputRefs(meta, yaml, cfnTemplate),
     ...checkDashboardSlotFiles(meta, dir),
     ...checkRegionConsistency(meta),
   ];
+
+  // CFn Outputs 構文 (`Key:`) を前提にした cross-ref は executable な aws/cloudformation
+  // engine のときだけ意味を持つ。 予約済み (sakura/azure/gcp) は出力 binding 機構が
+  // provider 固有 + まだ deploy 不可なので、 ここでは file 存在のみ担保し CFn check は skip。
+  if (isExecutableRuntime(runtime)) {
+    const yaml = readFileSync(templatePath, "utf8");
+    errors.push(
+      ...checkScoringOutputRefs(meta, yaml, runtime.entry),
+      ...checkEndpointOutputRefs(meta, yaml, runtime.entry),
+    );
+  }
+  return errors;
 }
 
 const REGION_RE = /^[a-z]{2,3}-[a-z]+-\d{1,2}$/;
@@ -337,4 +367,8 @@ function reportResult(failed: number, total: number): void {
   console.log(`\n${total} 件の metadata.json はすべて有効です`);
 }
 
-main();
+// CLI として直接実行されたときだけ走らせる。 test が helper を import しても
+// validation 全体が走らないようにする (= 他 scripts/*.ts と同じ import.meta.main guard)。
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

The problem validator was AWS-centric: it hand-rolled the runtime/template precedence and ran the CloudFormation `Outputs:`-syntax cross-refs (`scoring.flagOutputKey` / `endpoints[].key`) unconditionally. A **reserved-runtime** problem (`sakura/apprun`, `azure/bicep`, `gcp/infra-manager` per ADR-026 / ADR-027) whose deploy body is not a CFn template would get spurious *"key not found in Outputs"* failures — blocking authors from writing multi-cloud problems ahead of execution support.

Changes (`scripts/` — agent-owned; **no infra/CDK change**):

- **DRY**: replace the hand-rolled `resolveTemplatePath` with `normalizeRuntime` from `@tenkacloud/problem-runtime` (the single source of truth already shared by the deploy worker + problem CLI).
- **Multi-cloud**: gate the CFn-Outputs cross-refs to `isExecutableRuntime` (aws/cloudformation). Reserved runtimes keep the provider-agnostic checks (file-exists, runtime consistency, dashboard slots, region) but skip the CFn-specific ones.
- Add `checkRuntimeSupport` — a runtime that's neither executable nor a declared reserved pair is rejected as a likely **typo** (with the reserved list in the message).
- Reject a **malformed** `runtime` object (provider/engine/entry not all strings) loudly.
- Guard `main()` behind `import.meta.main` (matching the other `scripts/*.ts`) so importing helpers in tests no longer triggers a full validation pass.

This is the agent-lane slice of multi-cloud completion: problem **authoring** for Sakura/Azure/GCP now validates correctly. The deploy-worker execution adapters (Azure Bicep / GCP Infra Manager / Sakura AppRun) remain owner/infra-lane (registry in `infrastructure/lib/problem-deploy/`), tracked separately.

## Test plan

- `vitest run test/scripts/validate-problems-runtime.test.ts` — 11 new tests pass
- existing `validate-problems-*.test.ts` (cross-ref / region / error-messages) — 17 pass unchanged
- `bun run scripts/validate-problems.ts` — all 7 repo problems still valid
- `biome check`, `tsc --noEmit` (infrastructure), `make harness` clean

## Regression analysis

- Existing problems are all aws/cloudformation with no `runtime` object → `normalizeRuntime` yields aws/cloudformation → identical CFn cross-refs run. Behavior unchanged; E2E + 17 existing tests green.
- The `import.meta.main` guard mirrors `env-init.ts` / `audit-dependencies.ts` / `tenkacloud-problem.ts`; no test relied on the import-time `main()` side effect.

## Physical impact

- NO-OP on CFn / deployed artifacts. `validate-problems.ts` is a CI / author-time tool, not a deployed Lambda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for multi-cloud runtime support

* **Refactor**
  * Extended validation to recognize AWS CloudFormation, Azure Bicep, GCP Infra-Manager, and Sakura AppRun runtimes
  * Validation checks now adapt based on runtime type (executable vs. reserved)
  * Improved error messages for unsupported runtime combinations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->