### PR TITLE
test(admin-console): cover IdentityProviders page to 100%

### DIFF
--- a/apps/admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/admin-console/src/pages/IdentityProviders.tsx
@@ -153,6 +153,9 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
                   <Button
                     variant="inline-link"
                     onClick={async () => {
+                      // defensive: 行 (= items) は client.list 成功時のみ存在するので Delete button
+                      // が押せる時点で client は必ず非 null (= この guard は不到達)。
+                      /* v8 ignore next */
                       if (!client) return;
                       if (!confirm(`Delete IdP "${i.idpId}"?`)) return;
                       setBusy(true);

--- a/apps/admin-console/test/IdentityProviders.test.tsx
+++ b/apps/admin-console/test/IdentityProviders.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../src/config";
+import { IdentityProvidersPage } from "../src/pages/IdentityProviders";
+
+/**
+ * Issue #1418: 未テストだった admin IdentityProviders (SAML IdP 一覧/削除/追加) page を 100% に。
+ * useAuth / createIdpClient / i18n / format / 子 CreateIdpModal を mock し、 list 成功・失敗・空、
+ * 削除 (confirm 可否 / 成功 / 失敗)、 not-wired、 client 不在、 追加モーダル開閉を網羅する。
+ */
+const { mockUseAuth, mockCreateIdpClient, mockList, mockRemove } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  mockCreateIdpClient: vi.fn(),
+  mockList: vi.fn(),
+  mockRemove: vi.fn(),
+}));
+
+vi.mock("../src/auth/AuthProvider", () => ({ useAuth: mockUseAuth }));
+vi.mock("../src/api/idp-client", () => ({
+  createIdpClient: mockCreateIdpClient,
+  describeIdpError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+vi.mock("../src/i18n", () => ({ useLang: () => "en" }));
+vi.mock("../src/lib/format", () => ({ formatRelativeTime: (iso: string) => `rel:${iso}` }));
+vi.mock("../src/pages/CreateIdpModal", () => ({
+  CreateIdpModal: ({
+    onClose,
+    onCreated,
+  }: {
+    onClose: () => void;
+    onCreated: () => Promise<void>;
+  }) => (
+    <div data-testid="create-modal">
+      <button type="button" onClick={onClose}>
+        mock-modal-close
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onCreated();
+        }}
+      >
+        mock-modal-created
+      </button>
+    </div>
+  ),
+}));
+
+const config = {
+  apiBaseUrl: "https://api.example.com",
+  cognitoDomain: "auth.example.com",
+  cognitoClientId: "client-123",
+  scope: "openid email",
+  redirectUri: "https://app.example.com/callback",
+} as AppConfig;
+
+const idp = (over: Record<string, unknown> = {}) => ({
+  idpId: "okta",
+  displayName: "Okta",
+  description: "corp okta",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAuth.mockReturnValue({ tokens: { idToken: "id-token" } });
+  mockCreateIdpClient.mockReturnValue({ list: mockList, remove: mockRemove });
+  mockList.mockResolvedValue([]);
+  mockRemove.mockResolvedValue(undefined);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("IdentityProvidersPage", () => {
+  it("should show the not-wired alert when apiBaseUrl is missing", () => {
+    render(<IdentityProvidersPage config={{ ...config, apiBaseUrl: "" } as AppConfig} />);
+    expect(screen.getByText(/IdP CRUD API not wired up/)).toBeInTheDocument();
+  });
+
+  it("should not call list when there is no auth token (client null)", () => {
+    mockUseAuth.mockReturnValue({ tokens: null });
+    render(<IdentityProvidersPage config={config} />);
+    expect(mockCreateIdpClient).not.toHaveBeenCalled();
+    expect(mockList).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Add SAML IdP" })).toBeInTheDocument();
+  });
+
+  it("should render IdP rows with description fallback and a test-sign-in deep link", async () => {
+    mockList.mockResolvedValue([
+      idp(),
+      idp({ idpId: "entra", displayName: "Entra", description: undefined }),
+    ]);
+    render(<IdentityProvidersPage config={config} />);
+    expect(await screen.findByText("Okta")).toBeInTheDocument();
+    expect(screen.getByText("Entra")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument(); // description fallback for entra
+    const testLinks = screen.getAllByRole("link", { name: "Test sign-in" });
+    expect(testLinks[0]).toHaveAttribute("href", expect.stringContaining("identity_provider=okta"));
+    expect(testLinks[0]).toHaveAttribute("href", expect.stringContaining("client_id=client-123"));
+  });
+
+  it("should show the empty state when there are no IdPs", async () => {
+    mockList.mockResolvedValue([]);
+    render(<IdentityProvidersPage config={config} />);
+    expect(await screen.findByText(/No SAML IdPs configured/)).toBeInTheDocument();
+  });
+
+  it("should surface a load error", async () => {
+    mockList.mockRejectedValue(new Error("list failed"));
+    render(<IdentityProvidersPage config={config} />);
+    expect(await screen.findByText("list failed")).toBeInTheDocument();
+  });
+
+  it("should delete an IdP after confirmation and refresh", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockList.mockResolvedValue([idp()]);
+    render(<IdentityProvidersPage config={config} />);
+    await screen.findByText("Okta");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith("okta"));
+    expect(mockList).toHaveBeenCalledTimes(2); // initial + after delete
+  });
+
+  it("should not delete when the confirmation is dismissed", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    mockList.mockResolvedValue([idp()]);
+    render(<IdentityProvidersPage config={config} />);
+    await screen.findByText("Okta");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it("should surface a delete error", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockList.mockResolvedValue([idp()]);
+    mockRemove.mockRejectedValue(new Error("delete denied"));
+    render(<IdentityProvidersPage config={config} />);
+    await screen.findByText("Okta");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(await screen.findByText("delete denied")).toBeInTheDocument();
+  });
+
+  it("should open the create modal, close it, and refresh after creation", async () => {
+    mockList.mockResolvedValue([]);
+    render(<IdentityProvidersPage config={config} />);
+    await screen.findByText(/No SAML IdPs configured/);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add SAML IdP" }));
+    const modal = screen.getByTestId("create-modal");
+    // onClose path
+    fireEvent.click(within(modal).getByText("mock-modal-close"));
+    await waitFor(() => expect(screen.queryByTestId("create-modal")).not.toBeInTheDocument());
+
+    // re-open then onCreated path
+    fireEvent.click(screen.getByRole("button", { name: "Add SAML IdP" }));
+    fireEvent.click(within(screen.getByTestId("create-modal")).getByText("mock-modal-created"));
+    await waitFor(() => expect(screen.queryByTestId("create-modal")).not.toBeInTheDocument());
+    expect(mockList).toHaveBeenCalledTimes(2); // initial + after creation
+  });
+});


### PR DESCRIPTION
## Summary

**#1418 (100% coverage).** admin IdentityProviders (SAML IdP 一覧/追加/削除、 `src/pages/IdentityProviders.tsx`) は専用 test が無く coverage scope 外でした (未テスト SPA page バックログ)。 gated 100% scope に取り込む test 追加です。

- `useAuth` / `createIdpClient` / `useLang` / `formatRelativeTime` / 子 `CreateIdpModal` を mock し、 coverage scope を IdentityProviders.tsx に限定 (CreateIdpModal は別 test #1598)。
- 網羅: `apiBaseUrl` 未設定 → not-wired alert、 token 無し → client null で list 呼ばない、 list 成功 (description fallback "—" + Test sign-in deep link)、 空表示、 list error、 削除 (confirm OK → remove+refresh / confirm cancel → no-op / remove error)、 Add モーダル open → `onClose` / `onCreated` (refresh)。
- 削除 onClick 内 `if (!client) return` は行が `client.list` 成功時のみ存在するため**不到達** = `/* v8 ignore */` + 理由 (Jobs.tsx と同方針)。 `window.confirm` は `vi.spyOn` で制御。

## Test plan

- `apps/admin-console`: **236 tests green** (新規 9)、 branches/functions/lines すべて **100%** (373/373, 157/157, 560/560)
- `IdentityProviders.tsx` 単体: 18/18 branches, 14/14 functions, 45/45 lines = **100%**
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動 NO-OP**: production は不到達 guard への v8-ignore コメント追加のみ (ロジック不変)。 test 追加。
- coverage gate (#1424): apps/admin-console ✅ 100%。 他 workspace 無変更。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend test 追加 + v8-ignore コメントのみ。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Identity Provider management, validating creation, deletion, error handling, and confirmation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->