### PR TITLE
feat(app-admin): disable reserved-runtime problems in the event picker

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -138,3 +138,25 @@ export function listProblemSummaries(): readonly ProblemSummary[] {
     /* v8 ignore stop */
   }));
 }
+
+/**
+ * ADR-026 / ADR-027: 問題の deploy 先 cloud の表示名 (brand 名なので locale 非依存)。
+ * 未知 provider は raw 値をそのまま出す (= 新 provider 追加時の安全側 fallback)。
+ */
+export const PROVIDER_LABEL: Record<string, string> = {
+  aws: "AWS",
+  sakura: "Sakura Cloud",
+  azure: "Azure",
+  gcp: "Google Cloud",
+};
+
+/**
+ * ADR-023 D4: 今 deploy 可能なのは aws/cloudformation だけ。 予約済み (sakura/azure/gcp) は
+ * engine 未実装なので deploy 不可。 catalog / picker はこれで「近日対応」を出し分ける。
+ */
+export function isExecutableProblemRuntime(runtime: {
+  readonly provider: string;
+  readonly engine: string;
+}): boolean {
+  return runtime.provider === "aws" && runtime.engine === "cloudformation";
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -134,6 +134,7 @@
     "basic_info_header": "Basic info",
     "name_label": "Event name",
     "name_placeholder_example": "e.g. Tenka Battle Cup 2026",
+    "problem_reserved_tag": "Coming soon",
     "name_invalid": "1–{max} characters",
     "team_count_label": "Team count",
     "team_count_description": "{min}–{max} (TransactWrite limit minus 1 for the event row)",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -134,6 +134,7 @@
     "basic_info_header": "基本情報",
     "name_label": "Event 名",
     "name_placeholder_example": "例: Tenka Battle Cup 2026",
+    "problem_reserved_tag": "近日対応",
     "name_invalid": "1〜{max} 文字",
     "team_count_label": "チーム数",
     "team_count_description": "{min}〜{max} (= TransactWrite 上限から event 1 行を引いた値)",

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -21,6 +21,7 @@ import { EventCreateDeployPromptModal } from "./event-create/EventCreateDeployPr
 import { EventCreateProblemsetSection } from "./event-create/EventCreateProblemsetSection";
 import { EventCreateTeamsSection } from "./event-create/EventCreateTeamsSection";
 import {
+  buildProblemOptions,
   buildVerifiedAccountOption,
   INITIAL_TEAM_COUNT,
   NAME_MAX,
@@ -67,9 +68,11 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   const t = useT();
 
   const allProblems = useMemo(() => listProblemSummaries(), []);
+  // #1414: 予約済み runtime (sakura/azure/gcp) の問題は deploy 不可なので picker で
+  // disabled + 「近日対応」 にし、 event に組み込めないようにする。
   const problemOptions: MultiselectProps.Option[] = useMemo(
-    () => allProblems.map((p) => ({ value: p.id, label: `${p.name} (${p.id})` })),
-    [allProblems],
+    () => buildProblemOptions(allProblems, t("event_create.problem_reserved_tag")),
+    [allProblems, t],
   );
 
   // Phase 2.2 (Issue #459): verified=true な CompetitorAccounts のみを Select の選択肢にする。

--- a/apps/application-admin-console/src/pages/Problems.tsx
+++ b/apps/application-admin-console/src/pages/Problems.tsx
@@ -12,7 +12,7 @@ import SegmentedControl, {
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { listProblemSummaries, type ProblemSummary } from "../data/problems";
+import { listProblemSummaries, PROVIDER_LABEL, type ProblemSummary } from "../data/problems";
 import { interpolate, useT } from "../i18n";
 import {
   collectTagFacets,
@@ -25,17 +25,6 @@ import {
 } from "../lib/problem-filter";
 
 const DIFFICULTY_LEVELS: DifficultyLevel[] = [1, 2, 3, 4, 5];
-
-/**
- * ADR-026 / ADR-027: イベントを組む organizer に、 各問題の deploy 先 cloud を明示する
- * badge 表示名。 brand 名なので locale 非依存。 未知 provider は raw 値をそのまま出す。
- */
-const PROVIDER_LABEL: Record<string, string> = {
-  aws: "AWS",
-  sakura: "Sakura Cloud",
-  azure: "Azure",
-  gcp: "Google Cloud",
-};
 
 /**
  * 問題一覧ページ。Cloudscape Cards で 1 件ずつカード表示する。

--- a/apps/application-admin-console/src/pages/event-create/helpers.ts
+++ b/apps/application-admin-console/src/pages/event-create/helpers.ts
@@ -12,6 +12,7 @@
 import type { MultiselectProps, SelectProps } from "@cloudscape-design/components";
 import type { CompetitorAccountSummary } from "../../api/competitor-accounts-client";
 import { AWS_REGIONS } from "../../data/aws-regions";
+import { isExecutableProblemRuntime } from "../../data/problems";
 import type { useT } from "../../i18n";
 
 export const NAME_MAX = 120;
@@ -57,6 +58,28 @@ export type TeamTableItem = TeamRow & { idx: number };
 
 /** Multiselect option (value 必須) */
 export type ProblemOption = MultiselectProps.Option & { value: string };
+
+/**
+ * ADR-026 / ADR-027 (#1414): event の problem picker option を組み立てる。 deploy 可能な
+ * (aws/cloudformation) 問題は選択可、 予約済み (sakura/azure/gcp = engine 未実装) は
+ * `disabled` + 「近日対応」 tag にして deploy 不可な問題を event に組み込めないようにする
+ * (= deployable-but-failing entry を防ぐ)。
+ */
+export function buildProblemOptions(
+  problems: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly runtime: { readonly provider: string; readonly engine: string };
+  }[],
+  reservedTag: string,
+): ProblemOption[] {
+  return problems.map((p) => {
+    const base = { value: p.id, label: `${p.name} (${p.id})` };
+    return isExecutableProblemRuntime(p.runtime)
+      ? base
+      : { ...base, disabled: true, labelTag: reservedTag };
+  });
+}
 
 export function buildVerifiedAccountOption(a: CompetitorAccountSummary): SelectProps.Option {
   const descriptionParts = [a.alias, a.region, a.competitorRoleName].filter(

--- a/apps/application-admin-console/test/data/problems.test.ts
+++ b/apps/application-admin-console/test/data/problems.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   findProblem,
+  isExecutableProblemRuntime,
   listProblemSummaries,
   metadataToDetail,
   PROBLEM_CATALOG,
@@ -68,6 +69,21 @@ describe("metadataToDetail", () => {
       runtime: { provider: "gcp", engine: "infra-manager", entry: "main.tf" },
     });
     expect(detail.runtime).toEqual({ provider: "gcp", engine: "infra-manager" });
+  });
+});
+
+describe("isExecutableProblemRuntime (ADR-023 D4)", () => {
+  it("should be true only for aws/cloudformation", () => {
+    expect(isExecutableProblemRuntime({ provider: "aws", engine: "cloudformation" })).toBe(true);
+  });
+
+  it.each([
+    { provider: "sakura", engine: "apprun" },
+    { provider: "azure", engine: "bicep" },
+    { provider: "gcp", engine: "infra-manager" },
+    { provider: "aws", engine: "cdk" }, // 同 provider でも非 CFn engine は不可
+  ])("should be false for the reserved / non-CFn runtime $provider/$engine", (rt) => {
+    expect(isExecutableProblemRuntime(rt)).toBe(false);
   });
 });
 

--- a/apps/application-admin-console/test/pages/EventCreate.flow.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.flow.test.tsx
@@ -38,7 +38,11 @@ vi.mock("../../src/api/events-client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/api/events-client")>();
   return { ...actual, createEvent: mockCreate, bulkDeployEvent: mockBulk };
 });
