### PR TITLE
test(admin-console): use StatusCodes enum in Jobs test (no magic numbers)

### DIFF
--- a/apps/admin-console/test/Jobs.test.tsx
+++ b/apps/admin-console/test/Jobs.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StatusCodes } from "http-status-codes";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminInsightApiError } from "../src/api/admin-drill-down";
 import type { AppConfig } from "../src/config";
@@ -95,7 +96,7 @@ describe("JobsPage", () => {
   });
 
   it("should render the forbidden alert on a 403 AdminInsightApiError", async () => {
-    mockFetchPipeline.mockRejectedValue(new AdminInsightApiError(403, "denied"));
+    mockFetchPipeline.mockRejectedValue(new AdminInsightApiError(StatusCodes.FORBIDDEN, "denied"));
     render(<JobsPage config={config} />);
     expect(await screen.findByText("jobs_page.forbidden_header")).toBeInTheDocument();
   });
@@ -162,7 +163,7 @@ describe("DeprovisioningJobsTab", () => {
   });
 
   it("should render the forbidden alert on a 403", async () => {
-    mockFetchSfn.mockRejectedValue(new AdminInsightApiError(403, "denied"));
+    mockFetchSfn.mockRejectedValue(new AdminInsightApiError(StatusCodes.FORBIDDEN, "denied"));
     render(<DeprovisioningJobsTab config={config} />);
     expect(await screen.findByText("jobs_page.forbidden_header")).toBeInTheDocument();
   });
@@ -175,7 +176,9 @@ describe("DeprovisioningJobsTab", () => {
   });
 
   it("should treat a non-403 AdminInsightApiError as a fetch failure (not forbidden)", async () => {
-    mockFetchSfn.mockRejectedValue(new AdminInsightApiError(500, "server error"));
+    mockFetchSfn.mockRejectedValue(
+      new AdminInsightApiError(StatusCodes.INTERNAL_SERVER_ERROR, "server error"),
+    );
     render(<DeprovisioningJobsTab config={config} />);
     expect(await screen.findByText("jobs_page.fetch_failed_header")).toBeInTheDocument();
     expect(screen.queryByText("jobs_page.forbidden_header")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

PR #1593 の review (CodeRabbit) 指摘の fix。 `Jobs.test.tsx` が `AdminInsightApiError` を bare な HTTP status literal (`403` / `500`) で construct していました。 CLAUDE.md / AGENTS.md の「HTTP status code numeric literal 禁止、 `StatusCodes.*` を使う」 規約に揃えます (`Jobs.tsx` 本体は既に `StatusCodes.FORBIDDEN` を使用)。 harness の magic-number check は `c.json(body, N)` / `res.status === N` のみ検出し constructor 引数は拾わないため CI は通っていましたが、 規約上 literal を残すべきではありません。

- `403` → `StatusCodes.FORBIDDEN` (2 箇所)、 `500` → `StatusCodes.INTERNAL_SERVER_ERROR`。
- `http-status-codes` から `StatusCodes` を import。

## Test plan

- `apps/admin-console` Jobs test: **18 tests green**、 admin-console 100% 維持。
- `biome check` clean。

## Regression analysis

- **挙動 NO-OP**: `StatusCodes.FORBIDDEN`===403 / `INTERNAL_SERVER_ERROR`===500 で、 fake `AdminInsightApiError` に渡す数値は不変。
- test-only 変更。 production code は無変更。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 test source の rename のみ。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)