### PR TITLE
feat(validate): cross-ref interTeamCoordination.plugin file exists [#1420]

### DIFF
--- a/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
+++ b/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { checkCoordinationPluginFile } from "../../../scripts/validate-problems";
 
 /**
  * Issue #951 sub #2: validate-problems.ts の cross-ref check が壊れた問題 (=
@@ -38,5 +39,37 @@ describe("validate-problems cross-ref check (#951 sub #2)", () => {
       cwd: REPO_ROOT,
     });
     expect(out).toContain("件の metadata.json はすべて有効です");
+  });
+});
+
+describe("checkCoordinationPluginFile (#1420)", () => {
+  // microservice-migration-battle は interTeamCoordination.plugin=coordination/router.ts を宣言する
+  // 唯一の参照問題 (submodule)。 実在 path での positive と、 不在 path での negative を pin する。
+  const MS_DIR = join(REPO_ROOT, "problems/battles/microservice-migration-battle");
+
+  it("should pass when the declared coordination plugin file exists", () => {
+    expect(
+      checkCoordinationPluginFile(
+        { interTeamCoordination: { plugin: "coordination/router.ts" } },
+        MS_DIR,
+      ),
+    ).toEqual([]);
+  });
+
+  it("should error when the coordination plugin file is missing", () => {
+    const errors = checkCoordinationPluginFile(
+      { interTeamCoordination: { plugin: "coordination/does-not-exist.ts" } },
+      MS_DIR,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("coordination/does-not-exist.ts");
+  });
+
+  it("should be a no-op when interTeamCoordination is absent", () => {
+    expect(checkCoordinationPluginFile({}, MS_DIR)).toEqual([]);
+  });
+
+  it("should be a no-op when plugin is not a string", () => {
+    expect(checkCoordinationPluginFile({ interTeamCoordination: {} }, MS_DIR)).toEqual([]);
   });
 });

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -104,6 +104,7 @@ export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationErro
     ...checkRuntimeSupport(runtime),
     ...checkRuntimeConsistency(meta),
     ...checkDashboardSlotFiles(meta, dir),
+    ...checkCoordinationPluginFile(meta, dir),
     ...checkRegionConsistency(meta),
   ];
 
@@ -243,6 +244,23 @@ function checkDashboardSlotFiles(meta: Metadata, dir: string): ValidationError[]
   }
 
   return errors;
+}
+
+/**
+ * interTeamCoordination.plugin (ADR-028 / #1420) が物理 file として存在するか cross-ref する。
+ * dashboard.slots (portal/*.tsx) と同方針 — platform の dispatcher が runtime に動的 import する
+ * ため、 存在しない path を宣言したまま catalog に載ると実行時に coordination が無言で無効化され
+ * 出題者は気付けない。 SCHEMA は path pattern までしか保証しないので file 実在はここで止める。
+ * interTeamCoordination 未宣言の problem は無影響 (= 早期 return)。
+ */
+export function checkCoordinationPluginFile(meta: Metadata, dir: string): ValidationError[] {
+  const coordination = meta.interTeamCoordination as Record<string, unknown> | undefined;
+  const plugin = coordination?.plugin;
+  if (typeof plugin !== "string") return [];
+  if (!existsSync(join(dir, plugin))) {
+    return [`interTeamCoordination.plugin="${plugin}" file not found`];
+  }
+  return [];
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary

親 repo の `validate-problems.ts`(= `make validate-problems` / CI が mount 済 submodule problems を検証)も、`interTeamCoordination.plugin`(ADR-028)の **file 実在を cross-ref していなかった**。submodule 側 validator(TenkaCloudChallenge#31)に追加したのと同じ check を親にも入れ、**両 validator を等価に保つ**(片方だけだと drift する)。

`dashboard.slots`(portal/*.tsx)が既に file 存在を検証しているのと同方針。platform の dispatcher は plugin を runtime に動的 import するため、存在しない path を宣言したまま catalog に載ると coordination が無言で無効化され出題者は気付けない。`checkRuntimeSupport` と同様 export して unit test する。

## Test plan
- `checkCoordinationPluginFile` の 4 分岐(実在 / 不在 / 未宣言 / 非 string)を `validate-problems-cross-ref.test` に追加。
- `make validate-problems` 7/7 OK、infra 全 **2304 緑**、typecheck 0 / biome clean / `make harness` 違反なし。

## Regression analysis
- 新 check 1 本 + checks 配列への配線のみ。`interTeamCoordination` 未宣言の problem は早期 return で無影響。

## Physical impact
- **NO-OP**。validation script + test のみ。CFn / bundle / problem 定義は不変。

Relates #1420