### PR TITLE
feat(ci): enforce 100% coverage gate for agent-owned workspaces (#1424)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
         run: |
           make test-coverage
 
+      # Issue #1424: agent-owned workspace (3 SPA + 共有 package) の 100% coverage を enforce。
+      # test-coverage が生成した lcov.info を読み 100% 未満なら CI を落とす (= 回帰検知)。
+      - name: Coverage gate (100% for agent-owned workspaces)
+        run: |
+          make coverage-gate
+
       - name: Build
         run: |
           make build

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export JSII_DEPRECATED := quiet
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install install_ci build typecheck test test-coverage clean-test-outdir check before-commit beforecommit \
+.PHONY: help install install_ci build typecheck test test-coverage coverage-gate clean-test-outdir check before-commit beforecommit \
         build-docs check-docs audit-deps build-problems-index check-problems-index \
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
@@ -37,6 +37,11 @@ build:         ; bun run build
 typecheck:     ; bun run typecheck
 test:          ; bun run test
 test-coverage: ; bun run test:coverage
+# Issue #1424: agent-owned workspace (3 SPA + 共有 package) が 100% coverage を維持しているか
+# を lcov から検証する gate。 `make test-coverage` で各 workspace の coverage/lcov.info を
+# 生成してから実行する (CI は test-coverage の直後に走らせる)。 infrastructure は owner lane
+# のため gate 対象外 (現在値のみ表示)。
+coverage-gate: ; bun run scripts/check-coverage-gate.ts
 # Issue #1295: vitest setup (infrastructure/test/setup.ts) pins
 # CDK_OUTDIR to infrastructure/cdk.out.test/<worker>. Output is
 # overwritten per synth (= no accumulation), but a manual purge is

--- a/infrastructure/test/scripts/check-coverage-gate.test.ts
+++ b/infrastructure/test/scripts/check-coverage-gate.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  GATED_WORKSPACES,
+  isFullyCovered,
+  isMetricFull,
+  metricPct,
+  parseLcovTotals,
+} from "../../../scripts/check-coverage-gate";
+
+/**
+ * Issue #1424: coverage gate の lcov パーサ。 LF/LH・FNF/FNH・BRF/BRH を集計し、
+ * found===hit を 100% と判定する。 複数 SF レコードの合算と、 branches 0 件 (= 100%) を pin。
+ */
+const FULL_LCOV = [
+  "TN:",
+  "SF:src/a.ts",
+  "FNF:2",
+  "FNH:2",
+  "LF:10",
+  "LH:10",
+  "BRF:4",
+  "BRH:4",
+  "end_of_record",
+  "SF:src/b.ts",
+  "FNF:1",
+  "FNH:1",
+  "LF:5",
+  "LH:5",
+  "BRF:0",
+  "BRH:0",
+  "end_of_record",
+].join("\n");
+
+const PARTIAL_LCOV = [
+  "SF:src/c.ts",
+  "FNF:3",
+  "FNH:3",
+  "LF:20",
+  "LH:20",
+  "BRF:8",
+  "BRH:6", // 2 branches uncovered
+  "end_of_record",
+].join("\n");
+
+describe("parseLcovTotals", () => {
+  it("should sum metrics across all SF records", () => {
+    const t = parseLcovTotals(FULL_LCOV);
+    expect(t.lines).toEqual({ found: 15, hit: 15 });
+    expect(t.functions).toEqual({ found: 3, hit: 3 });
+    expect(t.branches).toEqual({ found: 4, hit: 4 });
+  });
+
+  it("should ignore non-metric lines and unparseable numbers", () => {
+    const t = parseLcovTotals("TN:\nSF:x\nDA:1,2\nLF:3\nLH:3\nend_of_record\nFNF:notnum");
+    expect(t.lines).toEqual({ found: 3, hit: 3 });
+    expect(t.functions).toEqual({ found: 0, hit: 0 });
+  });
+});
+
+describe("isMetricFull / isFullyCovered", () => {
+  it("should treat hit===found as full and found===0 as full", () => {
+    expect(isMetricFull({ found: 4, hit: 4 })).toBe(true);
+    expect(isMetricFull({ found: 0, hit: 0 })).toBe(true);
+    expect(isMetricFull({ found: 8, hit: 6 })).toBe(false);
+  });
+
+  it("should pass a fully-covered lcov and fail a partial one", () => {
+    expect(isFullyCovered(parseLcovTotals(FULL_LCOV))).toBe(true);
+    expect(isFullyCovered(parseLcovTotals(PARTIAL_LCOV))).toBe(false);
+  });
+});
+
+describe("metricPct", () => {
+  it("should report a percentage and treat 0-found as 100", () => {
+    expect(metricPct({ found: 8, hit: 6 })).toBe(75);
+    expect(metricPct({ found: 0, hit: 0 })).toBe(100);
+    expect(metricPct({ found: 10, hit: 10 })).toBe(100);
+  });
+});
+
+describe("GATED_WORKSPACES", () => {
+  it("should gate the three SPAs and the shared packages (not infrastructure)", () => {
+    expect(GATED_WORKSPACES).toContain("apps/participant-portal");
+    expect(GATED_WORKSPACES).toContain("packages/format");
+    expect(GATED_WORKSPACES).not.toContain("infrastructure");
+  });
+});

