### PR TITLE
docs(adr): ADR-030 coordination plugin loader security boundary [#1420]

### DIFF
--- a/docs/architecture/adr-030-coordination-plugin-loader-security.html
+++ b/docs/architecture/adr-030-coordination-plugin-loader-security.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-030: Coordination plugin loader — security boundary</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft { background: #ddf4ff; color: var(--c-link); }
+  .badge.accept { background: #dafbe1; color: var(--c-accept); }
+  .badge.reject { background: #ffe5e5; color: var(--c-reject); }
+  .badge.warn { background: #fff8c5; color: var(--c-warn); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  .risk-high { color: var(--c-reject); font-weight: 600; }
+  .risk-med { color: var(--c-warn); font-weight: 600; }
+  .ok { color: var(--c-accept); font-weight: 600; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-030: Coordination plugin loader — security boundary</h1>
+  <p><em>問題が同梱する coordination plugin を runtime に動的 load する際、 未信頼コードを安全に実行するための境界</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge draft">Proposed</span> 2026-06-01</div>
+    <div><b>Related:</b>
+      <a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a> (plugin contract / dispatcher),
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin, platform = host),
+      ADR-008 (problem payload を S3 で配信)
+    </div>
+  </div>
+</header>
+
+<section>
+<h2>Context</h2>
+
+<p><a href="./adr-028-inter-team-coordination-plugin.html">ADR-028</a> は、 Battle の他チーム interaction を「問題が <code>CoordinationPlugin</code> を同梱し platform の dispatcher が host する」 plugin 方式に決めた。 問題カタログは community が拡張するため (<a href="./adr-012-problem-plugin-architecture.html">ADR-012</a>)、 plugin を platform に静的バンドルすると「coordination 付き問題を 1 つ足すたびに platform を再デプロイ」 となり moat を殺す。 そこで ADR-028 D6 は plugin module を <strong>runtime に動的 load</strong> する方針を採った。</p>
+
+<p>動的 load とは、 問題が同梱した <code>coordination/&lt;name&gt;.ts</code> を取得 → materialize → <code>import()</code> で platform 側プロセスに読み込むことを意味する。 これは <strong>platform のプロセス内で「問題が書いたコード」を実行する</strong>ということであり、 問題コードが完全に信頼できない限り、 単なる data 読み込みとは質的に異なるリスクを伴う。</p>
+
+<p>ADR-028 D6 は「別 isolate は立てない。 plugin の bug は当該 event の 1 row に閉じ、 platform 全体には波及しない (optimistic lock + DDB write fail で停止)」 と述べた。 これは <strong>bug</strong> (= 誠実だが誤った plugin) には当てはまるが、 <strong>悪意あるコード</strong> には当てはまらない。 現行の participant-portal Lambda (= D6 が dispatcher を相乗りさせる候補) は、 Console SSO / CLI 資格情報発行のために次の強い権限を持つ:</p>
+
+<table>
+  <thead><tr><th>権限</th><th>用途</th><th>未信頼コードが悪用した場合</th></tr></thead>
+  <tbody>
+    <tr><td><code>sts:AssumeRole</code> on <code>arn:aws:iam::*:role/TenkaCloud-*</code></td><td>競技者アカウントへの federation (SSO / CLI creds)</td><td class="risk-high">競技者 AWS アカウントの資格情報を取得し外部送信できる</td></tr>
+    <tr><td><code>dynamodb:Query/UpdateItem/PutItem</code> on Deployments</td><td>全 team の deployment 行 (自 team scope は app 層で絞る)</td><td class="risk-high">他 team / 他 tenant の行を read/write しスコア・状態を改竄できる</td></tr>
+    <tr><td><code>ssm:GetParameter</code> + <code>kms:Decrypt</code></td><td>tenant ExternalId の復号</td><td class="risk-high">AssumeRole に必要な ExternalId を入手できる</td></tr>
+  </tbody>
+</table>
+
+<p>つまり <strong>この Lambda 内で未信頼コードを実行すると、 1 つの悪意ある (または supply-chain 汚染された) coordination plugin が競技者アカウントの資格情報・全テナントのデータに到達しうる</strong>。 blast radius は「当該 event の 1 row」 では全くない。 importer を実装する前に、 この境界を明示的に設計する必要がある (= 本 ADR)。</p>
+</section>
+
+<section>
+<h2>Decision</h2>
+
+<p>coordination plugin の loader は、 <strong>「信頼の単位 = レビュー済みカタログ」「実行の権限 = 最小」「契約 = 純 reducer」</strong> の三層で境界を引く。 動的 load による community 拡張性 (= platform 再デプロイ不要) は維持しつつ、 未信頼コードが competitor 資格情報・cross-tenant データに到達する経路を構造的に断つ。</p>
+
+<h3>S1 — 信頼の単位はレビュー済みカタログ (= 任意アップロードではない)</h3>
+<p>plugin は <strong>PR レビューを経た問題カタログ (TenkaCloudChallenge、 ADR-008 の S3 配信経路)</strong> からのみ load する。 participant や任意の第三者が runtime に任意コードを差し込む経路は存在しない。 community 拡張は「カタログへの PR → 人間レビュー → 公開」 を通る。 動的 load の対象は <strong>公開済みカタログ bundle</strong> であり、 platform 再デプロイは不要だが、 コードは必ずレビューを経ている。 レビュー観点はカタログ側 <code>AGENT.md</code> + reviewer checklist に明文化し、 <code>@aws-sdk/*</code> / <code>fetch</code> / OS / 環境変数アクセスを含む plugin は reject する。</p>
+
+<h3>S2 — 実行は専用の最小権限 Lambda (= competitor 資格情報に触れない)</h3>
+<p>coordination dispatcher は participant-portal Lambda に<strong>相乗りさせない</strong>。 専用 Lambda (<code>CoordinationDispatcherFunction</code>) を立て、 IAM は次だけに絞る:</p>
+<ul>
+  <li><code>dynamodb:GetItem / PutItem</code> on <strong>Deployments テーブルの coordination row のみ</strong> (= <code>PK = COORD#&lt;tenantId&gt;#&lt;eventId&gt;</code> に <code>dynamodb:LeadingKeys</code> 条件で限定)。</li>
+  <li><strong>無し</strong>: <code>sts:AssumeRole</code> / <code>ssm:GetParameter</code> / <code>kms:Decrypt</code> / 他テーブル。</li>
+</ul>
+<p>これにより、 仮にレビューをすり抜けた悪意ある (または supply-chain 汚染された) plugin が任意コードを実行しても、 到達できるのは coordination state row だけになり、 competitor 資格情報・他 tenant データ・ExternalId には構造的に到達できない。 S1 (レビュー) をすり抜けた場合の最終防壁が S2 (最小権限) である。 別 isolate (vm2 / Worker) は立てない — ADR-028 D6 の判断 (cost/複雑度) を踏襲しつつ、 isolate の代わりに <strong>IAM で blast radius を縛る</strong>。</p>
+
+<h3>S3 — 契約は副作用なしの純 reducer (= 防御の多層化)</h3>
+<p>SDK (<code>@tenkacloud/coordination-plugin-sdk</code>) の契約は既に全 hook を純関数とし、 AWS SDK / <code>fetch</code> に依存しない。 platform は <code>validateOp</code> → <code>applyOp</code> → <code>projectForTeam</code> を呼ぶだけで、 DDB I/O は platform 側が握る。 これは型では強制できない <em>規約</em> なので、 S1 のレビューと S2 の最小権限で裏打ちする (= 純 reducer は唯一の防壁ではなく、 多層防御の一層)。 plugin の <code>import()</code> 時に top-level で副作用を走らせる余地があるため、 materialize は <strong>レビュー済みカタログ由来のコードに限定</strong> (S1) し、 実行権限を最小化 (S2) することが本質的な担保となる。</p>
+</section>
+
+<section>
+<h2>Threat model</h2>
+<table>
+  <thead><tr><th>脅威</th><th>緩和</th><th>残留リスク</th></tr></thead>
+  <tbody>
+    <tr><td>plugin が <code>import()</code> 時 / hook 内で AWS SDK を呼び competitor 資格情報を抜く</td><td>S2 (Lambda に AssumeRole/SSM/KMS 権限なし) + S1 (レビューで AWS SDK import を reject)</td><td class="ok">資格情報経路が IAM 上存在しない</td></tr>
+    <tr><td>plugin が他 tenant / 他 team の DDB 行を read/write</td><td>S2 (<code>COORD#&lt;tenantId&gt;#&lt;eventId&gt;</code> の LeadingKeys 条件 + platform が key を組み立て、 plugin は state 値しか触れない)</td><td class="ok">key は plugin が指定不可</td></tr>
+    <tr><td>supply-chain: 依存パッケージ汚染で plugin が悪性化</td><td>S2 (最小権限で被害限定) + カタログ側の lockfile / 依存レビュー</td><td class="risk-med">coordination state の改竄は可能 → optimistic lock + 異常検知で対応</td></tr>
+    <tr><td>plugin が無限ループ / 巨大 state で DoS</td><td>Lambda timeout + DDB item size (400KB) で自然停止</td><td class="risk-med">当該 event の dispatch が遅延 (polling は継続)</td></tr>
+    <tr><td>projection が他 team の機密を漏らす</td><td>plugin 設計上 projection は「公開してよい投影」 + <code>safeProjectForTeam</code> fail-safe + レビュー</td><td class="risk-med">問題設計の責務 (= 機密を state に入れない)</td></tr>
+  </tbody>
+</table>
+</section>
+
+<section>
+<h2>Mechanisms</h2>
+<table>
+  <thead><tr><th>機構</th><th>担保する層</th></tr></thead>
+  <tbody>
+    <tr><td>専用 <code>CoordinationDispatcherFunction</code> (新 Lambda、 IAM = coordination row のみ)</td><td>S2。 既存 participant-portal Lambda の AssumeRole/SSM/KMS を継承しない。</td></tr>
+    <tr><td>動的 load 対象 = 公開済みカタログ bundle (ADR-008 の S3 経路)。 participant 入力からは到達不能。</td><td>S1。 community 拡張は維持しつつ、 任意コードアップロードを禁止。</td></tr>
+    <tr><td>カタログ reviewer checklist: <code>@aws-sdk/*</code> / <code>fetch</code> / <code>node:*</code> / <code>process.env</code> を import/参照する coordination plugin は reject</td><td>S1 + S3。 純 reducer 規約の人間による enforcement。</td></tr>
+    <tr><td>DDB <code>PutItem</code> に <code>Condition: aws:dynamodb:LeadingKeys = COORD#&lt;tenantId&gt;#&lt;eventId&gt;</code> 相当の scope 制約</td><td>S2。 cross-tenant write を IAM で封じる。</td></tr>
+    <tr><td>loader の契約検証 (<code>isCoordinationPlugin</code>) + <code>safeProjectForTeam</code> fail-safe (実装済み、 #1617)</td><td>S3。 契約不一致 / throw を null / fallback に倒し participant API を壊さない。</td></tr>
+  </tbody>
+</table>
+</section>
+
+<section>
+<h2>Alternatives considered</h2>
+<h3>A1: participant-portal Lambda に相乗り (ADR-028 D6 の素案)</h3>
+<p><span class="badge reject">却下</span> 実装は最短だが、 当該 Lambda は competitor アカウントへの <code>AssumeRole</code> + 全テナント DDB + ExternalId 復号権限を持つため、 未信頼コードの blast radius が競技者資格情報まで広がる。 「bug は event row に閉じる」 は成り立つが「悪意あるコードも閉じる」 は成り立たない。</p>
+<h3>A2: 別 isolate (vm2 / 分離 Worker / WASM) で sandbox 実行</h3>
+<p><span class="badge reject">却下 (現段階)</span> 最も強い分離だが、 Node の in-process sandbox (vm2 等) は歴史的に脱出 CVE が多く「安全な sandbox」 とは言い難い。 WASM 化は SDK / 問題 author の DX を大きく損なう。 cost/複雑度に見合わない。 S2 (IAM 最小権限) が実質同等の封じ込めを安価に達成する。 将来 plugin の規模が上がれば再検討する余地は残す。</p>
+<h3>A3: plugin を platform に静的バンドル (動的 load しない)</h3>
+<p><span class="badge reject">却下</span> 最も安全 (任意コード実行なし) だが、 coordination 付き問題を足すたびに platform 再デプロイが必要になり、 community が問題を後から追加できなくなる (= ADR-012 / ADR-028 の前提を破壊)。 S1 (レビュー済みカタログ bundle の動的 load) が「レビュー済み = 準信頼」 と「再デプロイ不要」 を両立する。</p>
+</section>
+
+<section>
+<h2>Consequences</h2>
+<h3>得るもの</h3>
+<ul>
+  <li>未信頼 (= community 製) coordination plugin を、 competitor 資格情報・cross-tenant データに触れさせずに実行できる (S2)。</li>
+  <li>community 拡張性 (platform 再デプロイ不要) を維持する (S1)。</li>
+  <li>ADR-028 D6 の blast-radius 主張を「bug にも悪意にも成り立つ」 形に正す。</li>
+</ul>
+<h3>失うもの / コスト</h3>
+<ul>
+  <li>専用 Lambda (+ IAM + デプロイ配線) の新設コスト。 participant-portal Lambda への相乗りより配線が増える。</li>
+  <li>カタログ reviewer に「coordination plugin の import 監査」 という負荷が乗る (checklist 化で軽減)。</li>
+  <li>in-process 実行のため、 timeout / メモリ枠内での DoS 耐性は IAM では縛れない (Lambda の実行制限に依存)。</li>
+</ul>
+</section>
+
+<section>
+<h2>Migration</h2>
+<ol>
+  <li><strong>Phase 1 (済)</strong>: loader + dispatcher orchestration + participant route を <strong>importer を seam として</strong> 配線。 importer 未配線の間は <code>unavailable</code> / fallback で安全に応答する。</li>
+  <li><strong>Phase 2</strong>: 専用 <code>CoordinationDispatcherFunction</code> (最小 IAM) を CDK で新設し、 coordination route をそちらへ移す。 participant-portal Lambda は coordination を扱わない。</li>
+  <li><strong>Phase 3</strong>: レビュー済みカタログ bundle から plugin を materialize → <code>import()</code> する実 importer を実装し seam に差す。 <code>PROBLEM_COORDINATION</code> env を CDK が配線する。</li>
+  <li><strong>Phase 4</strong>: カタログ reviewer checklist (import 監査) を <code>AGENT.md</code> / PR template に追加し、 reference 問題 (microservice-migration-battle) で end-to-end を確認する。</li>
+</ol>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

#1420 の残件 = **importer**(問題同梱 plugin を S3 から materialize → 動的 import)を実装する前に、未信頼(community 製)コードを platform プロセス内で安全に実行する**境界を設計**する(コードは含まない設計のみ)。

### 調査で判明した security gap
ADR-028 D6 は coordination dispatcher を participant-portal Lambda に相乗りさせる素案だったが、当該 Lambda は **competitor アカウントへの `sts:AssumeRole` + 全テナント DDB + `ssm:GetParameter`(ExternalId)+ `kms:Decrypt`** を持つ。ここで未信頼コードを `import()` すると、D6 の「blast radius は event の 1 row」は **bug には成り立つが悪意あるコードには成り立たず**、competitor 資格情報・cross-tenant データに到達しうる。

### ADR-030 の決定 — 三層境界
- **S1** 信頼の単位 = レビュー済みカタログ bundle(任意アップロード不可、community 拡張は PR 経由)
- **S2** 実行 = 専用最小権限 Lambda(`AssumeRole`/SSM/KMS なし、coordination row のみ)
- **S3** 契約 = 副作用なし純 reducer(型では強制できない規約を S1/S2 で裏打ち)

別 isolate(vm2/WASM)は却下し、IAM 最小権限で同等の封じ込めを安価に達成する。脅威モデル表・Mechanisms・Alternatives・Migration を含む。

> ⚠️ **self-merge しない(owner のセキュリティ設計レビュー用)。** 本 ADR は設計のみで、未信頼コードを実行する実装は含まない。

## Test plan
- `make harness` 違反なし(`adr-must-be-html` / `adr-self-contained` 通過)。chat 文脈 / rolling metadata / role-split note / TODO を含まない self-contained な設計文書。

## Regression analysis
- `docs/architecture/adr-030-*.html` の新規追加のみ。production code 無改変。

## Physical impact
- **NO-OP**。設計ドキュメントのみ。CFn / bundle / source は一切不変。

Relates #1420