### PR TITLE
test(infra): cover event-handler CRUD/bulk-deploy/notification routes to 100% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/bulk-deploy-routes.test.ts
+++ b/infrastructure/test/problem-deploy/bulk-deploy-routes.test.ts
@@ -1,0 +1,74 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: bulk-deploy fan-out route (routes/bulk-deploy.ts, #555)。
+ * POST /events/:eventId/deploy。 body は opt-in (空 body = bulk-all)。
+ * 空 body / 不正 body / not_found / accepted / error の分岐を pin する。
+ */
+const mocks = vi.hoisted(() => ({ bulkDeployEvent: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/bulk-deploy", () => ({
+  bulkDeployEvent: mocks.bulkDeployEvent,
+}));
+
+const { registerBulkDeployRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/bulk-deploy"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared。
+const shared = { ddb: { send: vi.fn() } } as any;
+const deploy = (body?: unknown) => {
+  const app = new Hono();
+  registerBulkDeployRoutes(app, shared);
+  const init: RequestInit =
+    body === undefined
+      ? { method: "POST" }
+      : {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        };
+  return app.request(`/events/${EVENT_ID}/deploy`, init);
+};
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /events/:eventId/deploy", () => {
+  it("should treat an empty body as bulk-all and 202 with the result", async () => {
+    mocks.bulkDeployEvent.mockResolvedValueOnce({ kind: "ok", result: { queued: 6 } });
+    const res = await deploy(); // no body
+    expect(res.status).toBe(StatusCodes.ACCEPTED);
+    expect(await res.json()).toEqual({ queued: 6 });
+    // empty body → parsed.data is {} (parseOptionalJsonBody default).
+    expect(mocks.bulkDeployEvent.mock.calls[0][4]).toEqual({});
+  });
+
+  it("should pass a provided filter body through to the service", async () => {
+    mocks.bulkDeployEvent.mockResolvedValueOnce({ kind: "ok", result: { queued: 1 } });
+    await deploy({ retryFailedOnly: true });
+    expect(mocks.bulkDeployEvent.mock.calls[0][4]).toMatchObject({ retryFailedOnly: true });
+  });
+
+  it("should 400 on an invalid body", async () => {
+    const res = await deploy({ retryFailedOnly: true, forceRedeploy: true }); // mutually exclusive
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.bulkDeployEvent).not.toHaveBeenCalled();
+  });
+
+  it("should 404 when the event is not found", async () => {
+    mocks.bulkDeployEvent.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await deploy()).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should surface a bulkDeployEvent error (5xx)", async () => {
+    mocks.bulkDeployEvent.mockRejectedValueOnce(new Error("boom"));
+    expect((await deploy()).status).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/infrastructure/test/problem-deploy/event-crud-routes.test.ts
+++ b/infrastructure/test/problem-deploy/event-crud-routes.test.ts
@@ -1,0 +1,179 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: event CRUD + bulk-teardown routes (routes/events.ts)。
+ * POST /events, GET /events, GET /events/:id, DELETE /events/:id の
+ * validation / duplicate / pagination / role-gated login-key / not_found / error 分岐。
+ *
+ * create module は importOriginal で error class (Duplicate*) を実体のまま残しつつ
+ * createEvent だけ mock 化する (= route の `err instanceof Duplicate*` を本物の class で判定)。
+ */
+const mocks = vi.hoisted(() => ({
+  createEvent: vi.fn(),
+  listEvents: vi.fn(),
+  getEventDetail: vi.fn(),
+  bulkTeardownEvent: vi.fn(),
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/create", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../lib/problem-deploy/handlers/event-handler/create")>();
+  return { ...actual, createEvent: mocks.createEvent };
+});
+vi.mock("../../lib/problem-deploy/handlers/event-handler/list", () => ({
+  listEvents: mocks.listEvents,
+  getEventDetail: mocks.getEventDetail,
+}));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/bulk-delete", () => ({
+  bulkTeardownEvent: mocks.bulkTeardownEvent,
+}));
+
+const { registerEventRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/events"
+);
+const { DuplicateInternalSlugError, DuplicateProblemIdError } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/create"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared。
+const shared = { ddb: { send: vi.fn() } } as any;
+const buildApp = () => {
+  const app = new Hono();
+  registerEventRoutes(app, shared);
+  return app;
+};
+const postEvent = (body: unknown) =>
+  buildApp().request("/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+const getEvents = (query = "") => buildApp().request(`/events${query}`);
+const getDetail = (query = "") => buildApp().request(`/events/${EVENT_ID}${query}`);
+const deleteEvent = () => buildApp().request(`/events/${EVENT_ID}`, { method: "DELETE" });
+const validCreateBody = {
+  name: "Spring Cup",
+  teams: [{ internalSlug: "team-a", awsAccountId: "123456789012" }],
+  problems: [{ problemId: "p-1", defaultRegion: "ap-northeast-1" }],
+};
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin"; // restore after per-test role overrides
+});
+
+describe("POST /events", () => {
+  it("should 400 on an invalid body", async () => {
+    const res = await postEvent({ name: "" }); // missing teams/problems
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.createEvent).not.toHaveBeenCalled();
+  });
+
+  it("should 201 with the created event", async () => {
+    mocks.createEvent.mockResolvedValueOnce({ eventId: "evt-1" });
+    const res = await postEvent(validCreateBody);
+    expect(res.status).toBe(StatusCodes.CREATED);
+    expect(await res.json()).toEqual({ eventId: "evt-1" });
+  });
+
+  it("should 400 with duplicate_internal_slug on DuplicateInternalSlugError", async () => {
+    mocks.createEvent.mockRejectedValueOnce(new DuplicateInternalSlugError("team-a"));
+    const res = await postEvent(validCreateBody);
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(await res.json()).toEqual({ error: "duplicate_internal_slug", slug: "team-a" });
+  });
+
+  it("should 400 with duplicate_problem_id on DuplicateProblemIdError", async () => {
+    mocks.createEvent.mockRejectedValueOnce(new DuplicateProblemIdError("p-1"));
+    const res = await postEvent(validCreateBody);
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(await res.json()).toEqual({ error: "duplicate_problem_id", problemId: "p-1" });
+  });
+
+  it("should surface an unexpected createEvent error (5xx)", async () => {
+    mocks.createEvent.mockRejectedValueOnce(new Error("boom"));
+    expect((await postEvent(validCreateBody)).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("GET /events", () => {
+  it("should 400 on an invalid limit", async () => {
+    const res = await getEvents("?limit=0");
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect((await res.json()).error).toBe("invalid_limit");
+  });
+
+  it("should 200 and pass limit + cursor to listEvents", async () => {
+    mocks.listEvents.mockResolvedValueOnce({ events: [], cursor: null });
+    const res = await getEvents("?limit=10&cursor=tok");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.listEvents).toHaveBeenCalledWith(shared, {
+      tenantId: "tenant-test",
+      limit: 10,
+      cursor: "tok",
+    });
+  });
+
+  it("should surface a listEvents error (5xx)", async () => {
+    mocks.listEvents.mockRejectedValueOnce(new Error("boom"));
+    expect((await getEvents()).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("GET /events/:eventId", () => {
+  it("should 404 when the detail is not found", async () => {
+    mocks.getEventDetail.mockResolvedValueOnce(null);
+    expect((await getDetail()).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should include login keys + score events for a mutating role with withScoreEvents=true", async () => {
+    mocks.getEventDetail.mockResolvedValueOnce({ eventId: EVENT_ID });
+    const res = await getDetail("?withScoreEvents=true");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.getEventDetail).toHaveBeenCalledWith(shared, "tenant-test", EVENT_ID, {
+      withScoreEvents: true,
+      includeLoginKeys: true,
+    });
+  });
+
+  it("should withhold login keys for a read-only viewer role", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantViewer";
+    mocks.getEventDetail.mockResolvedValueOnce({ eventId: EVENT_ID });
+    await getDetail();
+    expect(mocks.getEventDetail.mock.calls[0][3]).toEqual({
+      withScoreEvents: false,
+      includeLoginKeys: false,
+    });
+  });
+
+  it("should surface a getEventDetail error (5xx)", async () => {
+    mocks.getEventDetail.mockRejectedValueOnce(new Error("boom"));
+    expect((await getDetail()).status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("DELETE /events/:eventId", () => {
+  it("should 404 when the event is not found", async () => {
+    mocks.bulkTeardownEvent.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await deleteEvent()).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 202 with the teardown result", async () => {
+    mocks.bulkTeardownEvent.mockResolvedValueOnce({ kind: "ok", result: { teardown: 4 } });
+    const res = await deleteEvent();
+    expect(res.status).toBe(StatusCodes.ACCEPTED);
+    expect(await res.json()).toEqual({ teardown: 4 });
+  });
+
+  it("should surface a bulkTeardownEvent error (5xx)", async () => {
+    mocks.bulkTeardownEvent.mockRejectedValueOnce(new Error("boom"));
+    expect((await deleteEvent()).status).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/infrastructure/test/problem-deploy/notification-routes.test.ts
+++ b/infrastructure/test/problem-deploy/notification-routes.test.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: operator→competitor notification route (routes/notifications.ts, ADR-006)。
+ * POST /events/:eventId/notifications の body-validation / not_found / created / error 分岐。
+ */
+const mocks = vi.hoisted(() => ({ createNotification: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/create-notification", () => ({
+  createNotification: mocks.createNotification,
+}));
+
+const { registerNotificationRoutes } = await import(
+  "../../lib/problem-deploy/handlers/event-handler/routes/notifications"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// biome-ignore lint/suspicious/noExplicitAny: 最小 shared。
+const shared = { ddb: { send: vi.fn() } } as any;
+const post = (body: unknown) => {
+  const app = new Hono();
+  registerNotificationRoutes(app, shared);
+  return app.request(`/events/${EVENT_ID}/notifications`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+};
+const validBody = { title: "Heads up", body: "The arena resets in 5 minutes." };
+
+beforeAll(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /events/:eventId/notifications", () => {
+  it("should 400 on an invalid body", async () => {
+    const res = await post({ title: "" }); // empty title + missing body
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("should 404 when the event is not found", async () => {
+    mocks.createNotification.mockResolvedValueOnce({ kind: "not_found" });
+    expect((await post(validBody)).status).toBe(StatusCodes.NOT_FOUND);
+  });
+
+  it("should 201 with notificationId + occurredAt on success", async () => {
+    mocks.createNotification.mockResolvedValueOnce({
+      kind: "ok",
+      notificationId: "ntf-1",
+      occurredAt: "2026-06-01T00:00:00.000Z",
+    });
+    const res = await post(validBody);
+    expect(res.status).toBe(StatusCodes.CREATED);
+    expect(await res.json()).toEqual({
+      notificationId: "ntf-1",
+      occurredAt: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("should surface a createNotification error (5xx)", async () => {
+    mocks.createNotification.mockRejectedValueOnce(new Error("boom"));
+    expect((await post(validBody)).status).toBeGreaterThanOrEqual(500);
+  });
+});


### PR DESCRIPTION
## Summary
Brings the remaining three `event-handler/routes/*` files to **100%** coverage, completing the route sweep (all 7 route files now 100%) and advancing the #1424 infra coverage effort:

| file | before (branch) | after |
| --- | --- | --- |
| `routes/events.ts` | 41% | 100% |
| `routes/bulk-deploy.ts` | 50% | 100% |
| `routes/notifications.ts` | 0% | 100% |

Each is a thin validation + outcome-mapping layer over its services, so the gaps were the duplicate-slug / duplicate-problem error arms, the pagination invalid-limit guard, the role-gated login-key branch, and the not_found / accepted / created / error arms. Same bare-Hono + mocked-service + env-auth pattern as #1558 / #1559.

- **events.ts**: POST invalid→400 / created→201 / `DuplicateInternalSlugError`→400 / `DuplicateProblemIdError`→400 / unexpected→5xx; GET list invalid-limit→400 / limit+cursor passthrough→200 / error→5xx; GET detail not_found→404 / mutating-role includes login keys + score events / viewer role **withholds** them / error→5xx; DELETE not_found→404 / accepted→202 / error→5xx. The create module is mocked via `importOriginal` so the real `Duplicate*` error classes survive while only `createEvent` is stubbed (the route's `instanceof` checks stay valid).
- **bulk-deploy.ts**: empty body→bulk-all 202 / filter-body passthrough / invalid (mutually-exclusive flags)→400 / not_found→404 / error→5xx.
- **notifications.ts**: invalid body→400 / not_found→404 / created→201 / error→5xx.

## Test plan
- `vitest run {notification,bulk-deploy,event-crud}-routes.test.ts --coverage` → 24 passed, 100% (54/54 stmts, 20/20 branches, 9/9 funcs, 50/50 lines).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched, so no runtime behavior can regress. New test files only — no existing test modified, no collision with in-flight branches.
- Tests pin the exact shipped response shapes and the post-validation service call arguments (tenantId, limit, cursor, includeLoginKeys) rather than asserting new behavior.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test sources are not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for bulk deployment routes, including empty body handling and filter validation scenarios.
  * Added test coverage for event CRUD routes covering creation, retrieval, and deletion with request validation and role-based access control.
  * Added test coverage for notification routes with request body validation and error condition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->