### PR TITLE
test(infra): cover event-handler lifecycle/scoring routes to 100% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/lifecycle-routes.test.ts
+++ b/infrastructure/test/problem-deploy/lifecycle-routes.test.ts
@@ -1,0 +1,138 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: event lifecycle routes (routes/lifecycle.ts) の route 層を pin する。
+ * PATCH /events/:id/schedule と POST /events/:id/end の全 outcome→HTTP 分岐 + error path。
+ * service (schedule / end-event) は mock、 auth は dev override env、 eventId は valid ULID。
+ */
+const mocks = vi.hoisted(() => ({ setEventSchedule: vi.fn(), endEvent: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/schedule", () => ({
+  setEventSchedule: mocks.setEventSchedule,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/end-event", () => ({
+  endEvent: mocks.endEvent,
+}));
+
+const { registerLifecycleRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/lifecycle"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared (route は service に渡すだけ)。
+const shared = { ddb: { send: vi.fn() } } as any;
+const buildApp = () => {
+  const app = new Hono();
+  registerLifecycleRoutes(app, shared);
+  return app;
+};
+const patchSchedule = (body: unknown) =>
+  buildApp().request(`/events/${EVENT_ID}/schedule`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+const postEnd = () => buildApp().request(`/events/${EVENT_ID}/end`, { method: "POST" });
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+describe("PATCH /events/:eventId/schedule", () => {
+  it("should 400 on an invalid body", async () => {
+    const res = await patchSchedule({ startsAt: 12345 }); // not a string → schema reject
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("should resolve startNow to a server timestamp and return ok", async () => {
+    mocks.setEventSchedule.mockResolvedValueOnce({
+      kind: "ok",
+      startsAt: "2026-06-01T00:00:00.000Z",
+      endsAt: undefined,
+      updatedDeployments: 3,
+    });
+    const res = await patchSchedule({ startNow: true });
+    expect(res.status).toBe(StatusCodes.OK);
+    expect((await res.json()).updatedDeployments).toBe(3);
+    // startNow → resolvedStartsAt is an ISO string (not undefined).
+    expect(typeof mocks.setEventSchedule.mock.calls[0][3].startsAt).toBe("string");
+  });
+
+  it("should pass an explicit startsAt through when startNow is false", async () => {
+    mocks.setEventSchedule.mockResolvedValueOnce({ kind: "ok", updatedDeployments: 0 });
+    await patchSchedule({ startsAt: "2099-01-01T00:00:00.000Z" });
+    expect(mocks.setEventSchedule.mock.calls[0][3].startsAt).toBe("2099-01-01T00:00:00.000Z");
+  });
+
+  it.each([
+    ["not_found", { kind: "not_found" }, StatusCodes.NOT_FOUND, "not_found"],
+    [
+      "past_starts_at",
+      { kind: "past_starts_at", startsAt: "2000-01-01T00:00:00Z", nowMs: 0 },
+      StatusCodes.BAD_REQUEST,
+      "past_starts_at",
+    ],
+    [
+      "past_ends_at",
+      { kind: "past_ends_at", endsAt: "2000-01-01T00:00:00Z", nowMs: 0 },
+      StatusCodes.BAD_REQUEST,
+      "past_ends_at",
+    ],
+    [
+      "ends_before_starts",
+      {
+        kind: "ends_before_starts",
+        startsAt: "2099-01-02T00:00:00Z",
+        endsAt: "2099-01-01T00:00:00Z",
+      },
+      StatusCodes.BAD_REQUEST,
+      "ends_before_starts",
+    ],
+    ["no_op", { kind: "no_op" }, StatusCodes.BAD_REQUEST, "no_op"],
+  ])("should map the %s outcome to its HTTP response", async (_name, outcome, status, err) => {
+    mocks.setEventSchedule.mockResolvedValueOnce(outcome);
+    const res = await patchSchedule({ startNow: true });
+    expect(res.status).toBe(status);
+    expect((await res.json()).error).toBe(err);
+  });
+
+  it("should surface a schedule error via handleRouteError (5xx)", async () => {
+    mocks.setEventSchedule.mockRejectedValueOnce(new Error("ddb boom"));
+    const res = await patchSchedule({ startNow: true });
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("POST /events/:eventId/end", () => {
+  it("should 404 when the event is not found", async () => {
+    mocks.endEvent.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await postEnd()).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 409 with the current status when not endable", async () => {
+    mocks.endEvent.mockResolvedValueOnce({ kind: "not_endable", status: "DRAFT" });
+    const res = await postEnd();
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    expect(await res.json()).toMatchObject({ error: "not_endable", currentStatus: "DRAFT" });
+  });
+
+  it("should 200 with endsAt + updatedDeployments on success", async () => {
+    mocks.endEvent.mockResolvedValueOnce({
+      kind: "ok",
+      endsAt: "2026-06-01T00:00:00.000Z",
+      updatedDeployments: 2,
+    });
+    const res = await postEnd();
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ endsAt: "2026-06-01T00:00:00.000Z", updatedDeployments: 2 });
+  });
+
+  it("should surface an end error via handleRouteError (5xx)", async () => {
+    mocks.endEvent.mockRejectedValueOnce(new Error("end boom"));
+    expect((await postEnd()).status).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/infrastructure/test/problem-deploy/scoring-routes.test.ts
+++ b/infrastructure/test/problem-deploy/scoring-routes.test.ts
@@ -1,0 +1,136 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: scoring lock / archive routes (routes/scoring.ts) の route 層を pin する。
+ * POST/DELETE /lock-scoring と POST /archive の全 outcome→HTTP 分岐 (not_found / not_lockable /
+ * not_archivable / ok / already idempotent) + error path。 service は mock、 auth は env、
+ * eventId は valid ULID。
+ */
+const mocks = vi.hoisted(() => ({
+  lockScoring: vi.fn(),
+  unlockScoring: vi.fn(),
+  archiveEvent: vi.fn(),
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/lock-scoring", () => ({
+  lockScoring: mocks.lockScoring,
+  unlockScoring: mocks.unlockScoring,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/archive", () => ({
+  archiveEvent: mocks.archiveEvent,
+}));
+
+const { registerScoringRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/scoring"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared。
+const shared = { ddb: { send: vi.fn() } } as any;
+const buildApp = () => {
+  const app = new Hono();
+  registerScoringRoutes(app, shared);
+  return app;
+};
+const req = (method: string, suffix: string) =>
+  buildApp().request(`/events/${EVENT_ID}/${suffix}`, { method });
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /events/:eventId/lock-scoring", () => {
+  it("should 404 when not found", async () => {
+    mocks.lockScoring.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await req("POST", "lock-scoring")).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 409 with currentStatus when not lockable", async () => {
+    mocks.lockScoring.mockResolvedValueOnce({ kind: "not_lockable", status: "DRAFT" });
+    const res = await req("POST", "lock-scoring");
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    expect(await res.json()).toMatchObject({ error: "not_lockable", currentStatus: "DRAFT" });
+  });
+
+  it("should 200 with scoringLockedAt on a fresh lock", async () => {
+    mocks.lockScoring.mockResolvedValueOnce({
+      kind: "ok",
+      scoringLocked: true,
+      scoringLockedAt: "2026-06-01T00:00:00.000Z",
+    });
+    const res = await req("POST", "lock-scoring");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({
+      scoringLocked: true,
+      scoringLockedAt: "2026-06-01T00:00:00.000Z",
+      idempotent: false,
+    });
+  });
+
+  it("should 200 idempotent when already locked", async () => {
+    mocks.lockScoring.mockResolvedValueOnce({ kind: "already", scoringLocked: true });
+    expect((await (await req("POST", "lock-scoring")).json()).idempotent).toBe(true);
+  });
+
+  it("should surface a lock error (5xx)", async () => {
+    mocks.lockScoring.mockRejectedValueOnce(new Error("boom"));
+    expect((await req("POST", "lock-scoring")).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("DELETE /events/:eventId/lock-scoring", () => {
+  it("should 404 when not found", async () => {
+    mocks.unlockScoring.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await req("DELETE", "lock-scoring")).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 409 when not lockable", async () => {
+    mocks.unlockScoring.mockResolvedValueOnce({ kind: "not_lockable", status: "ARCHIVED" });
+    expect((await req("DELETE", "lock-scoring")).status).toBe(StatusCodes.CONFLICT);
+  });
+
+  it("should 200 on unlock and mark idempotent when already unlocked", async () => {
+    mocks.unlockScoring.mockResolvedValueOnce({ kind: "ok", scoringLocked: false });
+    expect((await (await req("DELETE", "lock-scoring")).json()).idempotent).toBe(false);
+    mocks.unlockScoring.mockResolvedValueOnce({ kind: "already", scoringLocked: false });
+    expect((await (await req("DELETE", "lock-scoring")).json()).idempotent).toBe(true);
+  });
+
+  it("should surface an unlock error (5xx)", async () => {
+    mocks.unlockScoring.mockRejectedValueOnce(new Error("boom"));
+    expect((await req("DELETE", "lock-scoring")).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("POST /events/:eventId/archive", () => {
+  it("should 404 when not found", async () => {
+    mocks.archiveEvent.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await req("POST", "archive")).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 409 with currentStatus when not archivable", async () => {
+    mocks.archiveEvent.mockResolvedValueOnce({ kind: "not_archivable", status: "RUNNING" });
+    const res = await req("POST", "archive");
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    expect(await res.json()).toMatchObject({ error: "not_archivable", currentStatus: "RUNNING" });
+  });
+
+  it("should 200 with archivedAt on success", async () => {
+    mocks.archiveEvent.mockResolvedValueOnce({
+      kind: "ok",
+      archivedAt: "2026-06-01T00:00:00.000Z",
+    });
+    const res = await req("POST", "archive");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ archivedAt: "2026-06-01T00:00:00.000Z" });
+  });
+
+  it("should surface an archive error (5xx)", async () => {
+    mocks.archiveEvent.mockRejectedValueOnce(new Error("boom"));
+    expect((await req("POST", "archive")).status).toBeGreaterThanOrEqual(500);
+  });
+});


### PR DESCRIPTION
## Summary
Two route-level unit tests bring `event-handler/routes/lifecycle.ts` (0%) and `routes/scoring.ts` (14% branch) to **100%** statements/branches/functions/lines (28/28 branches), continuing the #1424 infra coverage sweep. Both files are thin HTTP-mapping layers over their services, so the uncovered code was the `outcome.kind` → HTTP status switch arms — the branches a refactor can silently break.

Pattern matches the previously merged `audit-log-routes.test.ts` (#1557): bare `new Hono()` + `register*Routes(app, shared)`, services mocked via `vi.mock`/`vi.hoisted`, auth via `DEFAULT_TENANT_ID` / `DEFAULT_USER_ROLE` env, a valid ULID eventId.

- **lifecycle** (10 cases): invalid body→400, `startNow`→server-ISO resolution, explicit `startsAt` passthrough, every `scheduleOutcomeResponse` arm (`not_found`/`past_starts_at`/`past_ends_at`/`ends_before_starts`/`no_op`/`ok`), `endEvent` `not_found`/`not_endable`/`ok`, and the `handleRouteError` 5xx path.
- **scoring** (16 cases): lock / unlock / archive `not_found`(404) / `not_lockable`·`not_archivable`(409) / `ok`(200) / `already`(idempotent 200), plus each `catch`→5xx path.

## Test plan
- `vitest run lifecycle-routes.test.ts scoring-routes.test.ts --coverage` → 26 passed, 100% on both files (54/54 stmts, 28/28 branches, 8/8 funcs, 53/53 lines).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched, so no runtime behavior can regress. New test files only — no existing test modified, so no collision with in-flight branches editing other test files.
- Tests pin the exact response shapes already shipped (error keys, `currentStatus`, `idempotent`, `updatedDeployments`) rather than asserting a new contract.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test sources are not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)