### PR TITLE
refactor(admin): name the TenantList poll interval + drop a magic number

### DIFF
--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -36,7 +36,7 @@ import { computeTenantProgress, isInProgress } from "../lib/tenant-progress";
  * 5 tenants × ~50 deployments を 60s ごとに refresh して RCU 消費は 1 tenant あたり ~1 query。
  * Phase 3 dashboard で tenant 数が伸びるなら pre-aggregation table に置き換え。
  */
-const INSIGHT_POLLING_INTERVAL_MS = 60 * 1000;
+const TENANT_LIST_POLLING_INTERVAL_MS = 60 * 1000;
 
 /**
  * deprovision 済みの tenant かどうかを判定する。
@@ -123,7 +123,7 @@ export function TenantListPage({ config }: { config: AppConfig }) {
     void fetchInsight();
     const handle = window.setInterval(() => {
       void fetchInsight();
-    }, INSIGHT_POLLING_INTERVAL_MS);
+    }, TENANT_LIST_POLLING_INTERVAL_MS);
     return () => {
       cancelled = true;
       window.clearInterval(handle);
@@ -132,7 +132,7 @@ export function TenantListPage({ config }: { config: AppConfig }) {
 
   // #657: 経過時間の severity を 60 秒周期で再評価。 setInterval は cleanup 必須。
   useEffect(() => {
-    const handle = window.setInterval(() => setNowMs(Date.now()), 60_000);
+    const handle = window.setInterval(() => setNowMs(Date.now()), TENANT_LIST_POLLING_INTERVAL_MS);
     return () => window.clearInterval(handle);
   }, []);
 


### PR DESCRIPTION
## Summary

`TenantList` runs two 60s `setInterval` pollers — the insight-aggregation poll (used `INSIGHT_POLLING_INTERVAL_MS`) and the `nowMs` severity-re-eval poll (a bare `60_000` literal). This names the constant after the page's polling cadence (`TENANT_LIST_POLLING_INTERVAL_MS`) and routes the `nowMs` interval through it too — removing the magic number and centralizing the cadence (DRY).

(This landed as a stray uncommitted edit in the working tree; it's a clean, complete improvement, so I'm merging it rather than discarding.)

## Test plan

- `apps/admin-console`: TenantList test **22 passed** (the test spies on `setInterval`, not the constant, so the rename + identical value don't affect it)
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動完全保存**: value unchanged (`60 * 1000` === `60_000`); constant rename is local to `TenantList.tsx` (no dangling refs, grep-verified).

## Physical impact

- **NO-OP** on CFn / deployed artifacts — frontend literal→constant rename only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized polling interval management in tenant list functionality for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->