### PR TITLE
test(infra): cover endpoint store + external-id-audit repository to 100% (#1418)

### DIFF
--- a/infrastructure/test/problem-deploy/endpoints-store-and-audit-repository.test.ts
+++ b/infrastructure/test/problem-deploy/endpoints-store-and-audit-repository.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  composeRepositories,
+  createCompetitorAccountsRepository,
+} from "../../lib/problem-deploy/handlers/external-id-audit-handler/repository";
+import { queryOverrides } from "../../lib/problem-deploy/handlers/problem-endpoints-handler/store";
+
+/**
+ * Issue #1418: 残っていた 2 つの小さな service-module 分岐を pin する。
+ * - problem-endpoints-handler/store.ts queryOverrides の `out.Items ?? []` (no-Items) 枝。
+ * - external-id-audit-handler/repository.ts composeRepositories の cache miss / hit 両枝。
+ */
+afterEach(() => vi.clearAllMocks());
+
+describe("queryOverrides", () => {
+  it("should return the queried items", async () => {
+    const ddb = {
+      send: vi
+        .fn()
+        .mockResolvedValue({ Items: [{ PK: "p", SK: "SLOT#a", overrideUrl: "https://x" }] }),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal DynamoDBDocumentClient for the call.
+    } as any;
+    const out = await queryOverrides(ddb, "T", "tenant", "team", "p1");
+    expect(out).toHaveLength(1);
+    // The PK/SK condition is built from the (tenant, team, problem) tuple.
+    expect(ddb.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("should default to [] when the query returns no Items", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal client.
+    const ddb = { send: vi.fn().mockResolvedValue({}) } as any;
+    expect(await queryOverrides(ddb, "T", "tenant", "team", "p1")).toEqual([]);
+  });
+});
+
+describe("composeRepositories", () => {
+  it("should build both repositories and memoize the result across calls", () => {
+    const first = composeRepositories();
+    expect(first.competitorAccounts).toBeDefined();
+    expect(first.rotationAgeMetrics).toBeDefined();
+    // Module-scope cache: a second call returns the same instance (warm-invoke reuse).
+    expect(composeRepositories()).toBe(first);
+  });
+
+  it("scanPage should default items to [] when the scan returns no Items", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal client.
+    const ddb = { send: vi.fn().mockResolvedValue({}) } as any;
+    const page = await createCompetitorAccountsRepository(ddb).scanPage({
+      tableName: "T",
+      cursor: undefined,
+    });
+    expect(page.items).toEqual([]);
+    expect(page.nextCursor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Two small remaining problem-deploy service-module branches in the #1418 code-quality coverage effort, both → **100%** (stmts/branches/functions/lines):
- **problem-endpoints-handler/store.ts** `queryOverrides` (50%→100% branch): queried-items path + the `out.Items ?? []` no-Items default.
- **external-id-audit-handler/repository.ts** (50%→100% branch): `composeRepositories` cache miss + hit (module-scope memoization) and `createCompetitorAccountsRepository`'s `scanPage` `out.Items ?? []` default.

## Test plan
- `vitest run` (union) → store.ts + repository.ts both 100% (8/8 branches).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. New test file only; vitest isolates per file.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)