### PR TITLE
refactor(i18n): migrate participant + app-admin i18n to web-kit shim

### DIFF
--- a/apps/application-admin-console/src/i18n/index.tsx
+++ b/apps/application-admin-console/src/i18n/index.tsx
@@ -1,164 +1,39 @@
 /**
- * Issue #583 i18n Phase 1.A: participant-portal の i18n 基盤。
+ * Issue #583 i18n Phase 1.C / #1418 web-kit Stage 2: application-admin-console の i18n。
  *
- * 設計判断:
- *   - **homegrown 実装** (= react-i18next 等の lib 非導入)。 4 言語 × ~30 keys 規模なら自前で
- *     済む + supply-chain audit-baseline 更新が不要 + bundle size 増えない (= 50KB 削減)。
- *     Phase 1.B で 3 SPA 全部に展開する時にライブラリ採択を再評価する。
- *   - **navigator.language → localStorage** の 2 段検出: 起動時 navigator.language で auto-detect、
- *     UI で切り替えたら localStorage に永続化、 次回起動はそれが優先。
- *   - **fallback chain**: 指定 locale で key 不在 → en → key 文字列そのまま。 missing key を
- *     見つけやすくする (= 「app.title」 のような raw key が出たら抽出忘れ)。
- *   - **react context + hook**: Provider が現在 locale + setLocale を提供、 useT() hook で
- *     翻訳関数を取り出す。 子 component は import なしで利用可。
+ * detect → localStorage 永続化 → nested-key lookup → en fallback → interpolate という core は
+ * 3 SPA 共通だったため、 `@tenkacloud/web-kit` の `createI18n` factory に集約済み。 ここは
+ * 「locale dictionary (locales/*.json) + storage key を注入して factory を呼ぶ」 だけの thin shim で、
+ * 公開 API (I18nProvider / useI18n / useT / useLang / interpolate / SUPPORTED_LOCALES / LocaleCode /
+ * _testInternals) は移行前と byte 互換に保つ (= 各 page の import は不変)。 挙動 (keep-placeholder
+ * interpolate / ja default / en fallback) も移行前と同一。
  */
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createI18n, interpolate } from "@tenkacloud/web-kit";
 import en from "./locales/en.json";
 import ja from "./locales/ja.json";
 
 export const SUPPORTED_LOCALES = ["ja", "en"] as const;
 export type LocaleCode = (typeof SUPPORTED_LOCALES)[number];
 
