### PR TITLE
feat(portal): surface interTeamCoordination to plugin props

### DIFF
--- a/apps/participant-portal/src/data/problems.ts
+++ b/apps/participant-portal/src/data/problems.ts
@@ -39,6 +39,16 @@ export interface ProblemDisruptionEntry {
 }
 
 /**
+ * ADR-028 / Issue #1420: portal が表示してよい参加者間 coordination の公開情報。
+ * `publicHint === true` の問題だけ catalog に narrow される (= disruptions と同じ fairness 方針)。
+ * plugin path は platform 内部 (dispatcher が S3 から load) なので portal には出さない。
+ */
+export interface ProblemCoordinationEntry {
+  readonly name?: string;
+  readonly description?: string;
+}
+
+/**
  * ADR-012 Phase 5: 1 problem に紐づく portal plugin slot map。 `dashboard.slots[slotName]`
  * の各 entry は metadata.json で `portal/<SlotName>.tsx` 形式の相対 path を持つ。 portal
  * の plugin loader (= src/plugins/loader.ts) がこれを glob で照合して該当 chunk を lazy load する。
@@ -96,6 +106,8 @@ export interface ProblemCatalogEntry {
   readonly disruptions: readonly ProblemDisruptionEntry[];
   /** ADR-012 Phase 5: dashboard.slots[slotName] = portal/<file>.tsx 相対 path の map。 */
   readonly dashboardSlots?: ProblemDashboardSlots;
