### PR TITLE
refactor(portal): consolidate inline error-stringify into toErrorMessage (#1418)

### DIFF
--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -19,6 +19,7 @@ import {
 } from "../api/portal-client";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
+import { toErrorMessage } from "../lib/error-message";
 import { countUnread, loadLastSeenAt, saveLastSeenAt } from "../lib/notifications-storage";
 import { useAuth } from "./AuthProvider";
 import {
@@ -175,7 +176,7 @@ export type LeaderboardRefreshDecision =
   | { readonly kind: "auth-error" };
 
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return toErrorMessage(err);
 }
 
 function shouldStopProblemPolling(view: ParticipantTeamView): boolean {
@@ -312,7 +313,7 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
         auth.logout();
         return;
       }
-      setNotificationsError(err instanceof Error ? err.message : String(err));
+      setNotificationsError(toErrorMessage(err));
     }
   }, [isMock, sessionToken, config.apiBaseUrl, auth, eventIdForKey]);
 

--- a/apps/participant-portal/src/components/CliCredentialsPanel.tsx
+++ b/apps/participant-portal/src/components/CliCredentialsPanel.tsx
@@ -13,6 +13,7 @@ import {
   PortalValidationError,
 } from "../api/portal-client";
 import { useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 /**
  * Issue #1197: CLI / SDK 用一時資格情報を取得して表示する 1 problem 単位の panel。
@@ -72,7 +73,7 @@ export function CliCredentialsPanel({
         setError(t("sso_credentials.validation_error", { errorCode: err.errorCode }));
         return;
       }
-      setError(err instanceof Error ? err.message : String(err));
+      setError(toErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/apps/participant-portal/src/components/EndpointOverrideForm.tsx
+++ b/apps/participant-portal/src/components/EndpointOverrideForm.tsx
@@ -31,6 +31,7 @@ import {
   putProblemEndpointOverride,
 } from "../api/portal-client";
 import { useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 interface EndpointOverrideFormProps {
   readonly apiBaseUrl: string;
@@ -69,7 +70,7 @@ function formatValidationError(err: unknown, t: TFn): string {
         return t("problem_detail.endpoint_error_generic", { errorCode: err.errorCode });
     }
   }
-  return err instanceof Error ? err.message : String(err);
+  return toErrorMessage(err);
 }
 
 export function EndpointOverrideForm({
@@ -96,7 +97,7 @@ export function EndpointOverrideForm({
       })
       .catch((err) => {
         if (cancelled) return;
-        setListError(err instanceof Error ? err.message : String(err));
+        setListError(toErrorMessage(err));
       });
     return () => {
       cancelled = true;

--- a/apps/participant-portal/src/components/ScoreTimelineChart.tsx
+++ b/apps/participant-portal/src/components/ScoreTimelineChart.tsx
@@ -9,6 +9,7 @@ import {
   type TeamScoreEvents,
 } from "../api/portal-client";
 import { useI18n, useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 /**
  * audit table #12 + Issue #1038 P1 #6: 競技開始からの得点状況を折れ線グラフで可視化する。
@@ -69,7 +70,7 @@ export function buildCumulativePoints(team: TeamScoreEvents): readonly SeriesPoi
 
 export function toScoreTimelineLoadError(err: unknown): ScoreTimelineLoadResult {
   if (err instanceof Error && err.name === "AbortError") return { kind: "skip" };
-  return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  return { kind: "error", message: toErrorMessage(err) };
 }
 
 async function fetchScoreTimelineData(

--- a/apps/participant-portal/src/lib/error-message.ts
+++ b/apps/participant-portal/src/lib/error-message.ts
@@ -1,0 +1,13 @@
+/**
+ * unknown な throw 値を文字列に正規化する純関数。
+ *
+ * `Error` instance は `message` を、 それ以外 (string / 非 Error object) は `String()` で
+ * 文字列化して返す。 portal 各所の `catch (err) { ... err instanceof Error ? err.message :
+ * String(err) ... }` を 10 箇所コピペしていたのを 1 箇所へ集約する (#1418 DRY / 単一責務)。
+ *
+ * 競技者向けの文脈付き整形 (= ログイン期限切れ等) は friendly-error.ts の責務で、 本関数は
+ * その素の fallback (raw message) を担う。
+ */
+export function toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -17,6 +17,7 @@ import { DEV_MOCK_SCORE_EVENTS } from "../auth/dev-mock-fixtures";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 import { ScoreEventsTable } from "./ScoreEventsTable";
 
 const POLL_INTERVAL_MS = 30_000;
@@ -65,7 +66,7 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
         auth.logout();
         return;
       }
-      setError(err instanceof Error ? err.message : String(err));
+      setError(toErrorMessage(err));
     }
   }, [isMock, sessionToken, config.apiBaseUrl, auth]);
 

