### PR TITLE
fix(synth): skip Docker bundling in the per-commit check-synth gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,18 @@ before-commit: lint test validate-problems check-docs check-http-status check-te
 
 # `cdk synth` が通ることを保証 (= ts-node / tsx の module resolution、 stack 構築の type error
 # 等を本番 deploy 前にキャッチ)。 Makefile placeholder env で全 stack を synth するので AWS 認証は不要。
+#
+# #1446 follow-up: 毎コミット (pre-commit) で走るこの gate は「synth の shape (module 解決 /
+# 型 / construct ツリー / template 生成)」 を検証するのが目的で、 Lambda の実バンドルは不要。
+# 実バンドル (SBT の Python CognitoAuth 等を Docker で pip install) は毎回 `cdk-<hash>` イメージを
+# 生成し、 CDK はそれを掃除しないため Docker ディスクが青天井に膨らみ synth が ENOSPC で失敗していた。
+# よって check-synth では `CDK_SKIP_BUNDLING=1` を渡し、 bin/infrastructure.ts 側で
+# `aws:cdk:bundling-stacks=[]` を setContext して Docker バンドルを skip する
+# (= module 解決 / 型 / construct の検証はそのまま、 Docker 不要・高速・イメージ非蓄積)。
+# 実バンドルは `make synth` / `make deploy` 側で従来どおり行う (= env var 無しなら全 stack をバンドル)。
 check-synth:
-	@$(MAKE) synth >/dev/null 2>&1 || { echo "ERROR: cdk synth failed (= make deploy も失敗します)。 make synth で詳細を確認してください。"; exit 1; }
-	@echo "OK  cdk synth (= deploy 経路の module resolution が通る)"
+	@CDK_SKIP_BUNDLING=1 $(MAKE) synth >/dev/null 2>&1 || { echo "ERROR: cdk synth failed (= make deploy も失敗します)。 CDK_SKIP_BUNDLING=1 make synth で詳細を確認してください。"; exit 1; }
+	@echo "OK  cdk synth (module 解決 / 型 / construct を検証、 Docker バンドルは skip — 実バンドルは make synth)"
 
 # ===== Lint / Fix =====
 lint:   lint-md lint-text lint-format

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -17,6 +17,17 @@ import { buildTenkaCloudApp } from "../lib/app-wiring/index.js";
 
 const app = new cdk.App();
 
+// #1446 follow-up: pre-commit `make check-synth` は synth の shape (module 解決 / 型 /
+// construct ツリー / template 生成) だけを検証するのが目的で、 Lambda の実 Docker バンドルは
+// 不要。 SBT の Python Lambda 等のバンドルは毎回 `cdk-<hash>` イメージを生成し CDK が掃除しない
+// ため Docker ディスクが膨らみ synth が ENOSPC で失敗していた。 `CDK_SKIP_BUNDLING=1` のときは
+// `aws:cdk:bundling-stacks` を空にして全 stack のバンドルを skip する (= 検証は通り Docker 不要)。
+// CLI の `-c` は `aws:` prefix を拒否するため context は code 側で設定する。 実バンドルは
+// `make synth` / `make deploy` (env 無し) で従来どおり走る。
+if (process.env.CDK_SKIP_BUNDLING === "1") {
+  app.node.setContext("aws:cdk:bundling-stacks", []);
+}
+
 const config = resolveAppConfig({
   env: process.env,
   binDir: import.meta.dirname,


### PR DESCRIPTION
## Summary

The pre-commit gate (`make before-commit` → `check-synth` → `cdk synth`) ran **full Docker-based Lambda bundling** (SBT's Python `CognitoAuth` via pip/poetry) on **every commit**. CDK creates a `cdk-<hash>` image per bundle and never prunes them (58 had accumulated locally), so Docker Desktop's disk filled and `cdk synth` started failing with `ENOSPC` — **blocking every commit**.

`check-synth` only needs to validate the synth *shape* (module resolution, type errors, construct tree, template generation), not actually bundle the Lambdas:

- **`bin/infrastructure.ts`** — when `CDK_SKIP_BUNDLING=1`, set the `aws:cdk:bundling-stacks` context to `[]` (CLI `-c` rejects `aws:`-prefixed keys, so it must be set in code). Guarded no-op otherwise.
- **`Makefile check-synth`** — runs synth with `CDK_SKIP_BUNDLING=1` → no Docker, ~10s, no `cdk-*` image accumulation. `make synth` / `make deploy` (no env var) bundle for real, unchanged.

## Verification

- `CDK_SKIP_BUNDLING=1 make synth` invokes Docker **0 times**; `make check-synth` exits 0 in ~10s **even with a full Docker disk** (previously `ENOSPC`).
- This commit itself passed the real pre-commit `make before-commit` (lint + all-workspace tests + the fixed check-synth) end-to-end.

## Regression analysis

- `make synth` / `make deploy` unchanged (`CDK_SKIP_BUNDLING` unset → full bundling). Only `check-synth` opts out, and it never deployed — it validates the construct graph, which still synthesizes (assets stage their raw source instead of a Docker bundle). The `setContext` is env-guarded, so normal synth/deploy behavior is byte-identical.

## Physical impact

- NO-OP on CFn / deployed artifacts. Build-tooling + an env-guarded context set affecting only the local check-synth gate.

> Touches `infrastructure/bin/` — per the repo role-split I'm opening this for **owner review rather than self-merging**. Follow-up to the Docker-disk issue surfaced during #1446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to document test output directory handling and added directory purging automation for test runs
  * Modified check-synth validation gate to skip Docker-based bundling during validation checks with updated success/error messaging
  * Added pre-synth safeguard for CI environments to conditionally disable Lambda Docker bundling based on environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->