-const LOCALE_DICTIONARIES: Record<LocaleCode, Record<string, unknown>> = {
-  ja,
-  en,
+const kit = createI18n<LocaleCode>({
+  dictionaries: { ja, en },
+  supportedLocales: SUPPORTED_LOCALES,
+  defaultLocale: "ja",
+  fallbackLocale: "en",
+  storageKey: "tenkacloud.application-admin.locale",
+});
+
+export const I18nProvider = kit.I18nProvider;
+export const useI18n = kit.useI18n;
+export const useT = kit.useT;
+export const useLang = kit.useLang;
+export { interpolate };
+
+/** Tests / debug 用に dictionaries を露出。 console 本体からは使わない。 */
+export const _testInternals = {
+  LOCALE_DICTIONARIES: kit.internals.dictionaries,
+  resolveKey: kit.internals.resolveKey,
+  detectBrowserLocale: kit.internals.detectBrowserLocale,
+  interpolate,
 };
-
-const LOCAL_STORAGE_KEY = "tenkacloud.application-admin.locale";
-
-/**
- * `navigator.language` (= "en-US" / "ja-JP" 等) を SUPPORTED_LOCALES のいずれかに narrow。
- * 一致なければ "ja" を default にする (= 既存 UI を維持)。
- */
-function detectBrowserLocale(): LocaleCode {
-  // SSR guard: navigator は browser / jsdom では常に定義済みなので不到達。
-  /* v8 ignore next */
-  if (typeof navigator === "undefined") return "ja";
-  const raw = (navigator.language || "ja").toLowerCase();
-  for (const code of SUPPORTED_LOCALES) {
-    if (raw.startsWith(code)) return code;
-  }
-  return "ja";
-}
-
-function loadStoredLocale(): LocaleCode | undefined {
-  // SSR guard: window は browser / jsdom では常に定義済みなので不到達。
-  /* v8 ignore next */
-  if (typeof window === "undefined") return undefined;
-  try {
-    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
-      return stored as LocaleCode;
-    }
-  } catch {
-    // localStorage access denied (= incognito strict mode 等) → default fallback
-  }
-  return undefined;
-}
-
-function persistLocale(code: LocaleCode): void {
-  // SSR guard: 同上 (不到達)。
-  /* v8 ignore next */
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
-  } catch {
-    // ignore
-  }
-}
-
-/**
- * dot-separated key (e.g. "app.title") を nested object から取り出す。 未定義は undefined。
- */
-function resolveKey(dict: Record<string, unknown>, key: string): string | undefined {
-  const parts = key.split(".");
-  let node: unknown = dict;
-  for (const p of parts) {
-    if (typeof node !== "object" || node === null) return undefined;
-    node = (node as Record<string, unknown>)[p];
-  }
-  return typeof node === "string" ? node : undefined;
-}
-
-interface I18nContextValue {
-  readonly locale: LocaleCode;
-  readonly setLocale: (code: LocaleCode) => void;
-  readonly t: (key: string, params?: Readonly<Record<string, string | number>>) => string;
-}
-
-export function interpolate(
-  template: string,
-  params?: Readonly<Record<string, string | number>>,
-): string {
-  if (!params) return template;
-  return template.replace(/\{(\w+)\}/g, (match, name) => {
-    const v = params[name];
-    return v === undefined ? match : String(v);
-  });
-}
-
-const I18nContext = createContext<I18nContextValue | undefined>(undefined);
-
-export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<LocaleCode>(
-    () => loadStoredLocale() ?? detectBrowserLocale(),
-  );
-
-  // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
-  useEffect(() => {
-    // SSR guard: document は browser / jsdom では常に定義済みなので不到達。
-    /* v8 ignore next */
-    if (typeof document === "undefined") return;
-    document.documentElement.lang = locale;
-  }, [locale]);
-
-  const setLocale = useCallback((code: LocaleCode) => {
-    setLocaleState(code);
-    persistLocale(code);
-  }, []);
-
-  const t = useCallback(
-    (key: string, params?: Readonly<Record<string, string | number>>): string => {
-      // 1) 指定 locale で lookup → 2) en で fallback → 3) raw key
-      const v = resolveKey(LOCALE_DICTIONARIES[locale], key);
-      const template = v ?? resolveKey(LOCALE_DICTIONARIES.en, key) ?? key;
-      return interpolate(template, params);
-    },
-    [locale],
-  );
-
-  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
-
-  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
-}
-
-export function useI18n(): I18nContextValue {
-  const ctx = useContext(I18nContext);
-  if (!ctx) throw new Error("useI18n must be called inside <I18nProvider>");
-  return ctx;
-}
-
-/** 翻訳関数だけが必要な hot path 用 shortcut。 */
-export function useT(): (
-  key: string,
-  params?: Readonly<Record<string, string | number>>,
-) => string {
-  return useI18n().t;
-}
-
-/** Issue #1362: format helper に locale を渡すための shortcut hook。 */
-export function useLang(): LocaleCode {
-  return useI18n().locale;
-}
-
-/** Tests / debug 用に dictionaries を露出。 portal 本体からは使わない。 */
-export const _testInternals = { LOCALE_DICTIONARIES, resolveKey, detectBrowserLocale, interpolate };

--- a/apps/participant-portal/src/i18n/index.tsx
+++ b/apps/participant-portal/src/i18n/index.tsx
@@ -1,166 +1,40 @@
 /**
- * Issue #583 i18n Phase 1.A: participant-portal の i18n 基盤。
+ * Issue #583 i18n Phase 1.A / #1418 web-kit Stage 2: participant-portal の i18n。
  *
- * 設計判断:
- *   - **homegrown 実装** (= react-i18next 等の lib 非導入)。 4 言語 × ~30 keys 規模なら自前で
- *     済む + supply-chain audit-baseline 更新が不要 + bundle size 増えない (= 50KB 削減)。
- *     Phase 1.B で 3 SPA 全部に展開する時にライブラリ採択を再評価する。
- *   - **navigator.language → localStorage** の 2 段検出: 起動時 navigator.language で auto-detect、
- *     UI で切り替えたら localStorage に永続化、 次回起動はそれが優先。
- *   - **fallback chain**: 指定 locale で key 不在 → en → key 文字列そのまま。 missing key を
- *     見つけやすくする (= 「app.title」 のような raw key が出たら抽出忘れ)。
- *   - **react context + hook**: Provider が現在 locale + setLocale を提供、 useT() hook で
- *     翻訳関数を取り出す。 子 component は import なしで利用可。
+ * detect → localStorage 永続化 → nested-key lookup → en fallback → interpolate という core は
+ * 3 SPA 共通だったため、 `@tenkacloud/web-kit` の `createI18n` factory に集約済み。 ここは
+ * 「locale dictionary (locales/*.json) + storage key を注入して factory を呼ぶ」 だけの thin shim で、
+ * 公開 API (I18nProvider / useI18n / useT / useLang / SUPPORTED_LOCALES / LocaleCode / _testInternals)
+ * は移行前と byte 互換に保つ (= 各 page の import は不変)。 挙動 (keep-placeholder interpolate /
+ * ja default / en fallback) も移行前と同一。
  */
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createI18n } from "@tenkacloud/web-kit";
 import en from "./locales/en.json";
 import ja from "./locales/ja.json";
 
 export const SUPPORTED_LOCALES = ["ja", "en"] as const;
 export type LocaleCode = (typeof SUPPORTED_LOCALES)[number];
 
