### PR TITLE
refactor(admin-console): extract shared usePolling hook (DRY) [#1418]

### DIFF
--- a/apps/admin-console/src/pages/Jobs.tsx
+++ b/apps/admin-console/src/pages/Jobs.tsx
@@ -8,8 +8,9 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
 import Tabs from "@cloudscape-design/components/tabs";
+import { usePolling } from "@tenkacloud/web-kit";
 import { StatusCodes } from "http-status-codes";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   AdminInsightApiError,
   fetchPipelineExecutions,
@@ -95,24 +96,9 @@ export function JobsPage({ config }: { config: AppConfig }) {
     }
   }, [config, idToken]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      // cleanup が cancelled=true にした後の遅延 tick を弾く防御。 setInterval は cleanup で
-      // 即 clear され、 fake timer test では unmount 後に tick が発火しないので不到達。
-      /* v8 ignore next */
-      if (cancelled) return;
-      await fetchOnce();
-    };
-    void tick();
-    const handle = window.setInterval(() => {
-      void tick();
-    }, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(handle);
-    };
-  }, [fetchOnce]);
+  // 初回 fetch + 60s polling + unmount cleanup は usePolling (web-kit) に集約 (#1418 DRY)。
+  // idToken 不在は fetchOnce 側が弾く (= JobsPage は effect レベルの gate を持たない既存挙動)。
+  usePolling(fetchOnce, POLL_INTERVAL_MS);
 
   const columns = useMemo(
     () => [
@@ -276,12 +262,9 @@ export function DeprovisioningJobsTab({ config }: { config: AppConfig }) {
     }
   }, [config, idToken]);
 
-  useEffect(() => {
-    if (!idToken) return;
-    void fetchOnce();
-    const interval = setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchOnce, idToken]);
+  // 初回 fetch + 60s polling + unmount cleanup は usePolling (web-kit) に集約 (#1418 DRY)。
+  // idToken 解決前は enabled=false で timer を張らない (既存の effect gate を踏襲)。
+  usePolling(fetchOnce, POLL_INTERVAL_MS, { enabled: Boolean(idToken) });
 
   const sfnListUrl = useMemo(
     () => `https://${region}.console.aws.amazon.com/states/home?region=${region}#/statemachines`,

--- a/apps/admin-console/src/pages/TenantDetail.tsx
+++ b/apps/admin-console/src/pages/TenantDetail.tsx
@@ -9,7 +9,8 @@ import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePolling } from "@tenkacloud/web-kit";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useApiClient } from "../api/client";
 import {
@@ -76,13 +77,8 @@ export function TenantDetailPage({ config }: { config: AppConfig }) {
     }
   }, [api, tenantId, t]);
 
-  useEffect(() => {
-    void refresh();
-    const handle = window.setInterval(() => {
-      void refresh();
-    }, POLL_INTERVAL_MS);
-    return () => window.clearInterval(handle);
-  }, [refresh]);
+  // 初回 fetch + 60s polling + unmount cleanup は usePolling (web-kit) に集約 (#1418 DRY)。
+  usePolling(refresh, POLL_INTERVAL_MS);
 
   const parsedConfig = useMemo(() => parseTenantConfig(tenant?.tenantConfig), [tenant]);
 

--- a/apps/admin-console/src/pages/TenantList.tsx
+++ b/apps/admin-console/src/pages/TenantList.tsx
@@ -8,7 +8,7 @@ import Popover from "@cloudscape-design/components/popover";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
 import Toggle from "@cloudscape-design/components/toggle";
