### PR TITLE
test(admin-console): cover OAuth Callback page to 100%

### DIFF
--- a/apps/admin-console/test/Callback.test.tsx
+++ b/apps/admin-console/test/Callback.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../src/config";
+import { CallbackPage } from "../src/pages/Callback";
+
+/**
+ * Issue #1418: 未テストだった admin OAuth Callback page を 100% に引き上げる。
+ * code 交換 (completeLogin) の success / reject / code 欠落 / 二重交換 guard を、
+ * completeLogin / useAuth / useNavigate を mock + MemoryRouter で query を与えて網羅する。
+ */
+const { mockCompleteLogin, mockSetTokens, mockNavigate } = vi.hoisted(() => ({
+  mockCompleteLogin: vi.fn(),
+  mockSetTokens: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+// auth-client は全 mock (実 module を読み込まない → coverage scope を Callback.tsx に限定)。
+vi.mock("@tenkacloud/auth-client", () => ({ completeLogin: mockCompleteLogin }));
+vi.mock("../src/auth/AuthProvider", () => ({ useAuth: () => ({ setTokens: mockSetTokens }) }));
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const config = {} as AppConfig;
+
+const renderAt = (query: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/callback${query}`]}>
+      <CallbackPage config={config} />
+    </MemoryRouter>,
+  );
+
+afterEach(() => vi.clearAllMocks());
+
+describe("CallbackPage", () => {
+  beforeEach(() => {
+    mockCompleteLogin.mockResolvedValue({
+      idToken: "id",
+      accessToken: "ac",
+      refreshToken: "rf",
+      expiresAt: 9_999_999_999_999,
+    });
+  });
+
+  it("should exchange the code+state and navigate to /tenants on success", async () => {
+    renderAt("?code=auth-code&state=st");
+    expect(screen.getByText("サインインを確定しています…")).toBeInTheDocument();
+    await waitFor(() => expect(mockSetTokens).toHaveBeenCalledTimes(1));
+    expect(mockCompleteLogin).toHaveBeenCalledWith(config, "auth-code", "st");
+    expect(mockNavigate).toHaveBeenCalledWith("/tenants", { replace: true });
+  });
+
+  it("should pass undefined state when the state param is absent", async () => {
+    renderAt("?code=auth-code");
+    await waitFor(() => expect(mockCompleteLogin).toHaveBeenCalled());
+    expect(mockCompleteLogin).toHaveBeenCalledWith(config, "auth-code", undefined);
+  });
+
+  it("should show an error when the authorization code is missing", () => {
+    renderAt("");
+    expect(screen.getByText("サインインに失敗しました")).toBeInTheDocument();
+    expect(screen.getByText(/Authorization code/)).toBeInTheDocument();
+    expect(mockCompleteLogin).not.toHaveBeenCalled();
+  });
+
+  it("should surface the error message when completeLogin rejects", async () => {
+    mockCompleteLogin.mockRejectedValue(new Error("token endpoint down"));
+    renderAt("?code=auth-code");
+    expect(await screen.findByText("token endpoint down")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should exchange only once even if the effect re-runs (exchangedRef guard)", async () => {
+    const view = renderAt("?code=auth-code");
+    await waitFor(() => expect(mockCompleteLogin).toHaveBeenCalledTimes(1));
+    // 別 config object で re-render → effect dep 変化で再実行されるが exchangedRef が弾く。
+    view.rerender(
+      <MemoryRouter initialEntries={["/callback?code=auth-code"]}>
+        <CallbackPage config={{} as AppConfig} />
+      </MemoryRouter>,
+    );
+    await Promise.resolve();
+    expect(mockCompleteLogin).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

**#1418 (100% coverage).** admin OAuth Callback page (`src/pages/Callback.tsx`) は専用 test が無く coverage scope の外でした (未テスト SPA page バックログの 1 件)。 Jobs.tsx と同じパターンで gated 100% scope に取り込む pure な test 追加です。

- `completeLogin` (auth-client) / `useAuth` / `useNavigate` を mock、 `MemoryRouter` の `initialEntries` で `?code=&state=` query を与えて `useSearchParams` を駆動。
- 網羅: code+state 交換成功 → `setTokens` + `navigate("/tenants")`、 state 欠落時 `undefined` 渡し、 code 欠落 → error、 `completeLogin` reject → error message、 `exchangedRef` による二重交換防止 (re-render しても `completeLogin` は 1 回)。
- auth-client は全 mock (`importOriginal` 不使用) で実 module を読み込まず、 coverage scope を Callback.tsx に限定。

## Test plan

- `apps/admin-console`: **215 tests green** (新規 5)、 branches/functions/lines すべて **100%** (335/335, 127/127, 461/461)
- `Callback.tsx` 単体: 8/8 branches, 4/4 functions, 20/20 lines = **100%**
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動 NO-OP**: production code (Callback.tsx) は無変更。 test 追加のみ。
- coverage gate (#1424): apps/admin-console ✅ 100%。 他 workspace 無変更。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend test 追加のみ。 CDK stack には無関係。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)