### PR TITLE
test(infra): cover endEvent + bulk-deploy persistence to 100% (#1418)

### DIFF
--- a/infrastructure/test/problem-deploy/bulk-deploy-persistence.test.ts
+++ b/infrastructure/test/problem-deploy/bulk-deploy-persistence.test.ts
@@ -1,0 +1,125 @@
+import { TransactWriteCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  markBulkEventDeploying,
+  markPublishFailuresFailed,
+  writeBulkDeployPlan,
+} from "../../lib/problem-deploy/handlers/event-handler/bulk-deploy/persistence";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+/**
+ * Issue #1418: bulk-deploy/persistence.ts は 33% branch だった。 writeBulkDeployPlan の
+ * replaces-existing chunking + Put/Delete 構築、 markBulkEventDeploying / markPublishFailuresFailed
+ * の ConditionalCheck no-op / 非 CCF throw を pin する。
+ */
+const ccf = () =>
+  Object.assign(new Error("conditional"), { name: "ConditionalCheckFailedException" });
+const cfg = { eventUpdateReject: undefined as unknown, depUpdateReject: undefined as unknown };
+const ddb = {
+  // biome-ignore lint/suspicious/noExplicitAny: fake dispatches by command + TableName.
+  send: vi.fn(async (cmd: any) => {
+    if (cmd instanceof TransactWriteCommand) return {};
+    if (cmd instanceof UpdateCommand) {
+      if (cmd.input.TableName === "Events") {
+        if (cfg.eventUpdateReject) throw cfg.eventUpdateReject;
+        return {};
+      }
+      if (cfg.depUpdateReject) throw cfg.depUpdateReject;
+      return {};
+    }
+    return {};
+  }),
+};
+const shared = {
+  ddb,
+  eventsTableName: "Events",
+  deploymentsTableName: "Deployments",
+} as unknown as EventSharedResources;
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal PlanEntry list for the writer.
+const planEntry = (jobId: string, replacesJobId?: string): any => ({
+  item: { PK: `DEPLOYMENT#${jobId}`, jobId },
+  ...(replacesJobId ? { replacesJobId } : {}),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cfg.eventUpdateReject = undefined;
+  cfg.depUpdateReject = undefined;
+});
+
+describe("writeBulkDeployPlan", () => {
+  it("should issue a single Put-only TransactWrite for a small non-replacing plan", async () => {
+    await writeBulkDeployPlan(shared, "t1", [planEntry("a"), planEntry("b")], false);
+    const calls = ddb.send.mock.calls.filter((c) => c[0] instanceof TransactWriteCommand);
+    expect(calls).toHaveLength(1);
+    const items = calls[0][0].input.TransactItems;
+    expect(items).toHaveLength(2);
+    expect(items.every((i: Record<string, unknown>) => "Put" in i)).toBe(true);
+  });
+
+  it("should emit Put+Delete per entry when replacing and chunk by the 25-op limit", async () => {
+    // replacesExisting → 2 ops/entry → 12 entries/chunk (floor(25/2)). 13 entries → 2 chunks.
+    const plan = Array.from({ length: 13 }, (_, i) => planEntry(`j${i}`, `old${i}`));
+    await writeBulkDeployPlan(shared, "t1", plan, true);
+    const calls = ddb.send.mock.calls.filter((c) => c[0] instanceof TransactWriteCommand);
+    expect(calls).toHaveLength(2); // 13 entries / 12-per-chunk → 2 chunks
+    // First chunk: 12 entries × (Put + Delete) = 24 ops.
+    expect(calls[0][0].input.TransactItems).toHaveLength(24);
+    expect(
+      calls[0][0].input.TransactItems.some((i: Record<string, unknown>) => "Delete" in i),
+    ).toBe(true);
+  });
+
+  it("should omit the Delete op for an entry without replacesJobId even when replacing", async () => {
+    await writeBulkDeployPlan(shared, "t1", [planEntry("a")], true); // no replacesJobId
+    const items = ddb.send.mock.calls.find((c) => c[0] instanceof TransactWriteCommand)?.[0].input
+      .TransactItems;
+    expect(items).toHaveLength(1);
+    expect("Delete" in items[0]).toBe(false);
+  });
+});
+
+describe("markBulkEventDeploying", () => {
+  it("should update the event status to DEPLOYING", async () => {
+    await markBulkEventDeploying(shared, "t1", "e1", "2026-06-01T00:00:00Z");
+    expect(ddb.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("should swallow a ConditionalCheck failure (no-op)", async () => {
+    cfg.eventUpdateReject = ccf();
+    await expect(
+      markBulkEventDeploying(shared, "t1", "e1", "2026-06-01T00:00:00Z"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should rethrow a non-ConditionalCheck error", async () => {
+    cfg.eventUpdateReject = new Error("ddb down");
+    await expect(
+      markBulkEventDeploying(shared, "t1", "e1", "2026-06-01T00:00:00Z"),
+    ).rejects.toThrow("ddb down");
+  });
+});
+
+describe("markPublishFailuresFailed", () => {
+  const failures = [{ jobId: "1", reason: "boom" }];
+
+  it("should mark PENDING deployments FAILED", async () => {
+    await markPublishFailuresFailed(shared, "t1", failures, "2026-06-01T00:00:00Z");
+    expect(ddb.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("should swallow a ConditionalCheck failure (already advanced elsewhere)", async () => {
+    cfg.depUpdateReject = ccf();
+    await expect(
+      markPublishFailuresFailed(shared, "t1", failures, "2026-06-01T00:00:00Z"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should rethrow a non-ConditionalCheck error", async () => {
+    cfg.depUpdateReject = new Error("ddb down");
+    await expect(
+      markPublishFailuresFailed(shared, "t1", failures, "2026-06-01T00:00:00Z"),
+    ).rejects.toThrow("ddb down");
+  });
+});

--- a/infrastructure/test/problem-deploy/end-event-internals.test.ts
+++ b/infrastructure/test/problem-deploy/end-event-internals.test.ts
@@ -1,0 +1,113 @@
+import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
+
+/**
+ * Issue #1418: endEvent (event-handler/end-event.ts) は 62.5% branch だった。 ConditionalCheckFailed
+ * の probe による not_found / not_endable 区別、 非 CCF rethrow、 !updatedEvent、 per-deployment
+ * denormalize の CCF skip / 非 CCF throw / PK filter を pin する。
+ */
+const mocks = vi.hoisted(() => ({ queryDeploymentsByEvent: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/event-handler/shared", () => ({
+  queryDeploymentsByEvent: mocks.queryDeploymentsByEvent,
+}));
+
+const { endEvent } = await import("../../lib/problem-deploy/handlers/event-handler/end-event");
+
+const ccf = () =>
+  Object.assign(new Error("conditional"), { name: "ConditionalCheckFailedException" });
+const cfg = {
+  eventUpdate: undefined as { resolve?: unknown; reject?: unknown } | undefined,
+  probeItem: undefined as Record<string, unknown> | undefined,
+  depReject: undefined as unknown,
+};
+const ddb = {
+  // biome-ignore lint/suspicious/noExplicitAny: fake dispatches by command + TableName.
+  send: vi.fn(async (cmd: any) => {
+    if (cmd instanceof GetCommand) return { Item: cfg.probeItem };
+    if (cmd instanceof UpdateCommand) {
+      if (cmd.input.TableName === "Events") {
+        if (cfg.eventUpdate?.reject) throw cfg.eventUpdate.reject;
+        return { Attributes: cfg.eventUpdate?.resolve };
+      }
+      // deployments denormalize
+      if (cfg.depReject) throw cfg.depReject;
+      return {};
+    }
+    return {};
+  }),
+};
+const shared = {
+  ddb,
+  eventsTableName: "Events",
+  deploymentsTableName: "Deployments",
+} as unknown as EventSharedResources;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cfg.eventUpdate = { resolve: { eventId: "e1", status: "ENDED" } };
+  cfg.probeItem = undefined;
+  cfg.depReject = undefined;
+  mocks.queryDeploymentsByEvent.mockResolvedValue([]);
+});
+
+describe("endEvent", () => {
+  it("should end a READY event and denormalize eventEndsAt to its deployments", async () => {
+    mocks.queryDeploymentsByEvent.mockResolvedValueOnce([
+      { PK: "DEPLOYMENT#1" },
+      { PK: "DEPLOYMENT#2" },
+      { notPk: "x" }, // no PK string → filtered out
+    ]);
+    const res = await endEvent(shared, "t1", "e1", 1_700_000_000_000);
+    expect(res).toMatchObject({ kind: "ok", updatedDeployments: 2 });
+    // 1 event update + 2 deployment updates.
+    expect(ddb.send.mock.calls.filter((c) => c[0] instanceof UpdateCommand)).toHaveLength(3);
+  });
+
+  it("should return not_found when the ConditionalCheck fails and the event is absent", async () => {
+    cfg.eventUpdate = { reject: ccf() };
+    cfg.probeItem = undefined;
+    expect(await endEvent(shared, "t1", "e1", 1)).toEqual({ kind: "not_found" });
+  });
+
+  it("should return not_found on a tenant mismatch during the probe", async () => {
+    cfg.eventUpdate = { reject: ccf() };
+    cfg.probeItem = { tenantId: "other", status: "READY" };
+    expect(await endEvent(shared, "t1", "e1", 1)).toEqual({ kind: "not_found" });
+  });
+
+  it("should return not_endable with the current status when not READY", async () => {
+    cfg.eventUpdate = { reject: ccf() };
+    cfg.probeItem = { tenantId: "t1", status: "DRAFT" };
+    expect(await endEvent(shared, "t1", "e1", 1)).toEqual({ kind: "not_endable", status: "DRAFT" });
+  });
+
+  it("should report '?' status when the probed status is not a string", async () => {
+    cfg.eventUpdate = { reject: ccf() };
+    cfg.probeItem = { tenantId: "t1", status: 42 };
+    expect(await endEvent(shared, "t1", "e1", 1)).toEqual({ kind: "not_endable", status: "?" });
+  });
+
+  it("should rethrow a non-ConditionalCheck error from the event update", async () => {
+    cfg.eventUpdate = { reject: new Error("ddb down") };
+    await expect(endEvent(shared, "t1", "e1", 1)).rejects.toThrow("ddb down");
+  });
+
+  it("should return not_found when the update returns no Attributes", async () => {
+    cfg.eventUpdate = { resolve: undefined };
+    expect(await endEvent(shared, "t1", "e1", 1)).toEqual({ kind: "not_found" });
+  });
+
+  it("should skip a deployment denormalize that hits a ConditionalCheck (idempotent)", async () => {
+    mocks.queryDeploymentsByEvent.mockResolvedValueOnce([{ PK: "DEPLOYMENT#1" }]);
+    cfg.depReject = ccf();
+    const res = await endEvent(shared, "t1", "e1", 1);
+    expect(res).toMatchObject({ kind: "ok", updatedDeployments: 1 });
+  });
+
+  it("should rethrow a non-ConditionalCheck error from a deployment denormalize", async () => {
+    mocks.queryDeploymentsByEvent.mockResolvedValueOnce([{ PK: "DEPLOYMENT#1" }]);
+    cfg.depReject = new Error("dep ddb down");
+    await expect(endEvent(shared, "t1", "e1", 1)).rejects.toThrow("dep ddb down");
+  });
+});


### PR DESCRIPTION
## Summary
Two more event-handler service modules in the #1418 coverage effort, both → **100%** (28/28 branches combined):

- **end-event.ts** (62.5%→100%): `endEvent`'s ConditionalCheck-failed probe disambiguation (not_found for absent / tenant-mismatch, not_endable with current status, `"?"` for non-string status), the non-CCF rethrow, the `!updatedEvent` → not_found path, and the per-deployment `eventEndsAt` denormalize (PK filter, CCF idempotent skip, non-CCF rethrow).
- **bulk-deploy/persistence.ts** (33.3%→100%): `writeBulkDeployPlan` (Put-only non-replacing, Put+Delete replacing chunked by the 25-op TransactWrite limit, entry without `replacesJobId`), `markBulkEventDeploying` (success / CCF no-op / non-CCF throw), `markPublishFailuresFailed` (success / CCF no-op / non-CCF throw).

A command-dispatching fake DDB (command type + TableName) drives the writes; `queryDeploymentsByEvent` is mocked for `endEvent`.

## Test plan
- `vitest run end-event-internals.test.ts bulk-deploy-persistence.test.ts --coverage` → 18 passed, both 100% (28/28 branches).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. Two new test files only; vitest isolates per file.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test sources are not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)