--- a/scripts/check-coverage-gate.ts
+++ b/scripts/check-coverage-gate.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+/**
+ * Issue #1424: 100% coverage を CI で enforce する gate。
+ *
+ * `make test-coverage` が各 workspace 配下に生成する `coverage/lcov.info` を読み、
+ * **agent-owned workspace (3 SPA + 共有 package)** が lines / functions / branches すべて
+ * 100% であることを保証する。 1 つでも下回ったら exit 1 で CI を落とす (= 回帰検知)。
+ *
+ * `infrastructure` は owner lane (CDK + Lambda handlers) かつ現状 100% 未満なので gate からは
+ * 外し、 現在値だけ参考表示する (= #1424 の「100% への道筋を示す」)。 100% に到達したら
+ * GATED_WORKSPACES に移す。
+ *
+ * lcov に「statements」は無いが、 v8 では statements ≈ lines。 lines/functions/branches の
+ * 3 軸が 100% なら実質 4 軸 100% (= 回帰すれば必ずこのいずれかが落ちる)。
+ *
+ * Usage: `make test-coverage && bun run scripts/check-coverage-gate.ts`
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+
+/** 100% を必須とする agent-owned workspace。 回帰したら CI を落とす。 */
+export const GATED_WORKSPACES = [
+  "apps/admin-console",
+  "apps/application-admin-console",
+  "apps/participant-portal",
+  "packages/auth-client",
+  "packages/problem-runtime",
+  "packages/saml-utils",
+  "packages/trust-bridge",
+  "packages/format",
+] as const;
+
+/** gate しないが現在値を表示する workspace (owner lane、 100% への道筋表示用)。 */
+export const REPORTED_WORKSPACES = ["infrastructure"] as const;
+
+interface Metric {
+  readonly found: number;
+  readonly hit: number;
+}
+export interface LcovTotals {
+  readonly lines: Metric;
+  readonly functions: Metric;
+  readonly branches: Metric;
+}
+
+// lcov のメトリクス行 key → (どの metric の found/hit に足すか)。 if/else 連鎖より
+// 認知的複雑度が低く、 lcov の prefix 追加にも開かれている。
+const LCOV_KEY_MAP: Record<string, readonly [keyof LcovTotals, "found" | "hit"]> = {
+  LF: ["lines", "found"],
+  LH: ["lines", "hit"],
+  FNF: ["functions", "found"],
+  FNH: ["functions", "hit"],
+  BRF: ["branches", "found"],
+  BRH: ["branches", "hit"],
+};
+
+/** lcov.info を集計して lines / functions / branches の found・hit 合計を返す。 */
+export function parseLcovTotals(lcov: string): LcovTotals {
+  const acc = {
+    lines: { found: 0, hit: 0 },
+    functions: { found: 0, hit: 0 },
+    branches: { found: 0, hit: 0 },
+  };
+  for (const line of lcov.split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    const target = LCOV_KEY_MAP[line.slice(0, idx)];
+    if (!target) continue;
+    const n = Number(line.slice(idx + 1));
+    if (Number.isNaN(n)) continue;
+    acc[target[0]][target[1]] += n;
+  }
+  return acc;
+}
+
+/** found===hit (= 100%) なら true。 found===0 (計測対象なし) も 100% 扱い。 */
+export function isMetricFull(m: Metric): boolean {
+  return m.hit >= m.found;
+}
+
+export function isFullyCovered(t: LcovTotals): boolean {
+  return isMetricFull(t.lines) && isMetricFull(t.functions) && isMetricFull(t.branches);
+}
+
+/** 表示用 % (found=0 は 100)。 */
+export function metricPct(m: Metric): number {
+  return m.found === 0 ? 100 : Math.round((m.hit / m.found) * 10000) / 100;
+}
+
+interface WorkspaceResult {
+  readonly workspace: string;
+  readonly totals: LcovTotals | null; // null = lcov 不在
+  readonly full: boolean;
+}
+
+function evaluateWorkspace(workspace: string): WorkspaceResult {
+  const lcovPath = join(REPO_ROOT, workspace, "coverage", "lcov.info");
+  if (!existsSync(lcovPath)) {
+    return { workspace, totals: null, full: false };
+  }
+  const totals = parseLcovTotals(readFileSync(lcovPath, "utf8"));
+  return { workspace, totals, full: isFullyCovered(totals) };
+}
+
+function formatTotals(t: LcovTotals): string {
+  return `lines ${metricPct(t.lines)}% / functions ${metricPct(t.functions)}% / branches ${metricPct(t.branches)}%`;
+}
+
+function main(): void {
+  const failures: string[] = [];
+  console.log("Coverage gate (#1424) — agent-owned workspaces must be 100%:\n");
+
+  for (const ws of GATED_WORKSPACES) {
+    const r = evaluateWorkspace(ws);
+    if (r.totals === null) {
+      console.error(
+        `  ❌ ${ws}: coverage/lcov.info が見つかりません (make test-coverage を先に実行)`,
+      );
+      failures.push(ws);
+    } else if (!r.full) {
+      console.error(`  ❌ ${ws}: ${formatTotals(r.totals)}`);
+      failures.push(ws);
+    } else {
+      console.log(`  ✅ ${ws}: 100%`);
+    }
+  }
+
+  console.log("\n参考 (gate 対象外、 100% への道筋):");
+  for (const ws of REPORTED_WORKSPACES) {
+    const r = evaluateWorkspace(ws);
+    console.log(`  • ${ws}: ${r.totals ? formatTotals(r.totals) : "(lcov 不在)"}`);
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `\n${failures.length} workspace が 100% 未満です: ${failures.join(", ")}。 回帰したテストを直してください (config で mask しない)。`,
+    );
+    process.exit(1);
+  }
+  console.log(`\n${GATED_WORKSPACES.length} workspace すべて 100%。`);
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

