### PR TITLE
fix(tenant): UserPool featurePlan ESSENTIALS for V2 token claims [INFRA]

### DIFF
--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -129,6 +129,12 @@ export class IdentityProvider extends Construct {
     // は Gmail で改行が collapse して読めない問題があった。 多言語化が必要なら CustomMessage
     // Lambda Trigger + SES への移行 (= 別 issue) で対応する。
     this.tenantUserPool = new aws_cognito.UserPool(this, "tenantUserPool", {
+      // V2 pre-token-generation トリガ (= lite-admin-claims、 Issue #1327 / #1358) が id/access token に
+      // `custom:userRole=TenantAdmin` 等を注入するには UserPool が **Essentials 以上** の feature plan で
+      // なければならない。 Lite plan では V2 の token customization が無視され claim が乗らず、 tenant API の
+      // requireRole が 403 "not a TenantAdmin" を返す (= 監査ログ / IdP 画面の失敗の根因)。 admin のみが
+      // Cognito を使い MAU は極小なので Essentials 無料枠 (10k MAU) 内に収まる (cost-zero 原則を維持)。
+      featurePlan: aws_cognito.FeaturePlan.ESSENTIALS,
       autoVerify: { email: true },
       accountRecovery: aws_cognito.AccountRecovery.EMAIL_ONLY,
       // ADR-020 Phase E / audit MFA: tenant admin consoles は destructive 操作を扱う


### PR DESCRIPTION
## Summary

監査ログ画面の "Failed to fetch" と Identity providers 画面の "forbidden — your account is not a TenantAdmin or belongs to a different tenant" の **根因修正**。

tenant UserPool は V2 pre-token-generation トリガ (`lite-admin-claims`、 #1327 / #1358) で id/access token に `custom:userRole=TenantAdmin` + `custom:tenantId` を注入する設計。ところが UserPool に `featurePlan` を明示していなかったため、 Lite/legacy plan だと **AWS が V2 の token customization を黙って無視** し、 claim が token に乗らない。

結果として:
- tenant API の `requireRole` が 403 `not a TenantAdmin` を返す → **IdP 画面の forbidden**。
- audit-log route が JWT authorizer (claim 依存) の段で弾かれ、 API Gateway が CORS header 無しの拒否を返すため browser からは **"Failed to fetch"** (network error) に見える → **監査ログ画面**。

修正は `featurePlan: aws_cognito.FeaturePlan.ESSENTIALS` を UserPool props に明示するだけ。V2 token customization は Cognito Essentials 以上が AWS の要件。Cognito を使うのは admin のみで MAU は極小、Essentials は 10k MAU まで無料なので **cost-zero 原則を維持**する。

> ⚠️ **owner review + 再 deploy 用に open。self-merge しない。** 反映には `make deploy` 後、既存 admin が **sign-out → sign-in** で fresh JWT を取り直す必要がある (古い token には claim が無い)。

## Test plan
- infra `tsc --noEmit` = 0、biome clean、`make harness` error 0 (info: cdk.out 未生成のみ)。
- 影響 test 72 件緑: `identity-provider` / `tenant-template/*` / `tenkacloud-lite/*` / `app-plane-core/build-app-plane-core`。
- `featurePlan` を assert する既存 test は無く、assertion 影響なし。

## Regression analysis
- `featurePlan` は UserPool の update 可能プロパティ (`UserPoolTier`) であり replacement を誘発しない。既存 user / pool は保持され、MFA REQUIRED / custom attributes / invitation 等の既存挙動は不変。
- LITE→ESSENTIALS で V2 token customization が有効化されるのが唯一の振る舞い変化 (= 意図した修正)。
- 既存 admin の old JWT は再 sign-in まで claim が無いまま → deploy 直後は再ログインが必須 (上記の通り運用注意)。

## Physical impact
- **UPDATE** on `AWS::Cognito::UserPool` (`UserPoolTier`: LITE → ESSENTIALS)。in-place update、replacement なし。
- 他 CFn リソースは **NO-OP**。

Relates #1327
Relates #1294
Relates #1292