### PR TITLE
refactor(participant-portal): dedupe buildLocaleUtility into shared module [#1418]

### DIFF
--- a/apps/participant-portal/src/components/AppLayout.tsx
+++ b/apps/participant-portal/src/components/AppLayout.tsx
@@ -15,23 +15,11 @@ import type { LeaderboardResponse, ParticipantTeamView } from "../api/portal-cli
 import { useAuth } from "../auth/AuthProvider";
 import { TeamViewProvider, useTeamView } from "../auth/TeamViewProvider";
 import type { AppConfig } from "../config";
-import { type LocaleCode, SUPPORTED_LOCALES, useI18n } from "../i18n";
+import { useI18n } from "../i18n";
 import { CountdownTimer } from "./CountdownTimer";
-
-/**
- * Issue #583 Phase 1.A: locale switcher の display 名 map。 各 locale.json 内
- * `locale.name` を import せず literal で持つ (= bundle size 抑制 / 起動時依存削減)。
- */
-const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
-  ja: "日本語",
-  en: "English",
-};
+import { buildLocaleUtility } from "./locale-switcher";
 
 type Translate = (key: string) => string;
-
-export function isSupportedLocaleId(id: string): id is LocaleCode {
-  return (SUPPORTED_LOCALES as readonly string[]).includes(id);
-}
 
 export function formatTopNavScore(
   mode: AppConfig["mode"],
@@ -52,28 +40,6 @@ export function formatTopNavRank(
   const myEntry = leaderboard?.entries.find((e) => e.isMyTeam);
   const totalEntries = leaderboard?.entries.length;
   return myEntry && totalEntries ? `${myEntry.rank}/${totalEntries}` : "…";
-}
-
-export function buildLocaleUtility(
-  locale: LocaleCode,
-  setLocale: (locale: LocaleCode) => void,
-  t: Translate,
-): TopNavigationProps.Utility {
-  return {
-    type: "menu-dropdown",
-    iconName: "globe",
-    ariaLabel: t("switcher.aria_label"),
-    text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
-    items: SUPPORTED_LOCALES.map((code) => ({
-      id: code,
-      // SUPPORTED_LOCALES は dict と同期済なので ?? 右辺は型安全用の不到達分岐。
-      /* v8 ignore next */
-      text: LOCALE_DICTIONARIES_NAME[code] ?? code,
-    })),
-    onItemClick: ({ detail }) => {
-      if (isSupportedLocaleId(detail.id)) setLocale(detail.id);
-    },
-  };
 }
 
 export function buildScoreRankUtility(

--- a/apps/participant-portal/src/components/locale-switcher.ts
+++ b/apps/participant-portal/src/components/locale-switcher.ts
@@ -1,0 +1,45 @@
+import type { TopNavigationProps } from "@cloudscape-design/components/top-navigation";
+import { type LocaleCode, SUPPORTED_LOCALES } from "../i18n";
+
+type Translate = (key: string) => string;
+
+/**
+ * locale code → 表示名。 AppLayout / TeamSetup で重複定義されていた literal を 1 箇所へ集約
+ * (#1418 SOLID/DRY)。 SUPPORTED_LOCALES と同期する。
+ */
+const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
+  ja: "日本語",
+  en: "English",
+};
+
+/** menu-dropdown の item id が対応 locale か (= 不正 id で setLocale しない型ガード)。 */
+export function isSupportedLocaleId(id: string): id is LocaleCode {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(id);
+}
+
+/**
+ * TopNavigation の言語切替 dropdown utility を組む共有 util。 以前は AppLayout と TeamSetup が
+ * **別々に**(しかも引数順違いで)定義しており、 呼び間違いの footgun になっていたため、
+ * 中立な module に 1 本化した (引数順は `(locale, setLocale, t)` に統一)。
+ */
+export function buildLocaleUtility(
+  locale: LocaleCode,
+  setLocale: (locale: LocaleCode) => void,
+  t: Translate,
+): TopNavigationProps.Utility {
+  return {
+    type: "menu-dropdown",
+    iconName: "globe",
+    ariaLabel: t("switcher.aria_label"),
+    text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
+    items: SUPPORTED_LOCALES.map((code) => ({
+      id: code,
+      // SUPPORTED_LOCALES は dict と同期済なので ?? 右辺は型安全用の不到達分岐。
+      /* v8 ignore next */
+      text: LOCALE_DICTIONARIES_NAME[code] ?? code,
+    })),
+    onItemClick: ({ detail }) => {
+      if (isSupportedLocaleId(detail.id)) setLocale(detail.id);
+    },
+  };
+}

--- a/apps/participant-portal/src/pages/TeamSetup.tsx
+++ b/apps/participant-portal/src/pages/TeamSetup.tsx
@@ -14,17 +14,12 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { PortalAuthError, PortalValidationError, updateTeamName } from "../api/portal-client";
 import { useAuth } from "../auth/AuthProvider";
+import { buildLocaleUtility } from "../components/locale-switcher";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
-import { type LocaleCode, SUPPORTED_LOCALES, useI18n, useT } from "../i18n";
+import { useI18n, useT } from "../i18n";
 
 const TEAM_NAME_RE = /^[A-Za-z0-9 _\-぀-ヿ一-鿿]{1,40}$/;
-
-/** #1092: AppLayout の locale name と同期 (= 別 component に export せず literal で抑える)。 */
-const LOCALE_DICTIONARIES_NAME: Record<LocaleCode, string> = {
-  ja: "日本語",
-  en: "English",
-};
 
 interface TeamNameDraft {
   readonly trimmed: string;
@@ -52,34 +47,6 @@ export function formatTeamSetupSubmitError(err: unknown, validationMessage: stri
   if (err instanceof PortalValidationError) return validationMessage;
   if (err instanceof Error) return err.message;
   return String(err);
-}
-
-/**
- * TopNavigation の言語切替 dropdown utility を組む。 component から切り出して onItemClick の
- * 分岐 (= SUPPORTED_LOCALES に含まれる id のみ setLocale) を単体で検証できるようにした。
- */
-export function buildLocaleUtility(
-  locale: LocaleCode,
-  t: (key: string) => string,
-  setLocale: (code: LocaleCode) => void,
-): TopNavigationProps.Utility {
-  return {
-    type: "menu-dropdown",
-    iconName: "globe",
-    ariaLabel: t("switcher.aria_label"),
-    text: LOCALE_DICTIONARIES_NAME[locale] ?? locale,
-    items: SUPPORTED_LOCALES.map((code) => ({
-      id: code,
-      // SUPPORTED_LOCALES は dict と同期済なので ?? 右辺は型安全用の不到達分岐。
-      /* v8 ignore next */
-      text: LOCALE_DICTIONARIES_NAME[code] ?? code,
-    })),
-    onItemClick: ({ detail }) => {
-      if ((SUPPORTED_LOCALES as readonly string[]).includes(detail.id)) {
-        setLocale(detail.id as LocaleCode);
-      }
-    },
-  };
 }
 
 /**
@@ -155,7 +122,7 @@ export function TeamSetupPage({ config }: { config: AppConfig }) {
   };
 
   const utilities = useMemo<TopNavigationProps.Utility[]>(
-    () => [buildLocaleUtility(locale, t, setLocale)],
+    () => [buildLocaleUtility(locale, setLocale, t)],
     [locale, setLocale, t],
   );
 

--- a/apps/participant-portal/test/components/AppLayout.test.tsx
+++ b/apps/participant-portal/test/components/AppLayout.test.tsx
@@ -47,8 +47,6 @@ const {
   formatTopNavRank,
   formatTopNavScore,
   handleProfileMenuClick,
-  isSupportedLocaleId,
-  buildLocaleUtility,
   buildScoreRankUtility,
   buildProfileUtility,
   handleSideNavFollow,
@@ -122,12 +120,6 @@ describe("AppLayout top navigation helpers", () => {
     expect(formatTopNavRank("backend", null, false)).toBe("…");
     expect(formatTopNavRank("backend", leaderboard([]), false)).toBe("…");
   });
-
-  it("should accept only supported locale ids", () => {
-    expect(isSupportedLocaleId("ja")).toBe(true);
-    expect(isSupportedLocaleId("en")).toBe(true);
-    expect(isSupportedLocaleId("fr")).toBe(false);
-  });
 });
 
 describe("profile dropdown menu (Issue #1191)", () => {
@@ -164,7 +156,7 @@ describe("profile dropdown menu (Issue #1191)", () => {
 });
 
 // ── utility builders (callbacks unit-tested directly) ────────────────────────
-type MenuUtil = Extract<ReturnType<typeof buildLocaleUtility>, { type: "menu-dropdown" }>;
+type MenuUtil = Extract<ReturnType<typeof buildProfileUtility>, { type: "menu-dropdown" }>;
 type ButtonUtil = Extract<ReturnType<typeof buildScoreRankUtility>, { type: "button" }>;
 
 describe("utility builders", () => {
@@ -175,20 +167,6 @@ describe("utility builders", () => {
     expect(u.text).toContain("1/2");
     u.onClick?.({} as never);
     expect(navigate).toHaveBeenCalledWith("/scoreboard");
-  });
-
-  it("should build a locale dropdown that switches only to supported locales", () => {
-    const setLocale = vi.fn();
-    const u = buildLocaleUtility("ja", setLocale, (k) => k) as MenuUtil;
-    expect(u.text).toBe("日本語");
-    expect(u.items?.map((i) => i.id)).toEqual(["ja", "en"]);
-    u.onItemClick?.({ detail: { id: "en" } } as never);
-    expect(setLocale).toHaveBeenCalledWith("en");
-    u.onItemClick?.({ detail: { id: "bogus" } } as never);
-    expect(setLocale).toHaveBeenCalledTimes(1);
-    expect((buildLocaleUtility("zz" as LocaleCode, setLocale, (k) => k) as MenuUtil).text).toBe(
-      "zz",
-    );
   });
 
   it("should build a profile dropdown that dispatches menu clicks", () => {

--- a/apps/participant-portal/test/components/locale-switcher.test.ts
+++ b/apps/participant-portal/test/components/locale-switcher.test.ts
@@ -1,0 +1,48 @@
+import type { TopNavigationProps } from "@cloudscape-design/components/top-navigation";
+import { describe, expect, it, vi } from "vitest";
+import { buildLocaleUtility, isSupportedLocaleId } from "../../src/components/locale-switcher";
+import type { LocaleCode } from "../../src/i18n";
+
+/**
+ * #1418 SOLID/DRY: AppLayout / TeamSetup で重複していた locale switcher util を 1 箇所へ集約した
+ * 共有モジュールの単体テスト。 旧来は 2 ファイルに別々(引数順違い)で定義されていた。
+ */
+
+type MenuUtil = Extract<TopNavigationProps.Utility, { type: "menu-dropdown" }>;
+const t = (key: string) => key;
+
+describe("isSupportedLocaleId", () => {
+  it("should accept a supported locale id and reject an unknown one", () => {
+    expect(isSupportedLocaleId("ja")).toBe(true);
+    expect(isSupportedLocaleId("zz")).toBe(false);
+  });
+});
+
+describe("buildLocaleUtility", () => {
+  it("should build a globe menu showing the current locale's display name", () => {
+    const u = buildLocaleUtility("ja", vi.fn(), t) as MenuUtil;
+    expect(u.type).toBe("menu-dropdown");
+    expect(u.iconName).toBe("globe");
+    expect(u.text).toBe("日本語");
+    expect(u.items.map((i) => i.id)).toEqual(["ja", "en"]);
+  });
+
+  it("should fall back to the raw code when the locale is not in the dictionary", () => {
+    const u = buildLocaleUtility("zz" as LocaleCode, vi.fn(), t) as MenuUtil;
+    expect(u.text).toBe("zz");
+  });
+
+  it("should call setLocale when a supported item is clicked", () => {
+    const setLocale = vi.fn();
+    const u = buildLocaleUtility("ja", setLocale, t) as MenuUtil;
+    u.onItemClick?.({ detail: { id: "en" } } as never);
+    expect(setLocale).toHaveBeenCalledWith("en");
+  });
+
+  it("should ignore a click on an unsupported item id", () => {
+    const setLocale = vi.fn();
+    const u = buildLocaleUtility("ja", setLocale, t) as MenuUtil;
+    u.onItemClick?.({ detail: { id: "zz" } } as never);
+    expect(setLocale).not.toHaveBeenCalled();
+  });
+});

--- a/apps/participant-portal/test/pages/TeamSetup.test.tsx
+++ b/apps/participant-portal/test/pages/TeamSetup.test.tsx
@@ -35,13 +35,8 @@ vi.mock("../../src/api/portal-client", async (importOriginal) => {
   return { ...actual, updateTeamName: mockUpdate };
 });
 
-const {
-  TeamSetupPage,
-  describeTeamNameDraft,
-  canSubmitTeamName,
-  formatTeamSetupSubmitError,
-  buildLocaleUtility,
-} = await import("../../src/pages/TeamSetup");
+const { TeamSetupPage, describeTeamNameDraft, canSubmitTeamName, formatTeamSetupSubmitError } =
+  await import("../../src/pages/TeamSetup");
 
 const config = { apiBaseUrl: "https://api.example.com", eventTitle: "Test event" } as AppConfig;
 const updateSession = vi.fn();
@@ -112,25 +107,6 @@ describe("pure helpers", () => {
     );
     expect(formatTeamSetupSubmitError(new Error("boom"), "x")).toBe("boom");
     expect(formatTeamSetupSubmitError("plain", "x")).toBe("plain");
-  });
-
-  it("should build a locale utility that only switches to supported locales", () => {
-    const u = buildLocaleUtility("ja", (k) => k, mockSetLocale) as Extract<
-      ReturnType<typeof buildLocaleUtility>,
-      { type: "menu-dropdown" }
-    >;
-    expect(u.text).toBe("日本語");
-    expect(u.items?.map((i) => i.id)).toEqual(["ja", "en"]);
-    u.onItemClick?.({ detail: { id: "en" } } as never);
-    expect(mockSetLocale).toHaveBeenCalledWith("en");
-    u.onItemClick?.({ detail: { id: "bogus" } } as never);
-    expect(mockSetLocale).toHaveBeenCalledTimes(1); // bogus ignored
-    // 未知 locale → text は fallback で locale 文字列そのまま。
-    const unknown = buildLocaleUtility("zz" as LocaleCode, (k) => k, mockSetLocale) as Extract<
-      ReturnType<typeof buildLocaleUtility>,
-      { type: "menu-dropdown" }
-    >;
-    expect(unknown.text).toBe("zz");
   });
 });
 


### PR DESCRIPTION
## Summary
`buildLocaleUtility`(TopNavigation の言語切替 utility)が **AppLayout と TeamSetup で別々に定義**され、引数順が `(locale, setLocale, t)` vs `(locale, t, setLocale)` と**違っていて呼び間違いの footgun**だった(`LOCALE_DICTIONARIES_NAME` / `isSupportedLocaleId` も重複)。中立な共有モジュール `src/components/locale-switcher.ts` に **1 本化**し、引数順を `(locale, setLocale, t)` に統一(SOLID/DRY)。

## Test plan
- participant-portal **typecheck 0 / 594 test 緑 / coverage 100%**(branches 1093/1093, lines 1249/1249)。
- `locale-switcher.test.ts` を新設、AppLayout.test / TeamSetup.test の重複 locale テストを除去。biome clean / `make harness` 違反なし。

## Regression analysis
- 振る舞い不変(canonical は AppLayout 版、TeamSetup 版は機能等価)。重複 dict / 型ガードも集約。

## Physical impact
- **NO-OP**。participant-portal SPA の source 再編のみ。

Relates #1418