### PR TITLE
test(infra): cover competitor-accounts app routes to 97% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/competitor-accounts-index.test.ts
+++ b/infrastructure/test/problem-deploy/competitor-accounts-index.test.ts
@@ -1,0 +1,324 @@
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: competitor-accounts-handler の Hono app (index.ts, ADR-002 Phase 2.1) を
+ * route-wiring 層として pin する。 既存の competitor-accounts-routes.test.ts は CRUD happy +
+ * 一部 error を見ているが、 SAML config 4 route / onError (MissingTenantClaim / Forbidden+audit /
+ * generic) / 各 internal_error 枝 / ExternalIdMissing が未カバーで 55% branch だった。
+ *
+ * store / verify は importOriginal で実 error class を残しつつ関数だけ mock。 saml-routes /
+ * audit-log は mock。 auth は実物 (env-driven: DEFAULT_TENANT_ID / DEFAULT_USER_ROLE)。
+ */
+const mocks = vi.hoisted(() => ({
+  createCompetitorAccount: vi.fn(),
+  listCompetitorAccounts: vi.fn(),
+  deleteCompetitorAccount: vi.fn(),
+  verifyCompetitorAccount: vi.fn(),
+  routeGet: vi.fn(),
+  routePut: vi.fn(),
+  routeDelete: vi.fn(),
+  writeAuditEvent: vi.fn(),
+}));
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/shared", () => ({
+  buildCompetitorAccountsSharedResources: () => ({
+    tableName: "TestCompetitorAccounts",
+    env: "development",
+    tenkaCloudAccountId: "111111111111",
+    ddb: { send: vi.fn() },
+    ssm: { send: vi.fn() },
+    sts: { send: vi.fn() },
+  }),
+}));
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/store", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  createCompetitorAccount: mocks.createCompetitorAccount,
+  listCompetitorAccounts: mocks.listCompetitorAccounts,
+  deleteCompetitorAccount: mocks.deleteCompetitorAccount,
+}));
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/verify", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  verifyCompetitorAccount: mocks.verifyCompetitorAccount,
+}));
+vi.mock("../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes", () => ({
+  routeGet: mocks.routeGet,
+  routePut: mocks.routePut,
+  routeDelete: mocks.routeDelete,
+}));
+vi.mock("../../lib/problem-deploy/handlers/shared/audit-log", () => ({
+  extractAuditContext: () => ({
+    actor: "sub-1",
+    actorUsername: "admin@example.com",
+    ipAddress: "127.0.0.1",
+    userAgent: "vitest",
+  }),
+  writeAuditEvent: mocks.writeAuditEvent,
+}));
+
+const { app } = await import("../../lib/problem-deploy/handlers/competitor-accounts-handler/index");
+const { DuplicateCompetitorAccountError, CompetitorAccountNotFoundError } = await import(
+  "../../lib/problem-deploy/handlers/competitor-accounts-handler/store"
+);
+const { ExternalIdMissingError, AssumeRoleSanityCheckFailedError } = await import(
+  "../../lib/problem-deploy/handlers/competitor-accounts-handler/verify"
+);
+
+const ACCT = "123456789012";
+const validCreate = { awsAccountId: ACCT, competitorRoleName: "TenkaCloud-deploy-Role" };
+const json = (method: string, path: string, body?: unknown) =>
+  app.request(path, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+  mocks.writeAuditEvent.mockResolvedValue(undefined);
+  mocks.routeGet.mockResolvedValue({ status: 200, body: { enabled: false } });
+  mocks.routePut.mockResolvedValue({ status: 200, body: { enabled: true } });
+  mocks.routeDelete.mockResolvedValue({ status: 200, body: { deleted: true } });
+});
+afterEach(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+  vi.clearAllMocks();
+});
+
+describe("healthz + /admin/* role middleware", () => {
+  it("should serve healthz without a role check", async () => {
+    const res = await app.request("/admin/competitor-accounts/healthz");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("should 403 + audit a known-role mismatch (resolveTenantId succeeds)", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantUser"; // not in TENANT_ROLES
+    const res = await json("POST", "/admin/competitor-accounts", validCreate);
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    expect((await res.json()).error).toBe("forbidden_role");
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "forbidden", tenantId: "tenant-test" }),
+    );
+  });
+
+  it("should still audit as 'unknown' tenant when the claim is also missing", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantUser";
+    delete process.env.DEFAULT_TENANT_ID;
+    const res = await app.request("/admin/competitor-accounts");
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "forbidden", tenantId: "unknown" }),
+    );
+  });
+
+  it("should 403 with actualRole '(none)' when no role claim is present", async () => {
+    delete process.env.DEFAULT_USER_ROLE;
+    const res = await app.request("/admin/competitor-accounts");
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ extra: expect.objectContaining({ actualRole: "(none)" }) }),
+    );
+  });
+
+  it("should 401 missing_tenant_claim when resolveTenantId throws outside a try (POST create)", async () => {
+    // POST create resolves tenantId at the top level (outside the try), so a missing claim
+    // propagates to app.onError rather than the route's local 500 catch.
+    delete process.env.DEFAULT_TENANT_ID; // role ok, tenant claim absent
+    const res = await json("POST", "/admin/competitor-accounts", validCreate);
+    expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
+    expect((await res.json()).error).toBe("missing_tenant_claim");
+    expect(mocks.createCompetitorAccount).not.toHaveBeenCalled();
+  });
+
+  it("should 500 internal_error on an uncaught handler throw (SAML route)", async () => {
+    mocks.routeGet.mockRejectedValueOnce(new Error("boom"));
+    const res = await app.request("/admin/tenant-saml-config");
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect((await res.json()).error).toBe("internal_error");
+  });
+});
+
+describe("SAML config routes", () => {
+  it("should GET the SAML config", async () => {
+    const res = await app.request("/admin/tenant-saml-config");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.routeGet).toHaveBeenCalledTimes(1);
+  });
+  it("should PATCH the SAML config", async () => {
+    const res = await json("PATCH", "/admin/tenant-saml-config", { metadataUrl: "https://x" });
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.routePut).toHaveBeenCalledTimes(1);
+  });
+  it("should PUT the SAML config", async () => {
+    const res = await json("PUT", "/admin/tenant-saml-config", { metadataUrl: "https://x" });
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.routePut).toHaveBeenCalledTimes(1);
+  });
+  it("should DELETE the SAML config", async () => {
+    const res = await json("DELETE", "/admin/tenant-saml-config");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(mocks.routeDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /admin/competitor-accounts", () => {
+  it("should 400 invalid_body on malformed JSON", async () => {
+    const res = await app.request("/admin/competitor-accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect((await res.json()).error).toBe("invalid_body");
+  });
+
+  it("should 400 validation_failed on a bad account id", async () => {
+    const res = await json("POST", "/admin/competitor-accounts", {
+      awsAccountId: "abc",
+      competitorRoleName: "R",
+    });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect((await res.json()).error).toBe("validation_failed");
+  });
+
+  it("should 201 + write a success audit on create", async () => {
+    mocks.createCompetitorAccount.mockResolvedValueOnce({ awsAccountId: ACCT, externalId: "ext" });
+    const res = await json("POST", "/admin/competitor-accounts", validCreate);
+    expect(res.status).toBe(StatusCodes.CREATED);
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "create_competitor_account", outcome: "success" }),
+    );
+  });
+
+  it("should 409 + conflict audit on a duplicate", async () => {
+    mocks.createCompetitorAccount.mockRejectedValueOnce(new DuplicateCompetitorAccountError(ACCT));
+    const res = await json("POST", "/admin/competitor-accounts", validCreate);
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    expect((await res.json()).error).toBe("duplicate_account");
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "conflict" }),
+    );
+  });
+
+  it("should 500 on an unexpected create error", async () => {
+    mocks.createCompetitorAccount.mockRejectedValueOnce(new Error("ssm down"));
+    const res = await json("POST", "/admin/competitor-accounts", validCreate);
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
+
+  it("should 500 on a non-Error create rejection ('unknown error' branch)", async () => {
+    mocks.createCompetitorAccount.mockRejectedValueOnce("plain create fail");
+    expect((await json("POST", "/admin/competitor-accounts", validCreate)).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+});
+
+describe("GET /admin/competitor-accounts", () => {
+  it("should 200 with the listing", async () => {
+    mocks.listCompetitorAccounts.mockResolvedValueOnce([{ awsAccountId: ACCT }]);
+    const res = await app.request("/admin/competitor-accounts");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect((await res.json()).items).toHaveLength(1);
+  });
+
+  it("should 500 on a list error", async () => {
+    mocks.listCompetitorAccounts.mockRejectedValueOnce(new Error("ddb down"));
+    expect((await app.request("/admin/competitor-accounts")).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+
+  it("should 500 on a non-Error list rejection ('unknown error' branch)", async () => {
+    mocks.listCompetitorAccounts.mockRejectedValueOnce("plain list fail");
+    expect((await app.request("/admin/competitor-accounts")).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+});
+
+describe("POST /admin/competitor-accounts/:awsAccountId/verify", () => {
+  it("should 400 on an invalid account id", async () => {
+    expect((await json("POST", "/admin/competitor-accounts/abc/verify")).status).toBe(
+      StatusCodes.BAD_REQUEST,
+    );
+  });
+  it("should 200 on a successful verify", async () => {
+    mocks.verifyCompetitorAccount.mockResolvedValueOnce({ awsAccountId: ACCT, verified: true });
+    const res = await json("POST", `/admin/competitor-accounts/${ACCT}/verify`);
+    expect(res.status).toBe(StatusCodes.OK);
+    expect((await res.json()).verified).toBe(true);
+  });
+  it("should 404 when the account is not found", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(new CompetitorAccountNotFoundError(ACCT));
+    expect((await json("POST", `/admin/competitor-accounts/${ACCT}/verify`)).status).toBe(
+      StatusCodes.NOT_FOUND,
+    );
+  });
+  it("should 409 when the ExternalId is missing", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(new ExternalIdMissingError("tenant-test"));
+    const res = await json("POST", `/admin/competitor-accounts/${ACCT}/verify`);
+    expect(res.status).toBe(StatusCodes.CONFLICT);
+    expect((await res.json()).error).toBe("external_id_missing");
+  });
+  it("should 422 + underlyingErrorName when AssumeRole fails", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(
+      new AssumeRoleSanityCheckFailedError(ACCT, "AccessDenied", "denied"),
+    );
+    const res = await json("POST", `/admin/competitor-accounts/${ACCT}/verify`);
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+    expect((await res.json()).underlyingErrorName).toBe("AccessDenied");
+  });
+  it("should 500 on an unexpected verify error", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce(new Error("sts down"));
+    expect((await json("POST", `/admin/competitor-accounts/${ACCT}/verify`)).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+
+  it("should 500 on a non-Error verify rejection ('unknown error' branch)", async () => {
+    mocks.verifyCompetitorAccount.mockRejectedValueOnce("plain verify fail");
+    expect((await json("POST", `/admin/competitor-accounts/${ACCT}/verify`)).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+});
+
+describe("DELETE /admin/competitor-accounts/:awsAccountId", () => {
+  it("should 400 on an invalid account id", async () => {
+    expect((await json("DELETE", "/admin/competitor-accounts/abc")).status).toBe(
+      StatusCodes.BAD_REQUEST,
+    );
+  });
+  it("should 200 + write a success audit on delete", async () => {
+    mocks.deleteCompetitorAccount.mockResolvedValueOnce(undefined);
+    const res = await json("DELETE", `/admin/competitor-accounts/${ACCT}`);
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ deleted: true });
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "delete_competitor_account", outcome: "success" }),
+    );
+  });
+  it("should 404 when the account is not found", async () => {
+    mocks.deleteCompetitorAccount.mockRejectedValueOnce(new CompetitorAccountNotFoundError(ACCT));
+    expect((await json("DELETE", `/admin/competitor-accounts/${ACCT}`)).status).toBe(
+      StatusCodes.NOT_FOUND,
+    );
+  });
+  it("should 500 on an unexpected delete error", async () => {
+    mocks.deleteCompetitorAccount.mockRejectedValueOnce(new Error("ddb down"));
+    expect((await json("DELETE", `/admin/competitor-accounts/${ACCT}`)).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+
+  it("should 500 on a non-Error delete rejection ('unknown error' branch)", async () => {
+    mocks.deleteCompetitorAccount.mockRejectedValueOnce("plain delete fail");
+    expect((await json("DELETE", `/admin/competitor-accounts/${ACCT}`)).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
`competitor-accounts-handler/index.ts` (Competitor Accounts API Lambda, ADR-002 Phase 2.1) was at **55% branch**. The existing `competitor-accounts-routes.test.ts` covers CRUD happy paths and some errors but never exercised the **4 SAML-config routes**, the `app.onError` branches, the `ExternalIdMissing` arm, or the `internal_error` catches: **55% → 97.36%** (100% stmts/funcs/lines, 37/38 branches).

31 cases import `app`, mock `store`/`verify` via `importOriginal` (real error classes survive for the handler's `instanceof` checks), plus `saml-routes` and `audit-log`, with auth **real** (env-driven). Coverage:
- **onError**: `MissingTenantClaim`→401 (via POST create's pre-`try` `resolveTenantId`), `ForbiddenRole`→403 + audit in three shapes (known tenant / `unknown` tenant when the claim is also absent / `actualRole "(none)"`), and the generic 500 via an uncaught SAML-route throw.
- **/admin/\* middleware**: healthz skip, role-mismatch rejection.
- **SAML config** GET/PATCH/PUT/DELETE delegation.
- **POST create**: invalid_body / validation_failed / 201 + success audit / 409 duplicate + conflict audit / 500 (Error + non-Error).
- **GET list**: 200 / 500 (Error + non-Error).
- **POST verify**: invalid id / 200 / 404 / 409 ExternalIdMissing / 422 + underlyingErrorName / 500 (Error + non-Error).
- **DELETE**: invalid id / 200 + success audit / 404 / 500 (Error + non-Error).

### The one remaining branch (97.36%, not a gap I can close test-only)
The uncovered branch is the onError generic `err instanceof Error ? err.message : "unknown error"` **else-arm**. Hono routes only `Error` instances to `app.onError` — non-Error throws are rethrown by the framework — so that defensive fallback is **unreachable through the handler** (verified empirically). Closing it to 100% needs a one-line `/* v8 ignore */` on the handler source, which is owner-owned infra-lib; per the infra role split this PR stays **test-only** and leaves that to the owner.

## Test plan
- `vitest run competitor-accounts-index.test.ts --coverage` → 31 passed, 100% stmts/funcs/lines, 97.36% branch (37/38).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched, so no runtime behavior can regress. New test file only; the pre-existing `competitor-accounts-routes.test.ts` is untouched, and vitest isolates module mocks per file.
- Tests pin the shipped status mapping, audit-event shapes, and error codes rather than asserting new behavior.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)