### PR TITLE
feat(app-admin): SAML IdP setup guides + metadata upload

### DIFF
--- a/apps/application-admin-console/src/pages/CreateIdpModal.tsx
+++ b/apps/application-admin-console/src/pages/CreateIdpModal.tsx
@@ -1,35 +1,143 @@
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
+import CopyToClipboard from "@cloudscape-design/components/copy-to-clipboard";
+import ExpandableSection from "@cloudscape-design/components/expandable-section";
+import FileUpload from "@cloudscape-design/components/file-upload";
 import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
-import { useCallback, useState } from "react";
+import Tiles from "@cloudscape-design/components/tiles";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { describeTenantIdpError, type TenantIdpClient } from "../api/idp-client";
 
 interface CreateIdpModalProps {
   readonly client: TenantIdpClient | null;
+  readonly cognitoDomain: string;
   readonly onClose: () => void;
   readonly onCreated: () => Promise<void>;
   readonly busy: boolean;
   readonly setBusy: (b: boolean) => void;
 }
 
+type SamlProvider = "entra" | "google" | "okta" | "generic";
+
+interface ProviderGuide {
+  readonly label: string;
+  readonly description: string;
+  readonly steps: readonly string[];
+}
+
+const DEFAULT_EMAIL_ATTRIBUTE =
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+const SP_ENTITY_ID_PATTERN = "urn:amazon:cognito:sp:<userPoolId>";
+const METADATA_XML_ACCEPT = ".xml,text/xml,application/xml";
+const EMPTY_METADATA_FILE_ERROR = "The selected metadata XML file is empty.";
+const READ_METADATA_FILE_ERROR =
+  "Could not read the selected metadata XML file. Try another file or paste the XML below.";
+
+const PROVIDER_GUIDES: Record<SamlProvider, ProviderGuide> = {
+  entra: {
+    label: "Microsoft Entra ID",
+    description: "Microsoft Entra enterprise application",
+    steps: [
+      "In Microsoft Entra ID, open Enterprise applications -> New application -> Single sign-on -> SAML.",
+      "Set Reply URL to the ACS URL and Identifier to the SP Entity ID below.",
+      "Download Federation Metadata XML, then upload it below.",
+    ],
+  },
+  google: {
+    label: "Google Workspace",
+    description: "Google Admin custom SAML app",
+    steps: [
+      "In Google Workspace, open Admin console -> Apps -> Web and mobile apps -> Add custom SAML app.",
+      "Enter the ACS URL and Entity ID below.",
+      "Download the IdP metadata, then upload it below.",
+    ],
+  },
+  okta: {
+    label: "Okta",
+    description: "Okta SAML 2.0 app integration",
+    steps: [
+      "In Okta, open Applications -> Create App Integration -> SAML 2.0.",
+      "Set Single sign-on URL to the ACS URL and Audience URI to the SP Entity ID below.",
+      "Get the Identity Provider metadata URL or XML, then upload the XML below.",
+    ],
+  },
+  generic: {
+    label: "Generic SAML",
+    description: "Any SAML 2.0 identity provider",
+    steps: [
+      "Give the IdP administrator the ACS URL, SP Entity ID, and email attribute below.",
+      "Configure the IdP metadata XML, then upload it below.",
+    ],
+  },
+};
+
+const PROVIDER_TILES = (Object.entries(PROVIDER_GUIDES) as [SamlProvider, ProviderGuide][]).map(
+  ([value, guide]) => ({
+    value,
+    label: guide.label,
+    description: guide.description,
+  }),
+);
+
+function buildCognitoAcsUrl(cognitoDomain: string): string {
+  const origin = cognitoDomain.startsWith("https://") ? cognitoDomain : `https://${cognitoDomain}`;
+  return new URL("/saml2/idpresponse", origin).toString();
+}
+
+function CopyableSetupValue({
+  label,
+  value,
+  description,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly description: string;
+}) {
+  return (
+    <SpaceBetween size="xxs">
+      <Box variant="awsui-key-label">{label}</Box>
+      <CopyToClipboard
+        textToCopy={value}
+        copyButtonText={`Copy ${label}`}
+        copyButtonAriaLabel={`Copy ${label}`}
+        copySuccessText="Copied"
+        copyErrorText="Copy failed"
+        variant="inline"
+      />
+      <Box color="text-body-secondary">{description}</Box>
+    </SpaceBetween>
+  );
+}
+
 /**
  * Tenant SAML IdP 登録モーダル。 `IdentityProvidersPage` から切り出し、 Modal / FormField /
  * Input / Textarea 依存をこの module に閉じ込めた (= ページの高結合を解消)。
  */
