### PR TITLE
fix: audit-log route + IdP claim read + OAuth deep-link [app-admin auth bugs]

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -1,6 +1,7 @@
 import "@cloudscape-design/global-styles/index.css";
-import { Navigate, Route, Routes } from "react-router";
+import { Navigate, Route, Routes, useLocation } from "react-router";
 import { AuthProvider, useAuth } from "./auth/AuthProvider";
+import { buildLoginReturnPath, readLoginReturnPathState } from "./auth/login-return-path";
 import { ShellLayout } from "./components/AppLayout";
 import type { AppConfig } from "./config";
 import { AuditLogPage } from "./pages/AuditLog";
@@ -20,8 +21,11 @@ import { ProblemsPage } from "./pages/Problems";
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const auth = useAuth();
+  const location = useLocation();
   if (!auth.ready) return null;
-  if (!auth.tokens) return <Navigate to="/login" replace />;
+  if (!auth.tokens) {
+    return <Navigate to="/login" replace state={{ returnPath: buildLoginReturnPath(location) }} />;
+  }
   return <>{children}</>;
 }
 
@@ -33,11 +37,16 @@ function guarded(element: React.ReactNode) {
   );
 }
 
+function LoginRoute({ config }: { config: AppConfig }) {
+  const location = useLocation();
+  return <LoginPage config={config} returnPath={readLoginReturnPathState(location.state)} />;
+}
+
 export function App({ config }: { config: AppConfig }) {
   return (
     <AuthProvider config={config}>
       <Routes>
-        <Route path="/login" element={<LoginPage config={config} />} />
+        <Route path="/login" element={<LoginRoute config={config} />} />
         <Route path="/callback" element={<CallbackPage config={config} />} />
         <Route path="/" element={guarded(<HomePage />)} />
         <Route path="/problems" element={guarded(<ProblemsPage />)} />

--- a/apps/application-admin-console/src/auth/login-return-path.ts
+++ b/apps/application-admin-console/src/auth/login-return-path.ts
@@ -1,0 +1,59 @@
+const LOGIN_RETURN_PATH_KEY = "TenkaCloud.application_admin.login_return_path";
+const APP_ORIGIN = "https://application-admin.invalid";
+const DEFAULT_RETURN_PATH = "/";
+
+interface LocationParts {
+  readonly pathname: string;
+  readonly search: string;
+  readonly hash: string;
+}
+
+export function buildLoginReturnPath(location: LocationParts): string {
+  return (
+    sanitizeLoginReturnPath(`${location.pathname}${location.search}${location.hash}`) ??
+    DEFAULT_RETURN_PATH
+  );
+}
+
+export function readLoginReturnPathState(state: unknown): string | undefined {
+  if (!state || typeof state !== "object" || !("returnPath" in state)) return undefined;
+  return sanitizeLoginReturnPath((state as { readonly returnPath?: unknown }).returnPath);
+}
+
+export function rememberLoginReturnPath(returnPath: unknown): void {
+  const safePath = sanitizeLoginReturnPath(returnPath);
+  try {
+    if (safePath) {
+      sessionStorage.setItem(LOGIN_RETURN_PATH_KEY, safePath);
+    } else {
+      sessionStorage.removeItem(LOGIN_RETURN_PATH_KEY);
+    }
+  } catch {
+    // Storage may be unavailable in privacy-restricted browsers. Fall back to home after login.
+  }
+}
+
+export function consumeLoginReturnPath(): string {
+  try {
+    const returnPath = sessionStorage.getItem(LOGIN_RETURN_PATH_KEY);
+    sessionStorage.removeItem(LOGIN_RETURN_PATH_KEY);
+    return sanitizeLoginReturnPath(returnPath) ?? DEFAULT_RETURN_PATH;
+  } catch {
+    return DEFAULT_RETURN_PATH;
+  }
+}
+
+function sanitizeLoginReturnPath(returnPath: unknown): string | undefined {
+  if (
+    typeof returnPath !== "string" ||
+    !returnPath.startsWith("/") ||
+    returnPath.startsWith("//")
+  ) {
+    return undefined;
+  }
+  const url = new URL(returnPath, APP_ORIGIN);
+  if (url.origin !== APP_ORIGIN || url.pathname === "/login" || url.pathname === "/callback") {
+    return undefined;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/apps/application-admin-console/src/components/event-detail/EventProblemSetPanel.tsx
+++ b/apps/application-admin-console/src/components/event-detail/EventProblemSetPanel.tsx
@@ -2,6 +2,7 @@ import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import Table from "@cloudscape-design/components/table";
+import { useNavigate } from "react-router";
 import type { EventDetail } from "../../api/events-client";
 import { renderProblemDeployStatus, renderProblemJobLinks } from "./shared";
 
@@ -14,6 +15,7 @@ export function EventProblemSetPanel({
   readonly detail: EventDetail;
   readonly t: Translate;
 }) {
+  const navigate = useNavigate();
   return (
     <Container
       header={
@@ -49,7 +51,7 @@ export function EventProblemSetPanel({
           {
             id: "jobs",
             header: t("event_detail.problemset_col_jobs"),
-            cell: (p) => renderProblemJobLinks(detail.deploymentsByProblem[p.problemId]),
+            cell: (p) => renderProblemJobLinks(detail.deploymentsByProblem[p.problemId], navigate),
           },
         ]}
         empty={<Box>{t("event_detail.problemset_empty")}</Box>}

--- a/apps/application-admin-console/src/components/event-detail/shared.tsx
+++ b/apps/application-admin-console/src/components/event-detail/shared.tsx
@@ -2,6 +2,7 @@ import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import type { NavigateFunction } from "react-router";
 import type {
   EventDeploymentStatus,
   EventDeploymentSummary,
@@ -110,7 +111,10 @@ export function renderProblemDeployStatus(
 /**
  * 1 problem 行の deploy job click-through link 列 (#533)。
  */
-export function renderProblemJobLinks(deployments: readonly EventDeploymentSummary[] | undefined) {
+export function renderProblemJobLinks(
+  deployments: readonly EventDeploymentSummary[] | undefined,
+  navigate?: NavigateFunction,
+) {
   if (!deployments || deployments.length === 0) {
     return (
       <Box variant="small" color="text-status-inactive">
@@ -126,6 +130,11 @@ export function renderProblemJobLinks(deployments: readonly EventDeploymentSumma
             href={`/deployments/${encodeURIComponent(d.jobId)}`}
             external={false}
             ariaLabel={`Deploy job 詳細 (status: ${d.status})`}
+            onFollow={(e) => {
+              if (!navigate) return;
+              e.preventDefault();
+              navigate(`/deployments/${encodeURIComponent(d.jobId)}`);
+            }}
           >
             Job #{i + 1} ↗
           </Link>

--- a/apps/application-admin-console/src/pages/Callback.tsx
+++ b/apps/application-admin-console/src/pages/Callback.tsx
@@ -5,6 +5,7 @@ import { completeLogin } from "@tenkacloud/auth-client";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
+import { consumeLoginReturnPath } from "../auth/login-return-path";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 
@@ -29,7 +30,7 @@ export function CallbackPage({ config }: { config: AppConfig }) {
     completeLogin(config, code, state)
       .then((tokens) => {
         auth.setTokens(tokens);
-        navigate("/", { replace: true });
+        navigate(consumeLoginReturnPath(), { replace: true });
       })
       .catch((err: Error) => setError(err.message));
   }, [params, config, auth, navigate, t]);

--- a/apps/application-admin-console/src/pages/Login.tsx
+++ b/apps/application-admin-console/src/pages/Login.tsx
@@ -30,11 +30,12 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { distinctProviders, type IdpResolution, resolveIdp } from "../auth/idp-resolution";
+import { rememberLoginReturnPath } from "../auth/login-return-path";
 import { ProductLoginShell } from "../components/ProductLoginShell";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
 
-export function LoginPage({ config }: { config: AppConfig }) {
+export function LoginPage({ config, returnPath }: { config: AppConfig; returnPath?: string }) {
   const auth = useAuth();
   const t = useT();
   // mount 直後に auto-redirect を 1 回だけ走らせる guard (#1360)。 React StrictMode の 2 度
@@ -56,6 +57,7 @@ export function LoginPage({ config }: { config: AppConfig }) {
   const startLogin = async (options?: { identityProvider?: string }) => {
     setSigningIn(true);
     setErrorMessage(undefined);
+    rememberLoginReturnPath(returnPath);
     try {
       await auth.login(options);
       // 成功時は Cognito Hosted UI への redirect が走るため、 ここに到達しない (= browser

--- a/apps/application-admin-console/test/App.test.tsx
+++ b/apps/application-admin-console/test/App.test.tsx
@@ -99,6 +99,17 @@ describe("App", () => {
         }),
       ).toBeInTheDocument();
     });
+
+    it("should remember a deep link before redirecting through the login page", async () => {
+      renderApp("/deployments/job-1?view=logs#latest");
+      await screen.findByRole("heading", {
+        level: 1,
+        name: /TenkaCloud Application Admin Console/,
+      });
+      expect(sessionStorage.getItem("TenkaCloud.application_admin.login_return_path")).toBe(
+        "/deployments/job-1?view=logs#latest",
+      );
+    });
   });
 
   describe("when completing the Cognito callback with a valid token (ADR-025: memory-only)", () => {

--- a/apps/application-admin-console/test/auth/login-return-path.test.ts
+++ b/apps/application-admin-console/test/auth/login-return-path.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildLoginReturnPath,
+  consumeLoginReturnPath,
+  readLoginReturnPathState,
+  rememberLoginReturnPath,
+} from "../../src/auth/login-return-path";
+
+const KEY = "TenkaCloud.application_admin.login_return_path";
+
+afterEach(() => sessionStorage.clear());
+
+describe("login return path", () => {
+  it("should preserve a same-app deep link with its query and hash", () => {
+    const path = buildLoginReturnPath({
+      pathname: "/deployments/job-1",
+      search: "?view=logs",
+      hash: "#latest",
+    });
+    expect(path).toBe("/deployments/job-1?view=logs#latest");
+    expect(readLoginReturnPathState({ returnPath: path })).toBe(path);
+  });
+
+  it("should consume the remembered path exactly once", () => {
+    rememberLoginReturnPath("/deployments/job-1");
+    expect(consumeLoginReturnPath()).toBe("/deployments/job-1");
+    expect(consumeLoginReturnPath()).toBe("/");
+  });
+
+  it("should reject external, protocol-relative, and auth-loop paths", () => {
+    for (const path of [
+      "https://attacker.example/",
+      "//attacker.example/",
+      "/login",
+      "/callback?code=stale",
+    ]) {
+      sessionStorage.setItem(KEY, path);
+      expect(consumeLoginReturnPath()).toBe("/");
+    }
+  });
+
+  it("should clear an old remembered path when login starts without a deep link", () => {
+    sessionStorage.setItem(KEY, "/deployments/stale");
+    rememberLoginReturnPath(undefined);
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/apps/application-admin-console/test/auth/login-return-path.test.ts
+++ b/apps/application-admin-console/test/auth/login-return-path.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildLoginReturnPath,
   consumeLoginReturnPath,
@@ -19,6 +19,11 @@ describe("login return path", () => {
     });
     expect(path).toBe("/deployments/job-1?view=logs#latest");
     expect(readLoginReturnPathState({ returnPath: path })).toBe(path);
+  });
+
+  it("should fall back to home when the current location is not a safe deep link", () => {
+    // sanitize が undefined を返す location は `?? DEFAULT_RETURN_PATH` で home に倒す (line 13 の枝)。
+    expect(buildLoginReturnPath({ pathname: "/login", search: "", hash: "" })).toBe("/");
   });
 
   it("should consume the remembered path exactly once", () => {
@@ -43,5 +48,14 @@ describe("login return path", () => {
     sessionStorage.setItem(KEY, "/deployments/stale");
     rememberLoginReturnPath(undefined);
     expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("should fall back to home when sessionStorage is unavailable", () => {
+    // privacy-restricted ブラウザ等で getItem が throw する catch 経路 (= home へフォールバック)。
+    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    expect(consumeLoginReturnPath()).toBe("/");
+    spy.mockRestore();
   });
 });

--- a/apps/application-admin-console/test/components/event-detail/shared.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/shared.test.tsx
@@ -108,6 +108,15 @@ describe("renderProblemJobLinks", () => {
     await userEvent.click(screen.getByText("Job #1 ↗"));
     expect(navigate).toHaveBeenCalledWith("/deployments/j1");
   });
+
+  it("should fall back to the default anchor when no navigate fn is provided", async () => {
+    // navigate 省略時は onFollow が早期 return し (preventDefault せず)、 通常の anchor 遷移に委ねる。
+    render(renderProblemJobLinks([dep("COMPLETE", "j1")]));
+    const link = screen.getByText("Job #1 ↗");
+    await userEvent.click(link);
+    // 早期 return するため例外を投げず、 link は描画されたまま (= SPA navigation を行わない)。
+    expect(link).toBeInTheDocument();
+  });
 });
 
 describe("scoringBadge", () => {

--- a/apps/application-admin-console/test/components/event-detail/shared.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/shared.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import type {
   EventDeploymentSummary,
   EventDetail,
@@ -99,6 +100,13 @@ describe("renderProblemJobLinks", () => {
     expect(screen.getByText("Job #2 ↗")).toBeInTheDocument();
     expect(screen.getByText("COMPLETE")).toBeInTheDocument();
     expect(screen.getByText("FAILED")).toBeInTheDocument();
+  });
+
+  it("should use SPA navigation when following a job link so the memory-only token survives", async () => {
+    const navigate = vi.fn();
+    render(renderProblemJobLinks([dep("COMPLETE", "j1")], navigate));
+    await userEvent.click(screen.getByText("Job #1 ↗"));
+    expect(navigate).toHaveBeenCalledWith("/deployments/j1");
   });
 });
 

--- a/apps/application-admin-console/test/pages/Callback.test.tsx
+++ b/apps/application-admin-console/test/pages/Callback.test.tsx
@@ -26,12 +26,16 @@ const { CallbackPage } = await import("../../src/pages/Callback");
 const config = {} as AppConfig;
 
 beforeEach(() => {
+  sessionStorage.clear();
   mockNav.mockClear();
   mockSetTokens.mockClear();
   mockComplete.mockReset().mockResolvedValue({ idToken: "tok" });
   mockParams.mockReturnValue(new URLSearchParams("code=abc&state=xyz"));
 });
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  sessionStorage.clear();
+  vi.clearAllMocks();
+});
 
 describe("CallbackPage", () => {
   it("should show an error when no code is present and not exchange", () => {
@@ -48,6 +52,17 @@ describe("CallbackPage", () => {
     await waitFor(() => expect(mockSetTokens).toHaveBeenCalledWith({ idToken: "tok" }));
     expect(mockComplete).toHaveBeenCalledWith(config, "abc", "xyz");
     expect(mockNav).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("should return to the remembered deep link after a successful exchange", async () => {
+    sessionStorage.setItem(
+      "TenkaCloud.application_admin.login_return_path",
+      "/deployments/job-1?view=logs#latest",
+    );
+    render(<CallbackPage config={config} />);
+    await waitFor(() => expect(mockSetTokens).toHaveBeenCalledWith({ idToken: "tok" }));
+    expect(mockNav).toHaveBeenCalledWith("/deployments/job-1?view=logs#latest", { replace: true });
+    expect(sessionStorage.getItem("TenkaCloud.application_admin.login_return_path")).toBeNull();
   });
 
   it("should pass undefined state when the state param is absent", async () => {

--- a/infrastructure/lib/control-plane/handlers/idp-handler/auth.ts
+++ b/infrastructure/lib/control-plane/handlers/idp-handler/auth.ts
@@ -7,18 +7,28 @@
  * string and the tenant-scope binding differ.
  */
 
-import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+import type {
+  APIGatewayProxyEventV2WithJWTAuthorizer,
+  APIGatewayProxyWithCognitoAuthorizerEvent,
+} from "aws-lambda";
 import type { Context } from "hono";
 
 type JwtClaimValue = string | number | boolean | string[];
 type JwtClaims = { readonly [name: string]: JwtClaimValue };
+type AuthorizerEvent =
+  | APIGatewayProxyEventV2WithJWTAuthorizer
+  | APIGatewayProxyWithCognitoAuthorizerEvent;
 
 const SYSTEM_ADMIN_ROLE = "SystemAdmin";
 const TENANT_ADMIN_ROLE = "TenantAdmin";
 
 function readClaim(c: Context, name: string): string | undefined {
-  const event = (c.env as { event?: APIGatewayProxyEventV2WithJWTAuthorizer } | undefined)?.event;
-  const claims = event?.requestContext?.authorizer?.jwt?.claims as JwtClaims | undefined;
+  const event = (c.env as { event?: AuthorizerEvent } | undefined)?.event;
+  const authorizer = event?.requestContext?.authorizer;
+  if (!authorizer) return undefined;
+  const v2 = (authorizer as { jwt?: { claims?: unknown } }).jwt?.claims;
+  const v1 = (authorizer as { claims?: unknown }).claims;
+  const claims = (v2 && typeof v2 === "object" ? v2 : v1) as JwtClaims | undefined;
   const raw = claims?.[name];
   return typeof raw === "string" ? raw : undefined;
 }

--- a/infrastructure/lib/tenant-template/api-gateway.ts
+++ b/infrastructure/lib/tenant-template/api-gateway.ts
@@ -199,6 +199,14 @@ export class ApiGateway extends Construct {
     usersById.addMethod("DELETE", competitorAccountsIntegration, deployMethodOptions);
     usersById.addMethod("PATCH", competitorAccountsIntegration, deployMethodOptions);
 
+    // Issue #1292: Tenant Admin 向け監査ログ read / CSV export。
+    // EventApi handler 側の `/admin/audit-log*` route と同じ EventApi integration に公開する。
+    // API Gateway resource が無いと request は Lambda に届かず、Gateway 自身の 403 に CORS
+    // header が付かないため browser では response body ではなく "Failed to fetch" になる。
+    const auditLog = admin.addResource("audit-log");
+    auditLog.addMethod("GET", eventIntegration, deployMethodOptions);
+    auditLog.addResource("export").addMethod("GET", eventIntegration, deployMethodOptions);
+
     // Issue #1312: per-tenant SAML IdP CRUD route。 Application Plane (silo / Lite) のみ有効。
     //   /tenant/idp                  GET=list / POST=create
     //   /tenant/idp/{idpId}          GET=detail / PATCH=update / DELETE=remove

--- a/infrastructure/test/idp/auth.test.ts
+++ b/infrastructure/test/idp/auth.test.ts
@@ -15,6 +15,14 @@ function ctx(claims?: Record<string, unknown>): Context {
   } as unknown as Context;
 }
 
+function restApiCtx(claims?: Record<string, unknown>): Context {
+  return {
+    env: {
+      event: claims ? { requestContext: { authorizer: { claims } } } : undefined,
+    },
+  } as unknown as Context;
+}
+
 describe("isSystemAdmin", () => {
   it("should be true only when custom:userRole === SystemAdmin", () => {
     expect(isSystemAdmin(ctx({ "custom:userRole": "SystemAdmin" }))).toBe(true);
@@ -29,6 +37,10 @@ describe("isTenantAdmin", () => {
     expect(isTenantAdmin(ctx({ "custom:userRole": "TenantAdmin" }))).toBe(true);
     expect(isTenantAdmin(ctx({ "custom:userRole": "SystemAdmin" }))).toBe(false);
   });
+
+  it("should read custom:userRole from the REST API Cognito authorizer claims path", () => {
+    expect(isTenantAdmin(restApiCtx({ "custom:userRole": "TenantAdmin" }))).toBe(true);
+  });
 });
 
 describe("resolveTenantId", () => {
@@ -38,6 +50,9 @@ describe("resolveTenantId", () => {
   it("should return undefined when claim is missing or empty", () => {
     expect(resolveTenantId(ctx({ "custom:tenantId": "" }))).toBeUndefined();
     expect(resolveTenantId(ctx())).toBeUndefined();
+  });
+  it("should read custom:tenantId from the REST API Cognito authorizer claims path", () => {
+    expect(resolveTenantId(restApiCtx({ "custom:tenantId": "lite-local" }))).toBe("lite-local");
   });
 });
 

--- a/infrastructure/test/tenant-template/api-gateway.test.ts
+++ b/infrastructure/test/tenant-template/api-gateway.test.ts
@@ -179,4 +179,33 @@ describe("tenant ApiGateway", () => {
       ResourceId: { Ref: rotateResourceId },
     });
   });
+
+  it("should bind GET /admin/audit-log and GET /admin/audit-log/export to the EventApi integration (#1292)", () => {
+    const adminResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { PathPart: "admin" },
+      }),
+    )[0]?.[0];
+    expect(adminResourceId).toBeDefined();
+    const auditLogResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { ParentId: { Ref: adminResourceId }, PathPart: "audit-log" },
+      }),
+    )[0]?.[0];
+    expect(auditLogResourceId).toBeDefined();
+    const exportResourceId = Object.entries(
+      tpl.findResources("AWS::ApiGateway::Resource", {
+        Properties: { ParentId: { Ref: auditLogResourceId }, PathPart: "export" },
+      }),
+    )[0]?.[0];
+    expect(exportResourceId).toBeDefined();
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "GET",
+      ResourceId: { Ref: auditLogResourceId },
+    });
+    tpl.hasResourceProperties("AWS::ApiGateway::Method", {
+      HttpMethod: "GET",
+      ResourceId: { Ref: exportResourceId },
+    });
+  });
 });


### PR DESCRIPTION
application-admin-console(Lite モード)で報告された 3 つの認証系バグを修正。**Claude がライブ環境(account 672726205532 / ap-northeast-1)で root cause を実測確定 → Codex CLI に委譲して修正**。featurePlan/トークンは的外れで、実際は別の 3 つの原因だった。

## Bug 1 — 監査ログ "Failed to fetch"
- **原因(curl で実測確定)**: REST API `TenantAPI-local` に `/admin/audit-log`(+ `/export`)ルートが**存在しない**。`curl` → `403 MissingAuthenticationToken`(CORS ヘッダ無し)→ ブラウザは network error = "Failed to fetch"。Lambda の CORS middleware まで到達しない。
- **修正**: `infrastructure/lib/tenant-template/api-gateway.ts` に 2 ルートを追加。

## Bug 2 — Identity providers 403 "not a TenantAdmin"
- **原因**: IdP handler が `requestContext.authorizer.jwt.claims`(HTTP API V2 形式)だけを読んでいたが、Lite の **REST API Cognito authorizer は `requestContext.authorizer.claims`** に claim を置く。よって claim が見つからず 403。**featurePlan(ESSENTIALS で確認済)/トークン注入は無関係だった**。
- **修正**: `infrastructure/lib/control-plane/handlers/idp-handler/auth.ts` で V2(`jwt.claims`)/ REST(`claims`)両形式を読む。

## Bug 3 — Job deep-link がログイン画面→ホームに戻る
- **原因**: 通常 anchor の reload で memory-only token が消失し、OAuth callback が常に `/` へ戻していた。
- **修正**: same-app path のみ `sessionStorage` に保存して callback で復元(`auth/login-return-path.ts`)、リンクを SPA navigation 化(`event-detail/shared.tsx` 等)。

## Test plan
- idp auth / tenant-template test 32 緑、application-admin-console 896 緑、infra 全 test・typecheck・build・`make harness` 緑(Codex 検証 + Claude 再検証)。
- 新規/変更にテスト追加(auth.test / login-return-path.test / Callback.test 等)。
- **要デプロイ + 既存 admin の再ログイン**(Bug 2/3 はブラウザ確認が必要)。CI の check-synth はサンドボックス IPC 制約以外は緑。

## Regression analysis
- Bug 1: ルート追加のみ(既存ルート不変)。Bug 2: claim 読み取りを後方互換に拡張(V2 形式も維持)。Bug 3: deep-link 保存は same-app path のみ(open redirect 防止)。
- featurePlan(#1614)は的外れと判明(Tier は既に ESSENTIALS)→ #1614 はクローズ推奨。

## Physical impact
- **UPDATE** on `AWS::ApiGateway::RestApi`(TenantAPI に 2 メソッド追加、in-place)+ idp/app-admin の Lambda/SPA source。テーブル/IAM 置換なし。

Co-Authored-By: Codex CLI (delegated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login now preserves and returns users to their original deep link after authentication.
  * Added tenant-admin audit log endpoints.

* **Improvements**
  * Event detail job links support seamless in-app navigation.
  * Authentication helpers now handle multiple authorization event shapes.

* **Tests**
  * Added tests covering return-path behavior, callback redirect, and link navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->