### PR TITLE
feat(scoring): condition-triggered disruptions (ADR-013 Phase 2) [#1422]

### DIFF
--- a/docs/runbooks/capacity-pressure.html
+++ b/docs/runbooks/capacity-pressure.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Capacity pressure &amp; throttling response</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Capacity pressure &amp; throttling response</h1>
+<blockquote>
+<p>日本語: <a href="./capacity-pressure.ja.md">capacity-pressure.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>On-call operator (whoever receives the Free-Tier / capacity-pressure alarms)</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>On a <code>tenkacloud-freetier-*</code> / <code>tenkacloud-health-*</code> alarm, or a CostBudget 80 / 100 percent notification</td>
+</tr>
+<tr>
+<td>Time</td>
+<td>5–15 min triage per alarm; longer if a scale-up decision is involved</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>One timeline line per alarm: the observed number / the classification (false alarm / transient / actionable) / the action taken (including &quot;nothing&quot;)</td>
+</tr>
+</tbody></table>
+<p><a href="../../infrastructure/lib/observability/free-tier-alarms.ts"><code>free-tier-alarms.ts</code></a> and <code>CostBudget</code> <strong>detect</strong> capacity and cost pressure. This runbook defines the <strong>response</strong> side. An alarm says &quot;observe and classify&quot;, not &quot;act now&quot; — scaling in a panic pushes you past the Free Tier and burns cost for nothing. As in <a href="./live-monitoring.md">live-monitoring</a>, keep the order <strong>observe → classify → (only then) act</strong>.</p>
+<h2>Alarm catalog</h2>
+<table>
+<thead>
+<tr>
+<th>Alarm name</th>
+<th>Meaning</th>
+<th>Default threshold</th>
+<th>Likely cause</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>tenkacloud-freetier-lambda-&lt;fn&gt;</code></td>
+<td>Daily Lambda invocations exceed ~80 percent of the Free Tier (1M/month)</td>
+<td>26,666 / day</td>
+<td>runaway polling / retry loop / more participants than expected</td>
+</tr>
+<tr>
+<td><code>tenkacloud-health-lambda-errors-&lt;fn&gt;</code></td>
+<td>Daily Lambda error count exceeds the threshold</td>
+<td>50 / day</td>
+<td>deploy failure / missing permission / downstream fault</td>
+</tr>
+<tr>
+<td><code>tenkacloud-health-apigw-5xx-&lt;api&gt;</code></td>
+<td>Daily API Gateway 5XX count exceeds the threshold</td>
+<td>50 / day</td>
+<td>backend Lambda exception / timeout</td>
+</tr>
+<tr>
+<td><code>tenkacloud-freetier-ddb-read-&lt;table&gt;</code></td>
+<td>Daily ConsumedReadCapacityUnits exceed the threshold</td>
+<td>100,000 / day</td>
+<td>reads concentrated on the 1 RCU ceiling (throttle zone)</td>
+</tr>
+<tr>
+<td><code>tenkacloud-freetier-ddb-write-&lt;table&gt;</code></td>
+<td>Daily ConsumedWriteCapacityUnits exceed the threshold</td>
+<td>100,000 / day</td>
+<td>writes concentrated on the 1 WCU ceiling (throttle zone)</td>
+</tr>
+<tr>
+<td>CostBudget 80 / 100 percent</td>
+<td>Monthly cost reaches 80 / 100 percent of the ceiling (SNS email)</td>
+<td>monthly budget</td>
+<td>a resource has left the Free Tier</td>
+</tr>
+</tbody></table>
+<p>Every threshold is overridable per environment via CDK props (<code>lambdaDailyInvocationThreshold</code>, etc.). See the source constant comments for the rationale of each default.</p>
+<h2>Triage</h2>
+<ol>
+<li><strong>Observe</strong>: from the alarm name, identify the target (Lambda / API / table) and read its recent trend in CloudWatch metrics and the <a href="../../infrastructure/lib/observability/"><code>ObservabilityStack</code></a> dashboard. Distinguish a one-off spike from a sustained climb.</li>
+<li><strong>Classify</strong>:<ul>
+<li><strong>False alarm / transient</strong>: a single spike that already settled → record only, take no action.</li>
+<li><strong>Expected load</strong>: a normal rise from more participants → proceed to the scale decision below.</li>
+<li><strong>Anomaly</strong>: a retry loop / cascading errors / abnormal requests from one team → stop the cause (pair with <a href="./incident-response.ja.md">incident-response</a>).</li>
+</ul>
+</li>
+<li><strong>Act</strong>: only after the classification is settled, take the minimum necessary action.</li>
+</ol>
+<h2>Response per alarm</h2>
+<h3>DynamoDB capacity (<code>tenkacloud-freetier-ddb-read/write-*</code>)</h3>
+<p>The <code>DynamoDbLowCapacity</code> aspect pins every table to <strong>PROVISIONED 1 RCU / 1 WCU</strong> (to stay inside the 25/25 Free Tier). When read/write exceeds the sustained ceiling of one unit (~1 req/sec), DynamoDB <strong>throttles</strong>. First decide whether the throttling is actually harmful:</p>
+<ul>
+<li><strong>The SDK&#39;s retries absorb it</strong> (no user impact) → do nothing. Throttling is the intended cost-saving behaviour.</li>
+<li><strong>Throttling delays scoring ticks / deploys</strong> (user impact) → <strong>deliberately</strong> raise the capacity of the affected table.</li>
+</ul>
+<blockquote>
+<p>⚠️ Raising capacity is <strong>manual today</strong>. Runtime-adjustable capacity (the <code>[INFRA]</code> child of <a href="https://github.com/susumutomita/TenkaCloud/issues/1431">#1431</a>) is not yet implemented. Current procedure:</p>
+<ol>
+<li>In <code>infrastructure/lib/cdk-aspect/</code>, review the <code>DynamoDbLowCapacity</code> scope and either exclude the table or raise its capacity (owner review required).</li>
+<li>Run <code>make diff</code> and confirm the change is <strong>a PROVISIONED-value change only</strong> (not a table replacement).</li>
+<li>Anything above the 25 RCU/WCU Free Tier is <strong>billed</strong>. Trade it against the CostBudget headroom: raise it only for the event window and return it to 1/1 at teardown.</li>
+</ol>
+</blockquote>
+<p>Switching to <code>PAY_PER_REQUEST</code> (on-demand) is <strong>forbidden</strong> (<code>DynamoDbLowCapacity</code> blocks it — it makes cost unpredictable).</p>
+<h3>Lambda invocations (<code>tenkacloud-freetier-lambda-*</code>)</h3>
+<p>Approaching the 1M req/month Free Tier. First suspect a <strong>runaway</strong>:</p>
+<ul>
+<li>Is the frontend polling interval as expected? (Because we use polling rather than SSE/WebSocket, invocations scale straightforwardly with participants × interval.)</li>
+<li>Is the EventBridge-driven reconciliation (<a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>) firing too often?</li>
+<li>Is there a retry storm? (Does it co-fire with the errors alarm?)</li>
+</ul>
+<p>For a legitimate participant increase, invocations are linear and <strong>settle on their own when the event ends</strong> — usually no action is needed.</p>
+<h3>Lambda errors / API Gateway 5XX (<code>tenkacloud-health-*</code>)</h3>
+<p>A <strong>health</strong> alarm, not a capacity one. Filter CloudWatch Logs Insights by <code>jobId</code> etc. (<a href="../operations/deploy-trace.md">deploy-trace</a>) and identify the exception. If it is deploy-related, merge into <a href="./incident-response.ja.md">incident-response</a>.</p>
+<h3>CostBudget 80 / 100 percent</h3>
+<p>Monthly cost is approaching the ceiling. Use Cost Explorer to see the per-service breakdown and identify the resource that <strong>left the Free Tier</strong> (most often a forgotten DDB capacity raise from above, or unexpected data transfer). On 100 percent, tear down unnecessary resources to the extent that stops the billing.</p>
+<h2>Escalation</h2>
+<ul>
+<li>User-impacting throttling / errors lasting more than 15 minutes → escalate to the owner and get approval for the capacity raise (a billing decision).</li>
+<li>After the event, <strong>always return the raised capacity to 1/1</strong> (a forgotten raise is the single biggest driver of next month&#39;s cost).</li>
+</ul>
+<h2>Related</h2>
+<ul>
+<li><a href="./live-monitoring.md">live-monitoring</a> — the continuous monitoring loop during an event</li>
+<li><a href="./incident-response.ja.md">incident-response</a> — incident classification and response</li>
+<li><a href="../../infrastructure/lib/observability/free-tier-alarms.ts"><code>free-tier-alarms.ts</code></a> — alarm definitions (source of truth for thresholds)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/1431">#1431</a> — runtime-adjustable capacity (the <code>[INFRA]</code> child this runbook assumes)</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/capacity-pressure.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/capacity-pressure.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/capacity-pressure.ja.html
+++ b/docs/runbooks/capacity-pressure.ja.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Capacity pressure &amp; throttling response</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Capacity pressure &amp; throttling response</h1>
+<blockquote>
+<p>English: <a href="./capacity-pressure.md">capacity-pressure.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>値</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>オンコールオペレータ (= Free Tier / 容量逼迫アラームを受け取る人)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td><code>tenkacloud-freetier-*</code> / <code>tenkacloud-health-*</code> アラーム、 または CostBudget の 80％ / 100％ 通知を受けたとき</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>1 アラームあたり 5〜15 分の triage。 スケールアップ判断を伴う場合はそれ以上</td>
+</tr>
+<tr>
+<td>出力</td>
+<td>「観測した数値」 / 「分類 (誤検知 / 一時的 / 要対応)」 / 「打ち手 (何もしない含む)」 をイベントタイムラインに 1 ライン記録</td>
+</tr>
+</tbody></table>
+<p><a href="../../infrastructure/lib/observability/free-tier-alarms.ts"><code>free-tier-alarms.ts</code></a> と <code>CostBudget</code> は容量・コストの逼迫を <strong>検知</strong> する。 本 runbook はその <strong>応答側</strong> を定義する。 アラームは「動け」ではなく「観測して分類しろ」の合図であり、 圧力下で慌ててスケールすると Free Tier を抜けて無用なコストを生む。 <a href="./live-monitoring.ja.md">live-monitoring</a> と同じく、 <strong>観測 → 分類 → (必要なら) 行動</strong> の順を守る。</p>
+<h2>アラームカタログ</h2>
+<table>
+<thead>
+<tr>
+<th>アラーム名</th>
+<th>意味</th>
+<th>デフォルトしきい値</th>
+<th>主因の候補</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>tenkacloud-freetier-lambda-&lt;fn&gt;</code></td>
+<td>Lambda の日次 invocations が Free Tier (1M/月) の 80％ 相当を超過</td>
+<td>26,666 / 日</td>
+<td>polling 暴走 / retry ループ / 想定超の参加者数</td>
+</tr>
+<tr>
+<td><code>tenkacloud-health-lambda-errors-&lt;fn&gt;</code></td>
+<td>Lambda の日次エラー件数が超過</td>
+<td>50 / 日</td>
+<td>deploy 失敗 / 権限不足 / 依存先の異常</td>
+</tr>
+<tr>
+<td><code>tenkacloud-health-apigw-5xx-&lt;api&gt;</code></td>
+<td>API Gateway の日次 5XX が超過</td>
+<td>50 / 日</td>
+<td>backend Lambda の例外 / timeout</td>
+</tr>
+<tr>
+<td><code>tenkacloud-freetier-ddb-read-&lt;table&gt;</code></td>
+<td>テーブルの日次 ConsumedReadCapacityUnits 超過</td>
+<td>100,000 / 日</td>
+<td>1 RCU 上限への read 集中 (= throttle 圏)</td>
+</tr>
+<tr>
+<td><code>tenkacloud-freetier-ddb-write-&lt;table&gt;</code></td>
+<td>テーブルの日次 ConsumedWriteCapacityUnits 超過</td>
+<td>100,000 / 日</td>
+<td>1 WCU 上限への write 集中 (= throttle 圏)</td>
+</tr>
+<tr>
+<td>CostBudget 80％ / 100%</td>
+<td>月次コストが上限の 80％ / 100％ に到達 (SNS email)</td>
+<td>月次予算</td>
+<td>Free Tier 超過リソースの発生</td>
+</tr>
+</tbody></table>
+<p>しきい値はいずれも CDK props (<code>lambdaDailyInvocationThreshold</code> 等) で環境ごとに上書きできる。 デフォルト値の根拠はソースの定数コメントを参照する。</p>
+<h2>triage 手順</h2>
+<ol>
+<li><strong>観測</strong>: アラーム名から対象 (Lambda / API / テーブル) を特定し、 CloudWatch のメトリクスと <a href="../../infrastructure/lib/observability/"><code>ObservabilityStack</code></a> のダッシュボードで直近の推移を見る。 スパイクか、 右肩上がりの持続かを区別する。</li>
+<li><strong>分類</strong>:<ul>
+<li><strong>誤検知 / 一時的</strong>: 単発スパイクで既に収束 → 記録のみ、 行動しない。</li>
+<li><strong>想定内の負荷</strong>: 参加者増による正常な増加 → スケール判断 (下記) に進む。</li>
+<li><strong>異常</strong>: retry ループ / エラー連鎖 / 1 チームからの異常リクエスト → 原因を止める (<a href="./incident-response.ja.md">incident-response</a> と併用)。</li>
+</ul>
+</li>
+<li><strong>行動</strong>: 分類が確定してから、 必要な打ち手のみを実施する。</li>
+</ol>
+<h2>アラーム別の応答</h2>
+<h3>DynamoDB capacity (<code>tenkacloud-freetier-ddb-read/write-*</code>)</h3>
+<p><code>DynamoDbLowCapacity</code> Aspect が全テーブルを <strong>PROVISIONED 1 RCU / 1 WCU</strong> に固定している (Free Tier 25/25 内に収めるため)。 read/write が 1 ユニットの sustained 上限 (≒ 1 req/sec) を超えると DynamoDB が <strong>throttle</strong> する。 まず throttle が実害かどうかを次の基準で見極める。</p>
+<ul>
+<li><strong>read/write が SDK retry で吸収できている</strong> (= ユーザー影響なし) → 何もしない。 throttle は設計上の節約挙動。</li>
+<li><strong>throttle で scoring tick / deploy が遅延している</strong> (= ユーザー影響あり) → 対象テーブルのキャパシティを <strong>意図的に</strong> 引き上げる。</li>
+</ul>
+<blockquote>
+<p>⚠️ 容量の引き上げは <strong>現状マニュアル</strong> である。 ランタイム可変キャパシティ (<a href="https://github.com/susumutomita/TenkaCloud/issues/1431">#1431</a> の <code>[INFRA]</code> 子項目) は未実装。 現行の引き上げ手順は次のとおり。</p>
+<ol>
+<li><code>infrastructure/lib/cdk-aspect/</code> の <code>DynamoDbLowCapacity</code> 適用範囲を確認し、 対象テーブルを除外するか、 capacity を引き上げる設定変更を行う (owner レビュー必須)。</li>
+<li><code>make diff</code> で <strong>PROVISIONED 値の変化のみ</strong> であること (テーブル置換でないこと) を確認する。</li>
+<li>25 RCU/WCU の Free Tier を超える分は <strong>課金される</strong>。 CostBudget の残枠と引き換えに、 イベント期間だけ引き上げ、 teardown で 1/1 に戻す。</li>
+</ol>
+</blockquote>
+<p><code>PAY_PER_REQUEST</code> (オンデマンド) への切り替えは <strong>禁止</strong> (<code>DynamoDbLowCapacity</code> が阻止する。 コスト予測不能になるため)。</p>
+<h3>Lambda invocations (<code>tenkacloud-freetier-lambda-*</code>)</h3>
+<p>月次 1M req の Free Tier に接近している。 まず <strong>暴走でないか</strong> を次の観点で確かめる。</p>
+<ul>
+<li>フロントの polling 周期が想定どおりか (SSE/WebSocket を使わず polling に寄せている分、 invocations は素直に参加者数 × 周期で効く)。</li>
+<li>EventBridge 駆動の reconciliation (<a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014</a>) が過剰発火していないか。</li>
+<li>retry ストームが起きていないか (errors アラームと併発していないか)。</li>
+</ul>
+<p>正常な参加者増なら、 invocations は線形なので <strong>イベント終了で自然に収束</strong> する。 行動は不要なことが多い。</p>
+<h3>Lambda errors / API Gateway 5XX (<code>tenkacloud-health-*</code>)</h3>
+<p>容量ではなく <strong>健全性</strong> のアラーム。 CloudWatch Logs Insights を <code>jobId</code> 等でフィルタ (<a href="../operations/deploy-trace.md">deploy-trace</a>) し、 例外内容を特定する。 deploy 系なら <a href="./incident-response.ja.md">incident-response</a> に合流する。</p>
+<h3>CostBudget 80％ / 100%</h3>
+<p>月次コストが上限に接近。 Cost Explorer でサービス別内訳を見て、 <strong>Free Tier を抜けたリソース</strong> を特定する (多くは上記 DDB キャパシティ引き上げの戻し忘れ、 または想定外のデータ転送)。 100％ 到達時は、 課金を止められる範囲で不要リソースを teardown する。</p>
+<h2>エスカレーション</h2>
+<ul>
+<li>ユーザー影響のある throttle / エラーが 15 分以上継続 → owner にエスカレーションし、 キャパシティ引き上げ (課金判断) の承認を得る。</li>
+<li>イベント終了後は、 引き上げたキャパシティを <strong>必ず 1/1 に戻す</strong> (戻し忘れが翌月コストの最大要因)。</li>
+</ul>
+<h2>関連</h2>
+<ul>
+<li><a href="./live-monitoring.ja.md">live-monitoring</a> — イベント中の常時監視ループ</li>
+<li><a href="./incident-response.ja.md">incident-response</a> — インシデント分類と対応</li>
+<li><a href="../../infrastructure/lib/observability/free-tier-alarms.ts"><code>free-tier-alarms.ts</code></a> — アラーム定義 (しきい値の正本)</li>
+<li><a href="https://github.com/susumutomita/TenkaCloud/issues/1431">#1431</a> — ランタイム可変キャパシティ (本 runbook が前提とする <code>[INFRA]</code> 子項目)</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/capacity-pressure.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/capacity-pressure.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { Duration } from "aws-cdk-lib";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
-import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { type IEventBus, Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
@@ -41,6 +41,16 @@ export interface GenericScoringLambdaProps {
    * を持たない問題は不在キー。
    */
   readonly problemsPhases: Readonly<Record<string, unknown>>;
+  /**
+   * [#1422 / ADR-013 Phase 2] `{ [problemId]: ProblemDisruptionEntry[] }`。 `triggers[]` を持つ
+   * disruption を tick で eval し condition-triggered 発火する。 disruptions[] 無しの問題は不在キー。
+   */
+  readonly problemsDisruptions: Readonly<Record<string, unknown>>;
+  /**
+   * [#1422] condition-triggered disruption の publish 先 event bus (= 手動 fire と同じ deploy bus)。
+   * scoring Lambda に `events:PutEvents` を least-privilege で付与する。
+   */
+  readonly eventBus: IEventBus;
 }
 
 /**
@@ -88,6 +98,8 @@ export class GenericScoringLambda extends Construct {
         DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
+        // #1422: condition-triggered disruption の publish 先 (手動 fire と同じ deploy bus)。
+        DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -108,6 +120,10 @@ export class GenericScoringLambda extends Construct {
           "process.env.BATTLE_PROBLEMS_PHASES": JSON.stringify(
             JSON.stringify(props.problemsPhases),
           ),
+          // #1422: condition-triggered disruption catalog を build 時 literal 置換 (env 4KB 回避)。
+          "process.env.BATTLE_PROBLEMS_DISRUPTIONS": JSON.stringify(
+            JSON.stringify(props.problemsDisruptions),
+          ),
         },
       },
     });
@@ -120,6 +136,9 @@ export class GenericScoringLambda extends Construct {
     props.eventsTable.grantReadWriteData(this.fn);
     // Endpoint registry: per (tenant, team, problem) の override 行を Query する (= read-only)。
     props.endpointsTable.grantReadData(this.fn);
+    // #1422: condition-triggered disruption を event bus に publish する (= events:PutEvents、
+    // 当該 bus に scope された least-privilege)。
+    props.eventBus.grantPutEventsTo(this.fn);
 
     // EventBridge `rate(1 minute)`. Lambda 自身の invoke 権限は LambdaFunction target が自動付与。
     new Rule(this, "Schedule", {

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/condition-disruption-fire.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/condition-disruption-fire.ts
@@ -1,0 +1,108 @@
+import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { evaluateDisruptionTriggers, type FiredDisruption } from "./disruption-triggers.js";
+import type {
+  DeploymentScoringState,
+  GenericScoringSharedResources,
+  KindResult,
+  PhaseEntry,
+} from "./shared.js";
+
+/**
+ * #1422 (ADR-013 Phase 2): scoring tick の condition-triggered disruption 発火 I/O。
+ *
+ * 純粋な trigger 評価は {@link evaluateDisruptionTriggers} (disruption-triggers.ts) に閉じ、
+ * 本 module は「評価 → publish → idempotency 永続化」 の副作用 (EventBridge / DDB) だけを担う。
+ * dispatcher (index.ts) を routing/orchestration 層に保ち、 SDK 依存をこの service 層に寄せる
+ * (= Issue #986 SOLID 監査の routes / service / repository 分離方針)。
+ */
+
+const DISRUPTION_EVENT_SOURCE = "tenkacloud.disruptions";
+
+/**
+ * 1 deployment について condition-triggered disruption を評価 → publish → idempotency 記録。
+ * bus 未配線 / 当該 problem に disruption 無し / 新規発火 0 件なら no-op。 publish 失敗時は throw して
+ * firedDisruptions を永続化しない (= 次 tick で再評価、 at-least-once)。
+ */
+export async function maybeFireConditionDisruptions(
+  shared: GenericScoringSharedResources,
+  item: Partial<DeploymentItem>,
+  result: KindResult,
+  prevState: DeploymentScoringState,
+  phasesByProblemId: Record<string, readonly PhaseEntry[]>,
+  nowMs: number,
+  nowIso: string,
+): Promise<void> {
+  if (!shared.eventBusName || !item.problemId || !item.PK) return;
+  const disruptions = shared.problemsDisruptions[item.problemId];
+  if (!disruptions || disruptions.length === 0) return;
+
+  const createdAtMs = item.createdAt ? Date.parse(item.createdAt) : nowMs;
+  const elapsedMin = Math.max(0, (nowMs - createdAtMs) / 60_000);
+  const scoreAfter = (item.score ?? 0) + result.scoreDelta;
+  const alreadyFired = new Set(prevState.firedDisruptions ?? []);
+
+  const fired = evaluateDisruptionTriggers(
+    disruptions,
+    { scoreAfter, elapsedMin, phases: phasesByProblemId[item.problemId] ?? [] },
+    alreadyFired,
+  );
+  if (fired.length === 0) return;
+
+  // publish 成功後にだけ idempotency record を追記する (= 失敗時は throw して次 tick で再評価)。
+  await publishConditionDisruptions(shared, item, fired, nowIso);
+
+  // score state は applyKindResult が既に result.newState を書いているので、 それ (無ければ prevState)
+  // を base に firedDisruptions だけ merge する (= bonusAwarded / attackCount を温存)。
+  const baseState = result.newState ?? prevState;
+  const mergedFired = [...alreadyFired, ...fired.map((f) => f.disruptionId)];
+  await shared.ddb.send(
+    new UpdateCommand({
+      TableName: shared.deploymentsTableName,
+      Key: { PK: item.PK, SK: "META" },
+      UpdateExpression: "SET scoringState = :state, updatedAt = :now",
+      ExpressionAttributeValues: {
+        ":state": JSON.stringify({ ...baseState, firedDisruptions: mergedFired }),
+        ":now": nowIso,
+      },
+    }),
+  );
+}
+
+/**
+ * 発火対象 disruption を event bus に publish する。 detail shape は手動 fire
+ * (disruption-fire.ts publishEntries) と一致させ、 downstream の disruption Lambda が同列に扱える
+ * ようにする。 requestId は `${jobId}#${disruptionId}` で安定 (= cross-account dedup key 兼用)。
+ */
+async function publishConditionDisruptions(
+  shared: GenericScoringSharedResources,
+  item: Partial<DeploymentItem>,
+  fired: readonly FiredDisruption[],
+  firedAt: string,
+): Promise<void> {
+  const entries = fired.map((f) => ({
+    Source: DISRUPTION_EVENT_SOURCE,
+    DetailType: f.eventDetailType,
+    EventBusName: shared.eventBusName,
+    Detail: JSON.stringify({
+      disruptionId: f.disruptionId,
+      eventId: item.eventId,
+      problemId: item.problemId,
+      tenantId: item.tenantId,
+      teamId: item.teamId,
+      parameters: f.parameters,
+      requestId: `${item.jobId}#${f.disruptionId}`,
+      firedAt,
+      triggeredBy: f.triggerKind,
+    }),
+  }));
+  const resp = await shared.events.send(new PutEventsCommand({ Entries: entries }));
+  if ((resp.FailedEntryCount ?? 0) > 0) {
+    const codes = (resp.Entries ?? [])
+      .filter((e) => e.ErrorCode)
+      .map((e) => e.ErrorCode)
+      .join(",");
+    throw new Error(`condition disruption publish partial failure: ${codes}`);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-triggers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-triggers.ts
@@ -1,0 +1,76 @@
+import type {
+  DisruptionTrigger,
+  ProblemDisruptionEntry,
+} from "../../../utils/discover-problems-catalog.js";
+import { type PhaseEntry, resolveActivePhase } from "./shared.js";
+
+/**
+ * [ADR-013 Phase 2 / Issue #1422] condition-triggered disruption の純粋な評価ロジック。
+ *
+ * scoring Lambda の 1 tick で、 1 deployment (= 1 team の 1 problem) について観測値
+ * (= 採点後 score / deploy 経過分 / active phase) を見て、 どの disruption を「今」発火させるかを返す。
+ *
+ * - 複数 trigger は OR 結合 (= 最初に true になった条件で発火、 ADR-013 OQ#5)
+ * - 一度発火した disruption は `alreadyFired` で抑制 (= idempotency、 OQ#5 の fire-suppress)
+ * - `triggers` 未宣言の disruption は Phase 1 self-fire のみ (= ここでは無視)
+ *
+ * I/O を持たない純関数なので、 caller (index.ts) が publish と state 永続化を担う。
+ */
+
+export interface DisruptionTriggerContext {
+  /** この tick の採点を反映した後の team 累計 score。 */
+  readonly scoreAfter: number;
+  /** deploy からの経過分 (= `(nowMs - createdAtMs) / 60000`)。 */
+  readonly elapsedMin: number;
+  /** problem の phases[] (= phase-entered trigger の解決に使う)。 */
+  readonly phases: readonly PhaseEntry[];
+}
+
+export interface FiredDisruption {
+  readonly disruptionId: string;
+  readonly eventDetailType: string;
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly triggerKind: DisruptionTrigger["kind"];
+}
+
+/** 1 trigger が現在の観測値で成立しているか。 */
+export function triggerMatches(
+  trigger: DisruptionTrigger,
+  ctx: DisruptionTriggerContext,
+  currentPhaseName: string | undefined,
+): boolean {
+  switch (trigger.kind) {
+    case "after-deploy":
+      return ctx.elapsedMin >= trigger.afterMinutes;
+    case "team-score-above":
+      return ctx.scoreAfter > trigger.threshold;
+    case "phase-entered":
+      return currentPhaseName === trigger.phaseName;
+  }
+}
+
+/**
+ * 「今 tick で新たに発火すべき disruption」 を返す。 既に発火済み (= `alreadyFired`) や
+ * trigger 未宣言の disruption は除外する。
+ */
+export function evaluateDisruptionTriggers(
+  disruptions: readonly ProblemDisruptionEntry[],
+  ctx: DisruptionTriggerContext,
+  alreadyFired: ReadonlySet<string>,
+): FiredDisruption[] {
+  const currentPhaseName = resolveActivePhase(ctx.phases, ctx.elapsedMin)?.name;
+  const fired: FiredDisruption[] = [];
+  for (const d of disruptions) {
+    if (!d.triggers || d.triggers.length === 0) continue;
+    if (alreadyFired.has(d.id)) continue;
+    const match = d.triggers.find((t) => triggerMatches(t, ctx, currentPhaseName));
+    if (!match) continue;
+    fired.push({
+      disruptionId: d.id,
+      eventDetailType: d.eventDetailType,
+      parameters: d.parameters ?? {},
+      triggerKind: match.kind,
+    });
+  }
+  return fired;
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -9,6 +9,7 @@ import { decodeLargeEnvValue } from "../../../utils/env-encoding.js";
 import { buildEndpointPK } from "../../problem-endpoints-table.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { writeScoreEvent } from "../shared/score-event.js";
+import { maybeFireConditionDisruptions } from "./condition-disruption-fire.js";
 import { reconcileEventStatuses } from "./event-reconciler.js";
 import { runAttackDetectionKind } from "./kinds/attack-detection.js";
 import { runPhasedPollingKind } from "./kinds/phased-polling.js";
@@ -165,6 +166,20 @@ async function processDeployment(
   }
 
   await applyKindResult(shared, item, result, nowIso);
+
+  // #1422 (ADR-013 Phase 2): 採点後の score / phase / 経過分で condition-triggered disruption を
+  // 評価し、 成立した disruption を in-account event bus に発火する (= cross-account forward は #1419)。
+  // score 書き込み (applyKindResult) の後に走らせ、 publish 失敗は outer processDeployment の .catch
+  // に委ねる (= score は確定済、 disruption は次 tick で再評価)。
+  await maybeFireConditionDisruptions(
+    shared,
+    item,
+    result,
+    prevState,
+    phasesByProblemId,
+    nowMs,
+    nowIso,
+  );
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/phased-polling.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/phased-polling.ts
@@ -8,8 +8,8 @@ import {
   type KindResult,
   type KindScoreEvent,
   noopKindResult,
-  type PhaseEntry,
   probeUrl,
+  resolveActivePhase,
 } from "../shared.js";
 
 /**
@@ -213,23 +213,6 @@ function scorePhasedBonuses(
     if (bonus.once) awarded[bonus.kind] = true;
   }
   return { scoreDelta, scoreEvents, awarded };
-}
-
-/**
- * `phaseElapsedMin` から active phase を確定。phases[] は afterMinutes 昇順 (= metadata
- * 規約) を前提に、 elapsed 以下の最後の entry を返す。順序保証されない場合に備えて defensive
- * に sort する。
- */
-function resolveActivePhase(
-  phases: readonly PhaseEntry[],
-  elapsedMin: number,
-): PhaseEntry | undefined {
-  const sorted = [...phases].sort((a, b) => a.afterMinutes - b.afterMinutes);
-  let active: PhaseEntry | undefined;
-  for (const p of sorted) {
-    if (elapsedMin >= p.afterMinutes) active = p;
-  }
-  return active;
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -1,6 +1,11 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
+import {
+  type ProblemDisruptionEntry,
+  parseDisruptionsCatalogEnv,
+} from "../../../utils/discover-problems-catalog.js";
 import { type ProblemEndpointSlot, parseEndpointsEnv } from "../../../utils/endpoints-metadata.js";
 import { type ProblemScoringMetadata, parseScoringEnv } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
@@ -21,6 +26,11 @@ export interface GenericScoringSharedResources {
   readonly endpointsTableName: string;
   readonly problemsScoring: Record<string, ProblemScoringMetadata>;
   readonly problemsEndpoints: Record<string, readonly ProblemEndpointSlot[]>;
+  /** [#1422] condition-triggered disruption の catalog (= `BATTLE_PROBLEMS_DISRUPTIONS` env)。 */
+  readonly problemsDisruptions: Record<string, readonly ProblemDisruptionEntry[]>;
+  /** [#1422] condition-triggered fire の publish 先 event bus (= 空なら発火 skip)。 */
+  readonly eventBusName: string;
+  readonly events: EventBridgeClient;
 }
 
 export function buildSharedResources(): GenericScoringSharedResources {
@@ -31,6 +41,9 @@ export function buildSharedResources(): GenericScoringSharedResources {
     endpointsTableName: getEnv("PROBLEM_ENDPOINTS_TABLE_NAME"),
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
     problemsEndpoints: parseEndpointsEnv(process.env.PROBLEM_ENDPOINTS),
+    problemsDisruptions: parseDisruptionsCatalogEnv(process.env.BATTLE_PROBLEMS_DISRUPTIONS),
+    eventBusName: process.env.DEPLOY_EVENT_BUS_NAME ?? "",
+    events: new EventBridgeClient({}),
   };
 }
 
@@ -46,6 +59,11 @@ export function buildSharedResources(): GenericScoringSharedResources {
 export interface DeploymentScoringState {
   readonly bonusAwarded?: Readonly<Record<string, boolean>>;
   readonly attackCount?: number;
+  /**
+   * [#1422] 既に condition-triggered で発火済みの disruptionId 群。 OR semantics + 一度発火したら
+   * 以降抑制する idempotency record (= ADR-013 OQ#5)。 publish 成功後にだけ追記する。
+   */
+  readonly firedDisruptions?: readonly string[];
 }
 
 export function parseScoringState(raw: string | undefined): DeploymentScoringState {
@@ -67,10 +85,33 @@ export function parseScoringState(raw: string | undefined): DeploymentScoringSta
         )
       : undefined;
   const attackCount = typeof p.attackCount === "number" ? p.attackCount : undefined;
+  const firedRaw = (parsed as { firedDisruptions?: unknown }).firedDisruptions;
+  const firedDisruptions = Array.isArray(firedRaw)
+    ? firedRaw.filter((s): s is string => typeof s === "string")
+    : undefined;
   return {
     ...(bonusAwarded ? { bonusAwarded } : {}),
     ...(attackCount !== undefined ? { attackCount } : {}),
+    ...(firedDisruptions && firedDisruptions.length > 0 ? { firedDisruptions } : {}),
   };
+}
+
+/**
+ * [#1422] `phaseElapsedMin` から active phase を確定する。 phases[] は afterMinutes 昇順 (= metadata
+ * 規約) を前提に、 elapsed 以下の最後の entry を返す。 順序保証されない場合に備えて defensive に sort。
+ *
+ * phased-polling kind と condition-trigger 評価 (disruption-triggers.ts) で共有する (= DRY)。
+ */
+export function resolveActivePhase(
+  phases: readonly PhaseEntry[],
+  elapsedMin: number,
+): PhaseEntry | undefined {
+  const sorted = [...phases].sort((a, b) => a.afterMinutes - b.afterMinutes);
+  let active: PhaseEntry | undefined;
+  for (const p of sorted) {
+    if (elapsedMin >= p.afterMinutes) active = p;
+  }
+  return active;
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -423,6 +423,9 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsScoring: props.problemsScoring,
       problemsEndpoints: props.problemsEndpoints,
       problemsPhases: props.problemsPhases ?? {},
+      // #1422 (ADR-013 Phase 2): condition-triggered disruption の eval + in-account 発火。
+      problemsDisruptions: props.problemsDisruptions ?? {},
+      eventBus,
     });
     this.genericScoringLambda = genericScoring.fn;
 

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -155,6 +155,15 @@ export function discoverProblemsVisibility(problemsRoot: string): Record<string,
  *
  * `disruptions` を持たない問題はキーごと出さない (= env var を最小化)。
  */
+/**
+ * [ADR-013 Phase 2 / Issue #1422] condition-triggered disruption の発火条件。 OR で結合され、
+ * 最初に true になった trigger で発火する (= scoring Lambda 側 eval、 重複は idempotency で抑制)。
+ */
+export type DisruptionTrigger =
+  | { readonly kind: "after-deploy"; readonly afterMinutes: number }
+  | { readonly kind: "team-score-above"; readonly threshold: number }
+  | { readonly kind: "phase-entered"; readonly phaseName: string };
+
 export interface ProblemDisruptionEntry {
   readonly id: string;
   readonly name: string;
@@ -164,6 +173,31 @@ export interface ProblemDisruptionEntry {
   readonly operatorEditable?: readonly string[];
   readonly parameters?: Readonly<Record<string, unknown>>;
   readonly publicHint?: boolean;
+  /** [ADR-013 Phase 2 / #1422] 宣言時のみ condition-triggered 発火が有効 (省略 = Phase 1 self-fire のみ)。 */
+  readonly triggers?: readonly DisruptionTrigger[];
+}
+
+/** SCHEMA `disruptions[].triggers[]` (oneOf) を型付きで取り出す。 不正 / 不明 kind は drop。 */
+export function parseDisruptionTriggers(value: unknown): DisruptionTrigger[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: DisruptionTrigger[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") continue;
+    const t = raw as {
+      kind?: unknown;
+      afterMinutes?: unknown;
+      threshold?: unknown;
+      phaseName?: unknown;
+    };
+    if (t.kind === "after-deploy" && typeof t.afterMinutes === "number") {
+      out.push({ kind: "after-deploy", afterMinutes: t.afterMinutes });
+    } else if (t.kind === "team-score-above" && typeof t.threshold === "number") {
+      out.push({ kind: "team-score-above", threshold: t.threshold });
+    } else if (t.kind === "phase-entered" && typeof t.phaseName === "string") {
+      out.push({ kind: "phase-entered", phaseName: t.phaseName });
+    }
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 export function discoverProblemsDisruptions(
@@ -182,6 +216,23 @@ export function discoverProblemsDisruptions(
   return result;
 }
 
+/**
+ * Lambda env (= `BATTLE_PROBLEMS_DISRUPTIONS`、 `discoverProblemsDisruptions` の出力を JSON 化した
+ * もの) を `{ [problemId]: ProblemDisruptionEntry[] }` に戻す。 未設定 / 壊れた JSON は空 map。
+ */
+export function parseDisruptionsCatalogEnv(
+  raw: string | undefined,
+): Record<string, readonly ProblemDisruptionEntry[]> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as Record<string, readonly ProblemDisruptionEntry[]>;
+  } catch {
+    return {};
+  }
+}
+
 function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefined {
   if (!value || typeof value !== "object") return undefined;
   const v = value as {
@@ -193,6 +244,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
     operatorEditable?: unknown;
     parameters?: unknown;
     publicHint?: unknown;
+    triggers?: unknown;
   };
   if (
     typeof v.id !== "string" ||
@@ -201,6 +253,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
   ) {
     return undefined;
   }
+  const triggers = parseDisruptionTriggers(v.triggers);
   return {
     id: v.id,
     name: v.name,
@@ -219,6 +272,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
       ? { parameters: v.parameters as Record<string, unknown> }
       : {}),
     ...(typeof v.publicHint === "boolean" ? { publicHint: v.publicHint } : {}),
+    ...(triggers ? { triggers } : {}),
   };
 }
 

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   discoverProblemsCatalog,
+  discoverProblemsDisruptions,
   discoverProblemsScoring,
   discoverProblemsVisibility,
 } from "../lib/utils/discover-problems-catalog";
@@ -188,5 +189,39 @@ describe("discoverProblemsVisibility (Issue #642)", () => {
 
   it("空 workspace は空 map (= 全 public 扱い)", () => {
     expect(discoverProblemsVisibility(workspace)).toEqual({});
+  });
+});
+
+describe("discoverProblemsDisruptions triggers[] (#1422)", () => {
+  it("should surface condition triggers parsed from metadata.disruptions[]", () => {
+    writeProblem("battles", "latency-battle", {
+      id: "latency-battle",
+      disruptions: [
+        {
+          id: "latency",
+          name: "EC2 latency",
+          eventDetailType: "DegradedDisruptionFired",
+          parameters: { delayMs: 200 },
+          triggers: [
+            { kind: "after-deploy", afterMinutes: 60 },
+            { kind: "team-score-above", threshold: 5000 },
+            { kind: "bogus" },
+          ],
+        },
+      ],
+    });
+    const result = discoverProblemsDisruptions(workspace);
+    expect(result["latency-battle"]?.[0]?.triggers).toEqual([
+      { kind: "after-deploy", afterMinutes: 60 },
+      { kind: "team-score-above", threshold: 5000 },
+    ]);
+  });
+
+  it("should omit triggers when the disruption declares none (Phase 1 self-fire only)", () => {
+    writeProblem("battles", "plain-battle", {
+      id: "plain-battle",
+      disruptions: [{ id: "d1", name: "n", eventDetailType: "X" }],
+    });
+    expect(discoverProblemsDisruptions(workspace)["plain-battle"]?.[0]?.triggers).toBeUndefined();
   });
 });

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -117,6 +117,40 @@ describe("ProblemDeployBackendStack (MVP-1) — GenericScoring Lambda", () => {
     expect(vars.PROBLEM_ENDPOINTS).toBeUndefined();
     expect(vars.BATTLE_PROBLEMS_PHASES).toBeUndefined();
   });
+
+  it("GenericScoring Lambda should receive the deploy event bus name for condition-triggered disruptions (#1422)", () => {
+    // #1422: condition-triggered disruption の publish 先 bus を env で渡す。 catalog
+    // (BATTLE_PROBLEMS_DISRUPTIONS) は scoring / phases 同様 esbuild define で build 時 literal 化し env から除く。
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const genericScoring = Object.entries(functions).find(
+      ([name]) => name.includes("GenericScoring") && name.includes("Function"),
+    );
+    const vars =
+      (
+        genericScoring?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    expect(vars.DEPLOY_EVENT_BUS_NAME).toBeDefined();
+    expect(vars.BATTLE_PROBLEMS_DISRUPTIONS).toBeUndefined();
+  });
+
+  it("GenericScoring Lambda role should be granted events:PutEvents (#1422)", () => {
+    // grantPutEventsTo が当該 bus に scope した events:PutEvents statement を出すことを pin。
+    const policies = tpl.findResources("AWS::IAM::Policy");
+    const hasPutEvents = Object.values(policies).some((p) => {
+      const statements =
+        (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } }).Properties
+          ?.PolicyDocument?.Statement ?? [];
+      return statements.some((s) => {
+        const action = (s as { Action?: string | string[] }).Action;
+        return Array.isArray(action)
+          ? action.includes("events:PutEvents")
+          : action === "events:PutEvents";
+      });
+    });
+    expect(hasPutEvents).toBe(true);
+  });
 });
 
 describe("ProblemDeployBackendStack (MVP-1) — SystemAuditWriter Lambda (Issue #1034)", () => {

--- a/infrastructure/test/problem-deploy/disruption-triggers.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-triggers.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateDisruptionTriggers,
+  triggerMatches,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/disruption-triggers";
+import {
+  type PhaseEntry,
+  parseScoringState,
+  resolveActivePhase,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/shared";
+import {
+  type DisruptionTrigger,
+  type ProblemDisruptionEntry,
+  parseDisruptionsCatalogEnv,
+  parseDisruptionTriggers,
+} from "../../lib/utils/discover-problems-catalog";
+
+/**
+ * #1422 (ADR-013 Phase 2): condition-triggered disruption の純粋ロジックを pin する。
+ * - catalog の triggers[] / env パース
+ * - trigger 単体判定 + OR 評価 + idempotency 抑制 + phase 解決
+ * - scoringState の firedDisruptions persist / parse + resolveActivePhase 共有
+ */
+
+const baseDisruption = (over: Partial<ProblemDisruptionEntry> = {}): ProblemDisruptionEntry => ({
+  id: "latency",
+  name: "EC2 latency",
+  eventDetailType: "DegradedDisruptionFired",
+  parameters: { delayMs: 200 },
+  ...over,
+});
+
+describe("parseDisruptionTriggers", () => {
+  it("should parse the three supported trigger kinds and drop unknown / malformed", () => {
+    const parsed = parseDisruptionTriggers([
+      { kind: "after-deploy", afterMinutes: 60 },
+      { kind: "team-score-above", threshold: 5000 },
+      { kind: "phase-entered", phaseName: "degraded" },
+      { kind: "after-deploy" }, // missing afterMinutes → drop
+      { kind: "team-score-above", threshold: "nope" }, // wrong type → drop
+      { kind: "unknown-kind", x: 1 }, // unknown → drop
+      "not-an-object",
+    ]);
+    expect(parsed).toEqual([
+      { kind: "after-deploy", afterMinutes: 60 },
+      { kind: "team-score-above", threshold: 5000 },
+      { kind: "phase-entered", phaseName: "degraded" },
+    ]);
+  });
+
+  it("should return undefined for a non-array or all-invalid input", () => {
+    expect(parseDisruptionTriggers(undefined)).toBeUndefined();
+    expect(parseDisruptionTriggers("x")).toBeUndefined();
+    expect(parseDisruptionTriggers([{ kind: "bogus" }])).toBeUndefined();
+  });
+});
+
+describe("parseDisruptionsCatalogEnv", () => {
+  it("should parse a serialized catalog env", () => {
+    const env = JSON.stringify({
+      p1: [baseDisruption({ triggers: [{ kind: "after-deploy", afterMinutes: 1 }] })],
+    });
+    const parsed = parseDisruptionsCatalogEnv(env);
+    expect(parsed.p1?.[0]?.triggers?.[0]).toEqual({ kind: "after-deploy", afterMinutes: 1 });
+  });
+
+  it("should return an empty map for unset / malformed / non-object JSON", () => {
+    expect(parseDisruptionsCatalogEnv(undefined)).toEqual({});
+    expect(parseDisruptionsCatalogEnv("{not json")).toEqual({});
+    expect(parseDisruptionsCatalogEnv("[]")).toEqual({});
+    expect(parseDisruptionsCatalogEnv("null")).toEqual({});
+  });
+});
+
+describe("triggerMatches", () => {
+  const ctx = { scoreAfter: 100, elapsedMin: 30, phases: [] as readonly PhaseEntry[] };
+  it("should match after-deploy when elapsed >= afterMinutes", () => {
+    expect(triggerMatches({ kind: "after-deploy", afterMinutes: 30 }, ctx, undefined)).toBe(true);
+    expect(triggerMatches({ kind: "after-deploy", afterMinutes: 31 }, ctx, undefined)).toBe(false);
+  });
+  it("should match team-score-above strictly above the threshold", () => {
+    expect(triggerMatches({ kind: "team-score-above", threshold: 99 }, ctx, undefined)).toBe(true);
+    expect(triggerMatches({ kind: "team-score-above", threshold: 100 }, ctx, undefined)).toBe(
+      false,
+    );
+  });
+  it("should match phase-entered only on the active phase name", () => {
+    const t: DisruptionTrigger = { kind: "phase-entered", phaseName: "degraded" };
+    expect(triggerMatches(t, ctx, "degraded")).toBe(true);
+    expect(triggerMatches(t, ctx, "normal")).toBe(false);
+    expect(triggerMatches(t, ctx, undefined)).toBe(false);
+  });
+});
+
+describe("evaluateDisruptionTriggers", () => {
+  const phases: readonly PhaseEntry[] = [
+    { name: "normal", afterMinutes: 0 },
+    { name: "degraded", afterMinutes: 20 },
+  ];
+
+  it("should fire a disruption whose score trigger is satisfied (OR semantics)", () => {
+    const d = baseDisruption({
+      triggers: [
+        { kind: "after-deploy", afterMinutes: 999 }, // not yet
+        { kind: "team-score-above", threshold: 50 }, // satisfied
+      ],
+    });
+    const fired = evaluateDisruptionTriggers(
+      [d],
+      { scoreAfter: 100, elapsedMin: 5, phases },
+      new Set(),
+    );
+    expect(fired).toEqual([
+      {
+        disruptionId: "latency",
+        eventDetailType: "DegradedDisruptionFired",
+        parameters: { delayMs: 200 },
+        triggerKind: "team-score-above",
+      },
+    ]);
+  });
+
+  it("should fire on phase-entered using the active phase", () => {
+    const d = baseDisruption({ triggers: [{ kind: "phase-entered", phaseName: "degraded" }] });
+    const fired = evaluateDisruptionTriggers(
+      [d],
+      { scoreAfter: 0, elapsedMin: 25, phases },
+      new Set(),
+    );
+    expect(fired).toHaveLength(1);
+    expect(fired[0]?.triggerKind).toBe("phase-entered");
+  });
+
+  it("should skip disruptions already fired (idempotency)", () => {
+    const d = baseDisruption({ triggers: [{ kind: "team-score-above", threshold: 50 }] });
+    const fired = evaluateDisruptionTriggers(
+      [d],
+      { scoreAfter: 100, elapsedMin: 0, phases },
+      new Set(["latency"]),
+    );
+    expect(fired).toEqual([]);
+  });
+
+  it("should skip disruptions with no triggers (Phase 1 self-fire only)", () => {
+    const fired = evaluateDisruptionTriggers(
+      [baseDisruption()],
+      { scoreAfter: 9999, elapsedMin: 999, phases },
+      new Set(),
+    );
+    expect(fired).toEqual([]);
+  });
+
+  it("should not fire when no trigger condition is met", () => {
+    const d = baseDisruption({ triggers: [{ kind: "team-score-above", threshold: 5000 }] });
+    const fired = evaluateDisruptionTriggers(
+      [d],
+      { scoreAfter: 100, elapsedMin: 0, phases },
+      new Set(),
+    );
+    expect(fired).toEqual([]);
+  });
+
+  it("should default parameters to {} when the disruption declares none", () => {
+    const d = baseDisruption({
+      parameters: undefined,
+      triggers: [{ kind: "after-deploy", afterMinutes: 0 }],
+    });
+    const fired = evaluateDisruptionTriggers(
+      [d],
+      { scoreAfter: 0, elapsedMin: 1, phases: [] },
+      new Set(),
+    );
+    expect(fired[0]?.parameters).toEqual({});
+  });
+});
+
+describe("resolveActivePhase (shared, used by phased-polling + triggers)", () => {
+  it("should return the last phase whose afterMinutes <= elapsed, defensively sorted", () => {
+    const phases: readonly PhaseEntry[] = [
+      { name: "degraded", afterMinutes: 20 },
+      { name: "normal", afterMinutes: 0 },
+    ];
+    expect(resolveActivePhase(phases, 5)?.name).toBe("normal");
+    expect(resolveActivePhase(phases, 25)?.name).toBe("degraded");
+    expect(resolveActivePhase([], 10)).toBeUndefined();
+  });
+});
+
+describe("parseScoringState firedDisruptions (#1422 idempotency record)", () => {
+  it("should round-trip firedDisruptions string[]", () => {
+    expect(parseScoringState(JSON.stringify({ firedDisruptions: ["a", "b", 3] }))).toEqual({
+      firedDisruptions: ["a", "b"],
+    });
+  });
+  it("should omit firedDisruptions when absent / empty / not an array", () => {
+    expect(parseScoringState(JSON.stringify({ attackCount: 1 }))).toEqual({ attackCount: 1 });
+    expect(parseScoringState(JSON.stringify({ firedDisruptions: [] }))).toEqual({});
+    expect(parseScoringState(JSON.stringify({ firedDisruptions: "x" }))).toEqual({});
+  });
+});

--- a/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #1422 (ADR-013 Phase 2): scoring dispatcher が採点後に condition-triggered disruption を
+ * 評価し、 in-account event bus に PutEvents する経路を end-to-end で pin する。
+ * EventBridge + DynamoDB を mock し、 発火 / idempotency 抑制 / bus 未配線 / publish 失敗を網羅。
+ */
+
+const ddbSend = vi.fn();
+const ebSend = vi.fn();
+
+vi.mock("@aws-sdk/lib-dynamodb", async () => {
+  const actual =
+    await vi.importActual<typeof import("@aws-sdk/lib-dynamodb")>("@aws-sdk/lib-dynamodb");
+  return { ...actual, DynamoDBDocumentClient: { from: () => ({ send: ddbSend }) } };
+});
+vi.mock("@aws-sdk/client-eventbridge", async () => {
+  const actual = await vi.importActual<typeof import("@aws-sdk/client-eventbridge")>(
+    "@aws-sdk/client-eventbridge",
+  );
+  return {
+    ...actual,
+    EventBridgeClient: class {
+      send = ebSend;
+    },
+  };
+});
+
+process.env.DEPLOYMENTS_TABLE_NAME = "TestDeployments";
+process.env.EVENTS_TABLE_NAME = "TestEvents";
+process.env.PROBLEM_ENDPOINTS_TABLE_NAME = "TestEndpoints";
+
+const fetchMock = vi.fn();
+const NOW_ISO = "2026-05-12T10:00:00.000Z";
+
+function sampleDeployment(over: Record<string, unknown> = {}) {
+  return {
+    PK: "DEPLOYMENT#JOB-1",
+    SK: "META",
+    jobId: "JOB-1",
+    problemId: "hello-world-battle",
+    tenantId: "tenant-acme",
+    teamId: "team-1",
+    eventId: "event-1",
+    status: "COMPLETE",
+    createdAt: NOW_ISO,
+    eventStartsAt: "2026-05-12T09:00:00.000Z",
+    expiresAt: 9_999_999_999,
+    stackOutputs: JSON.stringify({ FrontendUrl: "https://frontend.example.com" }),
+    ...over,
+  };
+}
+
+function configureScoringAndDisruptions(): void {
+  process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
+    "hello-world-battle": {
+      kind: "uptime",
+      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+      pointsPerSuccess: 100,
+    },
+  });
+  process.env.PROBLEM_ENDPOINTS = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_PHASES = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_DISRUPTIONS = JSON.stringify({
+    "hello-world-battle": [
+      {
+        id: "latency",
+        name: "EC2 latency",
+        eventDetailType: "DegradedDisruptionFired",
+        parameters: { delayMs: 200 },
+        triggers: [{ kind: "team-score-above", threshold: 50 }],
+      },
+    ],
+  });
+}
+
+function mockDdb(deploymentOver: Record<string, unknown> = {}): void {
+  ddbSend.mockImplementation(async (cmd: { constructor: { name: string } }) => {
+    const name = cmd.constructor.name;
+    if (name === "ScanCommand") {
+      const tn = (cmd as { input: { TableName: string } }).input.TableName;
+      if (tn === "TestEvents") return { Items: [] };
+      if (tn === "TestDeployments") return { Items: [sampleDeployment(deploymentOver)] };
+    }
+    if (name === "BatchGetCommand") return { Responses: { TestEvents: [] } };
+    return {};
+  });
+}
+
+async function runHandler(): Promise<void> {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW_ISO));
+  try {
+    const { handler } = await import(
+      "../../lib/problem-deploy/handlers/generic-scoring-handler/index"
+    );
+    await handler();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+function updateCommands() {
+  return ddbSend.mock.calls
+    .map((c) => c[0] as { constructor: { name: string }; input: Record<string, unknown> })
+    .filter((c) => c.constructor.name === "UpdateCommand");
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+  ddbSend.mockReset();
+  ebSend.mockReset();
+  ebSend.mockResolvedValue({ FailedEntryCount: 0 });
+  process.env.DEPLOY_EVENT_BUS_NAME = "tc-deploy-bus";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  process.env.BATTLE_PROBLEMS_DISRUPTIONS = undefined;
+  process.env.DEPLOY_EVENT_BUS_NAME = undefined;
+});
+
+describe("condition-triggered disruption fire", () => {
+  it("should publish a disruption event and persist firedDisruptions when score crosses the threshold", async () => {
+    configureScoringAndDisruptions();
+    mockDdb();
+    await runHandler();
+
+    expect(ebSend).toHaveBeenCalledTimes(1);
+    const putCmd = ebSend.mock.calls[0][0] as {
+      input: { Entries: Array<{ DetailType: string; EventBusName: string; Detail: string }> };
+    };
+    const entry = putCmd.input.Entries[0];
+    expect(entry.DetailType).toBe("DegradedDisruptionFired");
+    expect(entry.EventBusName).toBe("tc-deploy-bus");
+    const detail = JSON.parse(entry.Detail);
+    expect(detail).toMatchObject({
+      disruptionId: "latency",
+      teamId: "team-1",
+      problemId: "hello-world-battle",
+      parameters: { delayMs: 200 },
+      requestId: "JOB-1#latency",
+      triggeredBy: "team-score-above",
+    });
+
+    // 2nd UpdateCommand persists firedDisruptions (1st = score).
+    const updates = updateCommands();
+    expect(updates.length).toBe(2);
+    const state = JSON.parse(
+      (updates[1].input.ExpressionAttributeValues as Record<string, string>)[":state"],
+    );
+    expect(state.firedDisruptions).toEqual(["latency"]);
+  });
+
+  it("should not re-fire a disruption already recorded in firedDisruptions (idempotency)", async () => {
+    configureScoringAndDisruptions();
+    mockDdb({ scoringState: JSON.stringify({ firedDisruptions: ["latency"] }) });
+    await runHandler();
+    expect(ebSend).not.toHaveBeenCalled();
+    expect(updateCommands().length).toBe(1); // score only, no fired-persist
+  });
+
+  it("should not fire when the event bus is unwired", async () => {
+    configureScoringAndDisruptions();
+    process.env.DEPLOY_EVENT_BUS_NAME = "";
+    mockDdb();
+    await runHandler();
+    expect(ebSend).not.toHaveBeenCalled();
+  });
+
+  it("should not persist firedDisruptions when publish reports a failed entry", async () => {
+    configureScoringAndDisruptions();
+    ebSend.mockResolvedValue({ FailedEntryCount: 1, Entries: [{ ErrorCode: "Throttled" }] });
+    mockDdb();
+    await runHandler();
+    expect(ebSend).toHaveBeenCalledTimes(1);
+    // publish 失敗 → 2nd UpdateCommand (firedDisruptions) は走らない (score の 1 件のみ)。
+    expect(updateCommands().length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Battle 競技中に platform が観測値へ reactive に disruption を自動発火する仕組み (**ADR-013 Phase 2 D2**)。 これまで disruption は手動 fire (#888) と deploy 時刻 offset の self-fire (ADR-012 Phase 1) のみで、 「スコアが伸びすぎたら難度を上げる」「フェーズ遷移で障害を入れる」 のような condition-triggered 発火ができなかった (= 競技フィデリティ tracker #1417 のギャップ)。

scoring Lambda の 1 分 tick で **採点後の team score / deploy 経過分 / active phase** を観測し、 `metadata.disruptions[].triggers[]` の条件成立時に該当 disruption を発火する。 cross-account forward (競技者 account への配信) は **Phase B (#1419)** に分離し、 本 PR は手動 fire (Phase A) と同じ in-account event bus への publish に留める。

### 実装
- **catalog**: `ProblemDisruptionEntry.triggers` (`after-deploy` / `team-score-above` / `phase-entered`) を SCHEMA から型付きで取り出す。 env 復元 helper (`parseDisruptionsCatalogEnv`) も追加。
- **純評価** (`disruption-triggers.ts`): triggers を **OR 評価**し「今 tick で新たに発火する disruption」 を返す。 phase 解決は phased-polling から `resolveActivePhase` を `shared` に抽出して共有 (DRY)。
- **I/O service** (`condition-disruption-fire.ts`): 評価 → EventBridge publish → idempotency 永続化 (`scoringState.firedDisruptions`)。 publish 成功後にだけ fired を記録 → 失敗時は次 tick で再評価。
- **scoring Lambda**: `BATTLE_PROBLEMS_DISRUPTIONS` を esbuild define で build 時 literal 化 (env 4KB 回避)、 `DEPLOY_EVENT_BUS_NAME` env + `events:PutEvents` IAM (当該 bus に scope) を least-privilege で付与。

**SOLID**: 純評価 / 副作用 / orchestration を 3 分離し、 dispatcher index.ts に AWS SDK を増やさない (= harness `handler-no-direct-sdk-import` を満たす)。

## Test plan
- 新規: `disruption-triggers.test.ts` (純評価 + catalog/env パース 16 件)、 `generic-scoring-disruption-fire.test.ts` (handler 統合: 発火 / idempotency / bus 未配線 / publish 失敗 4 件)、 catalog FS parse + CDK env/IAM assertion
- infra **2331 test** green (standalone `bunx vitest run`)、 tsc / biome / `make harness` (error 0) / `cdk synth` すべて pass

> Note: `make before-commit` ローカルでは (1) fresh worktree に gitignore された `.env` が無く `CDK_PARAM_SYSTEM_ADMIN_EMAIL` 未設定で check-synth が落ちる、 (2) 全 workspace 並列 bundling の資源競合で lite-mode 合成 test が 30s timeout に触れる、 の 2 点が環境要因で出る。 いずれも env を与える / 単独実行すると pass し (synth は `Successfully synthesized`、 lite-mode test は 7s で green)、 コード起因ではない。

## Regression analysis
- `triggers[]` 未宣言の既存 disruption は評価対象外 → 挙動完全不変 (Phase 1 self-fire のみ)。
- condition fire は `applyKindResult` (score 書き込み) の **後** に走り、 publish 失敗は outer `processDeployment` `.catch` に隔離 (score は確定済、 disruption だけ次 tick 再評価)。
- idempotency: `firedDisruptions` を publish 成功後に追記し OR semantics で再発火抑制 (ADR-013 OQ#5)。 `bonusAwarded` / `attackCount` は merge で温存。
- `resolveActivePhase` を phased-polling → shared へ移動 (同一ロジック、 import 変更のみ)。 phased-polling 全 test green。
- bus 未配線 / disruption 無し問題は no-op。 Lite mode 含め既存挙動不変。

## Physical impact
- generic-scoring Lambda: env に `DEPLOY_EVENT_BUS_NAME` 追加 + handler bundle 差分 (condition fire + eventbridge SDK) → **UPDATE**。 `BATTLE_PROBLEMS_DISRUPTIONS` は define 注入で env 非搭載。
- IAM Policy: scoring Lambda role に `events:PutEvents` (当該 bus scope) を +1 → **UPDATE**。
- 新規 CFn resource は無し (既存 deploy event bus を再利用、 table / API 追加なし)。
- docs/runbooks/capacity-pressure*.html: 生成物 2 件 → **CREATE** (docs のみ)。

Relates #1422
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)