-vi.mock("../../src/data/problems", () => ({ listProblemSummaries: mockListProblems }));
+vi.mock("../../src/data/problems", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/data/problems")>();
+  // listProblemSummaries だけ差し替え、 isExecutableProblemRuntime (buildProblemOptions が使う) は実物。
+  return { ...actual, listProblemSummaries: mockListProblems };
+});
 vi.mock("../../src/pages/event-create/useCompetitorAccountsLoader", () => ({
   useCompetitorAccountsLoader: mockLoader,
 }));
@@ -71,6 +75,7 @@ const problem = (over: Partial<ProblemSummary> = {}): ProblemSummary =>
     tags: [],
     defaultRegion: "us-east-1",
     supportedRegions: ["us-east-1", "ap-northeast-1"],
+    runtime: { provider: "aws", engine: "cloudformation" },
     ...over,
   }) as ProblemSummary;
 

--- a/apps/application-admin-console/test/pages/Problems.test.tsx
+++ b/apps/application-admin-console/test/pages/Problems.test.tsx
@@ -14,7 +14,11 @@ import type { ProblemSummary } from "../../src/data/problems";
 const { mockNav, mockList } = vi.hoisted(() => ({ mockNav: vi.fn(), mockList: vi.fn() }));
 
 vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
-vi.mock("../../src/data/problems", () => ({ listProblemSummaries: mockList }));
+vi.mock("../../src/data/problems", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/data/problems")>();
+  // listProblemSummaries だけ差し替え、 PROVIDER_LABEL (badge 表示名) は実物。
+  return { ...actual, listProblemSummaries: mockList };
+});
 vi.mock("../../src/i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/i18n")>();
   return { ...actual, useT: () => (key: string) => key };

