### PR TITLE
feat(coordination): ADR-030 Phase 2 + Phase 3 config wiring [#1420]

### DIFF
--- a/apps/admin-console/src/components/BudgetConsumptionPanel.tsx
+++ b/apps/admin-console/src/components/BudgetConsumptionPanel.tsx
@@ -3,13 +3,12 @@ import Box from "@cloudscape-design/components/box";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Spinner from "@cloudscape-design/components/spinner";
-import { usePolling } from "@tenkacloud/web-kit";
+import { toErrorMessage, usePolling } from "@tenkacloud/web-kit";
 import { useCallback, useState } from "react";
 import { type CostSummaryAvailable, fetchCostSummary } from "../api/insight";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useT } from "../i18n";
-import { toErrorMessage } from "../lib/error-message";
 
 // budget は AWS 側で日次更新されるため polling 圧は最小で十分 (= 5 分)。 DescribeBudget は無料。
 const COST_POLL_INTERVAL_MS = 300_000;

--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -66,6 +66,8 @@ const problemDeployBackend = new ProblemDeployBackendStack(
     problemsVisibility: (config.problems.visibility ?? {}) as Readonly<Record<string, "private">>,
     // Issue #888: Lite mode でも problemsDisruptions を Lambda env に渡す。
     problemsDisruptions: (config.problems.disruptions ?? {}) as Readonly<Record<string, unknown>>,
+    // #1420 ADR-030 Phase 3: Lite mode でも coordination plugin path を dispatcher へ渡す。
+    problemsCoordination: (config.problems.coordination ?? {}) as Readonly<Record<string, unknown>>,
     // Lite では participant portal を runtime-config "default-dev-mock" で立てる
     // (= portal Lambda + S3+CloudFront を持ち込む)。 frontend は backend mode で動く。
     participantPortal: { runtimeConfig: "default-dev-mock" },

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -11,6 +11,7 @@ import { parseTenantSamlIdpConfig } from "../tenant-template/saml-identity-provi
 import { loadConfig } from "../utils/config-loader.js";
 import {
   discoverProblemsCatalog,
+  discoverProblemsCoordination,
   discoverProblemsDisruptions,
   discoverProblemsEndpoints,
   discoverProblemsPhases,
@@ -280,6 +281,7 @@ function discoverAppProblems(input: ResolveAppConfigInput): ProblemsCatalogBundl
     phases: discoverProblemsPhases(problemsRoot),
     visibility: discoverProblemsVisibility(problemsRoot),
     disruptions: discoverProblemsDisruptions(problemsRoot),
+    coordination: discoverProblemsCoordination(problemsRoot),
   };
 }
 

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -153,4 +153,6 @@ export interface ProblemsCatalogBundle {
   readonly visibility: unknown;
   /** Issue #888: per-problem `disruptions[]` 宣言。 未宣言の問題はキー無し。 */
   readonly disruptions: unknown;
+  /** ADR-028/030 #1420: per-problem `interTeamCoordination.plugin` (= `{ [problemId]: { plugin } }`)。 未宣言はキー無し。 */
+  readonly coordination: unknown;
 }

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -122,6 +122,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       problemsVisibility: config.problems.visibility as ProblemDeployBackendVisibility,
       // Issue #888: per-problem `disruptions[]` を Lambda env に injection
       problemsDisruptions: config.problems.disruptions as Readonly<Record<string, unknown>>,
+      // #1420 ADR-030 Phase 3: per-problem coordination plugin path を dispatcher へ injection
+      problemsCoordination: config.problems.coordination as Readonly<Record<string, unknown>>,
       ...(challengePayloadBucketName ? { challengePayloadBucketName } : {}),
       participantPortal: config.participantPortal as
         | { runtimeConfig: ParticipantPortalRuntimeConfig | "default-dev-mock" }

--- a/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
+++ b/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
@@ -32,6 +32,12 @@ export interface CoordinationDispatcherLambdaProps {
   readonly eventsTable: ITable;
   /** `buildParticipantSharedResources` が要求する `DEPLOY_ENVIRONMENT`。 coordination では未使用。 */
   readonly environmentName: string;
+  /**
+   * [ADR-030 Phase 3 / #1420] `{ [problemId]: { plugin } }`。 問題が宣言する coordination plugin の
+   * module path。 scope resolver が team→moduleRef を解決するのに使う (= `PROBLEM_COORDINATION` env)。
+   * 未宣言の問題はキー無し。 省略時は空 (= 全 route `not_configured`)。
+   */
+  readonly problemsCoordination?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -101,6 +107,13 @@ export class CoordinationDispatcherLambda extends Construct {
         target: LAMBDA_NODEJS_BUNDLING_TARGET,
         sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
         externalModules: [],
+        // ADR-030 Phase 3 config layer: coordination catalog を build 時 literal 置換 (env 4KB 回避、
+        // scoring/disruptions と同方式)。 未宣言なら `{}` → scope resolver は全 team で not_configured。
+        define: {
+          "process.env.PROBLEM_COORDINATION": JSON.stringify(
+            JSON.stringify(props.problemsCoordination ?? {}),
+          ),
+        },
       },
     });
 

