### PR TITLE
feat(coordination): dispatcher core — state store + orchestration (ADR-028 D3/D6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,6 +133,7 @@
         "@aws-sdk/client-codepipeline": "^3.1048.0",
         "@aws-sdk/client-sfn": "^3.1048.0",
         "@cdklabs/sbt-aws": "0.3.9",
+        "@tenkacloud/coordination-plugin-sdk": "workspace:*",
         "@tenkacloud/problem-runtime": "workspace:*",
         "@tenkacloud/saml-utils": "workspace:*",
         "ajv": "8.18.0",

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-dispatch.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-dispatch.ts
@@ -1,0 +1,96 @@
+import {
+  type CoordinationContext,
+  type CoordinationPlugin,
+  dispatchOp,
+  safeProjectForTeam,
+} from "@tenkacloud/coordination-plugin-sdk";
+import {
+  type CoordinationStoreDeps,
+  readCoordinationState,
+  writeCoordinationState,
+} from "./coordination-store.js";
+
+/**
+ * ADR-028 D6 (#1420): platform-side coordination dispatcher の純粋なオーケストレーション。
+ *
+ * 副作用 (DDB read/write) は {@link CoordinationStoreDeps} 越しに注入し、 意味論 (validate / apply /
+ * project) は問題が同梱する {@link CoordinationPlugin} に委譲する。 platform は SDK の純 util
+ * (`dispatchOp` / `safeProjectForTeam`) を「DDB から read → dispatch → 楽観ロック write」 の外側で
+ * 呼ぶだけで、 問題依存の意味論を一切持たない (= ADR-012 の problem=plugin / platform=host)。
+ */
+
+/** dispatch 1 回の文脈。 route が team-login-key 認証 + event scope を解決して渡す。 */
+export interface CoordinationDispatchInput<Op> {
+  readonly tenantId: string;
+  readonly eventId: string;
+  readonly teamId: string;
+  readonly op: Op;
+  /** plugin が初期化に使う event 文脈 (= 参加チーム一覧)。 */
+  readonly ctx: CoordinationContext;
+  /** projection が失敗 / 未初期化のときに返す安全な既定値 (= 機密を出さない)。 */
+  readonly fallbackProjection: unknown;
+  readonly nowIso: string;
+}
+
+export type CoordinationDispatchOutcome =
+  | { readonly kind: "ok"; readonly projection: unknown }
+  | { readonly kind: "rejected"; readonly error: string }
+  | { readonly kind: "conflict" };
+
+/**
+ * op を受理 → 適用 → 永続化し、 当該 team 向け projection を返す。
+ *   1. 現在 state を読む (無ければ plugin.initialState で初期化、 version 0)
+ *   2. SDK `dispatchOp` で validate→apply (拒否なら `rejected`)
+ *   3. version 条件付き write (並行更新なら `conflict` → caller が 409 で退避)
+ *   4. `safeProjectForTeam` で fail-safe に projection を返す
+ */
+export async function dispatchCoordinationOp<State, Op, Projection>(
+  store: CoordinationStoreDeps,
+  plugin: CoordinationPlugin<State, Op, Projection>,
+  input: CoordinationDispatchInput<Op>,
+): Promise<CoordinationDispatchOutcome> {
+  const existing = await readCoordinationState(store, input.tenantId, input.eventId);
+  const state = (existing?.state as State) ?? plugin.initialState(input.ctx);
+  const version = existing?.version ?? 0;
+
+  const verdict = dispatchOp(plugin, state, input.teamId, input.op);
+  if (!verdict.ok) return { kind: "rejected", error: verdict.error };
+
+  const written = await writeCoordinationState(
+    store,
+    input.tenantId,
+    input.eventId,
+    verdict.state,
+    version,
+    input.nowIso,
+  );
+  if (written.kind === "conflict") return { kind: "conflict" };
+
+  const projection = safeProjectForTeam(
+    plugin,
+    verdict.state,
+    input.teamId,
+    input.fallbackProjection as Projection,
+  );
+  return { kind: "ok", projection };
+}
+
+/**
+ * 当該 team の現在 projection を読む (= 書き込みなし、 portal の polling 用)。 state 未初期化なら
+ * plugin.initialState を投影する。 plugin が throw しても `fallbackProjection` を返す (fail-safe)。
+ */
+export async function projectCoordinationForTeam<State, Op, Projection>(
+  store: CoordinationStoreDeps,
+  plugin: CoordinationPlugin<State, Op, Projection>,
+  input: {
+    readonly tenantId: string;
+    readonly eventId: string;
+    readonly teamId: string;
+    readonly ctx: CoordinationContext;
+    readonly fallbackProjection: unknown;
+  },
+): Promise<unknown> {
+  const existing = await readCoordinationState(store, input.tenantId, input.eventId);
+  const state = (existing?.state as State) ?? plugin.initialState(input.ctx);
+  return safeProjectForTeam(plugin, state, input.teamId, input.fallbackProjection as Projection);
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-dispatch.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-dispatch.ts
@@ -37,6 +37,15 @@ export type CoordinationDispatchOutcome =
   | { readonly kind: "rejected"; readonly error: string }
   | { readonly kind: "conflict" };
 
+/** ctx.eventId が永続化 key (eventId) と一致し、 認証 team が ctx.teamIds に含まれるか。 */
+function isContextConsistent(input: {
+  readonly eventId: string;
+  readonly teamId: string;
+  readonly ctx: CoordinationContext;
+}): boolean {
+  return input.ctx.eventId === input.eventId && input.ctx.teamIds.includes(input.teamId);
+}
+
 /**
  * op を受理 → 適用 → 永続化し、 当該 team 向け projection を返す。
  *   1. 現在 state を読む (無ければ plugin.initialState で初期化、 version 0)
@@ -49,6 +58,10 @@ export async function dispatchCoordinationOp<State, Op, Projection>(
   plugin: CoordinationPlugin<State, Op, Projection>,
   input: CoordinationDispatchInput<Op>,
 ): Promise<CoordinationDispatchOutcome> {
+  // ctx (= 初期化に使う event 文脈) が永続化 key (eventId) / 認証 team とズレていたら、
+  // 別 event 用に組んだ state を保存 / 配信してしまう。 read/write 前に fail-closed で弾く。
+  if (!isContextConsistent(input)) return { kind: "rejected", error: "context_mismatch" };
+
   const existing = await readCoordinationState(store, input.tenantId, input.eventId);
   const state = (existing?.state as State) ?? plugin.initialState(input.ctx);
   const version = existing?.version ?? 0;
@@ -90,6 +103,8 @@ export async function projectCoordinationForTeam<State, Op, Projection>(
     readonly fallbackProjection: unknown;
   },
 ): Promise<unknown> {
+  // ctx 不整合 (= 別 event 用 ctx / team が event 外) は fail-closed で fallback を返す (= 機密非漏洩)。
+  if (!isContextConsistent(input)) return input.fallbackProjection;
   const existing = await readCoordinationState(store, input.tenantId, input.eventId);
   const state = (existing?.state as State) ?? plugin.initialState(input.ctx);
   return safeProjectForTeam(plugin, state, input.teamId, input.fallbackProjection as Projection);

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-store.ts
@@ -1,0 +1,85 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * ADR-028 D3 (#1420): inter-team coordination の per-event 共有 state を保存する store。
+ *
+ * cast-event ([[feedback_inter_team_coordination_plugin]]) と同じく **既存 Deployments テーブルに
+ * 新 SK pattern を足すだけ** で新規 table / IAM / CDK は不要 (= participant-handler は既に
+ * Deployments への Put 権限を持つ)。 1 event 1 row、 N teams 共有:
+ *   PK = `COORD#<tenantId>#<eventId>`   SK = `STATE`
+ *   attrs: state (plugin state JSON) / version (optimistic lock) / updatedAt (ISO8601)
+ *
+ * 書き込みは version 条件付き Put で楽観ロックする (= 同時 op の lost-update を防ぐ。
+ * disruption-fire の conditional Put と同方針)。 conflict 時は caller が 409 で退避リトライ。
+ */
+
+const SK = "STATE";
+
+function pk(tenantId: string, eventId: string): string {
+  return `COORD#${tenantId}#${eventId}`;
+}
+
+export interface CoordinationStateRow {
+  /** plugin 固有の共有 state。 plugin の applyOp が返した値。 */
+  readonly state: unknown;
+  /** 楽観ロック用 version。 row が無いときは 0 を初期値として扱う。 */
+  readonly version: number;
+}
+
+/** store が必要とする DDB client の最小 shape (= test で容易に mock)。 */
+export interface CoordinationStoreDeps {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  readonly tableName: string;
+}
+
+/** 現在の coordination state を読む。 row が無ければ undefined (= 未初期化)。 */
+export async function readCoordinationState(
+  deps: CoordinationStoreDeps,
+  tenantId: string,
+  eventId: string,
+): Promise<CoordinationStateRow | undefined> {
+  const out = await deps.ddb.send(
+    new GetCommand({ TableName: deps.tableName, Key: { PK: pk(tenantId, eventId), SK } }),
+  );
+  if (!out.Item) return undefined;
+  return { state: out.Item.state, version: Number(out.Item.version ?? 0) };
+}
+
+export type WriteCoordinationOutcome = { kind: "ok" } | { kind: "conflict" };
+
+/**
+ * 楽観ロックで state を書く。 `expectedVersion` が現在の version と一致するときだけ成功し、
+ * version を +1 する。 新規 row (= version 不在) は `expectedVersion === 0` のときだけ作成する。
+ * 不一致 (= 並行更新) は `conflict` を返し、 caller がリトライ判断する。
+ */
+export async function writeCoordinationState(
+  deps: CoordinationStoreDeps,
+  tenantId: string,
+  eventId: string,
+  state: unknown,
+  expectedVersion: number,
+  nowIso: string,
+): Promise<WriteCoordinationOutcome> {
+  try {
+    await deps.ddb.send(
+      new PutCommand({
+        TableName: deps.tableName,
+        Item: {
+          PK: pk(tenantId, eventId),
+          SK,
+          state,
+          version: expectedVersion + 1,
+          updatedAt: nowIso,
+        },
+        ConditionExpression: "attribute_not_exists(version) OR version = :expected",
+        ExpressionAttributeValues: { ":expected": expectedVersion },
+      }),
+    );
+    return { kind: "ok" };
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) return { kind: "conflict" };
+    throw err;
+  }
+}

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@TenkaCloud/trust-bridge": "workspace:*",
+    "@tenkacloud/coordination-plugin-sdk": "workspace:*",
     "@tenkacloud/problem-runtime": "workspace:*",
     "@tenkacloud/saml-utils": "workspace:*",
     "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",

--- a/infrastructure/test/problem-deploy/coordination-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-dispatch.test.ts
@@ -164,3 +164,36 @@ describe("projectCoordinationForTeam", () => {
     expect(await projectCoordinationForTeam(store, counter, base)).toEqual({ count: 0 });
   });
 });
