### PR TITLE
test(infra): cover SAML route orchestrators to 97% (#1424)

### DIFF
--- a/infrastructure/test/problem-deploy/saml-routes-orchestrators.test.ts
+++ b/infrastructure/test/problem-deploy/saml-routes-orchestrators.test.ts
@@ -1,0 +1,177 @@
+import type { Context } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  defaultMakeCognitoDeps,
+  extractSelfPoolFromContext,
+  routeDelete,
+  routeGet,
+  routePut,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes";
+import type { CompetitorAccountsSharedResources } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/shared";
+
+/**
+ * Issue #1424: SAML route orchestrators (routeGet / routePut / routeDelete) + Cognito-deps
+ * 解決 helper (extractSelfPoolFromContext / defaultMakeCognitoDeps) を pin する。 既存
+ * tenant-saml.test は handle* を直接、 tenant-saml-tier-guard.test は pooled-tier 503 を見るが、
+ * orchestrator の missing-claims(422) / invalid-body(400) / iss-aud からの self-pool 解決 / GET 委譲 /
+ * DELETE 委譲が未カバーで 38% branch だった。
+ */
+const VALID_ISS = "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_ABC123";
+
+// extractClaims は c.env.event.requestContext.authorizer.jwt.claims を読む (tenant-saml-tier-guard と同形)。
+const ctx = (opts: {
+  claims?: Record<string, unknown>;
+  body?: unknown;
+  bodyThrows?: boolean;
+}): Context =>
+  ({
+    env: {
+      event: {
+        requestContext: { authorizer: { jwt: { claims: opts.claims ?? {} } } },
+      },
+    },
+    req: {
+      json: opts.bodyThrows ? () => Promise.reject(new Error("bad body")) : async () => opts.body,
+    },
+  }) as unknown as Context;
+
+const shared = {
+  ddb: { send: vi.fn().mockResolvedValue({}) },
+  cognito: { send: vi.fn().mockResolvedValue({ UserPoolClient: {} }) },
+  tableName: "TestCompetitorAccounts",
+  env: "development",
+} as unknown as CompetitorAccountsSharedResources;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  shared.ddb.send = vi.fn().mockResolvedValue({});
+  shared.cognito.send = vi.fn().mockResolvedValue({ UserPoolClient: {} });
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+});
+afterEach(() => {
+  process.env.DEFAULT_TENANT_ID = "tenant-test";
+  vi.clearAllMocks();
+});
+
+describe("extractSelfPoolFromContext", () => {
+  it("should resolve userPoolId + clientId from iss + aud", async () => {
+    const out = extractSelfPoolFromContext(ctx({ claims: { iss: VALID_ISS, aud: "client-1" } }));
+    expect(out).toMatchObject({
+      userPoolId: "ap-northeast-1_ABC123",
+      userPoolClientId: "client-1",
+    });
+    // The skeleton's client.send is a placeholder that callers (defaultMakeCognitoDeps) override
+    // with shared.cognito; invoke it directly to pin the "not injected" guard.
+    await expect(out?.client.send({} as never)).rejects.toThrow(/client not injected/);
+  });
+
+  it("should fall back to client_id when aud is absent", () => {
+    const out = extractSelfPoolFromContext(
+      ctx({ claims: { iss: VALID_ISS, client_id: "client-2" } }),
+    );
+    expect(out?.userPoolClientId).toBe("client-2");
+  });
+
+  it("should return undefined when iss is not a Cognito issuer", () => {
+    expect(
+      extractSelfPoolFromContext(ctx({ claims: { iss: "https://evil", aud: "x" } })),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined when neither aud nor client_id is present", () => {
+    expect(extractSelfPoolFromContext(ctx({ claims: { iss: VALID_ISS } }))).toBeUndefined();
+  });
+});
+
+describe("defaultMakeCognitoDeps", () => {
+  it("should build deps from the self pool, using shared.cognito as the client", () => {
+    const deps = defaultMakeCognitoDeps(shared)(ctx({ claims: { iss: VALID_ISS, aud: "c" } }));
+    expect(deps).toMatchObject({ client: shared.cognito, userPoolId: "ap-northeast-1_ABC123" });
+  });
+
+  it("should return undefined when the context has no self pool", () => {
+    expect(defaultMakeCognitoDeps(shared)(ctx({ claims: {} }))).toBeUndefined();
+  });
+});
+
+describe("routeGet", () => {
+  it("should resolve the tenant and return the SAML config (disabled when absent)", async () => {
+    const res = await routeGet({ shared }, ctx({ claims: {} }));
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(res.body).toEqual({ enabled: false });
+  });
+});
+
+describe("routePut", () => {
+  it("should 422 when Cognito deps cannot be resolved", async () => {
+    const res = await routePut({ shared, makeCognitoDeps: () => undefined }, ctx({ claims: {} }));
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+    expect((res.body as { error: string }).error).toBe("missing_cognito_claims");
+  });
+
+  it("should 400 invalid_body when the JSON body cannot be parsed", async () => {
+    const res = await routePut(
+      {
+        shared,
+        makeCognitoDeps: () => ({ client: shared.cognito, userPoolId: "p", userPoolClientId: "c" }),
+      },
+      ctx({ claims: {}, bodyThrows: true }),
+    );
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect((res.body as { error: string }).error).toBe("invalid_body");
+  });
+
+  it("should delegate to handlePut (which 400s on an insecure metadataUrl)", async () => {
+    const res = await routePut(
+      {
+        shared,
+        makeCognitoDeps: () => ({ client: shared.cognito, userPoolId: "p", userPoolClientId: "c" }),
+      },
+      ctx({ claims: {}, body: { metadataUrl: "http://insecure" } }),
+    );
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("should resolve deps via defaultMakeCognitoDeps when none are injected (iss+aud present)", async () => {
+    const res = await routePut(
+      { shared }, // no makeCognitoDeps → defaultMakeCognitoDeps path
+      ctx({
+        claims: { iss: VALID_ISS, aud: "client-1" },
+        body: { metadataUrl: "http://insecure" },
+      }),
+    );
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST); // handlePut rejects the insecure URL
+  });
+
+  it("should 422 via defaultMakeCognitoDeps when the context lacks iss/aud", async () => {
+    const res = await routePut({ shared }, ctx({ claims: {}, body: {} }));
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+  });
+});
+
+describe("routeDelete", () => {
+  it("should 422 when Cognito deps cannot be resolved", async () => {
+    const res = await routeDelete(
+      { shared, makeCognitoDeps: () => undefined },
+      ctx({ claims: {} }),
+    );
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+  });
+
+  it("should delegate to handleDelete and return deleted:true", async () => {
+    const res = await routeDelete(
+      {
+        shared,
+        makeCognitoDeps: () => ({
+          client: { send: vi.fn().mockResolvedValue({ UserPoolClient: {} }) },
+          userPoolId: "ap-northeast-1_ABC123",
+          userPoolClientId: "client-1",
+        }),
+      },
+      ctx({ claims: {} }),
+    );
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(res.body).toEqual({ deleted: true });
+  });
+});


### PR DESCRIPTION
## Summary
`competitor-accounts-handler/saml-routes.ts` was at **38% branch**. The existing `tenant-saml.test` drives the `handle*` functions and `tenant-saml-tier-guard` covers the pooled-tier 503 block, but the route orchestrators (`routeGet`/`routePut`/`routeDelete`) and the Cognito-deps resolution helpers (`extractSelfPoolFromContext`/`defaultMakeCognitoDeps`) were uncovered: **38% → 97.72%** (100% stmts/funcs/lines, 43/44 branches).

14 cases (Context built with a JWT-claims shape mirroring the tier-guard helper):
- **extractSelfPoolFromContext**: iss+aud → skeleton, aud-absent → `client_id` fallback, non-Cognito iss → undefined, no aud/client_id → undefined, + the placeholder `client.send` "not injected" guard.
- **defaultMakeCognitoDeps**: builds deps using `shared.cognito` as the client; undefined when no self pool.
- **routeGet**: resolves tenant + returns the SAML config.
- **routePut**: 422 missing_cognito_claims (injected + via `defaultMakeCognitoDeps`), 400 invalid_body, delegation to handlePut (400 on insecure metadataUrl).
- **routeDelete**: 422 missing_cognito_claims + delegation to handleDelete (deleted:true).

### The one remaining branch (97.72%)
The `input.providerName ?? DEFAULT_SAML_PROVIDER_NAME` default inside `handlePutTenantSamlConfig`'s full Cognito-write happy path — that is the existing `tenant-saml.test`'s domain (it owns the handlePut success mocks), so this PR stays focused on the orchestrators rather than duplicating that setup.

## Test plan
- `vitest run saml-routes-orchestrators.test.ts` → 14 passed.
- Union coverage: 97.72% branch (43/44), 100% stmts/funcs/lines.
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. New test file only; pre-existing `tenant-saml.test` / `tenant-saml-tier-guard.test` untouched; vitest isolates per file.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication configuration and routing functionality, including validation of error handling, dependency resolution, and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->