-import { EmptyState, ErrorState } from "@tenkacloud/web-kit";
+import { EmptyState, ErrorState, usePolling } from "@tenkacloud/web-kit";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useApiClient } from "../api/client";
@@ -99,42 +99,26 @@ export function TenantListPage({ config }: { config: AppConfig }) {
   // tenants が解決済みなら AdminInsight API を叩いて集計を join する。
   // tokens が無い / config.adminInsightApiUrl 未設定なら fetch を skip して null のまま
   // にしておく (= column 自体を表示しない、UI に「未配線」状態を持ち込まない安全装置)。
-  useEffect(() => {
+  const pollInsight = useCallback(async () => {
     const idToken = auth.tokens?.idToken;
     if (!idToken || !tenants || !config.adminInsightApiUrl) return;
     const tenantIds = tenants.map((t) => t.tenantId);
-
-    let cancelled = false;
-    const fetchInsight = async () => {
-      try {
-        const summary = await fetchTenantsInsightSummary(config, idToken, tenantIds);
-        // cancelled は unmount 時のみ true (= test では fetch 中に unmount しないので不到達)。
-        /* v8 ignore next */
-        if (cancelled) return;
-        // null = 403 forbidden 等 (= SystemAdmin claim 無し)。column hide のため state も null。
-        setInsightByTenantId(summary ? indexSummaryByTenantId(summary) : null);
-      } catch {
-        // tenant 一覧の primary 表示は壊さない。集計列だけ未取得扱いにする (= null)。
-        // cancelled=true 側は unmount race (不到達)。
-        /* v8 ignore next */
-        if (!cancelled) setInsightByTenantId(null);
-      }
-    };
-    void fetchInsight();
-    const handle = window.setInterval(() => {
-      void fetchInsight();
-    }, TENANT_LIST_POLLING_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(handle);
-    };
+    try {
+      const summary = await fetchTenantsInsightSummary(config, idToken, tenantIds);
+      // null = 403 forbidden 等 (= SystemAdmin claim 無し)。column hide のため state も null。
+      setInsightByTenantId(summary ? indexSummaryByTenantId(summary) : null);
+    } catch {
+      // tenant 一覧の primary 表示は壊さない。集計列だけ未取得扱いにする (= null)。
+      setInsightByTenantId(null);
+    }
   }, [auth.tokens?.idToken, tenants, config]);
 
-  // #657: 経過時間の severity を 60 秒周期で再評価。 setInterval は cleanup 必須。
-  useEffect(() => {
-    const handle = window.setInterval(() => setNowMs(Date.now()), TENANT_LIST_POLLING_INTERVAL_MS);
-    return () => window.clearInterval(handle);
-  }, []);
+  // 即時 fetch + 60s polling + unmount cleanup は usePolling (web-kit) に集約 (#1418 DRY)。
+  usePolling(pollInsight, TENANT_LIST_POLLING_INTERVAL_MS);
+
+  // #657: 経過時間の severity を 60 秒周期で再評価 (即時実行は不要なので immediate=false)。
+  const tickNow = useCallback(() => setNowMs(Date.now()), []);
+  usePolling(tickNow, TENANT_LIST_POLLING_INTERVAL_MS, { immediate: false });
 
   const confirmDeprovision = async () => {
     // modal は pendingDeprovision!==null かつ行 (= api 有り) でしか開かないので guard は不到達。

--- a/apps/admin-console/test/TenantList.test.tsx
+++ b/apps/admin-console/test/TenantList.test.tsx
@@ -52,7 +52,10 @@ vi.mock("../src/lib/tenant-progress", () => ({
     return { label: "1m", severity: "normal" };
   },
 }));
-vi.mock("@tenkacloud/web-kit", () => ({
+// usePolling は純 timer hook なので実物を残し (= setInterval 捕捉が効く)、 Cloudscape 依存の
+// EmptyState / ErrorState だけ軽量 stub で差し替える。
+vi.mock("@tenkacloud/web-kit", async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
   EmptyState: ({
     headline,
     primaryAction,

--- a/packages/web-kit/src/index.ts
+++ b/packages/web-kit/src/index.ts
@@ -19,3 +19,4 @@ export {
 } from "./i18n";
 export { LoadingState, type LoadingStateProps } from "./LoadingState";
 export { StatusBadge, type StatusBadgeProps, type StatusTone, statusToTone } from "./StatusBadge";
+export { type UsePollingOptions, usePolling } from "./usePolling";

--- a/packages/web-kit/src/usePolling.ts
+++ b/packages/web-kit/src/usePolling.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+/** {@link usePolling} の任意設定。 */
+export interface UsePollingOptions {
+  /**
+   * mount 直後に 1 回 callback を即実行するか。 false なら最初の tick は `intervalMs` 経過後
+   * (= 一覧 fetch は即時が欲しいので既定 true、 時計の再評価のような「次の周期で十分」な用途は false)。
+   */
+  readonly immediate?: boolean;
+  /**
+   * false の間は interval を張らず polling を止める (= 条件が揃うまで待つ)。 false→true で polling 開始、
+   * true→false で停止 + cleanup。 認証 token / 依存 state が未解決の間 fetch を skip する用途 (既定 true)。
+   */
+  readonly enabled?: boolean;
+}
+
+/**
+ * 一定間隔で callback を呼ぶ共有 polling primitive (3 SPA 共通、 #1418)。
+ *
+ * `setInterval` + mount 時の即時実行 + unmount 時の `clearInterval` + 「unmount 後に解決した非同期
+ * tick が state を触らないための active guard」 という boilerplate が admin-console の
+ * TenantList / TenantDetail / Jobs に copy-paste されていたのを 1 箇所へ集約する (DRY / 単一責務)。
+ * 意味論 (何を fetch し state をどう更新するか) は callback 側に残り、 本 hook は timer 制御だけを担う。
+ *
+ * SSE/WebSocket を使わず polling に寄せる方針 (AGENTS.md) と整合。 純粋に timer を扱うだけで
+ * AWS SDK / fetch には依存しない (= portal-plugin-sdk と同様、 web-kit primitive の責務範囲)。
+ *
+ * @param callback 毎 tick 実行する処理。 引数 `isActive()` は hook が現在も mount 中かを返す
+ *                 (= 非同期処理の解決後に `if (!isActive()) return;` で stale な setState を防ぐ)。
+ * @param intervalMs polling 間隔 (ms)。
+ * @param options {@link UsePollingOptions}。 省略時は即時実行あり / 有効。
+ */
+export function usePolling(
+  callback: (isActive: () => boolean) => void | Promise<void>,
+  intervalMs: number,
+  options?: UsePollingOptions,
+): void {
+  const { immediate = true, enabled = true } = options ?? {};
+  useEffect(() => {
+    if (!enabled) return;
+    let active = true;
+    const isActive = () => active;
+    const run = () => {
+      void callback(isActive);
+    };
+    if (immediate) run();
+    const handle = window.setInterval(run, intervalMs);
+    return () => {
+      active = false;
+      window.clearInterval(handle);
+    };
+  }, [callback, intervalMs, immediate, enabled]);
+}

--- a/packages/web-kit/test/usePolling.test.tsx
+++ b/packages/web-kit/test/usePolling.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Issue #1418: 共有 polling primitive usePolling の regression test。
+ * 即時実行 / immediate=false / enabled gate / unmount cleanup / isActive guard を pin する。
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePolling } from "../src/usePolling";
+
+describe("usePolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should run the callback immediately and then once per interval", () => {
+    const cb = vi.fn();
+    renderHook(() => usePolling(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1); // immediate (= default options)
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(cb).toHaveBeenCalledTimes(4); // 1 immediate + 3 ticks
+  });
+
+  it("should skip the immediate run when immediate is false", () => {
+    const cb = vi.fn();
+    renderHook(() => usePolling(cb, 1000, { immediate: false }));
+    expect(cb).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(cb).toHaveBeenCalledTimes(1); // first tick only after the interval elapses
+  });
+
+  it("should not poll while enabled is false", () => {
+    const cb = vi.fn();
+    renderHook(() => usePolling(cb, 1000, { enabled: false }));
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("should start polling when enabled flips from false to true", () => {
+    const cb = vi.fn();
+    const { rerender } = renderHook(
+      ({ on }: { on: boolean }) => usePolling(cb, 1000, { enabled: on }),
+      {
+        initialProps: { on: false },
+      },
+    );
+    expect(cb).not.toHaveBeenCalled();
+    rerender({ on: true });
+    expect(cb).toHaveBeenCalledTimes(1); // immediate run once enabled
+  });
+
+  it("should stop polling after unmount", () => {
+    const cb = vi.fn();
+    const { unmount } = renderHook(() => usePolling(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb).toHaveBeenCalledTimes(1); // no further ticks after cleanup
+  });
+
+  it("should report isActive true while mounted and false after unmount", () => {
+    let captured: (() => boolean) | null = null;
+    const cb = vi.fn((isActive: () => boolean) => {
+      captured = isActive;
+    });
+    const { unmount } = renderHook(() => usePolling(cb, 1000));
+    // biome-ignore lint/style/noNonNullAssertion: immediate run guarantees captured is set
+    expect(captured!()).toBe(true);
+    unmount();
+    // biome-ignore lint/style/noNonNullAssertion: captured was set during the immediate run
+    expect(captured!()).toBe(false); // stale async tick can detect unmount and bail
+  });
+});


### PR DESCRIPTION
## Summary

`admin-console` の `TenantList` / `TenantDetail` / `Jobs` は **polling boilerplate**(`setInterval` + mount 時の即時実行 + unmount 時 `clearInterval` + 非同期 tick の active guard)を **5 effect** にわたって copy-paste していた。`application-admin-console` は既に `usePollingList` へ集約済みだったが、`admin-console` は手付かずの兄弟箇所だった。

3 SPA 共通の primitive を置く **`web-kit`**(#1418)に純 timer hook を新設して集約する:

```ts
usePolling(callback, intervalMs, { immediate, enabled })
```

- 意味論(何を fetch し state をどう更新するか)は callback 側に残り、hook は **timer 制御だけ**を担う(単一責務 / DRY)。
- `immediate: false` … TenantList の時計再評価(初回実行不要)。
- `enabled` … `DeprovisioningJobsTab` の `idToken` gate を表現。
- React 18 では unmount 後の `setState` が no-op になるため、旧コードで `v8-ignore` されていた `cancelled` guard は撤去。必要な caller 向けに hook が `isActive()` を提供する。

## Test plan
- `web-kit` … usePolling 6 test(immediate / immediate=false / enabled gate / enabled flip / unmount cleanup / isActive)、**100% coverage**。
- `admin-console` … 全 267 test 緑、**100% coverage (676/676 lines)**。`TenantList.test` の web-kit mock は `importOriginal` で実 `usePolling` を残し、Cloudscape 依存の `EmptyState`/`ErrorState` だけ stub 差し替え(= `setInterval` 捕捉が効く)。
- 全 workspace 緑(infra 2266 / admin 267 / app-admin 889 / portal 592 / web-kit 38 …)、typecheck 0 / biome clean / `make harness` error 0 / `cdk synth` 成功。

## Regression analysis
- **振る舞い不変**: 即時 fetch の有無 / polling 間隔 / interval 登録順(insight → clock)/ `idToken`・`config` 未解決時に fetch を skip する挙動を維持。setInterval 登録順に依存する TenantList の poller test も全 callback を発火する形なので影響なし。
- `cancelled` guard の撤去は、それらが旧コードで「test 不到達の防御 (v8-ignore)」であり React 18 では post-unmount setState が no-op であることに基づく(挙動差なし)。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。frontend(admin-console SPA)+ `web-kit` package の source only。bundle は Vite が出力する hash が変わるのみで配信構成は不変。

Relates #1418