-export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
+export function CreateIdpModal({
+  client,
+  cognitoDomain,
+  onClose,
+  onCreated,
+  busy,
+  setBusy,
+}: CreateIdpModalProps) {
   const [idpId, setIdpId] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
   const [metadataXml, setMetadataXml] = useState("");
-  const [emailAttr, setEmailAttr] = useState(
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-  );
+  const [metadataFiles, setMetadataFiles] = useState<readonly File[]>([]);
+  const [metadataFileError, setMetadataFileError] = useState<string | null>(null);
+  const [emailAttr, setEmailAttr] = useState(DEFAULT_EMAIL_ATTRIBUTE);
+  const [provider, setProvider] = useState<SamlProvider>("generic");
   const [error, setError] = useState<string | null>(null);
+  const metadataReadRequestId = useRef(0);
+  const acsUrl = useMemo(() => buildCognitoAcsUrl(cognitoDomain), [cognitoDomain]);
+  const providerGuide = PROVIDER_GUIDES[provider];
 
   const onSubmit = useCallback(async () => {
     if (!client) return;
@@ -52,11 +160,34 @@ export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: Cr
     }
   }, [client, idpId, displayName, description, metadataXml, emailAttr, onCreated, setBusy]);
 
+  const onMetadataFilesChange = useCallback(async (files: File[]) => {
+    const requestId = ++metadataReadRequestId.current;
+    setMetadataFiles(files);
+    setMetadataFileError(null);
+    const [file] = files;
+    if (!file) return;
+    const result = await file.text().then(
+      (contents) => ({ contents }),
+      () => ({ error: READ_METADATA_FILE_ERROR }),
+    );
+    if (requestId !== metadataReadRequestId.current) return;
+    if ("error" in result) {
+      setMetadataFileError(result.error);
+      return;
+    }
+    if (!result.contents.trim()) {
+      setMetadataFileError(EMPTY_METADATA_FILE_ERROR);
+      return;
+    }
+    setMetadataXml(result.contents);
+  }, []);
+
   return (
     <Modal
       visible
       onDismiss={onClose}
       header="Register SAML IdP"
+      size="large"
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
@@ -84,10 +215,54 @@ export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: Cr
         <FormField label="Email attribute (SAML)">
           <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
         </FormField>
+        <FormField
+          label="Identity provider"
+          description="Choose a provider to show concise SAML application setup steps."
+        >
+          <Tiles
+            value={provider}
+            items={PROVIDER_TILES}
+            columns={2}
+            onChange={(e) => setProvider(e.detail.value as SamlProvider)}
+          />
+        </FormField>
+        <ExpandableSection defaultExpanded header={`${providerGuide.label} setup guide`}>
+          <SpaceBetween size="s">
+            {providerGuide.steps.map((step) => (
+              <Box key={step}>{step}</Box>
+            ))}
+            <CopyableSetupValue
+              label="ACS URL (Reply / SSO URL)"
+              value={acsUrl}
+              description="Enter this as the assertion consumer service, reply, or single sign-on URL."
+            />
+            <CopyableSetupValue
+              label="SP Entity ID / Identifier (Audience)"
+              value={SP_ENTITY_ID_PATTERN}
+              description="Replace <userPoolId> with the relevant User Pool ID from the AWS Cognito console."
+            />
+            <CopyableSetupValue
+              label="Email attribute mapping"
+              value={emailAttr}
+              description="Map the IdP email claim to this SAML attribute. It follows the Email attribute (SAML) field above."
+            />
+          </SpaceBetween>
+        </ExpandableSection>
+        <FormField label="Metadata XML file" description="Upload the IdP metadata as an .xml file.">
+          <FileUpload
+            value={metadataFiles}
+            accept={METADATA_XML_ACCEPT}
+            errorText={metadataFileError ?? undefined}
+            onChange={(e) => void onMetadataFilesChange(e.detail.value)}
+          />
+        </FormField>
         <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
           <Textarea
             value={metadataXml}
-            onChange={(e) => setMetadataXml(e.detail.value)}
+            onChange={(e) => {
+              setMetadataXml(e.detail.value);
+              setMetadataFileError(null);
+            }}
             rows={10}
           />
         </FormField>

--- a/apps/application-admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/application-admin-console/src/pages/IdentityProviders.tsx
@@ -214,6 +214,7 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
       {showCreate ? (
         <CreateIdpModal
           client={client}
+          cognitoDomain={config.cognitoDomain}
           onClose={() => setShowCreate(false)}
           onCreated={async () => {
             setShowCreate(false);

--- a/apps/application-admin-console/test/pages/CreateIdpModal.test.tsx
+++ b/apps/application-admin-console/test/pages/CreateIdpModal.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TenantIdpClient } from "../../src/api/idp-client";
 import { CreateIdpModal } from "../../src/pages/CreateIdpModal";
@@ -11,12 +12,23 @@ import { CreateIdpModal } from "../../src/pages/CreateIdpModal";
 const makeClient = (create: ReturnType<typeof vi.fn>) => ({ create }) as unknown as TenantIdpClient;
 const props = (over = {}) => ({
   client: makeClient(vi.fn().mockResolvedValue(undefined)),
+  cognitoDomain: "auth.example.com",
   onClose: vi.fn(),
   onCreated: vi.fn().mockResolvedValue(undefined),
   busy: false,
   setBusy: vi.fn(),
   ...over,
 });
+const metadataTextarea = () => screen.getAllByRole("textbox")[4] as HTMLTextAreaElement;
+const metadataFileInput = () =>
+  document.querySelector<HTMLInputElement>('input[type="file"]') as HTMLInputElement;
+const metadataFile = (contents: string | Promise<string>, error?: Error) => {
+  const file = new File(["ignored"], "metadata.xml", { type: "text/xml" });
+  Object.defineProperty(file, "text", {
+    value: error ? vi.fn().mockRejectedValue(error) : vi.fn().mockResolvedValue(contents),
+  });
+  return file;
+};
 
 afterEach(() => vi.clearAllMocks());
 
@@ -88,5 +100,107 @@ describe("CreateIdpModal", () => {
     expect(onClose).toHaveBeenCalled();
     rerender(<CreateIdpModal {...props({ onClose, busy: true })} />);
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+  });
+
+  it("should load an uploaded XML file into the editable metadata textarea", async () => {
+    render(<CreateIdpModal {...props()} />);
+    const input = metadataFileInput();
+    expect(input).toHaveAttribute("accept", ".xml,text/xml,application/xml");
+    fireEvent.change(input, { target: { files: [metadataFile("<EntityDescriptor />")] } });
+    await waitFor(() => expect(metadataTextarea()).toHaveValue("<EntityDescriptor />"));
+    fireEvent.change(metadataTextarea(), { target: { value: "<edited />" } });
+    expect(metadataTextarea()).toHaveValue("<edited />");
+  });
+
+  it("should surface an empty uploaded XML file and clear the error after manual paste", async () => {
+    render(<CreateIdpModal {...props()} />);
+    fireEvent.change(metadataFileInput(), { target: { files: [metadataFile("  ")] } });
+    expect(await screen.findByText("The selected metadata XML file is empty.")).toBeInTheDocument();
+    fireEvent.change(metadataTextarea(), { target: { value: "<pasted />" } });
+    expect(screen.queryByText("The selected metadata XML file is empty.")).not.toBeInTheDocument();
+  });
+
+  it("should surface an XML file read failure and allow clearing the selected file", async () => {
+    render(<CreateIdpModal {...props()} />);
+    fireEvent.change(metadataFileInput(), {
+      target: { files: [metadataFile("", new Error("disk read failed"))] },
+    });
+    expect(
+      await screen.findByText(
+        "Could not read the selected metadata XML file. Try another file or paste the XML below.",
+      ),
+    ).toBeInTheDocument();
+    createWrapper(document.body).findFileUpload()?.findFileToken(1)?.findRemoveButton().click();
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "Could not read the selected metadata XML file. Try another file or paste the XML below.",
+        ),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("should ignore a stale XML file read after a newer upload finishes", async () => {
+    let finishStaleRead: (contents: string) => void = () => undefined;
+    const staleRead = new Promise<string>((resolve) => {
+      finishStaleRead = resolve;
+    });
+    render(<CreateIdpModal {...props()} />);
+    fireEvent.change(metadataFileInput(), { target: { files: [metadataFile(staleRead)] } });
+    fireEvent.change(metadataFileInput(), { target: { files: [metadataFile("<current />")] } });
+    await waitFor(() => expect(metadataTextarea()).toHaveValue("<current />"));
+    await act(async () => {
+      finishStaleRead("<stale />");
+      await staleRead;
+    });
+    expect(metadataTextarea()).toHaveValue("<current />");
+  });
+
+  it("should derive the ACS URL from both bare and HTTPS Cognito domains", () => {
+    const { rerender } = render(<CreateIdpModal {...props()} />);
+    expect(screen.getByText("https://auth.example.com/saml2/idpresponse")).toBeInTheDocument();
+    rerender(<CreateIdpModal {...props({ cognitoDomain: "https://auth.example.com" })} />);
+    expect(screen.getByText("https://auth.example.com/saml2/idpresponse")).toBeInTheDocument();
+    expect(screen.queryByText(/https:\/\/https:\/\//)).not.toBeInTheDocument();
+  });
+
+  it("should show provider-specific setup guides and copyable Cognito SP values", () => {
+    render(<CreateIdpModal {...props()} />);
+    expect(screen.getByText("Generic SAML setup guide")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Give the IdP administrator the ACS URL, SP Entity ID, and email attribute/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("urn:amazon:cognito:sp:<userPoolId>")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Replace <userPoolId> with the relevant User Pool ID from the AWS Cognito/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/identity\/claims\/emailaddress/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy ACS URL (Reply / SSO URL)" })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Copy SP Entity ID / Identifier (Audience)" }),
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Copy Email attribute mapping" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Microsoft Entra ID" }));
+    expect(screen.getByText("Microsoft Entra ID setup guide")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "In Microsoft Entra ID, open Enterprise applications -> New application -> Single sign-on -> SAML.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Google Workspace" }));
+    expect(screen.getByText("Google Workspace setup guide")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "In Google Workspace, open Admin console -> Apps -> Web and mobile apps -> Add custom SAML app.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Okta" }));
+    expect(screen.getByText("Okta setup guide")).toBeInTheDocument();
+    expect(
+      screen.getByText("In Okta, open Applications -> Create App Integration -> SAML 2.0."),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/application-admin-console/test/pages/IdentityProviders.test.tsx
+++ b/apps/application-admin-console/test/pages/IdentityProviders.test.tsx
@@ -30,8 +30,8 @@ vi.mock("../../src/auth/AuthProvider", () => ({ useAuth: mockUseAuth }));
 vi.mock("../../src/i18n", () => ({ useLang: () => "en" }));
 vi.mock("../../src/pages/CreateIdpModal", () => ({
   // biome-ignore lint/suspicious/noExplicitAny: stub props。
-  CreateIdpModal: ({ onClose, onCreated }: any) => (
-    <div data-testid="create-modal">
+  CreateIdpModal: ({ cognitoDomain, onClose, onCreated }: any) => (
+    <div data-testid="create-modal" data-cognito-domain={cognitoDomain}>
       <button type="button" onClick={onClose}>
         stub-close
       </button>
@@ -130,6 +130,10 @@ describe("IdentityProvidersPage", () => {
     await screen.findByText(/No SAML IdPs configured yet/);
     fireEvent.click(screen.getByRole("button", { name: "Add SAML IdP" }));
     expect(screen.getByTestId("create-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("create-modal")).toHaveAttribute(
+      "data-cognito-domain",
+      "auth.example.com",
+    );
 
     fireEvent.click(screen.getByText("stub-created"));
     await waitFor(() => expect(screen.queryByTestId("create-modal")).not.toBeInTheDocument());


### PR DESCRIPTION
ご要望の **Register SAML IdP モーダル強化**(代表的 IdP の設定手順 + メタデータのアップロード)。私がライブ環境の context を渡して **Codex に実装委譲 → Claude がレビュー・カバレッジ再検証**。

## 追加機能
1. **メタデータ XML のファイルアップロード** — Cloudscape `FileUpload`(`.xml`)。読み込んだ XML を textarea に反映し編集可能(貼り付け or アップロードのどちらでも)。空ファイル / read 失敗 / 古い非同期 read の上書きを処理。
2. **代表的 IdP の設定ガイド** — `Tiles` + `ExpandableSection` で **Microsoft Entra ID / Google Workspace / Okta / Generic SAML**。各ガイドで、ユーザーが IdP 側に入れる Cognito の値を `CopyToClipboard` 付きで提示:
   - **ACS URL**: `https://<cognitoDomain>/saml2/idpresponse`(`config.cognitoDomain` から bare host / `https://` 両対応で正規化)
   - **SP Entity ID**: `urn:amazon:cognito:sp:<userPoolId>` パターン + User Pool ID の注記
   - **Email 属性マッピング**

## Test plan
- application-admin-console **895 test 緑 + coverage 100%**(statements/branches/functions/lines、Claude が再検証)。
- typecheck / lint / build / `make harness` pass。

## Regression analysis
- app-admin-console のみ。既存登録フロー(`idp-client.create`)は不変、upload は既存フィールドへの反映のみ、ガイドは表示専用。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。SPA source のみ。

Co-Authored-By: Codex CLI (delegated)