### PR TITLE
docs(runbook): capacity pressure & throttling response [#1431]

### DIFF
--- a/docs/runbooks/capacity-pressure.ja.md
+++ b/docs/runbooks/capacity-pressure.ja.md
@@ -1,0 +1,81 @@
+# Capacity pressure & throttling response
+
+> English: [capacity-pressure.md](./capacity-pressure.md)
+
+| 属性 | 値 |
+|---|---|
+| Audience | オンコールオペレータ (= Free Tier / 容量逼迫アラームを受け取る人) |
+| 使うタイミング | `tenkacloud-freetier-*` / `tenkacloud-health-*` アラーム、 または CostBudget の 80％ / 100％ 通知を受けたとき |
+| 所要時間 | 1 アラームあたり 5〜15 分の triage。 スケールアップ判断を伴う場合はそれ以上 |
+| 出力 | 「観測した数値」 / 「分類 (誤検知 / 一時的 / 要対応)」 / 「打ち手 (何もしない含む)」 をイベントタイムラインに 1 ライン記録 |
+
+[`free-tier-alarms.ts`](../../infrastructure/lib/observability/free-tier-alarms.ts) と `CostBudget` は容量・コストの逼迫を **検知** する。 本 runbook はその **応答側** を定義する。 アラームは「動け」ではなく「観測して分類しろ」の合図であり、 圧力下で慌ててスケールすると Free Tier を抜けて無用なコストを生む。 [live-monitoring](./live-monitoring.ja.md) と同じく、 **観測 → 分類 → (必要なら) 行動** の順を守る。
+
+## アラームカタログ
+
+| アラーム名 | 意味 | デフォルトしきい値 | 主因の候補 |
+|---|---|---|---|
+| `tenkacloud-freetier-lambda-<fn>` | Lambda の日次 invocations が Free Tier (1M/月) の 80％ 相当を超過 | 26,666 / 日 | polling 暴走 / retry ループ / 想定超の参加者数 |
+| `tenkacloud-health-lambda-errors-<fn>` | Lambda の日次エラー件数が超過 | 50 / 日 | deploy 失敗 / 権限不足 / 依存先の異常 |
+| `tenkacloud-health-apigw-5xx-<api>` | API Gateway の日次 5XX が超過 | 50 / 日 | backend Lambda の例外 / timeout |
+| `tenkacloud-freetier-ddb-read-<table>` | テーブルの日次 ConsumedReadCapacityUnits 超過 | 100,000 / 日 | 1 RCU 上限への read 集中 (= throttle 圏) |
+| `tenkacloud-freetier-ddb-write-<table>` | テーブルの日次 ConsumedWriteCapacityUnits 超過 | 100,000 / 日 | 1 WCU 上限への write 集中 (= throttle 圏) |
+| CostBudget 80％ / 100% | 月次コストが上限の 80％ / 100％ に到達 (SNS email) | 月次予算 | Free Tier 超過リソースの発生 |
+
+しきい値はいずれも CDK props (`lambdaDailyInvocationThreshold` 等) で環境ごとに上書きできる。 デフォルト値の根拠はソースの定数コメントを参照する。
+
+## triage 手順
+
+1. **観測**: アラーム名から対象 (Lambda / API / テーブル) を特定し、 CloudWatch のメトリクスと [`ObservabilityStack`](../../infrastructure/lib/observability/) のダッシュボードで直近の推移を見る。 スパイクか、 右肩上がりの持続かを区別する。
+2. **分類**:
+   - **誤検知 / 一時的**: 単発スパイクで既に収束 → 記録のみ、 行動しない。
+   - **想定内の負荷**: 参加者増による正常な増加 → スケール判断 (下記) に進む。
+   - **異常**: retry ループ / エラー連鎖 / 1 チームからの異常リクエスト → 原因を止める ([incident-response](./incident-response.ja.md) と併用)。
+3. **行動**: 分類が確定してから、 必要な打ち手のみを実施する。
+
+## アラーム別の応答
+
+### DynamoDB capacity (`tenkacloud-freetier-ddb-read/write-*`)
+
+`DynamoDbLowCapacity` Aspect が全テーブルを **PROVISIONED 1 RCU / 1 WCU** に固定している (Free Tier 25/25 内に収めるため)。 read/write が 1 ユニットの sustained 上限 (≒ 1 req/sec) を超えると DynamoDB が **throttle** する。 まず throttle が実害かどうかを次の基準で見極める。
+
+- **read/write が SDK retry で吸収できている** (= ユーザー影響なし) → 何もしない。 throttle は設計上の節約挙動。
+- **throttle で scoring tick / deploy が遅延している** (= ユーザー影響あり) → 対象テーブルのキャパシティを **意図的に** 引き上げる。
+
+> ⚠️ 容量の引き上げは **現状マニュアル** である。 ランタイム可変キャパシティ ([#1431](https://github.com/susumutomita/TenkaCloud/issues/1431) の `[INFRA]` 子項目) は未実装。 現行の引き上げ手順は次のとおり。
+>
+> 1. `infrastructure/lib/cdk-aspect/` の `DynamoDbLowCapacity` 適用範囲を確認し、 対象テーブルを除外するか、 capacity を引き上げる設定変更を行う (owner レビュー必須)。
+> 2. `make diff` で **PROVISIONED 値の変化のみ** であること (テーブル置換でないこと) を確認する。
+> 3. 25 RCU/WCU の Free Tier を超える分は **課金される**。 CostBudget の残枠と引き換えに、 イベント期間だけ引き上げ、 teardown で 1/1 に戻す。
+
+`PAY_PER_REQUEST` (オンデマンド) への切り替えは **禁止** (`DynamoDbLowCapacity` が阻止する。 コスト予測不能になるため)。
+
+### Lambda invocations (`tenkacloud-freetier-lambda-*`)
+
+月次 1M req の Free Tier に接近している。 まず **暴走でないか** を次の観点で確かめる。
+
+- フロントの polling 周期が想定どおりか (SSE/WebSocket を使わず polling に寄せている分、 invocations は素直に参加者数 × 周期で効く)。
+- EventBridge 駆動の reconciliation ([ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html)) が過剰発火していないか。
+- retry ストームが起きていないか (errors アラームと併発していないか)。
+
+正常な参加者増なら、 invocations は線形なので **イベント終了で自然に収束** する。 行動は不要なことが多い。
+
+### Lambda errors / API Gateway 5XX (`tenkacloud-health-*`)
+
+容量ではなく **健全性** のアラーム。 CloudWatch Logs Insights を `jobId` 等でフィルタ ([deploy-trace](../operations/deploy-trace.md)) し、 例外内容を特定する。 deploy 系なら [incident-response](./incident-response.ja.md) に合流する。
+
+### CostBudget 80％ / 100%
+
+月次コストが上限に接近。 Cost Explorer でサービス別内訳を見て、 **Free Tier を抜けたリソース** を特定する (多くは上記 DDB キャパシティ引き上げの戻し忘れ、 または想定外のデータ転送)。 100％ 到達時は、 課金を止められる範囲で不要リソースを teardown する。
+
+## エスカレーション
+
+- ユーザー影響のある throttle / エラーが 15 分以上継続 → owner にエスカレーションし、 キャパシティ引き上げ (課金判断) の承認を得る。
+- イベント終了後は、 引き上げたキャパシティを **必ず 1/1 に戻す** (戻し忘れが翌月コストの最大要因)。
+
+## 関連
+
+- [live-monitoring](./live-monitoring.ja.md) — イベント中の常時監視ループ
+- [incident-response](./incident-response.ja.md) — インシデント分類と対応
+- [`free-tier-alarms.ts`](../../infrastructure/lib/observability/free-tier-alarms.ts) — アラーム定義 (しきい値の正本)
+- [#1431](https://github.com/susumutomita/TenkaCloud/issues/1431) — ランタイム可変キャパシティ (本 runbook が前提とする `[INFRA]` 子項目)

--- a/docs/runbooks/capacity-pressure.md
+++ b/docs/runbooks/capacity-pressure.md
@@ -1,0 +1,81 @@
+# Capacity pressure & throttling response
+
+> 日本語: [capacity-pressure.ja.md](./capacity-pressure.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | On-call operator (whoever receives the Free-Tier / capacity-pressure alarms) |
+| When to use | On a `tenkacloud-freetier-*` / `tenkacloud-health-*` alarm, or a CostBudget 80 / 100 percent notification |
+| Time | 5–15 min triage per alarm; longer if a scale-up decision is involved |
+| Output | One timeline line per alarm: the observed number / the classification (false alarm / transient / actionable) / the action taken (including "nothing") |
+
+[`free-tier-alarms.ts`](../../infrastructure/lib/observability/free-tier-alarms.ts) and `CostBudget` **detect** capacity and cost pressure. This runbook defines the **response** side. An alarm says "observe and classify", not "act now" — scaling in a panic pushes you past the Free Tier and burns cost for nothing. As in [live-monitoring](./live-monitoring.md), keep the order **observe → classify → (only then) act**.
+
+## Alarm catalog
+
+| Alarm name | Meaning | Default threshold | Likely cause |
+|---|---|---|---|
+| `tenkacloud-freetier-lambda-<fn>` | Daily Lambda invocations exceed ~80 percent of the Free Tier (1M/month) | 26,666 / day | runaway polling / retry loop / more participants than expected |
+| `tenkacloud-health-lambda-errors-<fn>` | Daily Lambda error count exceeds the threshold | 50 / day | deploy failure / missing permission / downstream fault |
+| `tenkacloud-health-apigw-5xx-<api>` | Daily API Gateway 5XX count exceeds the threshold | 50 / day | backend Lambda exception / timeout |
+| `tenkacloud-freetier-ddb-read-<table>` | Daily ConsumedReadCapacityUnits exceed the threshold | 100,000 / day | reads concentrated on the 1 RCU ceiling (throttle zone) |
+| `tenkacloud-freetier-ddb-write-<table>` | Daily ConsumedWriteCapacityUnits exceed the threshold | 100,000 / day | writes concentrated on the 1 WCU ceiling (throttle zone) |
+| CostBudget 80 / 100 percent | Monthly cost reaches 80 / 100 percent of the ceiling (SNS email) | monthly budget | a resource has left the Free Tier |
+
+Every threshold is overridable per environment via CDK props (`lambdaDailyInvocationThreshold`, etc.). See the source constant comments for the rationale of each default.
+
+## Triage
+
+1. **Observe**: from the alarm name, identify the target (Lambda / API / table) and read its recent trend in CloudWatch metrics and the [`ObservabilityStack`](../../infrastructure/lib/observability/) dashboard. Distinguish a one-off spike from a sustained climb.
+2. **Classify**:
+   - **False alarm / transient**: a single spike that already settled → record only, take no action.
+   - **Expected load**: a normal rise from more participants → proceed to the scale decision below.
+   - **Anomaly**: a retry loop / cascading errors / abnormal requests from one team → stop the cause (pair with [incident-response](./incident-response.ja.md)).
+3. **Act**: only after the classification is settled, take the minimum necessary action.
+
+## Response per alarm
+
+### DynamoDB capacity (`tenkacloud-freetier-ddb-read/write-*`)
+
+The `DynamoDbLowCapacity` aspect pins every table to **PROVISIONED 1 RCU / 1 WCU** (to stay inside the 25/25 Free Tier). When read/write exceeds the sustained ceiling of one unit (~1 req/sec), DynamoDB **throttles**. First decide whether the throttling is actually harmful:
+
+- **The SDK's retries absorb it** (no user impact) → do nothing. Throttling is the intended cost-saving behaviour.
+- **Throttling delays scoring ticks / deploys** (user impact) → **deliberately** raise the capacity of the affected table.
+
+> ⚠️ Raising capacity is **manual today**. Runtime-adjustable capacity (the `[INFRA]` child of [#1431](https://github.com/susumutomita/TenkaCloud/issues/1431)) is not yet implemented. Current procedure:
+>
+> 1. In `infrastructure/lib/cdk-aspect/`, review the `DynamoDbLowCapacity` scope and either exclude the table or raise its capacity (owner review required).
+> 2. Run `make diff` and confirm the change is **a PROVISIONED-value change only** (not a table replacement).
+> 3. Anything above the 25 RCU/WCU Free Tier is **billed**. Trade it against the CostBudget headroom: raise it only for the event window and return it to 1/1 at teardown.
+
+Switching to `PAY_PER_REQUEST` (on-demand) is **forbidden** (`DynamoDbLowCapacity` blocks it — it makes cost unpredictable).
+
+### Lambda invocations (`tenkacloud-freetier-lambda-*`)
+
+Approaching the 1M req/month Free Tier. First suspect a **runaway**:
+
+- Is the frontend polling interval as expected? (Because we use polling rather than SSE/WebSocket, invocations scale straightforwardly with participants × interval.)
+- Is the EventBridge-driven reconciliation ([ADR-014](../architecture/adr-014-eventbridge-driven-state-reconciliation.html)) firing too often?
+- Is there a retry storm? (Does it co-fire with the errors alarm?)
+
+For a legitimate participant increase, invocations are linear and **settle on their own when the event ends** — usually no action is needed.
+
+### Lambda errors / API Gateway 5XX (`tenkacloud-health-*`)
+
+A **health** alarm, not a capacity one. Filter CloudWatch Logs Insights by `jobId` etc. ([deploy-trace](../operations/deploy-trace.md)) and identify the exception. If it is deploy-related, merge into [incident-response](./incident-response.ja.md).
+
+### CostBudget 80 / 100 percent
+
+Monthly cost is approaching the ceiling. Use Cost Explorer to see the per-service breakdown and identify the resource that **left the Free Tier** (most often a forgotten DDB capacity raise from above, or unexpected data transfer). On 100 percent, tear down unnecessary resources to the extent that stops the billing.
+
+## Escalation
+
+- User-impacting throttling / errors lasting more than 15 minutes → escalate to the owner and get approval for the capacity raise (a billing decision).
+- After the event, **always return the raised capacity to 1/1** (a forgotten raise is the single biggest driver of next month's cost).
+
+## Related
+
+- [live-monitoring](./live-monitoring.md) — the continuous monitoring loop during an event
+- [incident-response](./incident-response.ja.md) — incident classification and response
+- [`free-tier-alarms.ts`](../../infrastructure/lib/observability/free-tier-alarms.ts) — alarm definitions (source of truth for thresholds)
+- [#1431](https://github.com/susumutomita/TenkaCloud/issues/1431) — runtime-adjustable capacity (the `[INFRA]` child this runbook assumes)


### PR DESCRIPTION
## Summary

#1431 の子項目 **「Bottleneck/throttling response」** を埋める。`FreeTierAlarms` / `CostBudget` は容量・コスト逼迫を**検知**するが、**応答側の runbook が無かった**(= issue が "app-layer/docs" と明記した gap)。

`docs/runbooks/capacity-pressure.{ja,md}` を新設し、各アラームの意味・既定しきい値・triage(観測 → 分類 → 行動)・応答手順を定義:
- `tenkacloud-freetier-lambda-<fn>`(26,666/日)/ `tenkacloud-freetier-ddb-read|write-<table>`(100,000/日)/ `tenkacloud-health-lambda-errors` / `tenkacloud-health-apigw-5xx` / CostBudget 80・100%。
- DDB 容量引き上げは**現状マニュアル**(#1431 の `[INFRA]` 子項目が未実装)である点、`make diff` で PROVISIONED 値のみ変更(テーブル置換でない)を確認する手順、イベント後に **1/1 へ戻す**運用注意を明記。
- `live-monitoring` / `incident-response` / `deploy-trace` / `free-tier-alarms.ts` / ADR-014 と相互リンク。

## Test plan
- markdownlint **0 error** / textlint **clean**(ja は全角 `％`、en は `percent` 表記で既存 `live-monitoring.md` の no-`%` 慣習に整合)/ `make harness` 違反なし。
- cross-ref 先のファイルは全て実在を確認。

## Regression analysis
- **docs のみ**(runbook 2 file 新規)。production code / infra 無改変。

## Physical impact
- **NO-OP**。運用ドキュメントのみ。

Relates #1431