### PR TITLE
refactor(i18n): migrate admin-console i18n to web-kit shim

### DIFF
--- a/apps/admin-console/src/i18n/index.tsx
+++ b/apps/admin-console/src/i18n/index.tsx
@@ -1,163 +1,31 @@
 /**
- * Issue #583 i18n Phase 1.A: participant-portal の i18n 基盤。
+ * Issue #583 i18n Phase 1.B / #1418 web-kit Stage 2: admin-console の i18n。
  *
- * 設計判断:
- *   - **homegrown 実装** (= react-i18next 等の lib 非導入)。 4 言語 × ~30 keys 規模なら自前で
- *     済む + supply-chain audit-baseline 更新が不要 + bundle size 増えない (= 50KB 削減)。
- *     Phase 1.B で 3 SPA 全部に展開する時にライブラリ採択を再評価する。
- *   - **navigator.language → localStorage** の 2 段検出: 起動時 navigator.language で auto-detect、
- *     UI で切り替えたら localStorage に永続化、 次回起動はそれが優先。
- *   - **fallback chain**: 指定 locale で key 不在 → en → key 文字列そのまま。 missing key を
- *     見つけやすくする (= 「app.title」 のような raw key が出たら抽出忘れ)。
- *   - **react context + hook**: Provider が現在 locale + setLocale を提供、 useT() hook で
- *     翻訳関数を取り出す。 子 component は import なしで利用可。
+ * detect → localStorage 永続化 → nested-key lookup → en fallback → interpolate という core は
+ * 3 SPA 共通だったため、 `@tenkacloud/web-kit` の `createI18n` factory に集約済み。 ここは
+ * 「locale dictionary (locales/*.json) + storage key + interpolate policy を注入して factory を
+ * 呼ぶ」 だけの thin shim で、 公開 API (I18nProvider / useI18n / useT / useLang / interpolate /
+ * SUPPORTED_LOCALES / LocaleCode / _testInternals) は移行前と byte 互換に保つ (= 各 page の
+ * import は不変)。
+ *
+ * admin-console だけ interpolate が **fail-closed** (未供給 placeholder → 空文字。 raw `{name}` を
+ * UI に漏らさない #655)。 他 2 SPA の keep-placeholder と方針が逆なので、 web-kit factory の
+ * `interpolate` override で注入する (= core は共有しつつ補間ポリシーだけ差し替える)。
  */
 
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createI18n } from "@tenkacloud/web-kit";
 import en from "./locales/en.json";
 import ja from "./locales/ja.json";
 
 export const SUPPORTED_LOCALES = ["ja", "en"] as const;
 export type LocaleCode = (typeof SUPPORTED_LOCALES)[number];
 
