### PR TITLE
test(admin-console): cover CreateIdpModal to 100%

### DIFF
--- a/apps/admin-console/test/CreateIdpModal.test.tsx
+++ b/apps/admin-console/test/CreateIdpModal.test.tsx
@@ -1,0 +1,99 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { IdpClient } from "../src/api/idp-client";
+import { CreateIdpModal } from "../src/pages/CreateIdpModal";
+
+/**
+ * Issue #1418: 未テストだった admin CreateIdpModal (SAML IdP 登録モーダル) を 100% に。
+ * client は prop 注入なので mock client を渡し、 Cloudscape test-utils で input/textarea を駆動。
+ * describe-error helper のみ module mock し coverage scope を modal に限定する。
+ */
+vi.mock("../src/api/idp-client", () => ({
+  describeIdpError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+type Props = ComponentProps<typeof CreateIdpModal>;
+const clientWith = (create: Mock): IdpClient => ({ create }) as unknown as IdpClient;
+const makeProps = (over: Partial<Props> = {}): Props => ({
+  client: clientWith(vi.fn().mockResolvedValue(undefined)),
+  onClose: vi.fn(),
+  onCreated: vi.fn().mockResolvedValue(undefined),
+  busy: false,
+  setBusy: vi.fn(),
+  ...over,
+});
+
+// Cloudscape Modal は body にポータルされるので body を wrap する。
+const body = () => createWrapper(document.body);
+const register = () => screen.getByRole("button", { name: "Register" });
+
+afterEach(() => vi.clearAllMocks());
+
+describe("CreateIdpModal", () => {
+  it("should submit including description and the email attribute when entered", async () => {
+    const create = vi.fn().mockResolvedValue(undefined);
+    const props = makeProps({ client: clientWith(create) });
+    render(<CreateIdpModal {...props} />);
+    const inputs = body().findAllInputs(); // idpId, displayName, description, emailAttr
+    inputs[0]?.setInputValue("my-idp");
+    inputs[1]?.setInputValue("My IdP");
+    inputs[2]?.setInputValue("a desc");
+    inputs[3]?.setInputValue("urn:oid:0.9.2342.19200300.100.1.3"); // email attribute override
+    body().findTextarea()?.setTextareaValue("<xml/>");
+    fireEvent.click(register());
+    await waitFor(() => expect(props.onCreated).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idpId: "my-idp",
+        displayName: "My IdP",
+        description: "a desc",
+        metadataXml: "<xml/>",
+        attributeMapping: { email: "urn:oid:0.9.2342.19200300.100.1.3" },
+        groupToRole: {},
+      }),
+    );
+    expect(props.setBusy).toHaveBeenCalledWith(true);
+    expect(props.setBusy).toHaveBeenCalledWith(false);
+  });
+
+  it("should omit the description key when left blank", async () => {
+    const create = vi.fn().mockResolvedValue(undefined);
+    const props = makeProps({ client: clientWith(create) });
+    render(<CreateIdpModal {...props} />);
+    const inputs = body().findAllInputs();
+    inputs[0]?.setInputValue("idp2");
+    inputs[1]?.setInputValue("IdP 2");
+    body().findTextarea()?.setTextareaValue("<xml/>");
+    fireEvent.click(register());
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(create.mock.calls[0][0]).not.toHaveProperty("description");
+  });
+
+  it("should show an error alert when create rejects", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("invalid metadata"));
+    const props = makeProps({ client: clientWith(create) });
+    render(<CreateIdpModal {...props} />);
+    body().findAllInputs()[0]?.setInputValue("idp3");
+    fireEvent.click(register());
+    expect(await screen.findByText("invalid metadata")).toBeInTheDocument();
+    expect(props.onCreated).not.toHaveBeenCalled();
+    expect(props.setBusy).toHaveBeenLastCalledWith(false); // finally で必ず解除
+  });
+
+  it("should do nothing on submit when the client is null", () => {
+    const props = makeProps({ client: null });
+    render(<CreateIdpModal {...props} />);
+    fireEvent.click(register());
+    expect(props.setBusy).not.toHaveBeenCalled();
+    expect(props.onCreated).not.toHaveBeenCalled();
+  });
+
+  it("should call onClose on cancel", () => {
+    const props = makeProps();
+    render(<CreateIdpModal {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

**#1418 (100% coverage).** admin CreateIdpModal (SAML IdP 登録モーダル、 `src/pages/CreateIdpModal.tsx`) は専用 test が無く coverage scope 外でした (未テスト SPA page バックログ)。 gated 100% scope に取り込む pure test 追加です。

- `client` は prop 注入なので mock client を渡し、 Cloudscape test-utils (`createWrapper` → `findAllInputs`/`setInputValue` / `findTextarea`/`setTextareaValue`) で modal の input/textarea を駆動 (Modal は `document.body` にポータルされるため body を wrap)。
- `describeIdpError` のみ module mock し coverage scope を modal に限定。 `IdpClient` は型 import。
- 網羅: description 入力あり submit → create に description 含む + `setBusy(true/false)`、 description 空 → description key を omit、 create reject → error alert + finally で `setBusy(false)`、 client null → submit 何もしない、 Cancel → `onClose`。

## Test plan

- `apps/admin-console`: **227 tests green** (新規 5)、 branches/functions/lines すべて **100%** (357/357, 143/143, 516/516)
- `CreateIdpModal.tsx` 単体: 6/6 branches, 7/7 functions, 21/21 lines = **100%**
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動 NO-OP**: production code 無変更、 test 追加のみ。
- coverage gate (#1424): apps/admin-console ✅ 100%。 他 workspace 無変更。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend test 追加のみ。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)