### PR TITLE
test(infra): cover discover-problems sibling extractors to 100% (#1418)

### DIFF
--- a/infrastructure/test/discover-problems-extractors.test.ts
+++ b/infrastructure/test/discover-problems-extractors.test.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverProblemsDisruptions,
+  discoverProblemsEndpoints,
+  discoverProblemsPhases,
+  discoverProblemsScoring,
+  discoverProblemsVisibility,
+} from "../lib/utils/discover-problems-catalog";
+
+/**
+ * Issue #1418: discover-problems-catalog.ts の sibling extractors (scoring / endpoints / phases /
+ * visibility / disruptions) は 22.5% branch だった。 既存 test は discoverProblemsCatalog のみ。
+ * 同じ temp-dir fixture pattern で 5 関数 + parsePhaseEntry / parseDisruptionEntry の全 guard を pin。
+ */
+let root: string;
+
+function writeProblem(category: string, dir: string, metadata: unknown): void {
+  const target = path.join(root, category, dir);
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, "metadata.json"), JSON.stringify(metadata));
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "discover-extractors-"));
+  // "full": every section populated (valid + invalid entries to exercise the filters).
+  writeProblem("challenges", "full", {
+    id: "full-prob",
+    scoring: { kind: "flag", flagOutputKey: "F", points: 100 },
+    visibility: "private",
+    endpoints: [
+      {
+        slot: "frontend",
+        default: { from: "cfn-output", key: "FrontendUrl", appendPath: "/health" },
+        overridable: true,
+        label: "FE",
+        description: "d",
+      },
+      { slot: "bad" }, // no default → parseEndpointSlot undefined
+      "not-an-object", // non-object → undefined
+    ],
+    phases: [
+      { name: "warmup", afterMinutes: 0 }, // minimal valid (no effect/description)
+      {
+        name: "attack",
+        afterMinutes: 30,
+        effect: { scorePathOverride: "$.x", switchPlatformToDegraded: ["edge", 5, "core"] },
+        description: "desc",
+      },
+      { name: "noAfter" }, // afterMinutes missing → undefined
+      "string-phase", // non-object → undefined
+      { afterMinutes: 10 }, // name missing → undefined
+      { name: "e2", afterMinutes: 5, effect: "not-object" }, // effect not object → no effect
+      { name: "e3", afterMinutes: 7, effect: {} }, // effect object but no scorePathOverride/switchPlatform
+    ],
+    disruptions: [
+      { id: "d1", name: "Latency", eventDetailType: "D.L" }, // minimal valid
+      {
+        id: "d2",
+        name: "Full",
+        eventDetailType: "D.F",
+        description: "x",
+        defaultAfterMinutes: 5,
+        operatorEditable: ["latencyMs", 7],
+        parameters: { base: 1 },
+        publicHint: true,
+      }, // all optional present, operatorEditable non-string filtered
+      { name: "noId", eventDetailType: "x" }, // id missing → undefined
+      "not-an-object", // non-object → undefined
+      { id: "d3", name: "Arr", eventDetailType: "D.A", parameters: [1, 2] }, // parameters array → rejected
+    ],
+  });
+  // "bare": id only → excluded from every sibling map; non-array sections → skip branches.
+  writeProblem("challenges", "bare", { id: "bare-prob" });
+  // "empty": array sections present but every entry invalid → slots/phases/entries empty →
+  // excluded (covers the `length > 0` exclusion branches).
+  writeProblem("challenges", "empty", {
+    id: "empty-prob",
+    endpoints: ["invalid"],
+    phases: ["invalid"],
+    disruptions: ["invalid"],
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("discoverProblemsScoring", () => {
+  it("should include problems with valid scoring and exclude those without", () => {
+    const out = discoverProblemsScoring(root);
+    expect(out["full-prob"]).toMatchObject({ kind: "flag" });
+    expect(out["bare-prob"]).toBeUndefined();
+  });
+});
+
+describe("discoverProblemsEndpoints", () => {
+  it("should keep valid slots, drop invalid ones, and exclude problems with none", () => {
+    const out = discoverProblemsEndpoints(root);
+    expect(out["full-prob"]).toHaveLength(1);
+    expect(out["full-prob"]?.[0]).toMatchObject({ slot: "frontend", overridable: true });
+    expect(out["bare-prob"]).toBeUndefined(); // endpoints absent → non-array skip
+    expect(out["empty-prob"]).toBeUndefined(); // all slots invalid → empty → excluded
+  });
+});
+
+describe("discoverProblemsPhases", () => {
+  it("should keep valid phases (incl. effect filtering) and drop invalid ones", () => {
+    const out = discoverProblemsPhases(root);
+    expect(out["full-prob"]).toHaveLength(4); // warmup + attack + e2 + e3
+    expect(out["empty-prob"]).toBeUndefined(); // all phases invalid → empty → excluded
+    const attack = out["full-prob"]?.find((p) => p.name === "attack");
+    expect(attack?.effect).toEqual({
+      scorePathOverride: "$.x",
+      switchPlatformToDegraded: ["edge", "core"], // 5 filtered out
+    });
+    expect(attack?.description).toBe("desc");
+    // e2 has a non-object effect → no effect field.
+    expect(out["full-prob"]?.find((p) => p.name === "e2")?.effect).toBeUndefined();
+    expect(out["bare-prob"]).toBeUndefined();
+  });
+});
+
+describe("discoverProblemsVisibility", () => {
+  it("should include only private problems", () => {
+    const out = discoverProblemsVisibility(root);
+    expect(out["full-prob"]).toBe("private");
+    expect(out["bare-prob"]).toBeUndefined();
+  });
+});
+
+describe("discoverProblemsDisruptions", () => {
+  it("should keep valid disruptions (with optional-field + array filters) and drop invalid", () => {
+    const out = discoverProblemsDisruptions(root);
+    // d1 + d2 + d3 are valid (id/name/eventDetailType all strings); noId + non-object dropped.
+    expect(out["full-prob"]).toHaveLength(3);
+    const d2 = out["full-prob"]?.find((d) => d.id === "d2");
+    expect(d2).toMatchObject({
+      description: "x",
+      defaultAfterMinutes: 5,
+      operatorEditable: ["latencyMs"], // 7 filtered
+      parameters: { base: 1 },
+      publicHint: true,
+    });
+    // d3 is valid but its array `parameters` is rejected → no parameters field.
+    const d3 = out["full-prob"]?.find((d) => d.id === "d3");
+    expect(d3).toBeDefined();
+    expect(d3).not.toHaveProperty("parameters");
+    expect(out["bare-prob"]).toBeUndefined();
+    expect(out["empty-prob"]).toBeUndefined(); // all disruptions invalid → empty → excluded
+  });
+});


### PR DESCRIPTION
## Summary
`discover-problems-catalog.ts` was at **22.5% branch → 100%** (80/80, with the existing catalog test). The existing test covers `discoverProblemsCatalog` + the scan internals, but the five sibling extractors (scoring / endpoints / phases / visibility / disruptions) and their parse helpers (`parsePhaseEntry` / `parseDisruptionEntry`) were uncovered.

A temp-dir fixture test (mirroring the existing pattern) with:
- **"full"** — every section populated with valid + invalid entries
- **"bare"** — id only → non-array skip / excluded everywhere
- **"empty"** — array sections whose every entry is invalid → empty → exclusion

Covers each extractor's keep/drop/exclude logic plus the parse-helper filters: phase `effect` (scorePathOverride present/absent, switchPlatformToDegraded array with non-strings filtered, empty effect, non-object effect, missing name/afterMinutes, non-object entry) and disruption entry (all optional fields, operatorEditable non-string filter, array-`parameters` rejection, missing id, non-object).

## Test plan
- `vitest run discover-problems-extractors.test.ts discover-problems-catalog.test.ts --coverage` → 18 passed, 100% (80/80 branches).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. New test file only (the existing `discover-problems-catalog.test.ts` is untouched); each test uses an isolated `mkdtemp` dir cleaned in `afterEach`.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)