### PR TITLE
test(infra): cover event-handler app wiring to 87% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/event-handler-index.test.ts
+++ b/infrastructure/test/problem-deploy/event-handler-index.test.ts
@@ -1,0 +1,78 @@
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: event-handler の Hono app (index.ts) の wiring 層 (cors / onError 3 枝 /
+ * /events/* role middleware / healthz) を pin する。 routes/* は各 route test で 100% だが、
+ * この index.ts の onError MissingTenantClaim 枝と healthz-skip 枝が未カバーで 62% branch だった。
+ *
+ * onError の 3 枝は try/catch を経由しない top-level throwing route で踏む
+ * (handler-error-cors.test.ts と同手法。 `/events/*` 配下に置くと `/events/:eventId` と衝突して
+ * 400 になるため top-level に置く)。 ForbiddenRole + middleware は実 `/events/:eventId` 経路で踏む。
+ * buildEventSharedResources のみ mock。
+ */
+vi.mock("../../lib/problem-deploy/handlers/event-handler/shared", () => ({
+  buildEventSharedResources: () => ({
+    eventsTableName: "TestEvents",
+    teamsTableName: "TestTeams",
+    deploymentsTableName: "TestDeployments",
+    eventBusName: "test-bus",
+    ddb: { send: vi.fn() },
+    events: { send: vi.fn() },
+    problemsCatalog: {},
+  }),
+  queryDeploymentsByEvent: vi.fn(),
+}));
+
+const { app } = await import("../../lib/problem-deploy/handlers/event-handler/index");
+const { MissingTenantClaimError } = await import(
+  "../../lib/problem-deploy/handlers/deploy-handler/auth"
+);
+
+const EVENT_ID = "01HZX0K3M3K9ZQHB3MRQHBA1B2";
+// top-level (= /events/* 外) の throwing route。 middleware を介さず onError に直接到達する。
+app.get("/__throw_missing_tenant__", () => {
+  throw new MissingTenantClaimError();
+});
+app.get("/__throw_generic__", () => {
+  throw new Error("boom");
+});
+
+beforeEach(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+afterEach(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  process.env.DEFAULT_USER_ROLE = "TenantAdmin";
+});
+
+describe("event-handler app wiring", () => {
+  it("should serve /events/healthz, skipping the role middleware", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantUser"; // would 403 if the middleware did not skip
+    const res = await app.request("/events/healthz");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("should map MissingTenantClaimError to 401 via onError (with CORS)", async () => {
+    const res = await app.request("/__throw_missing_tenant__");
+    expect(res.status).toBe(StatusCodes.UNAUTHORIZED);
+    expect((await res.json()).error).toBe("missing_tenant_claim");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("should map an uncaught throw to 500 + CORS via onError", async () => {
+    const res = await app.request("/__throw_generic__");
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect((await res.json()).error).toBe("internal_error");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("should 403 forbidden_role via the /events/* middleware on a non-tenant role", async () => {
+    process.env.DEFAULT_USER_ROLE = "TenantUser"; // not in TENANT_ROLES
+    const res = await app.request(`/events/${EVENT_ID}`);
+    expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    expect((await res.json()).error).toBe("forbidden_role");
+  });
+});


### PR DESCRIPTION
## Summary
`event-handler/index.ts` (the Event API Lambda's Hono `app`) was at **62% branch**. Its 7 registered route groups are each 100% via their own `routes/*` tests, but the file's own wiring — the `app.onError` MissingTenantClaim branch and the `/events/*` middleware healthz-skip branch — was never exercised through `app`: **62.5% → 87.5%** (100% stmts/funcs/lines, 7/8 branches).

4 cases import `app` (`buildEventSharedResources` mocked):
- onError's three arms via top-level throwing routes added to the imported app (same technique as `handler-error-cors.test.ts`; placed **outside** `/events/*` so they don't collide with `/events/:eventId` and 400).
- middleware + ForbiddenRole arm via a real `/events/:eventId` request with a non-tenant role.
- healthz-skip via `/events/healthz` with a would-be-rejected role.

Covers: healthz (middleware skip), `MissingTenantClaim`→401 + CORS, uncaught throw→500 + CORS, `ForbiddenRole`→403.

### The one remaining branch (87.5%)
Same as competitor-accounts (#1563): the onError generic `err instanceof Error ? err.message : "unknown error"` **else-arm**. Hono routes only `Error` instances to `app.onError` (non-Error throws are rethrown), so it is unreachable through the handler. Closing it needs a one-line `/* v8 ignore */` on the handler source (owner-owned infra-lib); this PR stays **test-only**.

## Test plan
- `vitest run event-handler-index.test.ts --coverage` → 4 passed, 100% stmts/funcs/lines, 87.5% branch (7/8).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched, so no runtime behavior can regress. New test file only; the pre-existing `handler-error-cors.test.ts` / `role-gates.test.ts` are untouched, and vitest isolates module mocks per file. The throwing routes are added to a test-local app instance only.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)