-const LOCALE_DICTIONARIES: Record<LocaleCode, Record<string, unknown>> = {
-  ja,
-  en,
-};
+const kit = createI18n<LocaleCode>({
+  dictionaries: { ja, en },
+  supportedLocales: SUPPORTED_LOCALES,
+  defaultLocale: "ja",
+  fallbackLocale: "en",
+  storageKey: "tenkacloud.portal.locale",
+});
 
-const LOCAL_STORAGE_KEY = "tenkacloud.portal.locale";
-
-/**
- * `navigator.language` (= "en-US" / "ja-JP" 等) を SUPPORTED_LOCALES のいずれかに narrow。
- * 一致なければ "ja" を default にする (= 既存 UI を維持)。
- */
-function detectBrowserLocale(): LocaleCode {
-  if (typeof navigator === "undefined") return "ja";
-  const raw = (navigator.language || "ja").toLowerCase();
-  for (const code of SUPPORTED_LOCALES) {
-    if (raw.startsWith(code)) return code;
-  }
-  return "ja";
-}
-
-function loadStoredLocale(): LocaleCode | undefined {
-  if (typeof window === "undefined") return undefined;
-  try {
-    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
-      return stored as LocaleCode;
-    }
-  } catch {
-    // localStorage access denied (= incognito strict mode 等) → default fallback
-  }
-  return undefined;
-}
-
-function persistLocale(code: LocaleCode): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
-  } catch {
-    // ignore
-  }
-}
-
-/**
- * dot-separated key (e.g. "app.title") を nested object から取り出す。 未定義は undefined。
- */
-function resolveKey(dict: Record<string, unknown>, key: string): string | undefined {
-  const parts = key.split(".");
-  let node: unknown = dict;
-  for (const p of parts) {
-    if (typeof node !== "object" || node === null) return undefined;
-    node = (node as Record<string, unknown>)[p];
-  }
-  return typeof node === "string" ? node : undefined;
-}
-
-interface I18nContextValue {
-  readonly locale: LocaleCode;
-  readonly setLocale: (code: LocaleCode) => void;
-  readonly t: (key: string, params?: Readonly<Record<string, string | number>>) => string;
-}
-
-/**
- * `"Welcome, {teamName}"` のような placeholder を params の値で差し替える。
- * params 未指定 placeholder はそのまま残す (= missing key を debug しやすくする)。
- */
-function interpolate(template: string, params?: Readonly<Record<string, string | number>>): string {
-  if (!params) return template;
-  return template.replace(/\{(\w+)\}/g, (match, name) => {
-    const v = params[name];
-    return v === undefined ? match : String(v);
-  });
-}
-
-const I18nContext = createContext<I18nContextValue | undefined>(undefined);
-
-export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<LocaleCode>(
-    () => loadStoredLocale() ?? detectBrowserLocale(),
-  );
-
-  // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
-  useEffect(() => {
-    // SSR safety guard。 jsdom test 環境では document が常に存在するため到達不能。
-    /* v8 ignore next */
-    if (typeof document === "undefined") return;
-    document.documentElement.lang = locale;
-  }, [locale]);
-
-  const setLocale = useCallback((code: LocaleCode) => {
-    setLocaleState(code);
-    persistLocale(code);
-  }, []);
-
-  const t = useCallback(
-    (key: string, params?: Readonly<Record<string, string | number>>): string => {
-      // 1) 指定 locale で lookup → 2) en で fallback → 3) raw key
-      const v = resolveKey(LOCALE_DICTIONARIES[locale], key);
-      const template = v ?? resolveKey(LOCALE_DICTIONARIES.en, key) ?? key;
-      return interpolate(template, params);
-    },
-    [locale],
-  );
-
-  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
-
-  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
-}
-
-export function useI18n(): I18nContextValue {
-  const ctx = useContext(I18nContext);
-  if (!ctx) throw new Error("useI18n must be called inside <I18nProvider>");
-  return ctx;
-}
-
-/** 翻訳関数だけが必要な hot path 用 shortcut。 */
-export function useT(): (
-  key: string,
-  params?: Readonly<Record<string, string | number>>,
-) => string {
-  return useI18n().t;
-}
-
-/** Issue #1362: format helper に locale を渡すための shortcut hook。 */
-export function useLang(): LocaleCode {
-  return useI18n().locale;
-}
+export const I18nProvider = kit.I18nProvider;
+export const useI18n = kit.useI18n;
+export const useT = kit.useT;
+export const useLang = kit.useLang;
 
 /** Tests / debug 用に dictionaries / 内部 helper を露出。 portal 本体からは使わない。 */
 export const _testInternals = {
-  LOCALE_DICTIONARIES,
-  resolveKey,
-  detectBrowserLocale,
-  interpolate,
-  loadStoredLocale,
-  persistLocale,
+  LOCALE_DICTIONARIES: kit.internals.dictionaries,
+  resolveKey: kit.internals.resolveKey,
+  detectBrowserLocale: kit.internals.detectBrowserLocale,
+  interpolate: kit.internals.interpolate,
+  loadStoredLocale: kit.internals.loadStoredLocale,
+  persistLocale: kit.internals.persistLocale,
 };


