### PR TITLE
feat(app-admin): group admin nav items under a 管理 section

### DIFF
--- a/apps/application-admin-console/src/components/AppLayout.tsx
+++ b/apps/application-admin-console/src/components/AppLayout.tsx
@@ -111,12 +111,20 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/problems", text: t("nav.problems") },
               { type: "link", href: "/deployments", text: t("nav.deployments") },
               { type: "link", href: "/competitor-accounts", text: t("nav.competitor_accounts") },
-              // Issue #1292: 自テナント監査ログ (= deploy / event 操作の audit)。
-              { type: "link", href: "/audit-log", text: t("nav.audit_log") },
-              // Issue #1294: per-tenant SAML SSO (silo tier only — page shows a warning
-              // alert for pooled tenants). Reintroduces the link removed in #1066 (which
-              // had been replaced by hard MFA), now scoped to silo + multi-IdP.
-              { type: "link", href: "/identity-providers", text: "Identity providers" },
+              // 管理系 (監査ログ / IdP) は日常運用メニューと混ざると見つけにくいので、 1 つの
+              // category section にまとめて flat な羅列を解消する。
+              {
+                type: "section",
+                text: t("nav.admin_section"),
+                items: [
+                  // Issue #1292: 自テナント監査ログ (= deploy / event 操作の audit)。
+                  { type: "link", href: "/audit-log", text: t("nav.audit_log") },
+                  // Issue #1294: per-tenant SAML SSO (silo tier only — page shows a warning
+                  // alert for pooled tenants). Reintroduces the link removed in #1066 (which
+                  // had been replaced by hard MFA), now scoped to silo + multi-IdP.
+                  { type: "link", href: "/identity-providers", text: "Identity providers" },
+                ],
+              },
             ]}
             onFollow={(e) => {
               // SideNavigation の link は全て internal (external:true なし) なので偽は不到達。

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -16,7 +16,8 @@
     "problems": "Problems",
     "deployments": "Deployments",
     "competitor_accounts": "Competitor Accounts",
-    "audit_log": "Audit log"
+    "audit_log": "Audit log",
+    "admin_section": "Admin"
   },
   "auth": {
     "sign_out": "Sign out"

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -16,7 +16,8 @@
     "problems": "Problems",
     "deployments": "Deployments",
     "competitor_accounts": "Competitor Accounts",
-    "audit_log": "監査ログ"
+    "audit_log": "監査ログ",
+    "admin_section": "管理"
   },
   "auth": {
     "sign_out": "サインアウト"


### PR DESCRIPTION
## Summary

Feedback: the Application Admin Console's flat sidebar makes admin-type menus (監査ログ / Identity providers) hard to distinguish from day-to-day operational menus. This groups the two admin items under a Cloudscape `SideNavigation` **`section`** titled **管理 / Admin**, while keeping the operational items (Home / Events / Problems / Deployments / Competitor Accounts) at top level.

```
Home
Events
Problems
Deployments
Competitor Accounts
── 管理 (Admin) ──
  監査ログ (Audit log)
  Identity providers
```

- `AppLayout.tsx`: `audit-log` + `identity-providers` nested into a `type: "section"`. href / navigate behavior unchanged.
- i18n: added `nav.admin_section` (ja: 「管理」 / en: "Admin").

## Test plan

- `apps/application-admin-console`: **889 tests green**, branches/functions/lines **100%** (2269/2269 stmts). Existing AppLayout test (pins `/problems` link nav) unaffected — operational links stay top-level.
- `tsc --noEmit` clean / `biome check` clean / `make harness` invariant 違反 0

## Regression analysis

- **挙動保存**: links keep their href + internal `onFollow` navigate (now inside a section). i18n key added to both ja/en (locale parity).

## Physical impact

- **NO-OP** on CFn / deployed artifacts — SPA nav only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)