### PR TITLE
test(admin-console): cover Jobs page to 100%

### DIFF
--- a/apps/admin-console/src/pages/Jobs.tsx
+++ b/apps/admin-console/src/pages/Jobs.tsx
@@ -46,11 +46,11 @@ const STATUS_COLOR: Record<string, "blue" | "green" | "grey" | "red"> = {
   Superseded: "grey",
 };
 
-function colorFor(status: string): "blue" | "green" | "grey" | "red" {
+export function colorFor(status: string): "blue" | "green" | "grey" | "red" {
   return STATUS_COLOR[status] ?? "grey";
 }
 
-function formatElapsed(startIso: string | undefined, endIso: string | undefined): string {
+export function formatElapsed(startIso: string | undefined, endIso: string | undefined): string {
   if (!startIso) return "—";
   const start = Date.parse(startIso);
   if (Number.isNaN(start)) return "—";
@@ -98,6 +98,9 @@ export function JobsPage({ config }: { config: AppConfig }) {
   useEffect(() => {
     let cancelled = false;
     const tick = async () => {
+      // cleanup が cancelled=true にした後の遅延 tick を弾く防御。 setInterval は cleanup で
+      // 即 clear され、 fake timer test では unmount 後に tick が発火しないので不到達。
+      /* v8 ignore next */
       if (cancelled) return;
       await fetchOnce();
     };
@@ -237,7 +240,7 @@ export function JobsPage({ config }: { config: AppConfig }) {
  * deprovisioning SM の ListExecutions を返す。 503 (= not_configured、 旧 stack 互換) は
  * legacy placeholder にフォールバック。
  */
-function DeprovisioningJobsTab({ config }: { config: AppConfig }) {
+export function DeprovisioningJobsTab({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const t = useT();
   const [items, setItems] = useState<readonly StateMachineExecutionItem[] | null>(null);
@@ -249,6 +252,9 @@ function DeprovisioningJobsTab({ config }: { config: AppConfig }) {
   const region = config.awsRegion || "ap-northeast-1";
 
   const fetchOnce = useCallback(async () => {
+    // defensive guard: 下の useEffect が `!idToken` を先に弾くため fetchOnce は token 有り時しか
+    // 呼ばれない (= この early return は不到達)。 JobsPage 側は effect に guard が無いので到達する。
+    /* v8 ignore next */
     if (!idToken) return;
     try {
       const res = await fetchStateMachineExecutions(config, idToken, { limit: PAGE_SIZE });

--- a/apps/admin-console/test/Jobs.test.tsx
+++ b/apps/admin-console/test/Jobs.test.tsx
@@ -1,0 +1,225 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminInsightApiError } from "../src/api/admin-drill-down";
+import type { AppConfig } from "../src/config";
+import { colorFor, DeprovisioningJobsTab, formatElapsed, JobsPage } from "../src/pages/Jobs";
+
+/**
+ * Issue #1418: 未テストだった admin Provisioning Jobs page を 100% に引き上げる。
+ * pure helper (colorFor / formatElapsed) を直接 unit-test し、 JobsPage と
+ * DeprovisioningJobsTab は useAuth / admin-drill-down API / i18n を mock して render 分岐
+ * (loading / not-configured / forbidden / error+dismiss / table) を網羅する。
+ */
+const { mockAuth, mockFetchPipeline, mockFetchSfn } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFetchPipeline: vi.fn(),
+  mockFetchSfn: vi.fn(),
+}));
+
+vi.mock("../src/auth/AuthProvider", () => ({ useAuth: mockAuth }));
+// admin-drill-down は全 mock (importOriginal を使わない) → 実 module を読み込まず、 本 test の
+// coverage scope を Jobs.tsx に限定する (API client 自体の coverage は別 PR の責務)。
+// fake error class は Jobs.tsx の `err instanceof AdminInsightApiError` を満たす。
+vi.mock("../src/api/admin-drill-down", () => {
+  class AdminInsightApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(`AdminInsight API ${status}: ${message}`);
+      this.name = "AdminInsightApiError";
+    }
+  }
+  return {
+    AdminInsightApiError,
+    fetchPipelineExecutions: mockFetchPipeline,
+    fetchStateMachineExecutions: mockFetchSfn,
+  };
+});
+vi.mock("../src/i18n", () => {
+  // 安定参照の t (毎 render で新関数を返すと columns useMemo の dep が変わり無限 render)。
+  const stableT = (key: string, params?: Readonly<Record<string, string | number>>) =>
+    params ? `${key}|${JSON.stringify(params)}` : key;
+  const interpolate = (tmpl: string, vars: Readonly<Record<string, string>>) =>
+    tmpl.replace(/\{(\w+)\}/g, (_m, k) => (k in vars ? vars[k] : ""));
+  return { useT: () => stableT, interpolate };
+});
+
+const config = { awsRegion: "" } as AppConfig;
+const loggedIn = { tokens: { idToken: "id-token" } };
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("Jobs helpers", () => {
+  it("should map known statuses to a color and fall back to grey", () => {
+    expect(colorFor("Succeeded")).toBe("green");
+    expect(colorFor("InProgress")).toBe("blue");
+    expect(colorFor("WeirdUnknown")).toBe("grey");
+  });
+
+  it("should format elapsed time across hour / minute / second granularities", () => {
+    expect(formatElapsed("2026-01-01T00:00:00Z", "2026-01-01T02:30:00Z")).toBe("2h 30m");
+    expect(formatElapsed("2026-01-01T00:00:00Z", "2026-01-01T00:05:30Z")).toBe("5m 30s");
+    expect(formatElapsed("2026-01-01T00:00:00Z", "2026-01-01T00:00:45Z")).toBe("45s");
+  });
+
+  it("should return em-dash for missing or unparseable start time", () => {
+    expect(formatElapsed(undefined, undefined)).toBe("—");
+    expect(formatElapsed("not-a-date", "2026-01-01T00:00:00Z")).toBe("—");
+  });
+
+  it("should use the current time when there is no end time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10Z"));
+    expect(formatElapsed("2026-01-01T00:00:00Z", undefined)).toBe("10s");
+  });
+});
+
+describe("JobsPage", () => {
+  beforeEach(() => mockAuth.mockReturnValue(loggedIn));
+
+  it("should show the loading spinner while no token / no data yet", () => {
+    mockAuth.mockReturnValue({ tokens: undefined });
+    render(<JobsPage config={config} />);
+    expect(screen.getByText("jobs_page.loading")).toBeInTheDocument();
+    expect(mockFetchPipeline).not.toHaveBeenCalled();
+  });
+
+  it("should render the not-configured alert when the API returns null", async () => {
+    mockFetchPipeline.mockResolvedValue(null);
+    render(<JobsPage config={config} />);
+    expect(await screen.findByText("jobs_page.not_configured_header")).toBeInTheDocument();
+  });
+
+  it("should render the forbidden alert on a 403 AdminInsightApiError", async () => {
+    mockFetchPipeline.mockRejectedValue(new AdminInsightApiError(403, "denied"));
+    render(<JobsPage config={config} />);
+    expect(await screen.findByText("jobs_page.forbidden_header")).toBeInTheDocument();
+  });
+
+  it("should show a dismissible error alert on a non-403 failure", async () => {
+    mockFetchPipeline.mockRejectedValue(new Error("network down"));
+    render(<JobsPage config={config} />);
+    expect(await screen.findByText("jobs_page.error_header")).toBeInTheDocument();
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    // error 状態では table data が無く、 alert の dismiss button が唯一の button。
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.queryByText("network down")).not.toBeInTheDocument());
+  });
+
+  it("should render the executions table with status badge and elapsed / em-dash cells", async () => {
+    mockFetchPipeline.mockResolvedValue({
+      pipelineName: "p",
+      items: [
+        {
+          executionId: "exec-1234567890abc",
+          status: "Succeeded",
+          startTimeIso: "2026-01-01T00:00:00Z",
+          lastUpdateTimeIso: "2026-01-01T00:01:00Z",
+          consoleUrl: "https://console/exec1",
+        },
+        {
+          executionId: "exec-pending",
+          status: "Running",
+          startTimeIso: undefined,
+          lastUpdateTimeIso: undefined,
+          consoleUrl: "https://console/exec2",
+        },
+      ],
+    });
+    render(<JobsPage config={config} />);
+    expect(await screen.findByText(/exec-1234567/)).toBeInTheDocument();
+    expect(screen.getByText("Succeeded")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("should re-fetch on the 60s polling interval", async () => {
+    vi.useFakeTimers();
+    mockFetchPipeline.mockResolvedValue({ pipelineName: "p", items: [] });
+    render(<JobsPage config={config} />);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchPipeline).toHaveBeenCalledTimes(2); // initial + 1 interval tick
+  });
+});
+
+describe("DeprovisioningJobsTab", () => {
+  beforeEach(() => mockAuth.mockReturnValue(loggedIn));
+
+  it("should return early and render nothing fetched when there is no token", () => {
+    mockAuth.mockReturnValue({ tokens: undefined });
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(mockFetchSfn).not.toHaveBeenCalled();
+  });
+
+  it("should render the phase-1 placeholder + console link when the API returns null", async () => {
+    mockFetchSfn.mockResolvedValue(null);
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(await screen.findByText("jobs_page.deprovisioning_phase1_header")).toBeInTheDocument();
+    expect(screen.getByText("jobs_page.deprovisioning_open_console")).toBeInTheDocument();
+  });
+
+  it("should render the forbidden alert on a 403", async () => {
+    mockFetchSfn.mockRejectedValue(new AdminInsightApiError(403, "denied"));
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(await screen.findByText("jobs_page.forbidden_header")).toBeInTheDocument();
+  });
+
+  it("should render the fetch-failed alert on a non-403 failure", async () => {
+    mockFetchSfn.mockRejectedValue(new Error("sfn boom"));
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(await screen.findByText("jobs_page.fetch_failed_header")).toBeInTheDocument();
+    expect(screen.getByText("sfn boom")).toBeInTheDocument();
+  });
+
+  it("should treat a non-403 AdminInsightApiError as a fetch failure (not forbidden)", async () => {
+    mockFetchSfn.mockRejectedValue(new AdminInsightApiError(500, "server error"));
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(await screen.findByText("jobs_page.fetch_failed_header")).toBeInTheDocument();
+    expect(screen.queryByText("jobs_page.forbidden_header")).not.toBeInTheDocument();
+  });
+
+  it("should render the executions table with rows (region from config)", async () => {
+    mockFetchSfn.mockResolvedValue({
+      kind: "ok",
+      stateMachineArn: "arn:sfn",
+      items: [
+        {
+          executionArn: "arn:exec1",
+          name: "deprov-1",
+          status: "Succeeded",
+          startTimeIso: "2026-01-01T00:00:00Z",
+          stopTimeIso: "2026-01-01T00:02:00Z",
+          consoleUrl: "https://console/sfn1",
+        },
+        {
+          executionArn: "arn:exec2",
+          name: "deprov-2",
+          status: "Failed",
+          startTimeIso: undefined,
+          stopTimeIso: undefined,
+          consoleUrl: "https://console/sfn2",
+        },
+      ],
+    });
+    render(<DeprovisioningJobsTab config={{ awsRegion: "us-east-1" } as AppConfig} />);
+    expect(await screen.findByText("deprov-1")).toBeInTheDocument();
+    expect(screen.getByText("deprov-2")).toBeInTheDocument();
+  });
+
+  it("should render the empty state when there are no executions", async () => {
+    mockFetchSfn.mockResolvedValue({ kind: "ok", stateMachineArn: "arn:sfn", items: [] });
+    render(<DeprovisioningJobsTab config={config} />);
+    expect(await screen.findByText("jobs_page.empty_deprovisioning")).toBeInTheDocument();
+  });
+
+  it("should re-fetch on the 60s polling interval", async () => {
+    vi.useFakeTimers();
+    mockFetchSfn.mockResolvedValue({ kind: "ok", stateMachineArn: "arn:sfn", items: [] });
+    render(<DeprovisioningJobsTab config={config} />);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchSfn).toHaveBeenCalledTimes(2); // initial + 1 interval tick
+  });
+});


### PR DESCRIPTION
## Summary

**#1418 (100% coverage).** admin Provisioning Jobs page (`src/pages/Jobs.tsx`) は専用 test が無く、 v8 の「import された file だけ計測」 仕様で coverage scope の外に落ちていました (= 未テストの admin UI)。 本 PR は同 page を gated scope に取り込み **100%** にする pure な test 追加です。

- pure helper `colorFor` / `formatElapsed` を export して直接 unit-test (audit-log page と同じ「helper は export して直接 test」パターン)。 元 file 内 helper だった `DeprovisioningJobsTab` も export して単独 render test 可能に。
- `JobsPage` / `DeprovisioningJobsTab` を `useAuth` / `admin-drill-down` API / `i18n` を mock して render 分岐 (loading / not-configured / forbidden / 非403 error+dismiss / table / empty / 60s polling interval) を網羅。
- `admin-drill-down` は **全 mock** (`importOriginal` 不使用) で実 module を読み込まず、 本 test の coverage scope を Jobs.tsx に限定 (API client 自体の coverage は別 PR)。
- DeprovisioningJobsTab の `fetchOnce` 内 `if (!idToken) return` は useEffect が先に `!idToken` を弾くため**不到達** = `/* v8 ignore */` + 理由付与 (JobsPage 側は effect に guard が無く到達するので ignore 無し)。 polling interval callback は fake timer で発火。

## Test plan

- `apps/admin-console`: **210 tests green** (新規 18)、 branches/functions/lines すべて **100%** (327/327, 123/123, 441/441)
- `Jobs.tsx` 単体: branches 64/64, functions 25/25, lines 97/97 = **100%**
- `bun run scripts/check-coverage-gate.ts` — apps/admin-console ✅ 100%
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動 NO-OP**: Jobs.tsx は helper 2 つ + `DeprovisioningJobsTab` を export 追加しただけ (実装ロジック不変)。 `App.tsx` の `import { JobsPage }` は不変。 既存挙動には無影響。
- admin-drill-down は全 mock で coverage scope 外 (本 PR で計測対象に巻き込まない)。 他 workspace は無変更。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend test 追加 + testability の export/ignore のみ。 CDK stack には無関係。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Jobs page and deprovisioning tab, validating loading states, error handling, data display, and periodic refresh behavior.

* **Refactor**
  * Enhanced code organization by restructuring Jobs page components for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->