### PR DESCRIPTION
## Summary

**#1418 web-kit Stage 2 (PR B).** PR A (#1587) で `@tenkacloud/web-kit` に追加した `createI18n` factory を consume し、 **participant-portal** と **application-admin-console** の `src/i18n/index.tsx` を「locale dictionary + storage key を注入して factory を呼ぶ」 だけの **thin shim** に載せ替えます。

detect → localStorage 永続化 → nested-key lookup → en fallback → interpolate という ~130 行の homegrown core が 2 SPA 分まるごと消え、 web-kit の 1 実装に集約されます (DRY / SOLID-SRP)。

この 2 SPA は `interpolate` の挙動 (**keep-placeholder**: 未供給 placeholder を `{name}` のまま残す) が web-kit と byte 互換なので、 移行は **挙動完全保存**。 公開 API (`I18nProvider` / `useI18n` / `useT` / `useLang` / `SUPPORTED_LOCALES` / `LocaleCode` / `_testInternals`、 app-admin はさらに `interpolate`) も移行前と同一シグネチャで、 各 page の import は 1 行も変えていません。

> **admin-console** は `interpolate` が **fail-closed** (未供給 placeholder → 空文字、 専用 test + 「raw `{name}` を UI に漏らさない」 という明示的意図あり) で web-kit と挙動が異なるため、 本 PR には **含めず**、 別 PR で factory に interpolate policy を注入する形で慎重に扱います。

## Test plan

- `apps/participant-portal`: **588 tests green**, branches/functions/lines **100%**
- `apps/application-admin-console`: **889 tests green**, branches/functions/lines **100%**
- 各 SPA の既存 i18n pin test (placeholder 残し・fallback chain・localStorage 復元・`<html lang>` 追従・Provider 外 throw) が **無改変で緑** = 挙動不変の安全網
- `tsc --noEmit` clean (両 SPA) / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動完全保存**: 2 SPA の旧 interpolate / t / detect / resolve / persist は web-kit `createI18n` と byte 互換 (keep-placeholder / ja default / en fallback / 同一 storageKey)。 既存 pin test が無改変で緑。
- 公開 export は全て保持 (importer 30+ 箇所の `useT` / `useI18n` / `useLang` / `SUPPORTED_LOCALES` / `LocaleCode` / `interpolate` を grep 済、 drop なし)。
- admin-console は未変更なので fail-closed interpolate の test も影響なし。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend SPA のソース refactor のみ。 web-kit は既に両 SPA の workspace dep (#1586) なので bundle 依存グラフも不変 (同一コードが per-SPA copy から shared package 経由に変わるだけ)。 CDK stack には無関係。

Relates #1418
Relates #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)