### PR TITLE
test(infra): cover event-handler disruption routes to 100% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/disruption-routes.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-routes.test.ts
@@ -1,0 +1,196 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: Red Team disruption routes (routes/disruptions.ts, #888 Phase A) の
+ * route 層を pin する。 GET /disruptions, GET /disruptions/audit, POST /disruptions/fire の
+ * ownership guard (requireEventOwnership)・ parseLimit・ 全 fire outcome→HTTP 分岐・ error path。
+ *
+ * disruption-fire module 全体を mock: service 3 本 (catalog / audit / fire) に加え、
+ * route-helpers の requireEventOwnership が内部で呼ぶ isEventOwnedByTenant も差し替える
+ * (同 module export なので 1 つの vi.mock で両方を制御できる)。
+ */
+const mocks = vi.hoisted(() => ({
+  fireDisruption: vi.fn(),
+  listDisruptionAudit: vi.fn(),
+  listDisruptionCatalog: vi.fn(),
+  isEventOwnedByTenant: vi.fn(),
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/disruption-fire", () => ({
+  fireDisruption: mocks.fireDisruption,
+  listDisruptionAudit: mocks.listDisruptionAudit,
+  listDisruptionCatalog: mocks.listDisruptionCatalog,
+  isEventOwnedByTenant: mocks.isEventOwnedByTenant,
+}));
+
+const { registerDisruptionRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/disruptions"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared (service / ownership とも mock)。
+const shared = { ddb: { send: vi.fn() }, eventsTableName: "events" } as any;
+const buildApp = () => {
+  const app = new Hono();
+  registerDisruptionRoutes(app, shared);
+  return app;
+};
+const get = (suffix: string) => buildApp().request(`/events/${EVENT_ID}/disruptions${suffix}`);
+const fire = (body: unknown) =>
+  buildApp().request(`/events/${EVENT_ID}/disruptions/fire`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+const validFireBody = {
+  disruptionId: "d1",
+  problemId: "p1",
+  scope: "all",
+  requestId: "req-12345678",
+};
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isEventOwnedByTenant.mockResolvedValue(true); // default: owned
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("GET /events/:eventId/disruptions", () => {
+  it("should 404 when the event is not owned by the tenant", async () => {
+    mocks.isEventOwnedByTenant.mockResolvedValueOnce(false);
+    expect((await get("")).status).toBe(StatusCodes.NOT_FOUND);
+    expect(mocks.listDisruptionCatalog).not.toHaveBeenCalled();
+  });
+
+  it("should 200 with the catalog when owned", async () => {
+    mocks.listDisruptionCatalog.mockResolvedValueOnce({ disruptions: [] });
+    const res = await get("");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ disruptions: [] });
+  });
+
+  it("should surface a catalog error (5xx)", async () => {
+    mocks.listDisruptionCatalog.mockRejectedValueOnce(new Error("boom"));
+    expect((await get("")).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("GET /events/:eventId/disruptions/audit", () => {
+  it("should 400 on an invalid limit before touching ownership", async () => {
+    const res = await get("/audit?limit=0");
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect((await res.json()).error).toBe("invalid_limit");
+    expect(mocks.isEventOwnedByTenant).not.toHaveBeenCalled();
+  });
+
+  it("should 404 when not owned", async () => {
+    mocks.isEventOwnedByTenant.mockResolvedValueOnce(false);
+    expect((await get("/audit")).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 200 and pass limit + cursor through to the service", async () => {
+    mocks.listDisruptionAudit.mockResolvedValueOnce({ items: [], cursor: null });
+    const res = await get("/audit?limit=5&cursor=abc");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.listDisruptionAudit).toHaveBeenCalledWith(shared, EVENT_ID, {
+      limit: 5,
+      cursor: "abc",
+    });
+  });
+
+  it("should default limit to undefined when omitted", async () => {
+    mocks.listDisruptionAudit.mockResolvedValueOnce({ items: [] });
+    await get("/audit");
+    expect(mocks.listDisruptionAudit.mock.calls[0][2]).toMatchObject({ limit: undefined });
+  });
+
+  it("should surface an audit error (5xx)", async () => {
+    mocks.listDisruptionAudit.mockRejectedValueOnce(new Error("boom"));
+    expect((await get("/audit")).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("POST /events/:eventId/disruptions/fire", () => {
+  it("should 400 on an invalid body", async () => {
+    const res = await fire({ scope: "team" }); // missing required fields
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.fireDisruption).not.toHaveBeenCalled();
+  });
+
+  it("should 404 when not owned", async () => {
+    mocks.isEventOwnedByTenant.mockResolvedValueOnce(false);
+    expect((await fire(validFireBody)).status).toBe(StatusCodes.NOT_FOUND);
+    expect(mocks.fireDisruption).not.toHaveBeenCalled();
+  });
+
+  it("should 201 on ok and apply parameter/target defaults for scope=all", async () => {
+    mocks.fireDisruption.mockResolvedValueOnce({ kind: "ok", result: { fired: 3 } });
+    const res = await fire(validFireBody);
+    expect(res.status).toBe(StatusCodes.CREATED);
+    expect(await res.json()).toEqual({ fired: 3 });
+    // parameters ?? {} と targetTeamIds ?? [] の default 経路。
+    const call = mocks.fireDisruption.mock.calls[0][1];
+    expect(call.parameters).toEqual({});
+    expect(call.targetTeamIds).toEqual([]);
+    expect(call.randomCount).toBeUndefined();
+  });
+
+  it("should 200 on duplicate and pass explicit parameters + targetTeamIds (scope=team)", async () => {
+    mocks.fireDisruption.mockResolvedValueOnce({ kind: "duplicate", result: { fired: 0 } });
+    const res = await fire({
+      ...validFireBody,
+      scope: "team",
+      parameters: { latencyMs: 100 },
+      targetTeamIds: ["team-1"],
+    });
+    expect(res.status).toBe(StatusCodes.OK);
+    const call = mocks.fireDisruption.mock.calls[0][1];
+    expect(call.parameters).toEqual({ latencyMs: 100 });
+    expect(call.targetTeamIds).toEqual(["team-1"]);
+  });
+
+  it("should include randomCount when scope=random-n", async () => {
+    mocks.fireDisruption.mockResolvedValueOnce({ kind: "unknown_problem" });
+    await fire({ ...validFireBody, scope: "random-n", randomCount: 2 });
+    expect(mocks.fireDisruption.mock.calls[0][1].randomCount).toBe(2);
+  });
+
+  it.each([
+    ["unknown_problem", { kind: "unknown_problem" }, StatusCodes.BAD_REQUEST, "unknown_problem"],
+    [
+      "unknown_disruption",
+      { kind: "unknown_disruption" },
+      StatusCodes.BAD_REQUEST,
+      "unknown_disruption",
+    ],
+    [
+      "invalid_parameters",
+      { kind: "invalid_parameters", reason: "bad" },
+      StatusCodes.BAD_REQUEST,
+      "invalid_parameters",
+    ],
+    [
+      "invalid_scope",
+      { kind: "invalid_scope", reason: "bad" },
+      StatusCodes.BAD_REQUEST,
+      "invalid_scope",
+    ],
+    ["no_targets", { kind: "no_targets" }, StatusCodes.CONFLICT, "no_targets"],
+    ["default", { kind: "unexpected_kind" }, StatusCodes.INTERNAL_SERVER_ERROR, "internal_error"],
+  ])("should map the %s outcome to its HTTP response", async (_name, outcome, status, err) => {
+    mocks.fireDisruption.mockResolvedValueOnce(outcome);
+    const res = await fire(validFireBody);
+    expect(res.status).toBe(status);
+    expect((await res.json()).error).toBe(err);
+  });
+
+  it("should surface a fire error (5xx)", async () => {
+    mocks.fireDisruption.mockRejectedValueOnce(new Error("boom"));
+    expect((await fire(validFireBody)).status).toBeGreaterThanOrEqual(500);
+  });
+});


### PR DESCRIPTION
## Summary
Brings `event-handler/routes/disruptions.ts` (Red Team injection, #888 Phase A) from 13% to **100%** statements/branches/functions/lines (24/24 branches), continuing the #1424 infra coverage sweep. The route is a tenant-ownership guard + outcome-mapping layer over the disruption-fire services, so the uncovered code was exactly the guard / parseLimit / `fireDisruption` outcome→status arms.

The whole `disruption-fire` module is mocked, which also drives `requireEventOwnership` — it internally calls the mocked `isEventOwnedByTenant` (same module export), so one `vi.mock` controls both the ownership guard and the three services. Auth via `DEFAULT_TENANT_ID` / `DEFAULT_USER_ROLE` env, valid ULID eventId. Same pattern as the just-merged lifecycle/scoring tests (#1558) and `audit-log-routes.test.ts` (#1557).

- **GET /disruptions**: not-owned→404, owned→200, service throw→5xx.
- **GET /disruptions/audit**: invalid limit→400 (before ownership), not-owned→404, limit+cursor passthrough, omitted-limit→`undefined`, service throw→5xx.
- **POST /disruptions/fire**: invalid body→400, not-owned→404, every outcome arm (`ok`→201 / `duplicate`→200 / `unknown_problem` / `unknown_disruption` / `invalid_parameters` / `invalid_scope`→400 / `no_targets`→409 / `default`→500), the `parameters ?? {}` / `targetTeamIds ?? []` defaults, the `randomCount` conditional-spread branch, and catch→5xx.

## Test plan
- `vitest run disruption-routes.test.ts --coverage` → 20 passed, 100% (44/44 stmts, 24/24 branches, 5/5 funcs, 39/39 lines).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched, so no runtime behavior can regress. New test file only — no existing test modified, no collision with in-flight branches.
- Tests pin the shipped response shapes and the post-default service call arguments rather than asserting new behavior.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)