--- a/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
+++ b/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
@@ -1,0 +1,117 @@
+import * as path from "node:path";
+import { Duration } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import {
+  ManagedPolicy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import {
+  Architecture,
+  type FunctionUrl,
+  FunctionUrlAuthType,
+  HttpMethod,
+} from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime.js";
+
+export interface CoordinationDispatcherLambdaProps {
+  /** team-login-key 認証 (GSI2 Query) + coordination state 行 (PK=COORD#...) の Get/Put 先。 */
+  readonly deploymentsTable: ITable;
+  /**
+   * `buildParticipantSharedResources` が `EVENTS_TABLE_NAME` env を要求するため渡す。 coordination
+   * route は events を読まない (= IAM も付与しない)。 共有 builder の env 要件を満たすためだけの配線。
+   */
+  readonly eventsTable: ITable;
+  /** `buildParticipantSharedResources` が要求する `DEPLOY_ENVIRONMENT`。 coordination では未使用。 */
+  readonly environmentName: string;
+}
+
+/**
+ * ADR-030 Phase 2 (#1420): inter-team coordination dispatch 専用 Lambda。
+ *
+ * coordination route (`POST/GET /portal/me/coordination/*`) を participant-portal Lambda から
+ * **本 Lambda へ分離**する。 participant-portal Lambda は AWS Console SSO / CLI 資格情報発行のため
+ * `sts:AssumeRole`(競技者 federation) + `ssm:GetParameter` + `kms:Decrypt`(ExternalId 復号) を持つ。
+ * 将来 Phase 3 で未信頼の問題同梱 plugin を in-process 動的実行しても、 本 Lambda は Deployments
+ * テーブルの coordination / team-lookup 行しか触れない最小 IAM のため、 競技者資格情報・他テナント
+ * データ・ExternalId に **構造的に到達できない** (ADR-030 S2 = blast radius を IAM で封じる)。
+ *
+ * Function URL は AuthType=NONE で公開し、 `Authorization: Bearer <teamLoginKey>` を handler 内で検証する。
+ * plugin の実 import (S3 materialize) は Phase 3 の seam。 現状は load 不可 → `not_configured` / `unavailable`。
+ */
+export class CoordinationDispatcherLambda extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly url: FunctionUrl;
+
+  constructor(scope: Construct, id: string, props: CoordinationDispatcherLambdaProps) {
+    super(scope, id);
+
+    const role = new Role(this, "Role", {
+      assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+      inlinePolicies: {
+        // team-login-key 認証 (= GSI2 Query) + coordination state 行 (PK=COORD#...) の Get/Put。
+        // ADR-030 S2: sts:AssumeRole / ssm:GetParameter / kms:Decrypt は **意図的に付与しない**
+        // (= 未信頼 plugin が競技者資格情報・ExternalId に到達する経路を IAM 上に存在させない)。
+        CoordinationRW: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ["dynamodb:Query"],
+              resources: [
+                props.deploymentsTable.tableArn,
+                `${props.deploymentsTable.tableArn}/index/GSI2`,
+              ],
+            }),
+            new PolicyStatement({
+              actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+              resources: [props.deploymentsTable.tableArn],
+            }),
+          ],
+        }),
+      },
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+      ],
+    });
+
+    this.fn = new NodejsFunction(this, "Function", {
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(import.meta.dirname, "handlers/coordination-dispatcher-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(10),
+      memorySize: 512,
+      role,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        // 共有 builder (buildParticipantSharedResources) の env 要件。 coordination では未使用。
+        EVENTS_TABLE_NAME: props.eventsTable.tableName,
+        DEPLOY_ENVIRONMENT: props.environmentName,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: LAMBDA_NODEJS_BUNDLING_TARGET,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
+        externalModules: [],
+      },
+    });
+
+    this.url = this.fn.addFunctionUrl({
+      authType: FunctionUrlAuthType.NONE,
+      cors: {
+        allowedOrigins: ["*"],
+        allowedMethods: [HttpMethod.GET, HttpMethod.POST],
+        allowedHeaders: ["content-type", "authorization"],
+        maxAge: Duration.minutes(10),
+      },
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
@@ -1,0 +1,98 @@
+import { type Context, Hono } from "hono";
+import { handle } from "hono/aws-lambda";
+import { StatusCodes } from "http-status-codes";
+import {
+  type CoordinationHandlerDeps,
+  handleCoordinationOp,
+  handleCoordinationProjection,
+  makeCoordinationScopeResolver,
+  parseCoordinationConfig,
+} from "../participant-handler/coordination-handler.js";
+import type { PluginImporter } from "../participant-handler/coordination-plugin-loader.js";
+import { parseJsonBody, withBearerAuth } from "../participant-handler/route-helpers.js";
+import { CoordinationOpBodySchema } from "../participant-handler/schemas.js";
+import { buildParticipantSharedResources } from "../participant-handler/shared.js";
+import { RATE_LIMITS } from "../shared/rate-limiter.js";
+
+/**
+ * ADR-030 Phase 2 (#1420): inter-team coordination dispatch を participant-portal Lambda から
+ * 分離した **専用 Lambda** の Hono app。
+ *
+ * participant-portal Lambda は AWS Console SSO / CLI 資格情報発行のため `sts:AssumeRole`(競技者
+ * federation) + `ssm:GetParameter` + `kms:Decrypt`(ExternalId 復号) を持つ。 そこで未信頼の
+ * 問題同梱 coordination plugin を動的実行すると、 1 つの悪性 plugin が競技者アカウントの資格情報・
+ * 全テナントデータに到達しうる (ADR-030 S2 の脅威)。 本 Lambda は Deployments テーブルの
+ * coordination / team-lookup 行しか触れない最小 IAM で動かし、 blast radius を IAM で構造的に縛る。
+ *
+ * importer は依然 seam (Phase 3 で レビュー済みカタログ bundle の S3 materialize を実装)。 未配線の
+ * 間は load 不可 → `unavailable` / fallback projection で participant API を壊さない。
+ */
+const shared = buildParticipantSharedResources();
+
+const coordinationImporter: PluginImporter = (ref) =>
+  Promise.reject(new Error(`coordination plugin importer not configured: ${ref}`));
+
+const coordinationDeps: CoordinationHandlerDeps = {
+  importer: coordinationImporter,
+  store: { ddb: shared.ddb, tableName: shared.tableName },
+  resolveScope: makeCoordinationScopeResolver(
+    shared,
+    parseCoordinationConfig(process.env.PROBLEM_COORDINATION),
+  ),
+};
+
+/** coordination handler の outcome を HTTP 応答に写す (= StatusCodes 名で意図を明示)。 */
+function respondCoordination(
+  c: Context,
+  outcome: Awaited<ReturnType<typeof handleCoordinationProjection>>,
+): Response {
+  switch (outcome.kind) {
+    case "ok":
+      return c.json({ projection: outcome.projection }, StatusCodes.OK);
+    case "rejected":
+      return c.json({ error: outcome.error }, StatusCodes.UNPROCESSABLE_ENTITY);
+    case "conflict":
+      return c.json({ error: "conflict" }, StatusCodes.CONFLICT);
+    case "unavailable":
+      return c.json({ error: "unavailable" }, StatusCodes.SERVICE_UNAVAILABLE);
+    default:
+      return c.json({ error: "not_configured" }, StatusCodes.NOT_FOUND);
+  }
+}
+
+const app = new Hono();
+
+app.get("/portal/healthz", (c) => c.json({ ok: true }));
+
+// ADR-028 D4/D5 (#1420): 参加者間 coordination の op 提出 + projection polling。
+app.post("/portal/me/coordination/op", (c) =>
+  withBearerAuth(
+    c,
+    "coordination-op",
+    async (token) => {
+      const parsed = await parseJsonBody(c, CoordinationOpBodySchema);
+      if (!parsed.ok) return parsed.response;
+      const outcome = await handleCoordinationOp(
+        coordinationDeps,
+        token,
+        parsed.data.op,
+        new Date().toISOString(),
+      );
+      return respondCoordination(c, outcome);
+    },
+    RATE_LIMITS.WRITE_LOW,
+  ),
+);
+
+app.get("/portal/me/coordination/projection", (c) =>
+  withBearerAuth(
+    c,
+    "coordination-projection",
+    async (token) =>
+      respondCoordination(c, await handleCoordinationProjection(coordinationDeps, token)),
+    RATE_LIMITS.READ_HIGH,
+  ),
+);
+
+export const handler = handle(app);
+export { app };

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -11,14 +11,6 @@ import { RATE_LIMITS } from "../shared/rate-limiter.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { castEvent, INBOX_SINCE_MS_MAX, readInbox } from "./cast-event.js";
 import {
-  type CoordinationHandlerDeps,
-  handleCoordinationOp,
-  handleCoordinationProjection,
-  makeCoordinationScopeResolver,
-  parseCoordinationConfig,
-} from "./coordination-handler.js";
-import type { PluginImporter } from "./coordination-plugin-loader.js";
-import {
   defaultDeployLogDeps,
   getParticipantDeployLogs,
   parseDeployLogLimit,
@@ -38,7 +30,6 @@ import {
 import {
   BattleAttacksQuerySchema,
   CastEventBodySchema,
-  CoordinationOpBodySchema,
   DeployLogsQuerySchema,
   EventInboxQuerySchema,
   NotificationsQuerySchema,
@@ -76,38 +67,10 @@ import { setDisplayTeamName } from "./update.js";
  */
 const shared = buildParticipantSharedResources();
 
-// ADR-028 D6 (#1420): 問題同梱 coordination plugin を S3 (ADR-008 payload 経路) から materialize して
-// import する実装は別 increment (= seam)。 未配線の間は reject → loader が null 化 → route は
-// `unavailable` / fallback projection で安全に応答する (= 機能は inert だが participant API は壊れない)。
-const coordinationImporter: PluginImporter = (ref) =>
-  Promise.reject(new Error(`coordination plugin importer not configured: ${ref}`));
-const coordinationDeps: CoordinationHandlerDeps = {
-  importer: coordinationImporter,
-  store: { ddb: shared.ddb, tableName: shared.tableName },
-  resolveScope: makeCoordinationScopeResolver(
-    shared,
-    parseCoordinationConfig(process.env.PROBLEM_COORDINATION),
-  ),
-};
-
-/** coordination handler の outcome を HTTP 応答に写す (= StatusCodes 名で意図を明示)。 */
-function respondCoordination(
-  c: Context,
-  outcome: Awaited<ReturnType<typeof handleCoordinationProjection>>,
-): Response {
-  switch (outcome.kind) {
-    case "ok":
-      return c.json({ projection: outcome.projection }, StatusCodes.OK);
-    case "rejected":
-      return c.json({ error: outcome.error }, StatusCodes.UNPROCESSABLE_ENTITY);
-    case "conflict":
-      return c.json({ error: "conflict" }, StatusCodes.CONFLICT);
-    case "unavailable":
-      return c.json({ error: "unavailable" }, StatusCodes.SERVICE_UNAVAILABLE);
-    default:
-      return c.json({ error: "not_configured" }, StatusCodes.NOT_FOUND);
-  }
-}
+// ADR-030 Phase 2 (#1420): inter-team coordination の op/projection route は専用の最小 IAM
+// CoordinationDispatcherLambda (coordination-dispatcher-handler) へ分離した。 participant-portal
+// Lambda は sts:AssumeRole / ssm / kms を持つため、 未信頼 plugin を実行する coordination は
+// ここに置かない (ADR-030 S2 = blast radius を IAM で封じる)。
 const app = new Hono();
 
 app.get("/portal/healthz", (c) => c.json({ ok: true }));
@@ -184,38 +147,6 @@ app.get("/portal/me/notifications", (c) =>
       if (outcome.kind === "ok") return c.json(outcome.response, StatusCodes.OK);
       return respondError(c, outcome.kind);
     },
-    RATE_LIMITS.READ_HIGH,
-  ),
-);
-
-// ADR-028 D4/D5 (#1420): 参加者間 coordination の op 提出 + projection polling。
-// semantics は問題同梱 plugin (動的 import) に閉じ、 platform は dispatch / projection だけを担う。
-// importer 未配線 (seam) の間は unavailable / fallback で安全に応答する。
-app.post("/portal/me/coordination/op", (c) =>
-  withBearerAuth(
-    c,
-    "coordination-op",
-    async (token) => {
-      const parsed = await parseJsonBody(c, CoordinationOpBodySchema);
-      if (!parsed.ok) return parsed.response;
-      const outcome = await handleCoordinationOp(
-        coordinationDeps,
-        token,
-        parsed.data.op,
-        new Date().toISOString(),
-      );
-      return respondCoordination(c, outcome);
-    },
-    RATE_LIMITS.WRITE_LOW,
-  ),
-);
-
-app.get("/portal/me/coordination/projection", (c) =>
-  withBearerAuth(
-    c,
-    "coordination-projection",
-    async (token) =>
-      respondCoordination(c, await handleCoordinationProjection(coordinationDeps, token)),
     RATE_LIMITS.READ_HIGH,
   ),
 );

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -10,6 +10,7 @@ import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine
 import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda.js";
 import { CompetitorAccountsTable } from "./competitor-accounts-table.js";
 import { CompetitorBootstrapHosting } from "./competitor-bootstrap-hosting.js";
+import { CoordinationDispatcherLambda } from "./coordination-dispatcher-lambda.js";
 import { DeployApiLambda } from "./deploy-api-lambda.js";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project.js";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine.js";
@@ -453,6 +454,25 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       new CfnOutput(this, "ParticipantPortalApiUrl", {
         value: portalLambda.url.url,
         description: "Participant Portal Lambda Function URL (auth via teamLoginKey bearer).",
+      });
+
+      // ADR-030 Phase 2 (#1420): inter-team coordination dispatch を participant-portal Lambda
+      // (sts:AssumeRole / ssm / kms 保持) から分離し、 coordination state 行しか触れない最小 IAM の
+      // 専用 Lambda で動かす。 未信頼の問題同梱 plugin を将来 in-process 実行しても competitor
+      // 資格情報・他テナントデータに到達できない (ADR-030 S2)。 plugin の実 import は Phase 3 の seam。
+      const coordinationDispatcher = new CoordinationDispatcherLambda(
+        this,
+        "CoordinationDispatcher",
+        {
+          deploymentsTable: deployments.table,
+          eventsTable: events.table,
+          environmentName: props.environmentName,
+        },
+      );
+      new CfnOutput(this, "CoordinationDispatcherApiUrl", {
+        value: coordinationDispatcher.url.url,
+        description:
+          "Coordination Dispatcher Lambda Function URL (ADR-030 最小 IAM、 teamLoginKey bearer 認証)。",
       });
 
       const portal = new ParticipantPortalHosting(this, "ParticipantPortal");

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -94,6 +94,12 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    */
   readonly problemsDisruptions?: Readonly<Record<string, unknown>>;
   /**
+   * ADR-028/030 Phase 3 (#1420): `problemId → { plugin }` の map。 `discoverProblemsCoordination` で
+   * metadata.json の `interTeamCoordination.plugin` から自動収集。 CoordinationDispatcher Lambda の
+   * scope resolver が team→moduleRef を解決するのに使う。 未宣言の問題はキーが無い。
+   */
+  readonly problemsCoordination?: Readonly<Record<string, unknown>>;
+  /**
    * Issue #910 (#895 Phase 2.C.2.b): bulk batch deploy を Distributed Map 経路で実行するか
    * (= EventApiLambda の \`BULK_DEPLOY_VIA_DISTRIBUTED_MAP\` env で切替)。 default=false で
    * 旧 fan-out 経路を維持し、 deploy 後に true に切替えて Distributed Map に移行する。
@@ -467,6 +473,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
           deploymentsTable: deployments.table,
           eventsTable: events.table,
           environmentName: props.environmentName,
+          // ADR-030 Phase 3 config layer: 問題の coordination plugin path を scope resolver へ渡す。
+          problemsCoordination: props.problemsCoordination ?? {},
         },
       );
       new CfnOutput(this, "CoordinationDispatcherApiUrl", {

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -147,6 +147,27 @@ export function discoverProblemsVisibility(problemsRoot: string): Record<string,
 }
 
 /**
+ * [ADR-028 / ADR-030 Phase 3 / #1420] `{ [problemId]: { plugin } }` を返す。 problem が
+ * `interTeamCoordination.plugin` (= coordination plugin の module path) を宣言していれば収集する。
+ * CoordinationDispatcher Lambda の `PROBLEM_COORDINATION` env へ JSON 化して渡し、 scope resolver が
+ * team→moduleRef を解決するのに使う。 宣言の無い問題はキーごと不在 (= coordination 無効)。
+ */
+export function discoverProblemsCoordination(
+  problemsRoot: string,
+): Record<string, { readonly plugin: string }> {
+  const result: Record<string, { readonly plugin: string }> = {};
+  for (const meta of iterateProblemsMetadata(problemsRoot)) {
+    const coord = meta.interTeamCoordination;
+    if (!coord || typeof coord !== "object" || Array.isArray(coord)) continue;
+    const plugin = (coord as { plugin?: unknown }).plugin;
+    if (typeof plugin === "string" && plugin.length > 0) {
+      result[meta.id] = { plugin };
+    }
+  }
+  return result;
+}
+
+/**
  * Issue #888: 各 problem metadata.json から `disruptions[]` 宣言を抽出する。
  *
  * Lambda runtime に渡す形は `{ [problemId]: ProblemDisruptionEntry[] }`。 fire API が
@@ -285,6 +306,7 @@ interface ProblemMetadataEntry {
   phases: unknown;
   visibility: unknown;
   disruptions: unknown;
+  interTeamCoordination: unknown;
 }
 
 function* iterateProblemsMetadata(problemsRoot: string): Generator<ProblemMetadataEntry> {
@@ -321,6 +343,7 @@ function readProblemMetadata(
       phases?: unknown;
       visibility?: unknown;
       disruptions?: unknown;
+      interTeamCoordination?: unknown;
     };
     if (typeof meta.id !== "string" || meta.id.length === 0) {
       console.warn(`[discoverProblemsCatalog] ${metadataPath}: missing or invalid 'id' field`);
@@ -335,6 +358,7 @@ function readProblemMetadata(
       phases: meta.phases,
       visibility: meta.visibility,
       disruptions: meta.disruptions,
+      interTeamCoordination: meta.interTeamCoordination,
     };
   } catch (err) {
     console.warn(

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   discoverProblemsCatalog,
+  discoverProblemsCoordination,
   discoverProblemsDisruptions,
   discoverProblemsScoring,
   discoverProblemsVisibility,
@@ -223,5 +224,28 @@ describe("discoverProblemsDisruptions triggers[] (#1422)", () => {
       disruptions: [{ id: "d1", name: "n", eventDetailType: "X" }],
     });
     expect(discoverProblemsDisruptions(workspace)["plain-battle"]?.[0]?.triggers).toBeUndefined();
+  });
+});
+
+describe("discoverProblemsCoordination (ADR-028/030 Phase 3 #1420)", () => {
+  it("should collect interTeamCoordination.plugin per problem", () => {
+    writeProblem("battles", "router-battle", {
+      id: "router-battle",
+      interTeamCoordination: { plugin: "coordination/router.ts", name: "Router" },
+    });
+    expect(discoverProblemsCoordination(workspace)).toEqual({
+      "router-battle": { plugin: "coordination/router.ts" },
+    });
+  });
+
+  it("should omit problems without a valid coordination plugin path", () => {
+    writeProblem("challenges", "no-coord", { id: "no-coord" });
+    writeProblem("battles", "empty-plugin", { id: "empty-plugin", interTeamCoordination: {} });
+    writeProblem("battles", "non-string", {
+      id: "non-string",
+      interTeamCoordination: { plugin: 42 },
+    });
+    writeProblem("battles", "array-coord", { id: "array-coord", interTeamCoordination: [] });
+    expect(discoverProblemsCoordination(workspace)).toEqual({});
   });
 });

--- a/infrastructure/test/problem-deploy-backend-stack.test-helpers.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test-helpers.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { CoordinationDispatcherLambda } from "../lib/problem-deploy/coordination-dispatcher-lambda";
 import { ParticipantPortalLambda } from "../lib/problem-deploy/participant-portal-lambda";
 import { ProblemDeployBackendStack } from "../lib/problem-deploy/problem-deploy-backend-stack";
 
@@ -92,6 +93,30 @@ export function synthParticipantPortalLambdaOnly(): Template {
     endpointsTable: endpoints,
     problemsScoring: {},
     problemsEndpoints: {},
+    environmentName: "development",
+  });
+  return Template.fromStack(stack);
+}
+
+/**
+ * ADR-030 Phase 2 (#1420): CoordinationDispatcherLambda 単体 synth。 stack 全体 synth は
+ * ParticipantPortalHosting の dist asset を要求するため、 IAM (最小権限) / Function URL の検証は
+ * construct 単体で行う (= synthParticipantPortalLambdaOnly と同方針)。
+ */
+export function synthCoordinationDispatcherLambdaOnly(): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack");
+  const deployments = new cdk.aws_dynamodb.Table(stack, "Deployments", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  const events = new cdk.aws_dynamodb.Table(stack, "Events", {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  });
+  new CoordinationDispatcherLambda(stack, "CoordinationDispatcher", {
+    deploymentsTable: deployments,
+    eventsTable: events,
     environmentName: "development",
   });
   return Template.fromStack(stack);

--- a/infrastructure/test/problem-deploy/coordination-dispatcher-index.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-dispatcher-index.test.ts
@@ -1,0 +1,110 @@
+import { StatusCodes } from "http-status-codes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ADR-030 Phase 2 (#1420): 専用 CoordinationDispatcherLambda (coordination-dispatcher-handler) の
+ * route glue を pin する。 coordination-handler / shared を mock し、 op/projection の outcome→HTTP
+ * 写像 + bearer auth を検証する (= participant-handler から移設した route の挙動保存)。
+ */
+const mocks = vi.hoisted(() => ({
+  handleCoordinationOp: vi.fn(),
+  handleCoordinationProjection: vi.fn(),
+}));
+
+vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
+  buildParticipantSharedResources: () => ({
+    ddb: { send: vi.fn() },
+    tableName: "T",
+    eventsTableName: "",
+    endpointsTableName: "",
+    problemsScoring: {},
+    problemsEndpoints: {},
+  }),
+}));
+vi.mock("../../lib/problem-deploy/handlers/participant-handler/coordination-handler", () => ({
+  handleCoordinationOp: mocks.handleCoordinationOp,
+  handleCoordinationProjection: mocks.handleCoordinationProjection,
+  makeCoordinationScopeResolver: () => async () => null,
+  parseCoordinationConfig: () => ({}),
+}));
+
+const { app } = await import(
+  "../../lib/problem-deploy/handlers/coordination-dispatcher-handler/index"
+);
+
+const BASE_KEY = "AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQ"; // 43-char base64url
+let tokenSeq = 0;
+/** request 毎に unique な 43-char token を返し、 in-memory rate limiter の bucket を分ける。 */
+const auth = (): Record<string, string> => {
+  tokenSeq += 1;
+  const suffix = String(tokenSeq).padStart(5, "0");
+  return { authorization: `Bearer ${BASE_KEY.slice(0, 43 - suffix.length)}${suffix}` };
+};
+const get = (path: string) => app.request(path, { headers: auth() });
+const send = (method: string, path: string, body?: unknown) =>
+  app.request(path, {
+    method,
+    headers: { ...auth(), "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("coordination dispatcher healthz", () => {
+  it("should serve healthz", async () => {
+    const res = await app.request("/portal/healthz");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
+describe("POST /portal/me/coordination/op", () => {
+  const OP = "/portal/me/coordination/op";
+  it("should 401 without a bearer token", async () => {
+    expect((await app.request(OP, { method: "POST" })).status).toBe(StatusCodes.UNAUTHORIZED);
+  });
+  it("should 200 with the projection on ok", async () => {
+    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "ok", projection: { count: 1 } });
+    const res = await send("POST", OP, { op: { kind: "inc" } });
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ projection: { count: 1 } });
+  });
+  it("should 422 with the error on a plugin rejection", async () => {
+    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "rejected", error: "bad_op" });
+    const res = await send("POST", OP, { op: { kind: "bad" } });
+    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+    expect(await res.json()).toEqual({ error: "bad_op" });
+  });
+  it("should 409 on a write conflict", async () => {
+    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "conflict" });
+    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.CONFLICT);
+  });
+  it("should 503 when the plugin is unavailable (importer seam)", async () => {
+    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "unavailable" });
+    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
+  });
+  it("should 404 when coordination is not configured for the team", async () => {
+    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "not_configured" });
+    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.NOT_FOUND);
+  });
+});
+
+describe("GET /portal/me/coordination/projection", () => {
+  const PROJ = "/portal/me/coordination/projection";
+  it("should 401 without a bearer token", async () => {
+    expect((await app.request(PROJ)).status).toBe(StatusCodes.UNAUTHORIZED);
+  });
+  it("should 200 with the team projection", async () => {
+    mocks.handleCoordinationProjection.mockResolvedValueOnce({
+      kind: "ok",
+      projection: { allies: [] },
+    });
+    const res = await get(PROJ);
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ projection: { allies: [] } });
+  });
+  it("should 404 when coordination is not configured", async () => {
+    mocks.handleCoordinationProjection.mockResolvedValueOnce({ kind: "not_configured" });
+    expect((await get(PROJ)).status).toBe(StatusCodes.NOT_FOUND);
+  });
+});

