### PR TITLE
feat(portal): show the target-cloud (runtime provider) badge

### DIFF
--- a/apps/participant-portal/src/data/problems.test.ts
+++ b/apps/participant-portal/src/data/problems.test.ts
@@ -46,6 +46,21 @@ describe("metadataToEntry (fairness projection)", () => {
     expect(entry.endpoints[0]?.slot).toBe("main");
   });
 
+  it("should default the runtime to aws/cloudformation when none is declared (ADR-026/027)", () => {
+    expect(metadataToEntry(FAIRNESS_FIXTURE).runtime).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+    });
+  });
+
+  it("should project a declared multi-cloud runtime", () => {
+    const withRuntime = {
+      ...FAIRNESS_FIXTURE,
+      runtime: { provider: "azure", engine: "bicep", entry: "main.bicep" },
+    } as Parameters<typeof metadataToEntry>[0];
+    expect(metadataToEntry(withRuntime).runtime).toEqual({ provider: "azure", engine: "bicep" });
+  });
+
   it("should project i18n.en (dropping its description) and omit i18n when the override is empty", () => {
     const withI18n = {
       ...FAIRNESS_FIXTURE,

--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -100,6 +100,8 @@ export interface ProblemCatalogEntry {
   readonly i18n?: {
     readonly en?: ProblemI18nOverride;
   };
+  /** ADR-026 / ADR-027: 問題が deploy される cloud (provider) と engine。 未宣言は aws/cloudformation。 */
+  readonly runtime: { readonly provider: string; readonly engine: string };
 }
 
 interface ProblemMetadata {
@@ -118,6 +120,8 @@ interface ProblemMetadata {
   exposedPorts?: { port: number; name: string }[];
   cfnTemplate?: string;
   cfnParameters?: Record<string, string>;
+  /** ADR-026 / ADR-027: 問題の実行環境 (provider/engine)。 未宣言は aws/cloudformation 既定。 */
+  runtime?: { provider?: string; engine?: string; entry?: string };
   endpoints?: {
     slot: string;
     default: { from: "cfn-output"; key: string; appendPath?: string };
@@ -247,6 +251,11 @@ export function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry 
       ? { dashboardSlots: dashboardSlots as ProblemDashboardSlots }
       : {}),
     ...(publicI18n ? { i18n: publicI18n } : {}),
+    // ADR-026 / ADR-027: 実行環境を露出。 未宣言の legacy 問題は aws/cloudformation 既定。
+    runtime: {
+      provider: metadata.runtime?.provider ?? "aws",
+      engine: metadata.runtime?.engine ?? "cloudformation",
+    },
   };
 }
 

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -221,6 +221,7 @@
     "info_header": "Problem info",
     "info_category": "Category",
     "info_difficulty": "Difficulty",
+    "info_runtime": "Runtime",
     "info_private_badge": "Answer hidden",
     "info_description_label": "Description",
     "difficulty_1": "Beginner",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -221,6 +221,7 @@
     "info_header": "問題情報",
     "info_category": "カテゴリ",
     "info_difficulty": "難易度",
+    "info_runtime": "実行環境",
     "info_private_badge": "答え非公開",
     "info_description_label": "問題説明",
     "difficulty_1": "入門",

--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -30,6 +30,17 @@ const DIFFICULTY_KEY: Record<ProblemCatalogEntry["difficulty"], string> = {
   5: "problem_detail.difficulty_5",
 };
 
+/**
+ * ADR-026 / ADR-027: 問題の実行先 cloud を競技者に明示する badge 表示名。 brand 名なので
+ * locale 非依存。 未知 provider は raw 値をそのまま出す (= 新 provider 追加時の安全側 fallback)。
+ */
+const PROVIDER_LABEL: Record<string, string> = {
+  aws: "AWS",
+  sakura: "Sakura Cloud",
+  azure: "Azure",
+  gcp: "Google Cloud",
+};
+
 interface ProblemDetailGate {
   readonly kind: string;
 }
@@ -266,6 +277,13 @@ function ProblemInfoSection({
           </InfoCell>
           <InfoCell label={t("problem_detail.info_difficulty")}>
             {t(DIFFICULTY_KEY[metadata.difficulty])}
+          </InfoCell>
+          {/* ADR-026 / ADR-027: 問題が deploy される cloud を明示。 aws 以外 (multi-cloud) は
+              緑で強調し、 競技者が自分の対象 cloud account を取り違えないようにする。 */}
+          <InfoCell label={t("problem_detail.info_runtime")}>
+            <Badge color={metadata.runtime.provider === "aws" ? "grey" : "green"}>
+              {PROVIDER_LABEL[metadata.runtime.provider] ?? metadata.runtime.provider}
+            </Badge>
           </InfoCell>
         </ColumnLayout>
 

--- a/apps/participant-portal/test/pages/ProblemDetail.test.tsx
+++ b/apps/participant-portal/test/pages/ProblemDetail.test.tsx
@@ -71,6 +71,7 @@ const meta = (over: Record<string, any> = {}): any => ({
   difficulty: 3,
   endpoints: [{ id: "e1" }],
   dashboardSlots: { dashboard: ["slot.tsx"] },
+  runtime: { provider: "aws", engine: "cloudformation" },
   ...over,
 });
 // biome-ignore lint/suspicious/noExplicitAny: useTeamView の戻りを部分的に組む。
@@ -237,5 +238,26 @@ describe("ProblemDetailPage", () => {
     expect(screen.getByText("Challenge")).toBeInTheDocument();
     expect(screen.getByText("problem_detail.info_private_badge")).toBeInTheDocument();
     expect(screen.getByText("problem_detail.difficulty_5")).toBeInTheDocument();
+  });
+
+  it("should show the runtime provider badge (AWS for the default runtime)", () => {
+    mockFindMeta.mockReturnValue(meta()); // runtime aws/cloudformation 既定
+    mockTeamView.mockReturnValue(teamView({ view: viewWith() }));
+    renderPage();
+    expect(screen.getByText("AWS")).toBeInTheDocument();
+  });
+
+  it("should map a reserved multi-cloud provider to its brand label", () => {
+    mockFindMeta.mockReturnValue(meta({ runtime: { provider: "sakura", engine: "apprun" } }));
+    mockTeamView.mockReturnValue(teamView({ view: viewWith() }));
+    renderPage();
+    expect(screen.getByText("Sakura Cloud")).toBeInTheDocument();
+  });
+
+  it("should fall back to the raw provider id for an unmapped provider", () => {
+    mockFindMeta.mockReturnValue(meta({ runtime: { provider: "fly", engine: "machines" } }));
+    mockTeamView.mockReturnValue(teamView({ view: viewWith() }));
+    renderPage();
+    expect(screen.getByText("fly")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

ADR-026 / ADR-027 declare **"catalog provider badges"** so competitors can see which cloud a problem deploys to. The portal catalog dropped the runtime entirely, so AWS / Sakura / Azure / GCP problems looked identical.

- **problems.ts** — add `runtime` to the portal's (curated) `ProblemMetadata` and to `ProblemCatalogEntry`; `metadataToEntry` projects it, defaulting a legacy problem with no `runtime` to `aws/cloudformation` (matching the deploy layer's normalization, ADR-023).
- **ProblemDetail** — render a runtime provider badge in the problem-info section: **grey** for AWS (baseline), **green** for a non-AWS multi-cloud target so competitors don't aim at the wrong cloud account. A `PROVIDER_LABEL` map gives brand names (AWS / Sakura Cloud / Azure / Google Cloud); an unmapped provider falls back to its raw id (safe for future providers).
- **i18n** — add `problem_detail.info_runtime` (ja 実行環境 / en Runtime) to both locales.

participant-portal stays at **100% coverage** (597 tests): added `metadataToEntry` runtime-projection tests + `ProblemDetail` badge tests (AWS / reserved brand label / unmapped fallback).

This is the catalog-badge phase of multi-cloud (ADR-026 Phase 3 / ADR-027 Phase 4), following the provider-aware validator (#1547). The deploy-worker execution adapters remain owner/infra-lane.

## Test plan

- `vitest run` the affected specs; `problems.ts` + `ProblemDetail.tsx` 100% merged
- full participant-portal suite — 597 tests pass; module total 100% all metrics
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Legacy problems declare no `runtime` → defaults to aws/cloudformation, so every existing problem shows an "AWS" badge with no other behavior change. `ProblemCatalogEntry.runtime` is always populated (required, never undefined). Full suite green.
- Brand labels are locale-independent; only the cell label is translated, added to both ja and en.

## Physical impact

- NO-OP on CFn / deployed artifacts. Frontend-only (`apps/participant-portal` source + locales + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)