--- a/apps/participant-portal/src/pages/SsoCredentials.tsx
+++ b/apps/participant-portal/src/pages/SsoCredentials.tsx
@@ -18,6 +18,7 @@ import { CliCredentialsPanel } from "../components/CliCredentialsPanel";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 type TranslateFn = (key: string, vars?: Record<string, string>) => string;
 
@@ -38,7 +39,7 @@ function describeOpenConsoleError(err: unknown, t: TranslateFn): string {
   if (err instanceof PortalValidationError) {
     return t("sso_credentials.validation_error", { errorCode: err.errorCode });
   }
-  return err instanceof Error ? err.message : String(err);
+  return toErrorMessage(err);
 }
 
 /**

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
@@ -16,6 +16,7 @@ import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import { PORTAL_SLOT_NAMES, type PortalSlotProps } from "@tenkacloud/portal-plugin-sdk";
 import { Component, type ErrorInfo, type ReactNode, Suspense, useMemo } from "react";
+import { toErrorMessage } from "../lib/error-message";
 import { loadPluginSlot } from "./loader";
 import {
   buildPortalDisruptions,
@@ -118,7 +119,7 @@ class PluginErrorBoundary extends Component<
   static getDerivedStateFromError(err: unknown): ErrorBoundaryState {
     return {
       hasError: true,
-      message: err instanceof Error ? err.message : String(err),
+      message: toErrorMessage(err),
     };
   }
 

--- a/apps/participant-portal/src/plugins/props-builder.ts
+++ b/apps/participant-portal/src/plugins/props-builder.ts
@@ -19,6 +19,7 @@ import type {
   PortalSlotProps,
 } from "@tenkacloud/portal-plugin-sdk";
 import { findProblemMetadata } from "../data/problems";
+import { toErrorMessage } from "../lib/error-message";
 
 /**
  * `base` + 任意 `appendPath` を結合して absolute URL を返す。 不正な URL は throw
@@ -52,7 +53,7 @@ export function buildPortalEndpointsFromOutputs(
         // `new URL()` は不正入力に対して必ず TypeError (= instanceof Error) を投げるため、
         // String(e) 側は到達不能な防御 fallback。 分岐 coverage 上ノイズになるので ignore。
         /* v8 ignore start */
-        const detail = e instanceof Error ? e.message : String(e);
+        const detail = toErrorMessage(e);
         /* v8 ignore stop */
         throw new Error(
           `Failed to build endpoint URL for problemId=${problemId} slot=${ep.slot} key=${ep.default.key}: ${detail}`,

--- a/apps/participant-portal/test/lib/error-message.test.ts
+++ b/apps/participant-portal/test/lib/error-message.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { toErrorMessage } from "../../src/lib/error-message";
+
+/**
+ * Issue #1418: portal 各所にコピペされていた `err instanceof Error ? err.message : String(err)` を
+ * toErrorMessage に集約した。 その純関数の 2 分岐を直接 pin する (call-site test の indirect
+ * coverage に依存しないため)。
+ */
+describe("toErrorMessage", () => {
+  it("should return an Error's message", () => {
+    expect(toErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("should stringify a non-Error value", () => {
+    expect(toErrorMessage("plain string")).toBe("plain string");
+    expect(toErrorMessage(42)).toBe("42");
+    expect(toErrorMessage({ toString: () => "obj" })).toBe("obj");
+  });
+});


### PR DESCRIPTION
## Summary
The participant-portal copy-pasted `X instanceof Error ? X.message : String(X)` in **10 places across 8 files** (TeamViewProvider, props-builder, PortalPluginSlots, CliCredentialsPanel, EndpointOverrideForm, ScoreTimelineChart, SsoCredentials, ScoreEvents). application-admin-console already centralizes this in a `toErrorMessage` helper; the portal had only `friendly-error.ts` (a different, competitor-facing translation concern), not the raw fallback.

This adds `src/lib/error-message.ts` with the same `toErrorMessage(err)` and replaces all 10 inline copies (#1418 DRY / single-responsibility). `friendly-error.ts` stays as the competitor-facing layer.

## Test plan
- New `error-message.test.ts` → 100% branch (2/2) on the util.
- Full `participant-portal` suite: **599 tests green** (was 597 + 2 new).
- `tsc --noEmit` + biome check clean.

## Regression analysis
- Pure refactor: `toErrorMessage(x)` returns exactly what `x instanceof Error ? x.message : String(x)` returned, so every call site is behaviorally identical. No control-flow / API / rendering change. `friendly-error.ts` untouched.

## Physical impact
- NO-OP on CFn / deployed artifacts. Frontend SPA source only; the same error strings are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)