--- a/infrastructure/test/problem-deploy/coordination-dispatcher-lambda.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-dispatcher-lambda.test.ts
@@ -1,0 +1,84 @@
+import { Match, type Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import {
+  SYNTH_TIMEOUT_MS,
+  synthCoordinationDispatcherLambdaOnly,
+} from "../problem-deploy-backend-stack.test-helpers";
+
+/**
+ * ADR-030 Phase 2 (#1420): 専用 CoordinationDispatcherLambda の最小 IAM 境界を pin する。
+ * 核心は「participant-portal Lambda が持つ sts:AssumeRole / ssm / kms を **継承しない**」こと
+ * (= 未信頼の問題同梱 plugin を将来 in-process 実行しても competitor 資格情報・ExternalId に
+ * 構造的に到達不能、 ADR-030 S2)。
+ */
+
+// Role の **inline 権限ポリシー** (= Properties.Policies) の action を集める。 trust policy
+// (AssumeRolePolicyDocument) は除外する (= 全 role が sts:AssumeRole を含むため、 権限境界の検証対象外)。
+function allActions(tpl: Template): string[] {
+  return Object.values(tpl.findResources("AWS::IAM::Role")).flatMap((r) => {
+    const policies =
+      (
+        r as {
+          Properties?: { Policies?: Array<{ PolicyDocument?: { Statement?: unknown[] } }> };
+        }
+      ).Properties?.Policies ?? [];
+    return policies.flatMap((p) =>
+      (p.PolicyDocument?.Statement ?? []).flatMap((s) => {
+        const a = (s as { Action?: string | string[] }).Action;
+        return Array.isArray(a) ? a : typeof a === "string" ? [a] : [];
+      }),
+    );
+  });
+}
+
+describe("CoordinationDispatcherLambda (ADR-030 Phase 2)", () => {
+  it(
+    "should provision a Node.js 22 / arm64 Lambda with a Function URL (AuthType=NONE)",
+    () => {
+      const tpl = synthCoordinationDispatcherLambdaOnly();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({ Runtime: "nodejs22.x", Architectures: ["arm64"] }),
+      );
+      tpl.hasResourceProperties("AWS::Lambda::Url", Match.objectLike({ AuthType: "NONE" }));
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "should pass the table-name env required by the shared builder",
+    () => {
+      const tpl = synthCoordinationDispatcherLambdaOnly();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              DEPLOYMENTS_TABLE_NAME: Match.anyValue(),
+              EVENTS_TABLE_NAME: Match.anyValue(),
+              DEPLOY_ENVIRONMENT: "development",
+            }),
+          }),
+        }),
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "should grant scoped DynamoDB access but NOT sts:AssumeRole / ssm / kms (ADR-030 S2)",
+    () => {
+      const tpl = synthCoordinationDispatcherLambdaOnly();
+      const actions = allActions(tpl);
+      // team-login-key 認証 (Query) + coordination state 行 (Get/Put) は持つ。
+      expect(actions).toContain("dynamodb:Query");
+      expect(actions).toContain("dynamodb:GetItem");
+      expect(actions).toContain("dynamodb:PutItem");
+      // competitor 資格情報・ExternalId への経路は **存在しない**。
+      expect(actions).not.toContain("sts:AssumeRole");
+      expect(actions).not.toContain("ssm:GetParameter");
+      expect(actions).not.toContain("kms:Decrypt");
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+});

