### PR TITLE
feat(web-kit): add shared Cognito AuthProvider (additive)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -242,6 +242,9 @@
     "packages/web-kit": {
       "name": "@tenkacloud/web-kit",
       "version": "0.1.0",
+      "dependencies": {
+        "@tenkacloud/auth-client": "workspace:*",
+      },
       "devDependencies": {
         "@cloudscape-design/components": "^3.0.1297",
         "@testing-library/jest-dom": "^6.9.1",

--- a/packages/web-kit/package.json
+++ b/packages/web-kit/package.json
@@ -14,6 +14,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=./coverage --coverage.exclude='dist/**' --coverage.exclude='**/*.test.tsx'"
   },
+  "dependencies": {
+    "@tenkacloud/auth-client": "workspace:*"
+  },
   "peerDependencies": {
     "@cloudscape-design/components": "^3.0.1297",
     "react": "^19.2.6"

--- a/packages/web-kit/src/auth.tsx
+++ b/packages/web-kit/src/auth.tsx
@@ -1,0 +1,123 @@
+/**
+ * Issue #1418 web-kit Stage 3: admin-console / application-admin-console に copy-paste されていた
+ * Cognito AuthProvider を共有化する。 両 SPA はコメント (Issue 参照) 以外コード byte 一致だった。
+ *
+ * 設計の要点:
+ *   - **ADR-025: tokens は memory (React state) のみで保持**し sessionStorage には残さない
+ *     (XSS によるトークン持ち出し面を断つ)。 reload で memory が消えると RequireAuth → Login が
+ *     Cognito Hosted UI へ auto-redirect し、 既存 session cookie 経由で silent re-auth に倒れる。
+ *   - **Issue #859: idle session 自動ログアウト**。 15 分間 mouse / keyboard / touch / focus /
+ *     scroll 操作が無ければ Cognito refresh token を revoke して logout し、 stolen JWT の利用窓を
+ *     idToken 寿命 (= 1h) ではなく 15 min に短縮する defense-in-depth。
+ *   - **Issue #833: logout は server-side revoke 経由**。 Cognito Hosted UI cookie + refresh token を
+ *     revoke してから /logout に redirect する (= local clear だけだと silent re-login していた)。
+ *
+ * config は render 時の prop として渡る (= 各 SPA の `AppConfig` は `CognitoOAuthConfig` の superset)
+ * ので factory 化は不要。 両 SPA は `export { AuthProvider, useAuth } from "@tenkacloud/web-kit"` で
+ * 載せ替える。
+ */
+
+import {
+  type BeginLoginOptions,
+  beginLogin,
+  beginLogout,
+  type CognitoOAuthConfig,
+  purgeLegacyTokenStorage,
+  type TokenSet,
+} from "@tenkacloud/auth-client";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export interface AuthState {
+  tokens: TokenSet | null;
+  ready: boolean;
+  /**
+   * Cognito Hosted UI へ redirect する。 LoginPage が signing-in / error UI 状態を出せるよう
+   * Promise を返す。 `identityProvider` 未指定なら local Cognito sign-in、 指定すると
+   * `identity_provider=` を付けて SAML IdP に直接飛ばす (= SP-initiated HRD bypass)。
+   */
+  login: (options?: BeginLoginOptions) => Promise<void>;
+  logout: () => void;
+  setTokens: (tokens: TokenSet) => void;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const IDLE_EVENTS = ["mousedown", "keydown", "touchstart", "focus", "scroll"] as const;
+
+export function AuthProvider({
+  config,
+  children,
+}: {
+  config: CognitoOAuthConfig;
+  children: ReactNode;
+}) {
+  const [tokens, setTokensState] = useState<TokenSet | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // ADR-025: 旧バージョンが永続化した token を purge してから ready にする。
+    purgeLegacyTokenStorage();
+    setReady(true);
+  }, []);
+
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const logout = useCallback(() => {
+    // ADR-025: token は memory 保持なので、 revoke 対象の現在値を beginLogout に渡す。
+    setTokensState(null);
+    void beginLogout(config, tokens);
+  }, [config, tokens]);
+
+  // Issue #859: idle timeout を tokens が存在するときのみ起動。
+  useEffect(() => {
+    if (!tokens) return;
+    const resetTimer = (): void => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        logout();
+      }, IDLE_TIMEOUT_MS);
+    };
+    resetTimer();
+    for (const evt of IDLE_EVENTS) {
+      window.addEventListener(evt, resetTimer, { passive: true });
+    }
+    return () => {
+      // cleanup 時は直前の resetTimer() で必ず timer が set 済 (この effect は tokens truthy
+      // のときだけ cleanup を登録し、 その run は必ず resetTimer() を呼ぶ)。 null 経路は不到達。
+      /* v8 ignore next */
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      for (const evt of IDLE_EVENTS) {
+        window.removeEventListener(evt, resetTimer);
+      }
+    };
+  }, [tokens, logout]);
+
+  const value = useMemo<AuthState>(
+    () => ({
+      tokens,
+      ready,
+      login: (options) => beginLogin(config, options),
+      logout,
+      setTokens: (t) => setTokensState(t),
+    }),
+    [tokens, ready, config, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
+  return ctx;
+}

--- a/packages/web-kit/src/index.ts
+++ b/packages/web-kit/src/index.ts
@@ -6,6 +6,7 @@
  *   - Cloudscape の Badge / Alert / Spinner を **直接** 触るのではなく、 一段抽象を挟むことで
  *     視覚 token (= 色 / 余白 / icon) を全 SPA 一括で変更できる。
  */
+export { AuthProvider, type AuthState, useAuth } from "./auth";
 export { EmptyState, type EmptyStateAction, type EmptyStateProps } from "./EmptyState";
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export {

--- a/packages/web-kit/test/auth.test.tsx
+++ b/packages/web-kit/test/auth.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Issue #1418 web-kit Stage 3: 共有 AuthProvider の regression test。
+ * idle-logout (#859) / token memory 保持 (ADR-025) / login・logout 委譲 / useAuth guard を pin。
+ */
+
+import type { CognitoOAuthConfig, TokenSet } from "@tenkacloud/auth-client";
+import { render, renderHook, screen } from "@testing-library/react";
+import { act, type ReactNode, useEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const beginLoginMock = vi.fn();
+const beginLogoutMock = vi.fn();
+vi.mock("@tenkacloud/auth-client", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, beginLogin: beginLoginMock, beginLogout: beginLogoutMock };
+});
+
+const { AuthProvider, useAuth } = await import("../src/auth");
+
+const config: CognitoOAuthConfig = {
+  cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
+  cognitoClientId: "abc",
+  redirectUri: "http://localhost:5173/callback",
+  scope: "openid email",
+};
+
+const validTokens: TokenSet = {
+  idToken: "id",
+  accessToken: "ac",
+  refreshToken: "rf",
+  expiresAt: 9_999_999_999_999,
+};
+
+const IDLE_PLUS = 15 * 60 * 1000 + 1000;
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AuthProvider config={config}>{children}</AuthProvider>
+);
+
+function TokensDisplay() {
+  const { tokens, ready } = useAuth();
+  return (
+    <div>
+      <span data-testid="ready">{ready ? "ready" : "not-ready"}</span>
+      <span data-testid="tokens">{tokens ? "has-tokens" : "no-tokens"}</span>
+    </div>
+  );
+}
+
+/** Callback 相当: mount 直後に一度だけ setTokens してログイン状態を作る (memory 保持)。 */
+function SignedIn({ tokens }: { tokens: TokenSet }) {
+  const { setTokens } = useAuth();
+  const done = useRef(false);
+  useEffect(() => {
+    if (done.current) return;
+    done.current = true;
+    setTokens(tokens);
+  }, [setTokens, tokens]);
+  return <TokensDisplay />;
+}
+
+describe("AuthProvider idle timeout (#859)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    beginLoginMock.mockReset();
+    beginLogoutMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should mark ready after mount and start with no tokens", async () => {
+    render(
+      <AuthProvider config={config}>
+        <TokensDisplay />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("ready")).toHaveTextContent("ready");
+    expect(screen.getByTestId("tokens")).toHaveTextContent("no-tokens");
+  });
+
+  it("should not start the idle timer when there are no tokens", async () => {
+    render(
+      <AuthProvider config={config}>
+        <TokensDisplay />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      vi.advanceTimersByTime(IDLE_PLUS);
+    });
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+  });
+
+  it("should call beginLogout with the current tokens after 15 min without activity", async () => {
+    render(
+      <AuthProvider config={config}>
+        <SignedIn tokens={validTokens} />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("tokens")).toHaveTextContent("has-tokens");
+
+    await act(async () => {
+      vi.advanceTimersByTime(14 * 60 * 1000 + 59 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).toHaveBeenCalledTimes(1);
+    expect(beginLogoutMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ idToken: "id", refreshToken: "rf" }),
+    );
+  });
+
+  it("should reset the idle timer on user activity (keydown)", async () => {
+    render(
+      <AuthProvider config={config}>
+        <SignedIn tokens={validTokens} />
+      </AuthProvider>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown"));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(14 * 60 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+      await Promise.resolve();
+    });
+    expect(beginLogoutMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AuthProvider login delegation", () => {
+  beforeEach(() => beginLoginMock.mockReset());
+
+  it("should delegate login to beginLogin with config and options", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await act(async () => {
+      await result.current.login({ identityProvider: "saml-idp" });
+    });
+    expect(beginLoginMock).toHaveBeenCalledWith(config, { identityProvider: "saml-idp" });
+  });
+});
+
+describe("useAuth guard", () => {
+  it("should throw when used outside an AuthProvider", () => {
+    const Bare = () => {
+      useAuth();
+      return null;
+    };
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Bare />)).toThrow("useAuth must be used inside <AuthProvider>");
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

**#1418 web-kit Stage 3 (PR A).** admin-console と application-admin-console は Cognito `AuthProvider` (memory-only token + 15min idle-logout + server-side revoke) を copy-paste で抱えており、 **コメント (Issue 参照) 以外コード byte 一致** でした。

その dedup の **第一歩** として、 `@tenkacloud/web-kit` に共有 `AuthProvider` + `useAuth` を **純加算** で追加します。 `config` は render 時の prop なので factory 化は不要 — config 型を `@tenkacloud/auth-client` の `CognitoOAuthConfig` (= 各 SPA `AppConfig` の subset) にすれば両 SPA から prop 渡しできます。 まだ誰も consume しないので auth 挙動には一切触れません (= blast-radius ゼロ)。 後続 PR で 2 SPA の `AuthProvider.tsx` を再 export shim に載せ替えます。

- **ADR-025**: tokens は memory (React state) のみ保持、 mount 時に旧永続化 token を purge。
- **Issue #859**: 15 分無操作 (mouse/keyboard/touch/focus/scroll) で refresh token revoke。
- **Issue #833**: logout は Cognito cookie + refresh token を server-side revoke してから redirect。
- web-kit に `@tenkacloud/auth-client` を dependency 追加 (**循環なし**: auth-client は `@tenkacloud` package に依存しない)。

## Test plan

- `bun run --filter @tenkacloud/web-kit test` — **32 tests green** (既存 26 + auth 6)
- `bun run --filter @tenkacloud/web-kit test:coverage` — **lines 83/83, functions 33/33, branches 51/51 = 100%** (web-kit は GATED #1424)
- 新規 auth test: idle-logout (set/reset/fire/no-token) + login 委譲 + useAuth guard を網羅
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **純加算**: 既存 export (design-system / i18n) は不変。 新規 `AuthProvider`/`useAuth`/`AuthState` を barrel に足すだけで、 現状この auth を import する consumer は存在しない (2 SPA は今も自前 `src/auth/AuthProvider.tsx`)。 よって auth 挙動・login/logout flow には無影響。
- auth-client への新規依存は web-kit のみ。 SPA build には影響しない (web-kit は既に 3 SPA の workspace dep、 auth-client も既存共有 package)。
- `bun.lock` は `@tenkacloud/auth-client` の web-kit 参照のみ。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend 共有 package のソース追加のみで、 どの SPA bundle にもまだ取り込まれない (consumer 不在)。 CDK stack には無関係。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)