-const LOCALE_DICTIONARIES: Record<LocaleCode, Record<string, unknown>> = {
-  ja,
-  en,
-};
-
-const LOCAL_STORAGE_KEY = "tenkacloud.admin.locale";
-
-/**
- * `navigator.language` (= "en-US" / "ja-JP" 等) を SUPPORTED_LOCALES のいずれかに narrow。
- * 一致なければ "ja" を default にする (= 既存 UI を維持)。
- */
-function detectBrowserLocale(): LocaleCode {
-  // SSR guard: navigator は browser / jsdom では常に定義済みなので不到達。
-  /* v8 ignore next */
-  if (typeof navigator === "undefined") return "ja";
-  const raw = (navigator.language || "ja").toLowerCase();
-  for (const code of SUPPORTED_LOCALES) {
-    if (raw.startsWith(code)) return code;
-  }
-  return "ja";
-}
-
-function loadStoredLocale(): LocaleCode | undefined {
-  // SSR guard: window は browser / jsdom では常に定義済みなので不到達。
-  /* v8 ignore next */
-  if (typeof window === "undefined") return undefined;
-  try {
-    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (stored && (SUPPORTED_LOCALES as readonly string[]).includes(stored)) {
-      return stored as LocaleCode;
-    }
-  } catch {
-    // localStorage access denied (= incognito strict mode 等) → default fallback
-  }
-  return undefined;
-}
-
-function persistLocale(code: LocaleCode): void {
-  // SSR guard: 同上 (不到達)。
-  /* v8 ignore next */
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(LOCAL_STORAGE_KEY, code);
-  } catch {
-    // ignore
-  }
-}
-
-/**
- * dot-separated key (e.g. "app.title") を nested object から取り出す。 未定義は undefined。
- */
-function resolveKey(dict: Record<string, unknown>, key: string): string | undefined {
-  const parts = key.split(".");
-  let node: unknown = dict;
-  for (const p of parts) {
-    if (typeof node !== "object" || node === null) return undefined;
-    node = (node as Record<string, unknown>)[p];
-  }
-  return typeof node === "string" ? node : undefined;
-}
-
-interface I18nContextValue {
-  readonly locale: LocaleCode;
-  readonly setLocale: (code: LocaleCode) => void;
-  readonly t: (key: string, params?: Readonly<Record<string, string | number>>) => string;
-}
-
-const I18nContext = createContext<I18nContextValue | undefined>(undefined);
-
-export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<LocaleCode>(
-    () => loadStoredLocale() ?? detectBrowserLocale(),
-  );
-
-  // <html lang="..."> も locale に追従させる (= a11y / screen reader 対応)。
-  useEffect(() => {
-    // SSR guard: document は browser / jsdom では常に定義済みなので不到達。
-    /* v8 ignore next */
-    if (typeof document === "undefined") return;
-    document.documentElement.lang = locale;
-  }, [locale]);
-
-  const setLocale = useCallback((code: LocaleCode) => {
-    setLocaleState(code);
-    persistLocale(code);
-  }, []);
-
-  const t = useCallback(
-    (key: string, params?: Readonly<Record<string, string | number>>): string => {
-      // 1) 指定 locale で lookup → 2) en で fallback → 3) raw key
-      const v = resolveKey(LOCALE_DICTIONARIES[locale], key);
-      const template = v ?? resolveKey(LOCALE_DICTIONARIES.en, key) ?? key;
-      if (!params) return template;
-      const stringified: Record<string, string> = {};
-      for (const k of Object.keys(params)) stringified[k] = String(params[k]);
-      return interpolate(template, stringified);
-    },
-    [locale],
-  );
-
-  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
-
-  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
-}
-
-export function useI18n(): I18nContextValue {
-  const ctx = useContext(I18nContext);
-  if (!ctx) throw new Error("useI18n must be called inside <I18nProvider>");
-  return ctx;
-}
-
-/** 翻訳関数だけが必要な hot path 用 shortcut。 */
-export function useT(): (
-  key: string,
-  params?: Readonly<Record<string, string | number>>,
-) => string {
-  return useI18n().t;
-}
-
-/** Issue #1362: format helper に locale を渡すための shortcut hook。 */
-export function useLang(): LocaleCode {
-  return useI18n().locale;
-}
-
 /**
  * 翻訳テンプレートに `{name}` 形式の placeholder を埋め込む helper。
  *
- * 単純な `template.replace("{x}", vars.x).replace("{y}", vars.y)` だと
- * `vars.x = "{y}"` のような病的 input で意図しない 2 重置換が起きる。 1 pass の regex
- * replacement で safety を担保する (= 各 placeholder は元 template 上の 1 度しか展開されない)。
+ * 単純な `template.replace("{x}", vars.x).replace("{y}", vars.y)` だと `vars.x = "{y}"` のような
+ * 病的 input で意図しない 2 重置換が起きる。 1 pass の regex replacement で safety を担保する
+ * (= 各 placeholder は元 template 上の 1 度しか展開されない)。
  *
  * 未定義 key は空文字列に置換 (= raw `{name}` を UI に漏らさない fail-closed)。
  *
@@ -167,5 +35,29 @@ export function interpolate(template: string, vars: Readonly<Record<string, stri
   return template.replace(/\{(\w+)\}/g, (_, key) => (key in vars ? vars[key] : ""));
 }
 
-/** Tests / debug 用に dictionaries を露出。 portal 本体からは使わない。 */
-export const _testInternals = { LOCALE_DICTIONARIES, resolveKey, detectBrowserLocale };
+const kit = createI18n<LocaleCode>({
+  dictionaries: { ja, en },
+  supportedLocales: SUPPORTED_LOCALES,
+  defaultLocale: "ja",
+  fallbackLocale: "en",
+  storageKey: "tenkacloud.admin.locale",
+  // fail-closed policy を t() にも適用する (params 未指定なら template をそのまま返す)。
+  interpolate: (template, params) => {
+    if (!params) return template;
+    const stringified: Record<string, string> = {};
+    for (const k of Object.keys(params)) stringified[k] = String(params[k]);
+    return interpolate(template, stringified);
+  },
+});
+
+export const I18nProvider = kit.I18nProvider;
+export const useI18n = kit.useI18n;
+export const useT = kit.useT;
+export const useLang = kit.useLang;
+
+/** Tests / debug 用に dictionaries を露出。 console 本体からは使わない。 */
+export const _testInternals = {
+  LOCALE_DICTIONARIES: kit.internals.dictionaries,
+  resolveKey: kit.internals.resolveKey,
+  detectBrowserLocale: kit.internals.detectBrowserLocale,
+};

