### PR TITLE
feat(app-admin): show the runtime provider badge in the problem catalog

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -35,6 +35,8 @@ export interface ProblemSummary {
    * 未宣言なら全 AWS region から選べる (= 後方互換)。
    */
   supportedRegions?: readonly string[];
+  /** ADR-026 / ADR-027: 問題が deploy される cloud (provider) と engine。 未宣言は aws/cloudformation。 */
+  runtime: { readonly provider: string; readonly engine: string };
 }
 
 export interface ProblemDetail extends ProblemSummary {
@@ -66,6 +68,8 @@ export interface ProblemMetadata {
   learningGoals: string[];
   cfnTemplate: string;
   cfnParameters?: Record<string, string>;
+  /** ADR-026 / ADR-027: 問題の実行環境 (provider/engine)。 未宣言は aws/cloudformation 既定。 */
+  runtime?: { provider?: string; engine?: string; entry?: string };
   /** Issue #1201: 問題作成者宣言の推奨 region。 wizard が初期値に使う。 */
   defaultRegion?: string;
   /** Issue #1201 Phase 2: 動作確認済 region 集合。 wizard が picker の選択肢を絞る。 */
@@ -93,6 +97,11 @@ export function metadataToDetail(metadata: ProblemMetadata): ProblemDetail {
     description: metadata.description,
     exposedPorts: metadata.exposedPorts,
     learningGoals: metadata.learningGoals,
+    // ADR-026 / ADR-027: 実行環境。 未宣言の legacy 問題は aws/cloudformation 既定。
+    runtime: {
+      provider: metadata.runtime?.provider ?? "aws",
+      engine: metadata.runtime?.engine ?? "cloudformation",
+    },
     ...(metadata.defaultRegion ? { defaultRegion: metadata.defaultRegion } : {}),
     ...(metadata.supportedRegions && metadata.supportedRegions.length > 0
       ? { supportedRegions: metadata.supportedRegions }
@@ -119,6 +128,7 @@ export function listProblemSummaries(): readonly ProblemSummary[] {
     difficulty: p.difficulty,
     estimatedDuration: p.estimatedDuration,
     tags: p.tags,
+    runtime: p.runtime,
     // region 系は ProblemSummary でも optional。 現状 catalog の全 problem が region を宣言
     // するため omit 分岐 (= region 無し problem) は実データで到達しない (= 将来 problem 用に保持)。
     // mapping 本体の分岐網羅は metadataToDetail のユニットテストで担保済。

--- a/apps/application-admin-console/src/lib/problem-filter.test.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.test.ts
@@ -17,6 +17,7 @@ const sample = (over: Partial<ProblemSummary> = {}): ProblemSummary => ({
   difficulty: 1,
   estimatedDuration: "30 分",
   tags: ["sample", "challenge", "ssm", "flag"],
+  runtime: { provider: "aws", engine: "cloudformation" },
   ...over,
 });
 

--- a/apps/application-admin-console/src/pages/Problems.tsx
+++ b/apps/application-admin-console/src/pages/Problems.tsx
@@ -27,6 +27,17 @@ import {
 const DIFFICULTY_LEVELS: DifficultyLevel[] = [1, 2, 3, 4, 5];
 
 /**
+ * ADR-026 / ADR-027: イベントを組む organizer に、 各問題の deploy 先 cloud を明示する
+ * badge 表示名。 brand 名なので locale 非依存。 未知 provider は raw 値をそのまま出す。
+ */
+const PROVIDER_LABEL: Record<string, string> = {
+  aws: "AWS",
+  sakura: "Sakura Cloud",
+  azure: "Azure",
+  gcp: "Google Cloud",
+};
+
+/**
  * 問題一覧ページ。Cloudscape Cards で 1 件ずつカード表示する。
  * クリックすると /problems/:id へ遷移して詳細 + Deploy ボタン。
  *
@@ -200,6 +211,10 @@ export function ProblemsPage() {
               content: (item) => (
                 <SpaceBetween direction="horizontal" size="xs">
                   <Badge color={item.category === "Battle" ? "red" : "blue"}>{item.category}</Badge>
+                  {/* ADR-026 / ADR-027: deploy 先 cloud。 aws 以外 (multi-cloud) は緑で強調。 */}
+                  <Badge color={item.runtime.provider === "aws" ? "grey" : "green"}>
+                    {PROVIDER_LABEL[item.runtime.provider] ?? item.runtime.provider}
+                  </Badge>
                   <Badge color="grey">
                     {interpolate(t("problems.badge_difficulty"), {
                       label: difficultyLabel(item.difficulty),

--- a/apps/application-admin-console/test/data/problems.test.ts
+++ b/apps/application-admin-console/test/data/problems.test.ts
@@ -54,6 +54,21 @@ describe("metadataToDetail", () => {
     const detail = metadataToDetail({ ...BASE_METADATA, supportedRegions: [] });
     expect(detail.supportedRegions).toBeUndefined();
   });
+
+  it("should default the runtime to aws/cloudformation when none is declared (ADR-026/027)", () => {
+    expect(metadataToDetail(BASE_METADATA).runtime).toEqual({
+      provider: "aws",
+      engine: "cloudformation",
+    });
+  });
+
+  it("should project a declared multi-cloud runtime", () => {
+    const detail = metadataToDetail({
+      ...BASE_METADATA,
+      runtime: { provider: "gcp", engine: "infra-manager", entry: "main.tf" },
+    });
+    expect(detail.runtime).toEqual({ provider: "gcp", engine: "infra-manager" });
+  });
 });
 
 describe("findProblem", () => {

--- a/apps/application-admin-console/test/lib/problem-filter.test.ts
+++ b/apps/application-admin-console/test/lib/problem-filter.test.ts
@@ -23,6 +23,7 @@ function p(over: Partial<ProblemSummary> & { id: string }): ProblemSummary {
     difficulty: 3,
     estimatedDuration: "30m",
     tags: [],
+    runtime: { provider: "aws", engine: "cloudformation" },
     ...over,
   };
 }

--- a/apps/application-admin-console/test/pages/Problems.test.tsx
+++ b/apps/application-admin-console/test/pages/Problems.test.tsx
@@ -32,6 +32,7 @@ const summary = (over: Partial<ProblemSummary> = {}): ProblemSummary =>
     difficulty: 1,
     estimatedDuration: "30m",
     tags: ["web", "sqli"],
+    runtime: { provider: "aws", engine: "cloudformation" },
     ...over,
   }) as ProblemSummary;
 const CATALOG: ProblemSummary[] = [
@@ -77,6 +78,18 @@ describe("ProblemsPage", () => {
     expect(
       screen.getAllByText("Battle").some((e) => e.closest(".awsui_badge, [class*=badge]")),
     ).toBe(true);
+  });
+
+  it("should render the runtime provider badge per card (AWS / multi-cloud brand / raw fallback)", () => {
+    mockList.mockReturnValue([
+      summary({ id: "a", name: "Alpha" }), // aws 既定
+      summary({ id: "s", name: "Sky", runtime: { provider: "sakura", engine: "apprun" } }),
+      summary({ id: "f", name: "Fly", runtime: { provider: "fly", engine: "machines" } }),
+    ]);
+    renderPage();
+    expect(screen.getByText("AWS")).toBeInTheDocument();
+    expect(screen.getByText("Sakura Cloud")).toBeInTheDocument();
+    expect(screen.getByText("fly")).toBeInTheDocument(); // 未知 provider は raw id
   });
 
   it("should filter by search text and show a filtered counter + clear button", () => {


### PR DESCRIPTION
## Summary

Mirror the portal catalog provider badge (#1548) on the **organizer** side: the `application-admin-console` problem catalog (where tenant admins browse and pick problems for an event) now shows each problem's target cloud. This completes the ADR-declared badge phase (ADR-026 Phase 3 / ADR-027 Phase 4) across both problem-browsing surfaces.

- **data/problems.ts** — add `runtime` to `ProblemSummary` (required) + the curated `ProblemMetadata` (optional); `metadataToDetail` projects it, defaulting a legacy problem with no `runtime` to `aws/cloudformation`; `listProblemSummaries` carries it through.
- **Problems.tsx** — add a provider `Badge` to each card: **grey** for AWS, **green** for a non-AWS multi-cloud target. `PROVIDER_LABEL` gives brand names; unmapped providers fall back to the raw id.
- Updated the two `problem-filter` test fixtures for the now-required `ProblemSummary.runtime`.

application-admin-console stays at **100% coverage** (892 tests).

## Test plan

- `vitest run` the affected specs; `data/problems.ts` + `Problems.tsx` 100% merged
- full app-admin suite — 892 tests pass; module total 100% all metrics
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Legacy problems default to aws/cloudformation → existing problems show an "AWS" badge, no other change. `ProblemSummary.runtime` is always populated. Filter logic ignores runtime, so filtering/sorting is unchanged.

## Physical impact

- NO-OP on CFn / deployed artifacts. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)