+  /** ADR-028 / Issue #1420: 参加者間 coordination の公開情報 (`publicHint: true` の問題のみ)。 */
+  readonly interTeamCoordination?: ProblemCoordinationEntry;
   /** Issue #583 Phase 5: 競技者向け field の locale override (en のみ、 #1108 で es / zh は廃止)。 ja は top-level。 */
   readonly i18n?: {
     readonly en?: ProblemI18nOverride;
@@ -148,6 +160,12 @@ interface ProblemMetadata {
   }[];
   dashboard?: {
     slots?: Record<string, string>;
+  };
+  interTeamCoordination?: {
+    plugin: string;
+    name?: string;
+    description?: string;
+    publicHint?: boolean;
   };
   /** ADR Issue #583 Phase 5 / #1108: 競技者向け field の locale override。 ja 自体は top-level が正本。 サポート対象は en のみ。 */
   i18n?: {
@@ -249,6 +267,15 @@ export function metadataToEntry(metadata: ProblemMetadata): ProblemCatalogEntry 
         ) ?? [],
     ...(dashboardSlots && Object.keys(dashboardSlots).length > 0
       ? { dashboardSlots: dashboardSlots as ProblemDashboardSlots }
+      : {}),
+    // ADR-028 / #1420: publicHint===true の coordination だけ portal に narrow (= disruptions と同方針)。
+    ...(metadata.interTeamCoordination?.publicHint === true
+      ? {
+          interTeamCoordination: omitUndefined({
+            name: metadata.interTeamCoordination.name,
+            description: metadata.interTeamCoordination.description,
+          }) as ProblemCoordinationEntry,
+        }
       : {}),
     ...(publicI18n ? { i18n: publicI18n } : {}),
     // ADR-026 / ADR-027: 実行環境を露出。 未宣言の legacy 問題は aws/cloudformation 既定。

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
@@ -24,12 +24,15 @@ vi.mock("./props-builder", () => ({
   buildPortalEndpointsFromOutputs: vi.fn(() => []),
   buildPortalPhases: vi.fn(() => []),
   buildPortalDisruptions: vi.fn(() => []),
+  buildPortalCoordination: vi.fn(() => undefined),
   buildPortalTeam: vi.fn((team) => team),
 }));
 
 const { loadPluginSlot } = await import("./loader");
+const { buildPortalCoordination } = await import("./props-builder");
 const { PortalPluginSlots } = await import("./PortalPluginSlots");
 const mockLoadPluginSlot = loadPluginSlot as ReturnType<typeof vi.fn>;
+const mockBuildCoordination = buildPortalCoordination as ReturnType<typeof vi.fn>;
 
 const baseProps = {
   problemId: "fake-problem",
@@ -41,6 +44,7 @@ const baseProps = {
 
 afterEach(() => {
   mockLoadPluginSlot.mockReset();
+  mockBuildCoordination.mockReset();
 });
 
 describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
@@ -59,6 +63,18 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
     );
     render(<PortalPluginSlots {...baseProps} />);
     await waitFor(() => expect(screen.getByTestId("fake-status")).toBeInTheDocument());
+  });
+
+  it("should pass interTeamCoordination to the slot props when present (#1420)", async () => {
+    mockBuildCoordination.mockReturnValue({ name: "Router", description: "service mesh" });
+    function CoordPanel(props: { coordination?: { name?: string } }) {
+      return <div data-testid="coord">{props.coordination?.name}</div>;
+    }
+    mockLoadPluginSlot.mockImplementation((_problemId, slotName) =>
+      slotName === "StatusPanel" ? CoordPanel : undefined,
+    );
+    render(<PortalPluginSlots {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId("coord")).toHaveTextContent("Router"));
   });
 
   it("should let ErrorBoundary fall back to an Alert when a plugin throws (= the whole portal does not crash) and elevate the log to console.error (Issue #1251)", async () => {

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
@@ -19,6 +19,7 @@ import { Component, type ErrorInfo, type ReactNode, Suspense, useMemo } from "re
 import { toErrorMessage } from "../lib/error-message";
 import { loadPluginSlot } from "./loader";
 import {
+  buildPortalCoordination,
   buildPortalDisruptions,
   buildPortalEndpointsFromOutputs,
   buildPortalPhases,
@@ -48,6 +49,7 @@ export function PortalPluginSlots({
   // から narrowed)。 endpoints は stackOutputs 依存なので別 memo に切る。
   const phases = useMemo(() => buildPortalPhases(problemId), [problemId]);
   const disruptions = useMemo(() => buildPortalDisruptions(problemId), [problemId]);
+  const coordination = useMemo(() => buildPortalCoordination(problemId), [problemId]);
   const endpoints = useMemo(
     () => buildPortalEndpointsFromOutputs(problemId, stackOutputs),
     [problemId, stackOutputs],
@@ -68,9 +70,10 @@ export function PortalPluginSlots({
       endpoints,
       phases,
       disruptions,
+      ...(coordination ? { coordination } : {}),
       nowIso,
     }),
-    [teamProp, problemId, jobId, score, endpoints, phases, disruptions, nowIso],
+    [teamProp, problemId, jobId, score, endpoints, phases, disruptions, coordination, nowIso],
   );
 
   const slotsToRender = useMemo(

--- a/apps/participant-portal/src/plugins/props-builder.test.ts
+++ b/apps/participant-portal/src/plugins/props-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPortalCoordination,
   buildPortalDisruptions,
   buildPortalEndpointsFromOutputs,
   buildPortalPhases,
@@ -83,5 +84,22 @@ describe("buildPortalDisruptions", () => {
 
   it("should return empty array for a non-existent problemId", () => {
     expect(buildPortalDisruptions("does-not-exist")).toEqual([]);
+  });
+});
+
+describe("buildPortalCoordination (#1420)", () => {
+  it("should return the public coordination info for a problem that declares it (publicHint=true)", () => {
+    const out = buildPortalCoordination("microservice-migration-battle");
+    expect(out?.name).toBeTruthy();
+    expect(out?.description).toBeTruthy();
+  });
+
+  it("should return undefined for problems without interTeamCoordination", () => {
+    expect(buildPortalCoordination("hello-world")).toBeUndefined();
+    expect(buildPortalCoordination("hello-world-battle")).toBeUndefined();
+  });
+
+  it("should return undefined for a non-existent problemId", () => {
+    expect(buildPortalCoordination("does-not-exist")).toBeUndefined();
   });
 });

--- a/apps/participant-portal/src/plugins/props-builder.ts
+++ b/apps/participant-portal/src/plugins/props-builder.ts
@@ -13,6 +13,7 @@
  */
 
 import type {
+  PortalCoordinationEntry,
   PortalDisruptionEntry,
   PortalEndpoint,
   PortalPhaseEntry,
@@ -86,6 +87,15 @@ export function buildPortalPhases(problemId: string): readonly PortalPhaseEntry[
 export function buildPortalDisruptions(problemId: string): readonly PortalDisruptionEntry[] {
   const disruptions = findProblemMetadata(problemId)?.disruptions ?? [];
   return disruptions.filter((d) => d.publicHint === true);
+}
+
+/**
+ * ADR-028 / Issue #1420: 参加者間 coordination の公開情報を plugin props 用に取り出す。
+ * catalog 側 `metadataToEntry` が既に `publicHint === true` で narrow 済 (= non-public は
+ * entry 自体が無い)ので、 ここは catalog の値をそのまま返す。 未宣言 problem は undefined。
+ */
+export function buildPortalCoordination(problemId: string): PortalCoordinationEntry | undefined {
+  return findProblemMetadata(problemId)?.interTeamCoordination;
 }
 
 /**

--- a/apps/participant-portal/test/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/test/plugins/PortalPluginSlots.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../src/plugins/loader", () => ({ loadPluginSlot: mockLoad }));
 vi.mock("../../src/plugins/props-builder", () => ({
   buildPortalPhases: () => [],
   buildPortalDisruptions: () => [],
+  buildPortalCoordination: () => undefined,
   buildPortalEndpointsFromOutputs: () => [],
   buildPortalTeam: (team: unknown) => team,
 }));

--- a/packages/portal-plugin-sdk/src/index.ts
+++ b/packages/portal-plugin-sdk/src/index.ts
@@ -42,6 +42,11 @@ export interface PortalSlotProps {
   readonly endpoints: readonly PortalEndpoint[];
   readonly phases: readonly PortalPhaseEntry[];
   readonly disruptions: readonly PortalDisruptionEntry[];
+  /**
+   * ADR-028 / Issue #1420: 参加者間 coordination の公開情報 (= `publicHint: true` の問題のみ)。
+   * 未宣言 / non-public な問題では undefined (= plugin 側で `props.coordination?.` で安全に扱う)。
+   */
+  readonly coordination?: PortalCoordinationEntry;
   readonly nowIso: string;
 }
 
@@ -77,6 +82,16 @@ export interface PortalDisruptionEntry {
   readonly defaultAfterMinutes?: number;
   readonly description?: string;
   readonly publicHint?: boolean;
+}
+
+/**
+ * ADR-028 / Issue #1420: 参加者間 coordination の公開情報。 `publicHint=true` の問題のみ portal
+ * (= props-builder) で narrow され plugin に届く。 plugin 側で publicHint を見る必要は無い。
+ * plugin path 等の platform 内部 field は portal には流さない (= 表示用の name / description のみ)。
+ */
+export interface PortalCoordinationEntry {
+  readonly name?: string;
+  readonly description?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

**#1420 (ADR-028) の portal slice.** submodule の `interTeamCoordination` 宣言 ([TenkaCloudChallenge#30](https://github.com/susumutomita/TenkaCloudChallenge/pull/30)、 pin #1603) を participant-portal の plugin props pipeline に通し、 問題の portal plugin (StatusPanel 等) が coordination の公開情報を受け取れるようにします。

- **portal-plugin-sdk**: `PortalCoordinationEntry` (name / description) + `PortalSlotProps.coordination?`。 plugin path 等の platform 内部 field は出さず、 公開表示用の name/description のみ。
- **data/problems.ts**: `ProblemMetadata.interTeamCoordination` + catalog `ProblemCatalogEntry` + `metadataToEntry` で **`publicHint===true` の問題だけ narrow** (= disruptions と同じ fairness projection)。
- **props-builder**: `buildPortalCoordination(problemId)`。
- **PortalPluginSlots**: `coordination` を `PortalSlotProps` に合流 (publicHint 無しは undefined → 省略)。

> dispatcher Lambda (ADR-028 D3、 infra) が live state を回すのは別 (= 本 PR は静的宣言の portal 露出まで)。 microservice-migration-battle が `publicHint:true` で参照宣言済なので catalog → props まで実データが流れます (props-builder test で実カタログ検証)。

## Test plan

- `apps/participant-portal`: **592 tests green** (新規: props-builder 3 + PortalPluginSlots present-branch 1)、 branches/functions/lines すべて **100%** (1453/1453 stmts)
- `packages/portal-plugin-sdk`: 型追加のみ (runtime 不変、 GATED 100%)
- `tsc --noEmit` (両 workspace) clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **既存挙動不変**: coordination 未宣言 / `publicHint!=true` の問題は `coordination=undefined` で従来の `PortalSlotProps` と同一 (新 field は optional)。 phases/disruptions の publicHint 方針を踏襲。
- PortalPluginSlots test の props-builder mock に `buildPortalCoordination` を追加 (既存 8 test 復旧)。

## Physical impact

- **NO-OP** on CFn / deployed artifacts。 frontend (portal) + 共有 SDK 型のソース変更のみ。 CDK stack / Lambda には無関係。

Relates #1420
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)