--- a/packages/web-kit/src/i18n.tsx
+++ b/packages/web-kit/src/i18n.tsx
@@ -59,6 +59,13 @@ export interface I18nConfig<L extends string> {
   readonly fallbackLocale: L;
   /** localStorage の永続化キー (SPA ごとに異なる)。 */
   readonly storageKey: string;
+  /**
+   * placeholder 補間関数の上書き (省略時は keep-placeholder の既定 {@link interpolate})。
+   * admin-console のように fail-closed (= 未供給 placeholder を空文字に落とす) など、
+   * SPA 固有の補間ポリシーを注入するための hook。 `t` と `internals.interpolate` の双方が
+   * これを使う (= SPA 内で挙動が一貫する)。
+   */
+  readonly interpolate?: typeof interpolate;
 }
 
 export interface I18nContextValue<L extends string> {
@@ -86,6 +93,7 @@ export interface I18nKit<L extends string> {
 /** config を閉じ込めた i18n Context + hooks を 1 組生成する。 */
 export function createI18n<L extends string>(config: I18nConfig<L>): I18nKit<L> {
   const { dictionaries, supportedLocales, defaultLocale, fallbackLocale, storageKey } = config;
+  const interpolateFn = config.interpolate ?? interpolate;
 
   function detectBrowserLocale(): L {
     // SSR guard: navigator は browser / jsdom では常に定義済みなので不到達。
@@ -147,7 +155,7 @@ export function createI18n<L extends string>(config: I18nConfig<L>): I18nKit<L> 
         // 1) 指定 locale で lookup → 2) fallback locale → 3) raw key
         const v = resolveKey(dictionaries[locale], key);
         const template = v ?? resolveKey(dictionaries[fallbackLocale], key) ?? key;
-        return interpolate(template, params);
+        return interpolateFn(template, params);
       },
       [locale],
     );
@@ -174,7 +182,7 @@ export function createI18n<L extends string>(config: I18nConfig<L>): I18nKit<L> 
     internals: {
       dictionaries,
       resolveKey,
-      interpolate,
+      interpolate: interpolateFn,
       detectBrowserLocale,
       loadStoredLocale,
       persistLocale,

--- a/packages/web-kit/test/i18n.test.tsx
+++ b/packages/web-kit/test/i18n.test.tsx
@@ -100,6 +100,33 @@ describe("createI18n internals", () => {
   });
 });
 
+describe("createI18n interpolate override", () => {
+  // fail-closed: 未供給 placeholder を [missing] に置換 (既定の keep-placeholder と区別できる印)。
+  const failClosed = (template: string, params?: Readonly<Record<string, string | number>>) =>
+    template.replace(/\{(\w+)\}/g, (_m, name) =>
+      params && name in params ? String(params[name]) : "[missing]",
+    );
+
+  it("should use a custom interpolate for t() and expose it via internals", () => {
+    const kit = createI18n<L>({
+      dictionaries,
+      supportedLocales: ["ja", "en"],
+      defaultLocale: "ja",
+      fallbackLocale: "en",
+      storageKey: STORAGE_KEY,
+      interpolate: failClosed,
+    });
+    expect(kit.internals.interpolate).toBe(failClosed);
+    vi.stubGlobal("navigator", { language: "ja-JP" });
+    const { I18nProvider } = kit;
+    const { result } = renderHook(() => kit.useT(), {
+      wrapper: ({ children }: { children: ReactNode }) => <I18nProvider>{children}</I18nProvider>,
+    });
+    // greet = "こんにちは {name}"。 name 未供給 → 既定なら "{name}" 残し、 override なら "[missing]"。
+    expect(result.current("greet", {})).toBe("こんにちは [missing]");
+  });
+});
+
 describe("I18nProvider + hooks", () => {
   // jsdom の navigator.language は "en-US" 既定なので、 ja-default を期待する test では
   // navigator を ja に固定する (stored-locale が無いケースの detect 経路を決定的にする)。


### PR DESCRIPTION
## Summary

**#1418 web-kit Stage 2 (PR C — 完結).** PR B (#1589) で participant-portal / application-admin-console を web-kit `createI18n` に載せ替えた残り、 **admin-console** を移行し、 **3 SPA すべての homegrown i18n core を web-kit の 1 実装に集約** します (DRY 完了)。

admin-console だけ `interpolate` が **fail-closed** (未供給 placeholder → 空文字。 raw `{name}` を UI に漏らさない #655) で、 他 2 SPA の **keep-placeholder** と方針が逆です。 そこで web-kit factory に `interpolate` **override option** を足し (省略時は従来の keep-placeholder)、 admin はそこへ fail-closed policy を注入します。 core (detect / resolve / persist / Provider / hooks) は共有しつつ、 **補間ポリシーだけ差し替える** 形です。

- **web-kit**: `I18nConfig.interpolate?` を追加。 factory の `t` と `internals.interpolate` の双方が resolved 関数 (`config.interpolate ?? 既定`) を使うので SPA 内で挙動が一貫。 override 経路の test を 1 件追加。
- **admin-console**: `src/i18n/index.tsx` を shim 化。 exported `interpolate` (fail-closed) はそのまま残し、 同じ関数を factory にも注入。 公開 API は byte 互換。

## Test plan

- **admin-console**: 192 tests green, branches/functions/lines **100%**
- **web-kit**: 26 tests green (既存 25 + override 1), branches **45/45 = 100%**
- admin の専用 pin test (`interpolate("Hello {missing}!", {})` → `"Hello !"`、 1-pass 病的入力防御、 `detectBrowserLocale` en/ja/fallback、 `resolveKey`、 fallback chain、 localStorage 復元、 `<html lang>` 追従、 Provider 外 throw) が **無改変で緑** = 挙動不変の安全網
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動完全保存**: admin の fail-closed interpolate / t / detect / resolve / persist は移行前と同一。 既存 pin test が無改変で緑。
- web-kit の override option は **optional** で既定は従来挙動。 participant / app-admin (override 未使用) は無影響。
- 公開 export 全保持 (importer の `useT`/`useI18n`/`useLang`/`SUPPORTED_LOCALES`/`LocaleCode`/`interpolate` を grep 済、 drop なし)。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend SPA + 共有 package のソース refactor のみ。 web-kit は既に admin-console の workspace dep (#1586)。 CDK stack には無関係。

Relates #1418
Relates #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)