### PR TITLE
refactor(admin): consolidate inline error-stringify into toErrorMessage (#1418)

### DIFF
--- a/apps/admin-console/src/lib/error-message.ts
+++ b/apps/admin-console/src/lib/error-message.ts
@@ -1,0 +1,11 @@
+/**
+ * unknown な throw 値を文字列に正規化する純関数。
+ *
+ * `Error` instance は `message` を、 それ以外 (string / 非 Error object) は `String()` で
+ * 文字列化して返す。 各 page の `catch (err) { setError(err instanceof Error ? err.message :
+ * String(err)) }` コピペを 1 箇所へ集約する (#1418 DRY / 単一責務、 sibling SPA の
+ * lib/error-message.ts と同一実装)。
+ */
+export function toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/admin-console/src/pages/Jobs.tsx
+++ b/apps/admin-console/src/pages/Jobs.tsx
@@ -20,6 +20,7 @@ import {
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { interpolate, useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 /**
  * Issue #658: admin-console の Tenant Provisioning Jobs 一覧 page。
@@ -89,7 +90,7 @@ export function JobsPage({ config }: { config: AppConfig }) {
       if (err instanceof AdminInsightApiError && err.status === StatusCodes.FORBIDDEN) {
         setForbidden(true);
       } else {
-        setError(err instanceof Error ? err.message : String(err));
+        setError(toErrorMessage(err));
       }
     }
   }, [config, idToken]);
@@ -265,7 +266,7 @@ function DeprovisioningJobsTab({ config }: { config: AppConfig }) {
         setForbidden(true);
         return;
       }
-      setError(err instanceof Error ? err.message : String(err));
+      setError(toErrorMessage(err));
     }
   }, [config, idToken]);
 

--- a/apps/admin-console/src/pages/TenantDetail.tsx
+++ b/apps/admin-console/src/pages/TenantDetail.tsx
@@ -21,6 +21,7 @@ import {
 } from "../api/tenants";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
+import { toErrorMessage } from "../lib/error-message";
 
 type TFn = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
@@ -69,7 +70,7 @@ export function TenantDetailPage({ config }: { config: AppConfig }) {
         setError(null);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(toErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/apps/admin-console/test/lib/error-message.test.ts
+++ b/apps/admin-console/test/lib/error-message.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { toErrorMessage } from "../../src/lib/error-message";
+
+/**
+ * Issue #1418: TenantDetail / Jobs にコピペされていた `err instanceof Error ? err.message :
+ * String(err)` を toErrorMessage に集約した。 その純関数の 2 分岐を直接 pin する。
+ */
+describe("toErrorMessage", () => {
+  it("should return an Error's message", () => {
+    expect(toErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("should stringify a non-Error value", () => {
+    expect(toErrorMessage("plain string")).toBe("plain string");
+    expect(toErrorMessage(42)).toBe("42");
+  });
+});


### PR DESCRIPTION
## Summary
admin-console copy-pasted `err instanceof Error ? err.message : String(err)` in **3 places** (TenantDetail ×1, Jobs ×2) with no shared helper. The other two SPAs already centralize this in `lib/error-message.ts`; this brings admin-console in line (#1418 DRY) — adds the same `toErrorMessage` util and replaces the 3 copies.

**All 3 SPAs now share an identical `toErrorMessage`; the inline ternary is gone from the codebase** (only the util definitions remain).

## Test plan
- New `error-message.test.ts` → 100% branch (2/2).
- Full `admin-console` suite: **203 tests green**.
- `tsc --noEmit` + biome check clean.

## Regression analysis
- Pure refactor: `toErrorMessage(x)` returns exactly what the inlined ternary did; the three call sites are behaviorally identical. No control-flow / API / rendering change.

## Physical impact
- NO-OP on CFn / deployed artifacts. Frontend SPA source only; same error strings shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)