### PR TITLE
test(infra): cover catalog + presigned-url utils to 100% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/catalog.test.ts
+++ b/infrastructure/test/problem-deploy/catalog.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseProblemsCatalog } from "../../lib/problem-deploy/handlers/shared/catalog";
+
+/**
+ * Issue #1424: BATTLE_PROBLEMS_CATALOG env decoder (shared/catalog.ts) は 0% だった。
+ * 不在 / 不正 JSON / 非 object / 非 string 値 drop の全分岐を pin する。
+ */
+afterEach(() => vi.restoreAllMocks());
+
+describe("parseProblemsCatalog", () => {
+  it("should return {} for undefined or empty input", () => {
+    expect(parseProblemsCatalog(undefined)).toEqual({});
+    expect(parseProblemsCatalog("")).toEqual({});
+  });
+
+  it("should warn and return {} on invalid JSON", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseProblemsCatalog("{not json")).toEqual({});
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("parse failed"));
+  });
+
+  it("should return {} when the JSON is an array or a non-object", () => {
+    expect(parseProblemsCatalog("[1,2,3]")).toEqual({});
+    expect(parseProblemsCatalog("42")).toEqual({});
+    expect(parseProblemsCatalog("null")).toEqual({});
+  });
+
+  it("should keep string values and drop non-string values", () => {
+    expect(parseProblemsCatalog('{"p1":"battle/p1","p2":42,"p3":"challenge/p3"}')).toEqual({
+      p1: "battle/p1",
+      p3: "challenge/p3",
+    });
+  });
+});

--- a/infrastructure/test/problem-deploy/presigned-url.test.ts
+++ b/infrastructure/test/problem-deploy/presigned-url.test.ts
@@ -1,0 +1,42 @@
+import type { S3Client } from "@aws-sdk/client-s3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1424: ADR-008 private 問題 presigned URL 発行 (deploy-handler/presigned-url.ts) は
+ * 0% branch だった。 default key / TTL と明示指定の両 branch を pin する。 S3 presigner は
+ * mock して network を踏ませない。
+ */
+const mocks = vi.hoisted(() => ({ getSignedUrl: vi.fn() }));
+vi.mock("@aws-sdk/s3-request-presigner", () => ({ getSignedUrl: mocks.getSignedUrl }));
+
+const { generateChallengePayloadUrl } = await import(
+  "../../lib/problem-deploy/handlers/deploy-handler/presigned-url"
+);
+
+const s3 = {} as S3Client;
+afterEach(() => vi.clearAllMocks());
+
+describe("generateChallengePayloadUrl", () => {
+  it("should sign the default <problemId>/latest.zip key with the 900s default TTL", async () => {
+    mocks.getSignedUrl.mockResolvedValueOnce("https://signed-default");
+    const url = await generateChallengePayloadUrl({ s3, bucketName: "payloads", problemId: "p1" });
+    expect(url).toBe("https://signed-default");
+    const [, command, options] = mocks.getSignedUrl.mock.calls[0];
+    expect(command.input).toEqual({ Bucket: "payloads", Key: "p1/latest.zip" });
+    expect(options).toEqual({ expiresIn: 900 });
+  });
+
+  it("should honor an explicit objectKey and expiresInSeconds", async () => {
+    mocks.getSignedUrl.mockResolvedValueOnce("https://signed-custom");
+    await generateChallengePayloadUrl({
+      s3,
+      bucketName: "payloads",
+      problemId: "p1",
+      objectKey: "p1/v2.zip",
+      expiresInSeconds: 60,
+    });
+    const [, command, options] = mocks.getSignedUrl.mock.calls[0];
+    expect(command.input.Key).toBe("p1/v2.zip");
+    expect(options).toEqual({ expiresIn: 60 });
+  });
+});


### PR DESCRIPTION
## Summary
Two small, **fully-untested** problem-deploy utility modules from the #1424 sweep, both → **100%** (stmts/branches/functions/lines).

- **shared/catalog.ts** (0%→100%): `parseProblemsCatalog` decodes the `BATTLE_PROBLEMS_CATALOG` env. Covers absent/empty input, invalid JSON (warn + `{}`), array / non-object / null, and the string-value filter that drops non-string entries.
- **deploy-handler/presigned-url.ts** (0% branch→100%): `generateChallengePayloadUrl` (ADR-008 private-problem S3 presigned URL). Covers the default `<problemId>/latest.zip` key + 900s TTL path and the explicit `objectKey` + `expiresInSeconds` path. The S3 presigner is mocked so no network is touched.

## Test plan
- `vitest run catalog.test.ts presigned-url.test.ts --coverage` → 100% (13/13 branches, 17/17 stmts).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. Two new test files only; vitest isolates the `s3-request-presigner` mock to the presigned-url file's module graph.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test sources are not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)