### PR TITLE
test(infra): cover system-audit-writer + describe-stack handlers (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/describe-stack-handler-gaps.test.ts
+++ b/infrastructure/test/problem-deploy/describe-stack-handler-gaps.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: describe-stack-handler/index.ts の残カバレッジ。 既存 describe-stack-handler.test.ts
+ * は describeStackForDeployment を広く通すが、 assertCompleteCredentials の incomplete throw (L37)、
+ * ExternalId-not-found throw (L89)、 logInputShape の field-detection 枝、 production `handler`
+ * wrapper の credentials 有無両 branch (L252-268) が未カバーだった。
+ *
+ * handler は module-scope で real AWS client を組むため、 sts / ssm / cloudformation を mock し
+ * controllable に。 残り (37/89/logInputShape) は injected deps で describeStackForDeployment を直接叩く。
+ */
+vi.mock("@aws-sdk/client-cloudformation", () => ({
+  CloudFormationClient: class {
+    send = vi.fn().mockRejectedValue(new Error("cfn send rejected"));
+  },
+  DescribeStacksCommand: class {},
+}));
+vi.mock("@aws-sdk/client-sts", () => ({
+  STSClient: class {
+    send = vi.fn().mockResolvedValue({
+      Credentials: { AccessKeyId: "AKIA", SecretAccessKey: "secret", SessionToken: "token" },
+    });
+  },
+  AssumeRoleCommand: class {},
+}));
+vi.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: class {
+    send = vi.fn().mockResolvedValue({ Parameter: { Value: "external-id", Version: 1 } });
+  },
+  GetParameterCommand: class {},
+}));
+
+const { describeStackForDeployment, handler } = await import(
+  "../../lib/problem-deploy/handlers/describe-stack-handler"
+);
+
+const withRole = {
+  detail: {
+    jobId: "01KRK6BATCE8QZHX663MQFX4E3",
+    namePrefix: "tc-stack-team-1",
+    region: "ap-northeast-1",
+    competitorRoleArn: "arn:aws:iam::123456789012:role/Deploy",
+    externalIdParameterName: "/tc/external-id",
+  },
+};
+// biome-ignore lint/suspicious/noExplicitAny: injected deps shape mirrors DescribeStackDeps.
+const makeDeps = (over: Record<string, unknown>): any => ({
+  ssm: { send: vi.fn(async () => ({ Parameter: { Value: "external", Version: 3 } })) },
+  sts: {
+    send: vi.fn(async () => ({
+      Credentials: { AccessKeyId: "AKIA", SecretAccessKey: "secret", SessionToken: "token" },
+    })),
+  },
+  cfnClient: vi.fn(() => ({ send: vi.fn(async () => ({ Stacks: [] })) })),
+  ...over,
+});
+
+describe("describeStackForDeployment defensive throws", () => {
+  it("should throw when AssumeRole returns incomplete credentials (L37)", async () => {
+    const deps = makeDeps({
+      sts: { send: vi.fn(async () => ({ Credentials: { AccessKeyId: "AKIA" } })) }, // missing secret/session
+    });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toThrow(
+      /incomplete credentials/,
+    );
+  });
+
+  it("should throw when the SSM ExternalId parameter has no value (L89)", async () => {
+    const deps = makeDeps({
+      ssm: { send: vi.fn(async () => ({ Parameter: { Value: undefined, Version: 1 } })) },
+    });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toThrow(
+      /ExternalId not found in SSM SecureString/,
+    );
+  });
+});
+
+describe("logInputShape diagnostics (missing jobId)", () => {
+  it("should log every field as present when detail carries them (jobId empty)", async () => {
+    const deps = makeDeps({});
+    // jobId="" → logInputShape fires; all other fields present → the truthy side of each check.
+    await expect(
+      describeStackForDeployment(
+        {
+          detail: {
+            jobId: "",
+            namePrefix: "n",
+            region: "ap-northeast-1",
+            tenantId: "t",
+            competitorRoleArn: "arn:aws:iam::1:role/r",
+            externalIdParameterName: "/p",
+          },
+        },
+        deps,
+      ),
+    ).rejects.toThrow(/detail.jobId/);
+  });
+
+  it("should handle a wholly absent detail (all fields falsy)", async () => {
+    const deps = makeDeps({});
+    await expect(describeStackForDeployment({}, deps)).rejects.toThrow(/detail.jobId/);
+  });
+});
+
+const accessDenied = () => Object.assign(new Error("denied"), { name: "AccessDenied" });
+
+describe("retryWithPreviousExternalId (ExternalId rotation grace)", () => {
+  it("should grace-fallback to the previous ExternalId version on AccessDenied and succeed", async () => {
+    const stsSend = vi.fn();
+    stsSend.mockRejectedValueOnce(accessDenied()); // current version → denied
+    stsSend.mockResolvedValueOnce({
+      Credentials: { AccessKeyId: "A", SecretAccessKey: "S", SessionToken: "T" },
+    }); // previous version → ok
+    const ssmSend = vi.fn();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "previous", Version: 2 } });
+    const deps = makeDeps({ sts: { send: stsSend }, ssm: { send: ssmSend } });
+    await expect(describeStackForDeployment(withRole, deps)).resolves.toBeDefined();
+    expect(stsSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("should rethrow when there is no previous version (Version defaults to 0)", async () => {
+    const stsSend = vi.fn().mockRejectedValue(accessDenied());
+    // Parameter has no Version → Number(undefined ?? 0) = 0 → previousVersion = -1 ≤ 0 → rethrow.
+    const ssmSend = vi.fn(async () => ({ Parameter: { Value: "current" } }));
+    const deps = makeDeps({ sts: { send: stsSend }, ssm: { send: ssmSend } });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toThrow(/denied/);
+  });
+
+  it("should rethrow when the previous-version parameter has no value", async () => {
+    const stsSend = vi.fn().mockRejectedValue(accessDenied());
+    const ssmSend = vi.fn();
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: "current", Version: 3 } });
+    ssmSend.mockResolvedValueOnce({ Parameter: { Value: undefined } }); // previous missing
+    const deps = makeDeps({ sts: { send: stsSend }, ssm: { send: ssmSend } });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toThrow(/denied/);
+  });
+
+  it("should rethrow immediately on a non-retryable Error (not AccessDenied)", async () => {
+    const stsSend = vi.fn().mockRejectedValue(new Error("Throttling"));
+    const deps = makeDeps({ sts: { send: stsSend } });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toThrow(/Throttling/);
+    expect(stsSend).toHaveBeenCalledTimes(1); // no grace retry
+  });
+
+  it("should rethrow immediately on a non-Error rejection (shouldRetry '' branch)", async () => {
+    const stsSend = vi.fn().mockRejectedValue("plain string failure");
+    const deps = makeDeps({ sts: { send: stsSend } });
+    await expect(describeStackForDeployment(withRole, deps)).rejects.toBe("plain string failure");
+  });
+});
+
+describe("handler production wrapper", () => {
+  it("should wire real clients with no credentials when no competitor role is given", async () => {
+    // competitorRoleArn 無し → AssumeRole skip → cfnClient(credentials=undefined) (= no-creds ternary)。
+    await expect(
+      handler({
+        detail: {
+          jobId: "01KRK6BATCE8QZHX663MQFX4E3",
+          namePrefix: "tc-stack",
+          region: "ap-northeast-1",
+        },
+      }),
+    ).rejects.toThrow(/cfn send rejected/);
+  });
+
+  it("should wire real clients with assumed credentials when a competitor role is given", async () => {
+    // competitorRoleArn + externalIdParameterName あり → mocked SSM/STS で creds 解決 →
+    // cfnClient(credentials present) (= with-creds ternary L258-265) を踏む。 CFN send は reject。
+    await expect(handler(withRole)).rejects.toThrow(/cfn send rejected/);
+  });
+});

