### PR TITLE
fix(admin): repoint BudgetConsumptionPanel toErrorMessage to web-kit [#1418]

### DIFF
--- a/apps/admin-console/src/components/BudgetConsumptionPanel.tsx
+++ b/apps/admin-console/src/components/BudgetConsumptionPanel.tsx
@@ -3,13 +3,12 @@ import Box from "@cloudscape-design/components/box";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Spinner from "@cloudscape-design/components/spinner";
-import { usePolling } from "@tenkacloud/web-kit";
+import { toErrorMessage, usePolling } from "@tenkacloud/web-kit";
 import { useCallback, useState } from "react";
 import { type CostSummaryAvailable, fetchCostSummary } from "../api/insight";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
-import { toErrorMessage } from "../lib/error-message";
 
 // budget は AWS 側で日次更新されるため polling 圧は最小で十分 (= 5 分)。 DescribeBudget は無料。
 const COST_POLL_INTERVAL_MS = 300_000;


### PR DESCRIPTION
## Summary

**main 復旧 hotfix。** #1627 (cost panel) が追加した `BudgetConsumptionPanel.tsx` は `../lib/error-message` から `toErrorMessage` を import していたが、 並行で merge した #1630 (toErrorMessage を web-kit へ集約) が同 module を**削除**した。 両 PR は別ファイルで text 衝突せず merge できたが、 結果として main で `admin-console` build が `TS2307: Cannot find module '../lib/error-message'` で壊れていた。

import を `@tenkacloud/web-kit` (`usePolling` と同一行に集約) へ張り替えて復旧する。

## Test plan
- `admin-console`: tsc clean / 全 **279 test** green / **coverage gate 100%** / biome clean
- 削除済み `../lib/error-message` を import する survivor は他に無し (grep 確認)

## Regression analysis
- 1 行の import 先変更のみ。 `toErrorMessage` の実装は web-kit で同一 → 挙動不変。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。 frontend source-only の import 修正 (build 復旧)。

Relates #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency reorganization with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->