### PR TITLE
test(infra): cover tenant idp tier-guard silo paths to 100% (#1418)

### DIFF
--- a/infrastructure/test/idp/tenant-tier-guard-paths.test.ts
+++ b/infrastructure/test/idp/tenant-tier-guard-paths.test.ts
@@ -1,0 +1,62 @@
+import type { Context } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1418: tenant-template/handlers/idp-handler/tier-guard.ts は 50% branch だった。 既存
+ * test は non-silo(503) / non-admin(403) を見るが、 silo + admin の missing-tenant(403) / success
+ * 経路 (49-55) が未カバー。 auth (isTenantAdmin / resolveTenantId) を mock して 4 分岐を pin する。
+ */
+const mocks = vi.hoisted(() => ({ isTenantAdmin: vi.fn(), resolveTenantId: vi.fn() }));
+vi.mock("../../lib/control-plane/handlers/idp-handler/auth", () => ({
+  isTenantAdmin: mocks.isTenantAdmin,
+  resolveTenantId: mocks.resolveTenantId,
+}));
+
+const { createTenantIdpResolveScope } = await import(
+  "../../lib/tenant-template/handlers/idp-handler/tier-guard"
+);
+
+// minimal Context: only c.json is used by the guard.
+const ctx = () =>
+  ({ json: (body: unknown, status: number) => ({ body, status }) }) as unknown as Context;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("createTenantIdpResolveScope", () => {
+  it("should 503 when the tier guard is not 'silo'", () => {
+    const out = createTenantIdpResolveScope("pooled")(ctx());
+    expect(out).toMatchObject({ forbidden: { status: StatusCodes.SERVICE_UNAVAILABLE } });
+    // auth is never consulted on the pooled path.
+    expect(mocks.isTenantAdmin).not.toHaveBeenCalled();
+  });
+
+  it("should 503 when the tier guard is undefined (fail-closed)", () => {
+    const out = createTenantIdpResolveScope(undefined)(ctx());
+    expect(out).toMatchObject({ forbidden: { status: StatusCodes.SERVICE_UNAVAILABLE } });
+  });
+
+  it("should 403 forbidden for a non-tenant-admin on a silo deployment", () => {
+    mocks.isTenantAdmin.mockReturnValue(false);
+    const out = createTenantIdpResolveScope("silo")(ctx());
+    expect(out).toMatchObject({
+      forbidden: { status: StatusCodes.FORBIDDEN, body: { error: "forbidden" } },
+    });
+  });
+
+  it("should 403 forbidden_missing_tenant when the tenant claim is absent", () => {
+    mocks.isTenantAdmin.mockReturnValue(true);
+    mocks.resolveTenantId.mockReturnValue(undefined);
+    const out = createTenantIdpResolveScope("silo")(ctx());
+    expect(out).toMatchObject({
+      forbidden: { status: StatusCodes.FORBIDDEN, body: { error: "forbidden_missing_tenant" } },
+    });
+  });
+
+  it("should resolve a tenant scope for a silo tenant admin", () => {
+    mocks.isTenantAdmin.mockReturnValue(true);
+    mocks.resolveTenantId.mockReturnValue("tenant-9");
+    const out = createTenantIdpResolveScope("silo")(ctx());
+    expect(out).toEqual({ kind: "tenant", tenantId: "tenant-9" });
+  });
+});


### PR DESCRIPTION
## Summary
`tenant-template/handlers/idp-handler/tier-guard.ts` was at **50% branch → 100%**. The existing `tenant-tier-guard.test` covers the non-silo (503) and non-admin (403) rejections; the silo + admin paths — missing-tenant 403 and the successful `{kind:"tenant"}` scope resolution — were uncovered.

A complementary test (auth mocked, minimal Context) exercises all four branches: non-silo→503, undefined-guard→503 (fail-closed), silo+non-admin→403 forbidden, silo+admin+no-tenant→403 forbidden_missing_tenant, silo+admin+tenant→tenant scope.

## Test plan
- `vitest run tenant-tier-guard-paths.test.ts --coverage` → 5 passed, 100% (6/6 branches).
- biome check clean.

## Regression analysis
- Test-only change. No library / handler / CFn source touched. New test file only (the existing `tenant-tier-guard.test` is untouched); vitest isolates per file.

## Physical impact
- NO-OP on CFn / deployed artifacts. Test source is not bundled into any Lambda; `cdk synth` output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)