--- a/apps/application-admin-console/test/pages/event-create/buildProblemOptions.test.ts
+++ b/apps/application-admin-console/test/pages/event-create/buildProblemOptions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildProblemOptions } from "../../../src/pages/event-create/helpers";
+
+/**
+ * #1414 (ADR-026 / ADR-027): event の problem picker option 組立。 deploy 可能な
+ * aws/cloudformation 問題は通常 option、 予約済み (sakura/azure/gcp) は disabled +
+ * 「近日対応」 tag にして event に組み込めないようにする (= deployable-but-failing 防止)。
+ */
+const problem = (id: string, provider: string, engine: string) => ({
+  id,
+  name: `Problem ${id}`,
+  runtime: { provider, engine },
+});
+
+describe("buildProblemOptions", () => {
+  it("should make an executable aws/cloudformation problem a normal selectable option", () => {
+    const [opt] = buildProblemOptions([problem("p1", "aws", "cloudformation")], "近日対応");
+    expect(opt).toEqual({ value: "p1", label: "Problem p1 (p1)" });
+    expect(opt.disabled).toBeUndefined();
+  });
+
+  it("should disable a reserved (non-executable) problem with the coming-soon tag", () => {
+    const [opt] = buildProblemOptions([problem("a1", "azure", "bicep")], "近日対応");
+    expect(opt).toMatchObject({
+      value: "a1",
+      label: "Problem a1 (a1)",
+      disabled: true,
+      labelTag: "近日対応",
+    });
+  });
+
+  it("should map a mixed catalog, disabling only the reserved entries", () => {
+    const opts = buildProblemOptions(
+      [
+        problem("aws-x", "aws", "cloudformation"),
+        problem("sakura-x", "sakura", "apprun"),
+        problem("gcp-x", "gcp", "infra-manager"),
+      ],
+      "近日対応",
+    );
+    expect(opts.map((o) => Boolean(o.disabled))).toEqual([false, true, true]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining piece of **#1414**: a reserved-runtime (non-AWS, engine not yet implemented) problem must not be a *deployable-but-failing* entry. With the catalog provider badges (#1548/#1549) and the provider-aware validator (#1547) already shipped, this stops an organizer from adding a non-deployable problem to an event.

- **data/problems.ts** — add `isExecutableProblemRuntime(runtime)` (true only for `aws/cloudformation`, ADR-023 D4) and promote `PROVIDER_LABEL` to a shared export (removing the copy in `Problems.tsx` — **DRY**).
- **event-create/helpers.ts** — extract a pure `buildProblemOptions(problems, reservedTag)`: executable problems are normal options; reserved ones are `disabled` + a "近日対応 / Coming soon" `labelTag`.
- **EventCreate.tsx** — build the picker options via `buildProblemOptions`, so reserved problems can't be selected for deploy.
- **i18n** — add `event_create.problem_reserved_tag` (ja 近日対応 / en Coming soon).

application-admin-console stays at **100% coverage** (900 tests).

## Test plan

- `vitest run` the changed specs; `data/problems.ts` + `helpers.ts` + `Problems.tsx` + `EventCreate.tsx` covered
- full app-admin suite — 900 tests pass; module total 100% all metrics
- `biome check`, `tsc --noEmit`, `make harness` clean

## Regression analysis

- Every existing problem is aws/cloudformation → `isExecutableProblemRuntime` true → normal selectable option, no behavior change; the disabled path is a forward-looking guard exercised by unit tests. `PROVIDER_LABEL` move is a pure relocation. The two `data/problems` test mocks now use `importOriginal` so the new pure helpers resolve; no production import path changed.

## Physical impact

- NO-OP on CFn / deployed artifacts. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Problem runtime support indicators now display "Coming soon" status for non-executable environments, disabling them in event creation to guide users toward supported configurations.

* **Refactor**
  * Consolidated provider label mappings into a shared data module for consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/TenkaCloud/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->