### PR TITLE
feat(coordination): wire op + projection routes (ADR-028 D4/D5) [#1420]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-handler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-handler.ts
@@ -1,0 +1,146 @@
+import type { CoordinationContext } from "@tenkacloud/coordination-plugin-sdk";
+import {
+  loadAndDispatchCoordinationOp,
+  loadAndProjectCoordinationForTeam,
+  type PluginImporter,
+} from "./coordination-plugin-loader.js";
+import type { CoordinationStoreDeps } from "./coordination-store.js";
+import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+
+/**
+ * ADR-028 D4/D5 (#1420): 参加者 portal 向け coordination route の handler。
+ *
+ * route は team-login-key で認証し、 {@link CoordinationHandlerDeps.resolveScope} が tenant/event/team
+ * scope + 問題が宣言した plugin の module path (interTeamCoordination.plugin) を解決する。 そこから先は
+ * #1606 の dispatcher core + #1617 の動的 loader に委譲するだけで、 platform は問題依存の意味論を持たない。
+ *
+ * **importer は seam** (ADR-028 D6): 問題同梱 plugin を S3 (ADR-008 payload 経路) から materialize して
+ * import する実装は別 increment。 本 handler は importer を注入で受け、 load 不可 (= 未配線 / 壊れた問題) は
+ * `unavailable` / fallback projection で participant API を壊さない。
+ */
+
+/** route が解決した 1 回分の実行 scope。 resolveScope が null を返したら scope 不成立。 */
+export interface CoordinationScope {
+  readonly tenantId: string;
+  readonly eventId: string;
+  readonly teamId: string;
+  /** plugin の initialState に渡す event 文脈 (= 参加チーム一覧)。 */
+  readonly ctx: CoordinationContext;
+  /** 問題が宣言する plugin module path (= interTeamCoordination.plugin)。 */
+  readonly moduleRef: string;
+  /** projection 失敗 / 未初期化時に返す安全な既定 (= 他 team の機密を出さない)。 */
+  readonly fallbackProjection: unknown;
+}
+
+export interface CoordinationHandlerDeps {
+  /** 問題同梱 plugin を動的 import する関数 (= 本番は S3 materialize、 別 increment の seam)。 */
+  readonly importer: PluginImporter;
+  readonly store: CoordinationStoreDeps;
+  /**
+   * team-login-key → 実行 scope。 認証不可 / 当該 event に coordination 宣言が無い場合は null
+   * (= route は `not_configured` で安全に応答する)。
+   */
+  readonly resolveScope: (teamLoginKey: string) => Promise<CoordinationScope | null>;
+}
+
+export type CoordinationHandlerOutcome =
+  | { readonly kind: "ok"; readonly projection: unknown }
+  | { readonly kind: "rejected"; readonly error: string }
+  | { readonly kind: "conflict" }
+  /** plugin が load 不可 (= importer 未配線 / 壊れた問題 plugin)。 op は適用されない。 */
+  | { readonly kind: "unavailable" }
+  /** 認証不可 or 当該 event に coordination 宣言が無い (= scope null)。 */
+  | { readonly kind: "not_configured" };
+
+/** op を受理 → 適用 → 永続化し、 当該 team 向け projection を返す (= write 経路)。 */
+export async function handleCoordinationOp(
+  deps: CoordinationHandlerDeps,
+  teamLoginKey: string,
+  op: unknown,
+  nowIso: string,
+): Promise<CoordinationHandlerOutcome> {
+  const scope = await deps.resolveScope(teamLoginKey);
+  if (!scope) return { kind: "not_configured" };
+  const outcome = await loadAndDispatchCoordinationOp(deps.importer, scope.moduleRef, deps.store, {
+    tenantId: scope.tenantId,
+    eventId: scope.eventId,
+    teamId: scope.teamId,
+    op,
+    ctx: scope.ctx,
+    fallbackProjection: scope.fallbackProjection,
+    nowIso,
+  });
+  return outcome.kind === "plugin_unavailable" ? { kind: "unavailable" } : outcome;
+}
+
+/** 当該 team の現在 projection を読む (= 書き込みなし、 portal polling 用)。 */
+export async function handleCoordinationProjection(
+  deps: CoordinationHandlerDeps,
+  teamLoginKey: string,
+): Promise<CoordinationHandlerOutcome> {
+  const scope = await deps.resolveScope(teamLoginKey);
+  if (!scope) return { kind: "not_configured" };
+  const projection = await loadAndProjectCoordinationForTeam(
+    deps.importer,
+    scope.moduleRef,
+    deps.store,
+    {
+      tenantId: scope.tenantId,
+      eventId: scope.eventId,
+      teamId: scope.teamId,
+      ctx: scope.ctx,
+      fallbackProjection: scope.fallbackProjection,
+    },
+  );
+  return { kind: "ok", projection };
+}
+
+/** `{ [problemId]: { plugin } }`。 問題が宣言する coordination plugin の module path を引く。 */
+export type CoordinationConfig = Readonly<Record<string, { readonly plugin: string }>>;
+
+/**
+ * `PROBLEM_COORDINATION` env (JSON) を parse する。 未設定 / 不正 JSON / 非 object は `{}` (=
+ * coordination 無効) を返す (= scoring/endpoints env と同方針)。 CDK が問題 metadata の
+ * interTeamCoordination を集約して渡す想定で、 未配線の間は空 = 全 route が `not_configured`。
+ */
+export function parseCoordinationConfig(raw: string | undefined): CoordinationConfig {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as CoordinationConfig) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * team-login-key → {@link CoordinationScope}。 active な代表 deployment 行から tenant/event/team を
+ * 引き、 その問題が coordination を宣言していれば moduleRef を確定する。 認証不可 / 未宣言は null
+ * (= route は `not_configured`)。
+ *
+ * 注: `ctx.teamIds` は現状 requester 自身のみ。 full event roster の解決は importer 配線
+ * (= 実 plugin が load される時) と同 increment で拡張する (plugin が load されない seam 状態では
+ * ctx は使われないため安全)。
+ */
+export function makeCoordinationScopeResolver(
+  shared: ParticipantSharedResources,
+  config: CoordinationConfig,
+): (teamLoginKey: string) => Promise<CoordinationScope | null> {
+  return async (teamLoginKey) => {
+    const items = await queryTeamItems(shared, teamLoginKey);
+    for (const item of items) {
+      const plugin = item.problemId ? config[item.problemId]?.plugin : undefined;
+      if (item.tenantId && item.eventId && item.teamId && plugin) {
+        return {
+          tenantId: item.tenantId,
+          eventId: item.eventId,
+          teamId: item.teamId,
+          ctx: { eventId: item.eventId, teamIds: [item.teamId] },
+          moduleRef: plugin,
+          fallbackProjection: {},
+        };
+      }
+    }
+    return null;
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -11,6 +11,14 @@ import { RATE_LIMITS } from "../shared/rate-limiter.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { castEvent, INBOX_SINCE_MS_MAX, readInbox } from "./cast-event.js";
 import {
+  type CoordinationHandlerDeps,
+  handleCoordinationOp,
+  handleCoordinationProjection,
+  makeCoordinationScopeResolver,
+  parseCoordinationConfig,
+} from "./coordination-handler.js";
+import type { PluginImporter } from "./coordination-plugin-loader.js";
+import {
   defaultDeployLogDeps,
   getParticipantDeployLogs,
   parseDeployLogLimit,
@@ -30,6 +38,7 @@ import {
 import {
   BattleAttacksQuerySchema,
   CastEventBodySchema,
+  CoordinationOpBodySchema,
   DeployLogsQuerySchema,
   EventInboxQuerySchema,
   NotificationsQuerySchema,
@@ -66,6 +75,39 @@ import { setDisplayTeamName } from "./update.js";
  * `participant-handler/schemas.ts` の zod schema 経由で全 route 統一 validate する。
  */
 const shared = buildParticipantSharedResources();
+
+// ADR-028 D6 (#1420): 問題同梱 coordination plugin を S3 (ADR-008 payload 経路) から materialize して
+// import する実装は別 increment (= seam)。 未配線の間は reject → loader が null 化 → route は
+// `unavailable` / fallback projection で安全に応答する (= 機能は inert だが participant API は壊れない)。
+const coordinationImporter: PluginImporter = (ref) =>
+  Promise.reject(new Error(`coordination plugin importer not configured: ${ref}`));
+const coordinationDeps: CoordinationHandlerDeps = {
+  importer: coordinationImporter,
+  store: { ddb: shared.ddb, tableName: shared.tableName },
+  resolveScope: makeCoordinationScopeResolver(
+    shared,
+    parseCoordinationConfig(process.env.PROBLEM_COORDINATION),
+  ),
+};
+
+/** coordination handler の outcome を HTTP 応答に写す (= StatusCodes 名で意図を明示)。 */
+function respondCoordination(
+  c: Context,
+  outcome: Awaited<ReturnType<typeof handleCoordinationProjection>>,
+): Response {
+  switch (outcome.kind) {
+    case "ok":
+      return c.json({ projection: outcome.projection }, StatusCodes.OK);
+    case "rejected":
+      return c.json({ error: outcome.error }, StatusCodes.UNPROCESSABLE_ENTITY);
+    case "conflict":
+      return c.json({ error: "conflict" }, StatusCodes.CONFLICT);
+    case "unavailable":
+      return c.json({ error: "unavailable" }, StatusCodes.SERVICE_UNAVAILABLE);
+    default:
+      return c.json({ error: "not_configured" }, StatusCodes.NOT_FOUND);
+  }
+}
 const app = new Hono();
 
 app.get("/portal/healthz", (c) => c.json({ ok: true }));
@@ -142,6 +184,38 @@ app.get("/portal/me/notifications", (c) =>
       if (outcome.kind === "ok") return c.json(outcome.response, StatusCodes.OK);
       return respondError(c, outcome.kind);
     },
+    RATE_LIMITS.READ_HIGH,
+  ),
+);
+
+// ADR-028 D4/D5 (#1420): 参加者間 coordination の op 提出 + projection polling。
+// semantics は問題同梱 plugin (動的 import) に閉じ、 platform は dispatch / projection だけを担う。
+// importer 未配線 (seam) の間は unavailable / fallback で安全に応答する。
+app.post("/portal/me/coordination/op", (c) =>
+  withBearerAuth(
+    c,
+    "coordination-op",
+    async (token) => {
+      const parsed = await parseJsonBody(c, CoordinationOpBodySchema);
+      if (!parsed.ok) return parsed.response;
+      const outcome = await handleCoordinationOp(
+        coordinationDeps,
+        token,
+        parsed.data.op,
+        new Date().toISOString(),
+      );
+      return respondCoordination(c, outcome);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
+);
+
+app.get("/portal/me/coordination/projection", (c) =>
+  withBearerAuth(
+    c,
+    "coordination-projection",
+    async (token) =>
+      respondCoordination(c, await handleCoordinationProjection(coordinationDeps, token)),
     RATE_LIMITS.READ_HIGH,
   ),
 );

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/schemas.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/schemas.ts
@@ -105,6 +105,16 @@ export const CastEventBodySchema = z.object({
 export type CastEventBody = z.infer<typeof CastEventBodySchema>;
 
 /**
+ * POST /portal/me/coordination/op — body は { op }。 op の意味論 (alliance / route / 等) は
+ * 問題同梱 plugin の validateOp が判定するので、 schema は op の存在だけを要求し中身は通す
+ * (= 過剰な platform 側 validation を持ち込まない。 size は DDB 400KB 制約が loud に弾く)。
+ */
+export const CoordinationOpBodySchema = z.object({
+  op: z.unknown(),
+});
+export type CoordinationOpBody = z.infer<typeof CoordinationOpBodySchema>;
+
+/**
  * POST /portal/me/problems/:problemId/endpoints/:slot — body は { url }。
  * URL の細かい validation (= http/https / 長さ / プライベート IP 等) は
  * `isValidOverrideUrl` (= service 側) が一手に行うので、 schema は `string` のみ要求。

--- a/infrastructure/test/problem-deploy/coordination-handler.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-handler.test.ts
@@ -1,0 +1,187 @@
+import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { CoordinationPlugin } from "@tenkacloud/coordination-plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { DeploymentItem } from "../../lib/problem-deploy/handlers/deploy-handler/types.js";
+import {
+  type CoordinationHandlerDeps,
+  type CoordinationScope,
+  handleCoordinationOp,
+  handleCoordinationProjection,
+  makeCoordinationScopeResolver,
+  parseCoordinationConfig,
+} from "../../lib/problem-deploy/handlers/participant-handler/coordination-handler.js";
+import type { PluginImporter } from "../../lib/problem-deploy/handlers/participant-handler/coordination-plugin-loader.js";
+import type { CoordinationStoreDeps } from "../../lib/problem-deploy/handlers/participant-handler/coordination-store.js";
+import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared.js";
+
+/**
+ * ADR-028 D4/D5 (#1420): coordination route handler を pin する。
+ * scope 解決 → 動的 load → dispatch/project の委譲、 認証不可 / plugin 未配線時の safe 応答を観測する。
+ */
+
+interface CounterState {
+  readonly count: number;
+}
+type CounterOp = { kind: "inc" } | { kind: "bad" };
+
+const counter: CoordinationPlugin<CounterState, CounterOp, { count: number }> = {
+  initialState: () => ({ count: 0 }),
+  validateOp: (_s, _t, op) => (op.kind === "bad" ? { ok: false, error: "bad_op" } : { ok: true }),
+  applyOp: (s) => ({ count: s.count + 1 }),
+  projectForTeam: (s) => ({ count: s.count }),
+};
+
+const scope: CoordinationScope = {
+  tenantId: "tn1",
+  eventId: "e1",
+  teamId: "t1",
+  ctx: { eventId: "e1", teamIds: ["t1", "t2"] },
+  moduleRef: "coordination/alliance.ts",
+  fallbackProjection: { count: -1 },
+};
+
+function fakeStore(getItem?: Record<string, unknown>): CoordinationStoreDeps {
+  const send = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof GetCommand) return { Item: getItem };
+    if (cmd instanceof PutCommand) return {};
+    throw new Error("unexpected command");
+  });
+  return { ddb: { send } as never, tableName: "Deployments" };
+}
+
+const importerOf =
+  (mod: unknown): PluginImporter =>
+  async () =>
+    mod;
+const throwingImporter: PluginImporter = async () => {
+  throw new Error("not configured");
+};
+
+function deps(over: Partial<CoordinationHandlerDeps> = {}): CoordinationHandlerDeps {
+  return {
+    importer: importerOf(counter),
+    store: fakeStore(undefined),
+    resolveScope: async () => scope,
+    ...over,
+  };
+}
+
+describe("handleCoordinationOp", () => {
+  it("should return not_configured when scope cannot be resolved", async () => {
+    const out = await handleCoordinationOp(
+      deps({ resolveScope: async () => null }),
+      "key",
+      { kind: "inc" },
+      "2026-06-01T00:00:00Z",
+    );
+    expect(out).toEqual({ kind: "not_configured" });
+  });
+
+  it("should load the plugin and apply a valid op", async () => {
+    const out = await handleCoordinationOp(deps(), "key", { kind: "inc" }, "2026-06-01T00:00:00Z");
+    expect(out).toEqual({ kind: "ok", projection: { count: 1 } });
+  });
+
+  it("should surface the plugin's rejection for an invalid op", async () => {
+    const out = await handleCoordinationOp(deps(), "key", { kind: "bad" }, "2026-06-01T00:00:00Z");
+    expect(out).toEqual({ kind: "rejected", error: "bad_op" });
+  });
+
+  it("should map a load failure to unavailable", async () => {
+    const out = await handleCoordinationOp(
+      deps({ importer: throwingImporter }),
+      "key",
+      { kind: "inc" },
+      "2026-06-01T00:00:00Z",
+    );
+    expect(out).toEqual({ kind: "unavailable" });
+  });
+});
+
+describe("handleCoordinationProjection", () => {
+  it("should return not_configured when scope cannot be resolved", async () => {
+    const out = await handleCoordinationProjection(deps({ resolveScope: async () => null }), "key");
+    expect(out).toEqual({ kind: "not_configured" });
+  });
+
+  it("should project the loaded plugin's per-team view", async () => {
+    const out = await handleCoordinationProjection(
+      deps({ store: fakeStore({ state: { count: 7 }, version: 2 }) }),
+      "key",
+    );
+    expect(out).toEqual({ kind: "ok", projection: { count: 7 } });
+  });
+
+  it("should fall back to the safe projection when the plugin is unavailable", async () => {
+    const out = await handleCoordinationProjection(deps({ importer: throwingImporter }), "key");
+    expect(out).toEqual({ kind: "ok", projection: { count: -1 } });
+  });
+});
+
+describe("parseCoordinationConfig", () => {
+  it("should return an empty config for unset / invalid / non-object input", () => {
+    expect(parseCoordinationConfig(undefined)).toEqual({});
+    expect(parseCoordinationConfig("not json")).toEqual({});
+    expect(parseCoordinationConfig("123")).toEqual({});
+  });
+
+  it("should parse a problemId → plugin map", () => {
+    expect(parseCoordinationConfig('{"p1":{"plugin":"coordination/alliance.ts"}}')).toEqual({
+      p1: { plugin: "coordination/alliance.ts" },
+    });
+  });
+});
+
+describe("makeCoordinationScopeResolver", () => {
+  function fakeShared(items: Partial<DeploymentItem>[]): ParticipantSharedResources {
+    const send = vi.fn(async () => ({ Items: items }));
+    return {
+      tableName: "Deployments",
+      eventsTableName: "Events",
+      endpointsTableName: "",
+      ddb: { send } as never,
+      problemsScoring: {},
+      problemsEndpoints: {},
+    };
+  }
+  const config = { p1: { plugin: "coordination/alliance.ts" } };
+
+  it("should resolve a scope when the team's problem declares coordination", async () => {
+    const resolve = makeCoordinationScopeResolver(
+      fakeShared([{ tenantId: "tn1", eventId: "e1", teamId: "t1", problemId: "p1" }]),
+      config,
+    );
+    expect(await resolve("key")).toEqual({
+      tenantId: "tn1",
+      eventId: "e1",
+      teamId: "t1",
+      ctx: { eventId: "e1", teamIds: ["t1"] },
+      moduleRef: "coordination/alliance.ts",
+      fallbackProjection: {},
+    });
+  });
+
+  it("should return null when no owned problem declares coordination", async () => {
+    const resolve = makeCoordinationScopeResolver(
+      fakeShared([{ tenantId: "tn1", eventId: "e1", teamId: "t1", problemId: "other" }]),
+      config,
+    );
+    expect(await resolve("key")).toBeNull();
+  });
+
+  it("should return null when the deployment row lacks event/team scope", async () => {
+    const resolve = makeCoordinationScopeResolver(
+      fakeShared([{ tenantId: "tn1", problemId: "p1" }]),
+      config,
+    );
+    expect(await resolve("key")).toBeNull();
+  });
+
+  it("should return null when the deployment row has no problemId", async () => {
+    const resolve = makeCoordinationScopeResolver(
+      fakeShared([{ tenantId: "tn1", eventId: "e1", teamId: "t1" }]),
+      config,
+    );
+    expect(await resolve("key")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

#1606(dispatcher core)+ #1617(動的 loader)を participant-portal の HTTP route に接続する。「問題は plugin、platform は host」の原則どおり、platform は **dispatch / projection だけ**を担い、semantics(alliance / routing / shared queue 等)は問題同梱 plugin に閉じる。

- **`coordination-handler.ts`** — team-login-key 認証 → scope 解決 → loader+dispatcher 委譲。outcome は `ok` / `rejected` / `conflict` / `unavailable` / `not_configured`。scope resolver は active な deployment 行から tenant/event/team を引き、その問題が `interTeamCoordination` を宣言していれば `moduleRef` を確定。`parseCoordinationConfig` は `PROBLEM_COORDINATION` env を parse。
- **`index.ts`** — `POST /portal/me/coordination/op` + `GET /portal/me/coordination/projection` を登録。outcome→HTTP は `StatusCodes` 名で明示(rejected=422 / conflict=409 / unavailable=503 / not_configured=404)。
- **`schemas.ts`** — `CoordinationOpBodySchema` (`{ op }`)。op の意味論は plugin の `validateOp` が判定。

> ⚠️ **importer は seam（ADR-028 D6）**: 問題同梱 plugin を S3(ADR-008 payload)から materialize して import する実装、`PROBLEM_COORDINATION` env の CDK 配線、full event roster の `ctx.teamIds` 解決は**別 increment(owner 領域: 未信頼コード実行 + Lambda bundling/IAM)**。未配線の間は loader が null → route は `unavailable` / fallback projection で安全に応答(= participant API を壊さない)。

## Test plan
- infra 全 **2291 test 緑**(従来 2278 + coordination-handler 13)。handler module **100%**(23/23 stmts, 20/20 branch, 5/5 func)。
- typecheck 0 / biome clean / `make harness` 違反なし。

## Regression analysis
- 既存 route は無改変。新 route 2 本 + handler module 追加、index.ts は宣言的 wiring のみ。
- `PROBLEM_COORDINATION` env は **optional**。未設定時は `parseCoordinationConfig`→`{}`→全 route `not_configured` で、既存挙動(coordination 無効)と等価。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。participant-handler Lambda の source に route + handler を追加するのみ(新 IAM / table なし)。optional env `PROBLEM_COORDINATION` は CDK 未配線でも absent=安全。

Relates #1420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added participant coordination endpoints: `POST /portal/me/coordination/op` for coordination operations and `GET /portal/me/coordination/projection` for team projections.
  * Introduced coordination configuration parsing and scope resolution for team-based operations.

* **Tests**
  * Added comprehensive test suite covering coordination operation handling, projection generation, configuration parsing, and scope resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->