--- a/infrastructure/test/problem-deploy/system-audit-writer-handler.test.ts
+++ b/infrastructure/test/problem-deploy/system-audit-writer-handler.test.ts
@@ -1,0 +1,125 @@
+import type { EventBridgeEvent } from "aws-lambda";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: system-audit-writer の EventBridge handler (index.ts 142-164) を pin する。
+ * 既存テストは pure mapper (mapEventToAudit / resolveActor / mapCodeBuildEvent) を直接叩くが、
+ * async handler (writeAuditEvent への配線 + optional field 組立 + fail-safe swallow) が未カバー。
+ *
+ * writeAuditEvent のみ mock。 mapper は実物を通す。
+ */
+const mocks = vi.hoisted(() => ({ writeAuditEvent: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/shared/audit-log", () => ({
+  writeAuditEvent: mocks.writeAuditEvent,
+}));
+
+const { handler } = await import("../../lib/problem-deploy/handlers/system-audit-writer/index");
+
+// biome-ignore lint/suspicious/noExplicitAny: 最小 EventBridgeEvent を直接組む。
+const ev = (detailType: string, detail: Record<string, unknown>, time?: string): any =>
+  ({ "detail-type": detailType, detail, time }) as EventBridgeEvent<string, never>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.writeAuditEvent.mockResolvedValue(true);
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("system-audit-writer handler", () => {
+  it("should skip a non-audit-worthy event without writing", async () => {
+    await handler(ev("SomeUnrelatedEvent", {}));
+    expect(mocks.writeAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("should write a full SBT onboarding row (actorUsername / target / extra present)", async () => {
+    await handler(
+      ev(
+        "onboardingSuccess",
+        {
+          tenantId: "tenant-9",
+          tier: "PREMIUM",
+          tenantName: "Acme",
+          sub: "sub-1",
+          cognitoUsername: "admin@example.com",
+        },
+        "2026-06-01T00:00:00.000Z",
+      ),
+    );
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "SYSTEM",
+        action: "tenant_create_succeeded",
+        outcome: "success",
+        target: "tenant-9",
+        actor: "sub-1",
+        actorUsername: "admin@example.com",
+        occurredAtMs: Date.parse("2026-06-01T00:00:00.000Z"),
+        extra: { tier: "PREMIUM", tenantName: "Acme" },
+      }),
+    );
+  });
+
+  it("should write a minimal row, omitting absent optional fields", async () => {
+    await handler(ev("onboardingRequest", {})); // no actor / target / tier / tenantName
+    const arg = mocks.writeAuditEvent.mock.calls[0][0];
+    expect(arg.actor).toBe("sbt-control-plane"); // fallback
+    expect(arg).not.toHaveProperty("actorUsername");
+    expect(arg).not.toHaveProperty("target");
+    expect(arg).not.toHaveProperty("extra");
+  });
+
+  it("should swallow an Error from writeAuditEvent (no throw)", async () => {
+    mocks.writeAuditEvent.mockRejectedValueOnce(new Error("ddb down"));
+    await expect(handler(ev("onboardingFailure", { tenantId: "t" }))).resolves.toBeUndefined();
+  });
+
+  it("should swallow a non-Error rejection (String(err) branch)", async () => {
+    mocks.writeAuditEvent.mockRejectedValueOnce("plain string failure");
+    await expect(handler(ev("offboardingSuccess", { tenantId: "t" }))).resolves.toBeUndefined();
+  });
+
+  it("should write a CodeBuild FAILED row, defaulting time and omitting region/build-id", async () => {
+    // no event.time → occurredAtMs falls back to Date.now(); no region / build-id → extra omits them.
+    await handler(
+      ev("CodeBuild Build State Change", {
+        "build-status": "FAILED",
+        "project-name": "tenant-pipe",
+      }),
+    );
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "codebuild_failed",
+        outcome: "error",
+        actor: "codebuild",
+        target: "tenant-pipe",
+        extra: { buildStatus: "FAILED" },
+      }),
+    );
+  });
+
+  it("should write a CodeBuild FAILED row with time + region + build-id present", async () => {
+    await handler(
+      ev(
+        "CodeBuild Build State Change",
+        {
+          "build-status": "FAILED",
+          "project-name": "tenant-pipe",
+          "build-id": "build-123",
+          region: "ap-northeast-1",
+        },
+        "2026-06-01T00:00:00.000Z",
+      ),
+    );
+    expect(mocks.writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        occurredAtMs: Date.parse("2026-06-01T00:00:00.000Z"),
+        extra: { buildStatus: "FAILED", buildId: "build-123", region: "ap-northeast-1" },
+      }),
+    );
+  });
+
+  it("should skip a SUCCEEDED CodeBuild event", async () => {
+    await handler(ev("CodeBuild Build State Change", { "build-status": "SUCCEEDED" }));
+    expect(mocks.writeAuditEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Two more problem-deploy handler index files in the #1424 sweep.

**system-audit-writer/index.ts — 67% → 100% branch.** The existing tests drive the pure mappers; the async EventBridge `handler` (writeAuditEvent wiring, optional-field assembly, fail-safe swallow) was uncovered. 8 cases (mock only `writeAuditEvent`): skip path, full SBT row, minimal row, Error/non-Error swallow, CodeBuild FAILED rows (with/without time·region·build-id) + SUCCEEDED skip. **100% all metrics.**

**describe-stack-handler/index.ts — 74.62% → 95.52% branch** (100% stmts/funcs/lines). Covers the `assertCompleteCredentials` incomplete-credentials throw, the ExternalId-not-found throw, the full `retryWithPreviousExternalId` grace-fallback (success + every rethrow condition), the `logInputShape` field-detection arms, and the production `handler` wrapper's **both** cfnClient branches (no-credentials + with-credentials; sts/ssm/cloudformation SDK clients mocked → no network).

The 3 remaining describe-stack branches are **unreachable defensive arms** guaranteed by upstream invariants: the `currentErr instanceof Error ? … : "Unknown"` else (the grace path only runs for a named AccessDenied Error) and the two `credentials.X ?? ""` arms (`assertCompleteCredentials` guarantees the fields are present before the cfnClient factory runs). Closing them needs a one-line `/* v8 ignore */` on the owner-owned handler source; these tests stay **test-only**.

## Test plan
- `vitest run system-audit-writer-handler.test.ts describe-stack-handler-gaps.test.ts` → 19 passed.
- Union coverage: system-audit-writer 100%; describe-stack 95.52% branch (64/67), 100% stmts/funcs/lines.
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. Two new test files only; pre-existing `describe-stack-handler.test.ts` and the system-audit-writer mapper tests untouched; vitest isolates module mocks per file (the AWS SDK mocks are scoped to the describe-stack file's module graph).

## Physical impact
- NO-OP on CFn / deployed artifacts. Test sources are not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)