--- a/infrastructure/test/problem-deploy/participant-handler-index.test.ts
+++ b/infrastructure/test/problem-deploy/participant-handler-index.test.ts
@@ -31,8 +31,6 @@ const mocks = vi.hoisted(() => ({
   listProblemEndpoints: vi.fn(),
   upsertProblemEndpointOverride: vi.fn(),
   deleteProblemEndpointOverride: vi.fn(),
-  handleCoordinationOp: vi.fn(),
-  handleCoordinationProjection: vi.fn(),
 }));
 
 vi.mock("../../lib/problem-deploy/handlers/participant-handler/shared", () => ({
@@ -85,15 +83,6 @@ vi.mock("../../lib/problem-deploy/handlers/participant-handler/battle-attacks", 
 vi.mock("../../lib/problem-deploy/handlers/participant-handler/deploy-logs", async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   getParticipantDeployLogs: mocks.getParticipantDeployLogs,
-}));
-
-// coordination-handler は handler 2 本だけ mock (= route glue を pin)。 makeCoordinationScopeResolver /
-// parseCoordinationConfig は index.ts の init で呼ばれるので無害な stub を返す (= resolver は未使用)。
-vi.mock("../../lib/problem-deploy/handlers/participant-handler/coordination-handler", () => ({
-  handleCoordinationOp: mocks.handleCoordinationOp,
-  handleCoordinationProjection: mocks.handleCoordinationProjection,
-  makeCoordinationScopeResolver: () => async () => null,
-  parseCoordinationConfig: () => ({}),
 }));
 
 const { app } = await import("../../lib/problem-deploy/handlers/participant-handler/index");
@@ -497,53 +486,15 @@ describe("DELETE /portal/me/problems/:problemId/endpoints/:slot", () => {
   });
 });
 
