### PR TITLE
refactor(app-admin): build usePollingList on shared usePolling [#1418]

### DIFF
--- a/apps/application-admin-console/src/hooks/usePollingList.ts
+++ b/apps/application-admin-console/src/hooks/usePollingList.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { usePolling } from "@tenkacloud/web-kit";
+import { useCallback, useState } from "react";
 import { toErrorMessage } from "../lib/error-message";
 
 export interface PollingListState<T> {
@@ -47,22 +48,9 @@ export function usePollingList<T>(
     }
   }, [fetcher, hasChanged]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      // unmount 時に clearInterval するので interval 経由の再 tick は来ない。 cancelled=true を
-      // 踏むのは teardown と既 queue の tick が競合する稀ケースのみ (= 防御的、不到達)。
-      /* v8 ignore next */
-      if (cancelled) return;
-      await refresh();
-    };
-    void tick();
-    const interval = setInterval(tick, intervalMs);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [refresh, intervalMs]);
+  // 即時 fetch + interval polling + unmount cleanup は web-kit の共有 primitive に委譲する
+  // (#1418: polling timer の boilerplate を usePolling 1 箇所へ集約。 admin-console も同 hook を使う)。
+  usePolling(refresh, intervalMs);
 
   return { items, error, refresh, clearError };
 }


### PR DESCRIPTION
## Summary

`usePollingList`(application-admin-console)は「即時 tick + `setInterval` + `cancelled` guard + unmount cleanup」を自前の `useEffect` で持っていたが、これは #1616 で web-kit に新設した共有 primitive **`usePolling`** と完全に同型だった。timer 制御を `usePolling` へ委譲し、`usePollingList` は items/error state + `refresh`/`clearError` の責務だけを持つようにする。

これで polling timer の boilerplate は **admin-console**(`usePolling` 直接利用)と **application-admin-console**(`usePollingList` 経由)の両方で **web-kit の 1 箇所に集約**される(#1418 DRY、polling timer の single source)。

`cancelled` guard は撤去: React 18 では unmount 後の `setState` が no-op で、旧 guard は v8-ignore された test 不到達の防御だった(`usePolling` が必要な caller 向けに `isActive()` を提供)。

## Test plan
- application-admin-console 全 **889 test 緑**、**100% coverage (2008/2008 lines)**。consumer(Deployments / EventList / ProblemDetail)も緑。
- typecheck 0 / biome clean / `make harness` no findings。app-admin の test は web-kit を mock しないため実 `usePolling` が走る(追加 mock 対応不要)。

## Regression analysis
- 振る舞い不変: 即時 fetch / interval 間隔 / `hasChanged` による reference 据え置き / error 文字列化 / `clearError` は維持。timer 経路だけ `usePolling` に置換。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。application-admin-console SPA の hook source のみ(web-kit は #1616 で配備済み)。

Relates #1418