CI already runs `make test-coverage` (per-workspace `coverage/lcov.info`) but nothing enforced a threshold, so coverage could silently regress. This adds a gate.

- **`scripts/check-coverage-gate.ts`** — reads each agent-owned workspace's `coverage/lcov.info` and asserts lines / functions / branches are all **100%**; exits 1 (listing offenders) otherwise. `infrastructure` is the owner lane and currently <100%, so it is **reported** (current %) but **not gated** — moved into the gate once it reaches 100% (#1424's "path to 100%").
- **`make coverage-gate`** + a CI step right after `make test-coverage`.
- Unit-tested lcov parser (multi-record sum, 0-branch = 100%, partial → fail).

Gated workspaces (verified 100% locally via the gate): admin-console, application-admin-console, participant-portal, auth-client, problem-runtime, saml-utils, trust-bridge, format.

This **locks in** the 100% reached across the frontend + shared packages so a PR that drops coverage fails CI. It does **not fully close #1424** (infrastructure 100% + its gating remain) — progress noted on the issue.

## Test plan

- `make test-coverage && make coverage-gate` → 8/8 agent workspaces 100%, exit 0
- `vitest` on the parser — 6 cases pass; `biome` / `tsc` / `make harness` clean

## Regression analysis

- Pure addition: a script + Makefile target + CI step + a unit test. No product code touched. The gate reads lcov that CI already generates.

## Physical impact

- NO-OP on CFn / deployed artifacts. CI tooling + a coverage-gate script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced automated code coverage enforcement in the CI pipeline that validates 100% coverage for designated workspaces; builds will fail if coverage does not meet this threshold.
  * Added comprehensive test suite for coverage validation utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->