-describe("POST /portal/me/coordination/op", () => {
-  const OP = "/portal/me/coordination/op";
-  it("should 401 without a bearer token", async () => {
-    expect((await app.request(OP, { method: "POST" })).status).toBe(StatusCodes.UNAUTHORIZED);
+// ADR-030 Phase 2 (#1420): coordination の op/projection route は専用 CoordinationDispatcherLambda
+// (coordination-dispatcher-handler) へ分離した。 route glue の test は coordination-dispatcher-index.test.ts。
+describe("coordination routes are no longer served by the participant-portal Lambda (ADR-030 Phase 2)", () => {
+  it("should 404 POST /portal/me/coordination/op (moved to the dedicated dispatcher)", async () => {
+    expect((await send("POST", "/portal/me/coordination/op", { op: {} })).status).toBe(
+      StatusCodes.NOT_FOUND,
+    );
   });
-  it("should 200 with the projection on ok", async () => {
-    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "ok", projection: { count: 1 } });
-    const res = await send("POST", OP, { op: { kind: "inc" } });
-    expect(res.status).toBe(StatusCodes.OK);
-    expect(await res.json()).toEqual({ projection: { count: 1 } });
-  });
-  it("should 422 with the error on a plugin rejection", async () => {
-    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "rejected", error: "bad_op" });
-    const res = await send("POST", OP, { op: { kind: "bad" } });
-    expect(res.status).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
-    expect(await res.json()).toEqual({ error: "bad_op" });
-  });
-  it("should 409 on a write conflict", async () => {
-    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "conflict" });
-    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.CONFLICT);
-  });
-  it("should 503 when the plugin is unavailable (importer seam)", async () => {
-    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "unavailable" });
-    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
-  });
-  it("should 404 when coordination is not configured for the team", async () => {
-    mocks.handleCoordinationOp.mockResolvedValueOnce({ kind: "not_configured" });
-    expect((await send("POST", OP, { op: {} })).status).toBe(StatusCodes.NOT_FOUND);
-  });
-});
-
-describe("GET /portal/me/coordination/projection", () => {
-  const PROJ = "/portal/me/coordination/projection";
-  it("should 401 without a bearer token", async () => {
-    expect((await app.request(PROJ)).status).toBe(StatusCodes.UNAUTHORIZED);
-  });
-  it("should 200 with the team projection", async () => {
-    mocks.handleCoordinationProjection.mockResolvedValueOnce({
-      kind: "ok",
-      projection: { allies: [] },
-    });
-    const res = await get(PROJ);
-    expect(res.status).toBe(StatusCodes.OK);
-    expect(await res.json()).toEqual({ projection: { allies: [] } });
-  });
-  it("should 404 when coordination is not configured", async () => {
-    mocks.handleCoordinationProjection.mockResolvedValueOnce({ kind: "not_configured" });
-    expect((await get(PROJ)).status).toBe(StatusCodes.NOT_FOUND);
+  it("should 404 GET /portal/me/coordination/projection (moved to the dedicated dispatcher)", async () => {
+    expect((await get("/portal/me/coordination/projection")).status).toBe(StatusCodes.NOT_FOUND);
   });
 });


### PR DESCRIPTION
## Summary

inter-team coordination の op/projection route を、 participant-portal Lambda から**専用の最小 IAM Lambda** (`CoordinationDispatcher`) へ分離する (**ADR-030 Phase 2 / S2**)。

**背景**: participant-portal Lambda は AWS Console SSO / CLI 資格情報発行のため `sts:AssumeRole`(競技者 federation) + `ssm:GetParameter` + `kms:Decrypt`(ExternalId 復号) を持つ。 ここで未信頼の問題同梱 coordination plugin を将来 in-process 動的実行 (Phase 3) すると、 1 つの悪性 plugin が競技者アカウントの資格情報・全テナントデータに到達しうる (ADR-030 が指摘した blast radius)。

### 実装
- 新 handler `coordination-dispatcher-handler/index.ts`: healthz + POST/GET coordination route を既存 coordination-handler / route-helpers / schemas を再利用して mount。
- 新 construct `CoordinationDispatcherLambda`: **DDB の team-lookup (GSI2 Query) + coordination 行 (Get/Put) のみ**の最小 IAM。 `sts:AssumeRole` / `ssm` / `kms` は**付与しない**。 Function URL (AuthType=NONE, teamLoginKey bearer)。
- participant-portal Lambda から coordination route + deps を撤去 (= 高権限 Lambda で未信頼コードを扱わない)。 route glue test も専用 handler 側へ移設。
- 実 plugin import (S3 materialize) + `PROBLEM_COORDINATION` 配線は **ADR-030 Phase 3**。 未配線の現状は `not_configured` / `unavailable` で安全に応答する。

## Test plan
- 新規 `coordination-dispatcher-index.test.ts` (route glue 移設) + `coordination-dispatcher-lambda.test.ts` (**最小 IAM を CDK template で固定**: dynamodb:Query/GetItem/PutItem を持ち sts:AssumeRole / ssm / kms を**持たない**)
- infra **2363 test** green、 tsc / biome / `make harness`(error 0) / `cdk synth` / 全 gate pass

## Regression analysis
- coordination は frontend から未呼び出し (= backend-only の inert 機能) のため、 route の Lambda 移設で participant API / portal の挙動変化なし。 旧 participant route は 404 (= 専用 dispatcher Function URL へ移動、 Phase 4 で frontend wire)。
- 最小 IAM 境界を CDK template test で固定。 participant-handler の coordination 撤去は「404 になった」test + 移設先 route glue test で挙動保存。
- **注**: 末尾 1 commit は #1632 と同一の `BudgetConsumptionPanel` import 修正 (main の #1627×#1630 merge race 復旧)。 本 branch を緑にするため同梱。 両者 byte-identical なので merge 時に auto-resolve。

## Physical impact
- 新 Lambda 1 個 (`CoordinationDispatcher`) + Function URL + 最小 IAM Role → **CREATE** (participantPortal 有効時のみ)。
- participant-portal Lambda: coordination handler 分の bundle 縮小 → **UPDATE**。 IAM 不変。
- 既存 deployed resource の REPLACE/DELETE なし。

Relates #1420
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)