+
+describe("coordination context guard (#1420 review)", () => {
+  it("should reject a dispatch when ctx.eventId differs from the persisted eventId", async () => {
+    const { store, send } = fakeStore({ getItem: undefined });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      ctx: { eventId: "OTHER", teamIds: ["t1"] },
+      op: { kind: "inc" },
+      nowIso: "now",
+    });
+    expect(out).toEqual({ kind: "rejected", error: "context_mismatch" });
+    expect(send).not.toHaveBeenCalled(); // fail-fast: no read/write
+  });
+
+  it("should reject a dispatch when the team is not in ctx.teamIds", async () => {
+    const { store } = fakeStore({ getItem: undefined });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      teamId: "intruder",
+      op: { kind: "inc" },
+      nowIso: "now",
+    });
+    expect(out).toEqual({ kind: "rejected", error: "context_mismatch" });
+  });
+
+  it("should return the fallback projection on an inconsistent context", async () => {
+    const { store, send } = fakeStore({ getItem: { state: { count: 9 }, version: 1 } });
+    expect(
+      await projectCoordinationForTeam(store, counter, { ...base, teamId: "intruder" }),
+    ).toEqual({ count: -1 });
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/infrastructure/test/problem-deploy/coordination-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-dispatch.test.ts
@@ -1,0 +1,166 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { CoordinationPlugin } from "@tenkacloud/coordination-plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatchCoordinationOp,
+  projectCoordinationForTeam,
+} from "../../lib/problem-deploy/handlers/participant-handler/coordination-dispatch.js";
+import {
+  type CoordinationStoreDeps,
+  readCoordinationState,
+  writeCoordinationState,
+} from "../../lib/problem-deploy/handlers/participant-handler/coordination-store.js";
+
+/**
+ * ADR-028 D3/D6 (#1420): coordination state store + dispatcher orchestration の pin。
+ * 既存 Deployments テーブル前提 (GetCommand / 条件付き PutCommand) を fake ddb で観測する。
+ */
+
+interface CounterState {
+  readonly count: number;
+}
+type CounterOp = { kind: "inc" } | { kind: "bad" };
+
+const counter: CoordinationPlugin<CounterState, CounterOp, { count: number }> = {
+  initialState: () => ({ count: 0 }),
+  validateOp: (_s, _t, op) => (op.kind === "bad" ? { ok: false, error: "bad_op" } : { ok: true }),
+  applyOp: (s) => ({ count: s.count + 1 }),
+  projectForTeam: (s) => ({ count: s.count }),
+};
+
+const ctx = { eventId: "e1", teamIds: ["t1", "t2"] };
+const base = {
+  tenantId: "tn1",
+  eventId: "e1",
+  teamId: "t1",
+  ctx,
+  fallbackProjection: { count: -1 },
+};
+
+/** GetCommand → getItem、 PutCommand → put 結果 (conflict 時は CCF を throw)。 */
+function fakeStore(opts: {
+  getItem?: Record<string, unknown>;
+  conflict?: boolean;
+  onPut?: (cmd: PutCommand) => void;
+}): { store: CoordinationStoreDeps; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand) return { Item: opts.getItem };
+    if (cmd instanceof PutCommand) {
+      opts.onPut?.(cmd);
+      if (opts.conflict) {
+        throw new ConditionalCheckFailedException({ message: "ccf", $metadata: {} });
+      }
+      return {};
+    }
+    throw new Error("unexpected command");
+  });
+  return { store: { ddb: { send } as never, tableName: "Deployments" }, send };
+}
+
+describe("coordination-store", () => {
+  it("should return undefined when the row does not exist", async () => {
+    const { store } = fakeStore({ getItem: undefined });
+    expect(await readCoordinationState(store, "tn1", "e1")).toBeUndefined();
+  });
+
+  it("should read state and default a missing version to 0", async () => {
+    const { store } = fakeStore({ getItem: { state: { count: 3 } } });
+    expect(await readCoordinationState(store, "tn1", "e1")).toEqual({
+      state: { count: 3 },
+      version: 0,
+    });
+  });
+
+  it("should write with the version condition and bump the version", async () => {
+    let captured: PutCommand | undefined;
+    const { store } = fakeStore({ onPut: (cmd) => (captured = cmd) });
+    const r = await writeCoordinationState(
+      store,
+      "tn1",
+      "e1",
+      { count: 1 },
+      4,
+      "2026-06-01T00:00:00Z",
+    );
+    expect(r).toEqual({ kind: "ok" });
+    expect(captured?.input.Item).toMatchObject({ PK: "COORD#tn1#e1", SK: "STATE", version: 5 });
+    expect(captured?.input.ExpressionAttributeValues).toEqual({ ":expected": 4 });
+  });
+
+  it("should return conflict on a ConditionalCheckFailed", async () => {
+    const { store } = fakeStore({ conflict: true });
+    expect(await writeCoordinationState(store, "tn1", "e1", {}, 0, "now")).toEqual({
+      kind: "conflict",
+    });
+  });
+
+  it("should rethrow non-conditional errors", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("ddb down");
+    });
+    const store = { ddb: { send } as never, tableName: "Deployments" };
+    await expect(writeCoordinationState(store, "tn1", "e1", {}, 0, "now")).rejects.toThrow(
+      "ddb down",
+    );
+  });
+});
+
+describe("dispatchCoordinationOp", () => {
+  it("should initialize, apply, persist, and project on a fresh event", async () => {
+    const { store, send } = fakeStore({ getItem: undefined });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      op: { kind: "inc" },
+      nowIso: "2026-06-01T00:00:00Z",
+    });
+    expect(out).toEqual({ kind: "ok", projection: { count: 1 } });
+    // version 0 condition (= 新規 row)
+    const put = send.mock.calls.map((c) => c[0]).find((c) => c instanceof PutCommand) as PutCommand;
+    expect(put.input.ExpressionAttributeValues).toEqual({ ":expected": 0 });
+  });
+
+  it("should apply on top of existing state", async () => {
+    const { store } = fakeStore({ getItem: { state: { count: 5 }, version: 2 } });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      op: { kind: "inc" },
+      nowIso: "now",
+    });
+    expect(out).toEqual({ kind: "ok", projection: { count: 6 } });
+  });
+
+  it("should reject an op that fails validateOp", async () => {
+    const { store, send } = fakeStore({ getItem: undefined });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      op: { kind: "bad" },
+      nowIso: "now",
+    });
+    expect(out).toEqual({ kind: "rejected", error: "bad_op" });
+    expect(send.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(false); // no write
+  });
+
+  it("should surface a write conflict", async () => {
+    const { store } = fakeStore({ getItem: undefined, conflict: true });
+    const out = await dispatchCoordinationOp(store, counter, {
+      ...base,
+      op: { kind: "inc" },
+      nowIso: "now",
+    });
+    expect(out).toEqual({ kind: "conflict" });
+  });
+});
+
+describe("projectCoordinationForTeam", () => {
+  it("should project existing state without writing", async () => {
+    const { store, send } = fakeStore({ getItem: { state: { count: 9 }, version: 1 } });
+    expect(await projectCoordinationForTeam(store, counter, base)).toEqual({ count: 9 });
+    expect(send.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(false);
+  });
+
+  it("should project the initial state when uninitialized", async () => {
+    const { store } = fakeStore({ getItem: undefined });
+    expect(await projectCoordinationForTeam(store, counter, base)).toEqual({ count: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

**⚠️ Infra PR — for your review, not self-merged** (new functionality in the `infrastructure` workspace; per the `infra は PR を開くが self-merge しない` directive).

Implements the **pure core** of #1420 / ADR-028's platform-side coordination dispatcher (D3 + D6), TDD-first — side effects DI'd, semantics delegated to the problem's plugin, platform stays a host.

- **`coordination-store.ts` (D3)** — per-event shared coordination state on the **existing Deployments table** (same approach as `cast-event`: no new table / IAM / CDK). `PK=COORD#<tenantId>#<eventId>` / `SK=STATE` / `version` optimistic lock. Read + version-conditional write (conflict → caller returns 409).
- **`coordination-dispatch.ts` (D6)** — orchestration: read-or-init → SDK `dispatchOp` (validate→apply) → optimistic-lock write → `safeProjectForTeam` (fail-safe projection). Store + plugin are DI'd → 100% unit-testable.
- Adds `@tenkacloud/coordination-plugin-sdk` to `infrastructure` deps.

> **Deliberately excluded** (needs your call): the participant-handler route (`POST/GET /portal/me/coordination/<eventId>`) + the **plugin loader**, because the loader is ADR-028 D6's bundle-glob-vs-S3 decision (build-coupling/runtime trade-off that's yours). This PR lands the loading-mechanism-independent tested core first.

## Test plan

- New modules: **11 tests, 100%** branches/functions/lines (16/16, 5/5, 22/22) — fresh-event init, apply-on-existing, validateOp rejection, write conflict, projection read, optimistic-lock condition, CCF→conflict, non-conditional rethrow.
- `infrastructure` `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0.

## Regression analysis

- **Additive + not yet wired**: 2 new modules + 1 test. No route imports them yet, so the participant-handler bundle/behavior is unchanged. No effect on existing tests.
- `COORD#` PK doesn't collide with the table's `DEPLOYMENT#` PK schema. SDK dep already used by other (gated 100%) workspaces.

## Physical impact

- **NO-OP** on CFn / deployed artifacts. No new CDK construct (state rides the existing Deployments table). Modules aren't bundled into any Lambda yet (route unwired), so the participant-handler artifact is also unchanged.

Relates #1420
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new inter-team coordination system for managing shared state during events
  * Added optimistic concurrency control with automatic conflict detection for concurrent team operations
  * Implemented team-specific state projections with fallback safeguards

* **Tests**
  * Added comprehensive test coverage for coordination store and dispatch operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->