### PR TITLE
feat(coordination): ADR-030 Phase 3b dynamic plugin importer [#1420]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -142,6 +142,7 @@
         "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "dotenv": "^17.4.2",
+        "esbuild": "^0.27.7",
         "http-status-codes": "^2.3.0",
         "winston": "^3.19.0",
       },

--- a/infrastructure/bin/tenkacloud-lite.ts
+++ b/infrastructure/bin/tenkacloud-lite.ts
@@ -68,6 +68,10 @@ const problemDeployBackend = new ProblemDeployBackendStack(
     problemsDisruptions: (config.problems.disruptions ?? {}) as Readonly<Record<string, unknown>>,
     // #1420 ADR-030 Phase 3: Lite mode でも coordination plugin path を dispatcher へ渡す。
     problemsCoordination: (config.problems.coordination ?? {}) as Readonly<Record<string, unknown>>,
+    // #1420 ADR-030 Phase 3b: Lite mode でも synth-bundle 済み coordination plugin を S3 へ配置。
+    problemsCoordinationBundles: (config.problems.coordinationBundles ?? {}) as Readonly<
+      Record<string, string>
+    >,
     // Lite では participant portal を runtime-config "default-dev-mock" で立てる
     // (= portal Lambda + S3+CloudFront を持ち込む)。 frontend は backend mode で動く。
     participantPortal: { runtimeConfig: "default-dev-mock" },

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -8,6 +8,7 @@ import { getEnv } from "../helper-functions.js";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
 import { parseTenantAdminAllowlist } from "../tenant-template/saml-admin-allowlist.js";
 import { parseTenantSamlIdpConfig } from "../tenant-template/saml-identity-providers.js";
+import { bundleCoordinationPlugins } from "../utils/bundle-coordination-plugins.js";
 import { loadConfig } from "../utils/config-loader.js";
 import {
   discoverProblemsCatalog,
@@ -282,6 +283,8 @@ function discoverAppProblems(input: ResolveAppConfigInput): ProblemsCatalogBundl
     visibility: discoverProblemsVisibility(problemsRoot),
     disruptions: discoverProblemsDisruptions(problemsRoot),
     coordination: discoverProblemsCoordination(problemsRoot),
+    // ADR-030 Phase 3b: synth 時に coordination plugin を self-contained .mjs へ bundle (esbuild)。
+    coordinationBundles: bundleCoordinationPlugins(problemsRoot),
   };
 }
 

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -155,4 +155,6 @@ export interface ProblemsCatalogBundle {
   readonly disruptions: unknown;
   /** ADR-028/030 #1420: per-problem `interTeamCoordination.plugin` (= `{ [problemId]: { plugin } }`)。 未宣言はキー無し。 */
   readonly coordination: unknown;
+  /** ADR-030 Phase 3b #1420: `{ [problemId]: bundledMjs }` (= synth-bundle 済み coordination plugin)。 */
+  readonly coordinationBundles: unknown;
 }

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -124,6 +124,10 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
       problemsDisruptions: config.problems.disruptions as Readonly<Record<string, unknown>>,
       // #1420 ADR-030 Phase 3: per-problem coordination plugin path を dispatcher へ injection
       problemsCoordination: config.problems.coordination as Readonly<Record<string, unknown>>,
+      // #1420 ADR-030 Phase 3b: synth-bundle 済み coordination plugin (.mjs) を S3 へ配置
+      problemsCoordinationBundles: config.problems.coordinationBundles as Readonly<
+        Record<string, string>
+      >,
       ...(challengePayloadBucketName ? { challengePayloadBucketName } : {}),
       participantPortal: config.participantPortal as
         | { runtimeConfig: ParticipantPortalRuntimeConfig | "default-dev-mock" }

--- a/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
+++ b/infrastructure/lib/problem-deploy/coordination-dispatcher-lambda.ts
@@ -15,6 +15,7 @@ import {
   HttpMethod,
 } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import type { IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import {
   LAMBDA_NODEJS_BUNDLING_TARGET,
@@ -38,6 +39,12 @@ export interface CoordinationDispatcherLambdaProps {
    * 未宣言の問題はキー無し。 省略時は空 (= 全 route `not_configured`)。
    */
   readonly problemsCoordination?: Readonly<Record<string, unknown>>;
+  /**
+   * [ADR-030 Phase 3b / #1420] synth-bundle 済み coordination plugin (.mjs) を置く S3 bucket。
+   * dispatcher は `coordination/<problemId>.mjs` を runtime download → `import()` する。 read-only。
+   * 省略時は importer 未配線 → 全 route `unavailable`。
+   */
+  readonly pluginBucket?: IBucket;
 }
 
 /**
@@ -100,6 +107,10 @@ export class CoordinationDispatcherLambda extends Construct {
         // 共有 builder (buildParticipantSharedResources) の env 要件。 coordination では未使用。
         EVENTS_TABLE_NAME: props.eventsTable.tableName,
         DEPLOY_ENVIRONMENT: props.environmentName,
+        // ADR-030 Phase 3b: plugin .mjs を materialize する S3 bucket。 未指定なら importer 未配線。
+        ...(props.pluginBucket
+          ? { COORDINATION_PLUGIN_BUCKET: props.pluginBucket.bucketName }
+          : {}),
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -116,6 +127,10 @@ export class CoordinationDispatcherLambda extends Construct {
         },
       },
     });
+
+    // ADR-030 Phase 3b: plugin bundle bucket の read-only。 sts/ssm/kms は依然付与しないため、
+    // 動的 load した未信頼 plugin の到達範囲は coordination state 行 + 自身の bundle に限定される。
+    props.pluginBucket?.grantRead(this.fn);
 
     this.url = this.fn.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,

--- a/infrastructure/lib/problem-deploy/coordination-plugin-bundle.ts
+++ b/infrastructure/lib/problem-deploy/coordination-plugin-bundle.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { RemovalPolicy } from "aws-cdk-lib";
+import { BlockPublicAccess, Bucket, BucketEncryption, type IBucket } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+
+export interface CoordinationPluginBundleProps {
+  /**
+   * `{ [problemId]: bundledMjs }` (= `bundleCoordinationPlugins` の出力)。 各 problem の coordination
+   * plugin を SDK inline 済み self-contained ESM に bundle したもの。
+   */
+  readonly bundles: Readonly<Record<string, string>>;
+}
+
+/**
+ * ADR-030 Phase 3b (#1420): synth-bundle 済み coordination plugin を **専用 S3 bucket** に配置する。
+ *
+ * CoordinationDispatcher Lambda が runtime に `coordination/<problemId>.mjs` を download → `import()`
+ * する (= ADR-030 S1 の「レビュー済みカタログ bundle の動的 load」)。 bucket は private (BlockPublicAccess)
+ * + SSL 必須 + S3 managed 暗号化。 dispatcher 以外には読ませない (= S2 と合わせ未信頼コードの到達範囲を絞る)。
+ */
+export class CoordinationPluginBundle extends Construct {
+  public readonly bucket: IBucket;
+
+  constructor(scope: Construct, id: string, props: CoordinationPluginBundleProps) {
+    super(scope, id);
+
+    this.bucket = new Bucket(this, "Bucket", {
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      // plugin bundle は catalog から都度再生成できる派生物なので ephemeral で良い。
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    // synth で各 plugin の .mjs を staging dir に書き出し、 coordination/ prefix で upload。
+    const staging = mkdtempSync(path.join(tmpdir(), "coord-bundle-"));
+    const dest = path.join(staging, "coordination");
+    mkdirSync(dest, { recursive: true });
+    for (const [problemId, js] of Object.entries(props.bundles)) {
+      writeFileSync(path.join(dest, `${problemId}.mjs`), js);
+    }
+
+    new BucketDeployment(this, "Deploy", {
+      sources: [Source.asset(staging)],
+      destinationBucket: this.bucket,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
@@ -13,6 +13,7 @@ import { parseJsonBody, withBearerAuth } from "../participant-handler/route-help
 import { CoordinationOpBodySchema } from "../participant-handler/schemas.js";
 import { buildParticipantSharedResources } from "../participant-handler/shared.js";
 import { RATE_LIMITS } from "../shared/rate-limiter.js";
+import { defaultS3PluginImporter } from "./s3-plugin-importer.js";
 
 /**
  * ADR-030 Phase 2 (#1420): inter-team coordination dispatch を participant-portal Lambda から
@@ -24,13 +25,16 @@ import { RATE_LIMITS } from "../shared/rate-limiter.js";
  * 全テナントデータに到達しうる (ADR-030 S2 の脅威)。 本 Lambda は Deployments テーブルの
  * coordination / team-lookup 行しか触れない最小 IAM で動かし、 blast radius を IAM で構造的に縛る。
  *
- * importer は依然 seam (Phase 3 で レビュー済みカタログ bundle の S3 materialize を実装)。 未配線の
- * 間は load 不可 → `unavailable` / fallback projection で participant API を壊さない。
+ * ADR-030 Phase 3b: importer は `COORDINATION_PLUGIN_BUCKET` が配線されていれば S3 から
+ * synth-bundle 済み .mjs を materialize → `import()` する (= 最小 IAM 下での動的 load)。 未配線
+ * (= bucket env 空) なら reject し、 load 不可 → `unavailable` / fallback で participant API を壊さない。
  */
 const shared = buildParticipantSharedResources();
 
-const coordinationImporter: PluginImporter = (ref) =>
-  Promise.reject(new Error(`coordination plugin importer not configured: ${ref}`));
+const pluginBucket = process.env.COORDINATION_PLUGIN_BUCKET ?? "";
+const coordinationImporter: PluginImporter = pluginBucket
+  ? defaultS3PluginImporter(pluginBucket)
+  : (ref) => Promise.reject(new Error(`coordination plugin bucket not configured: ${ref}`));
 
 const coordinationDeps: CoordinationHandlerDeps = {
   importer: coordinationImporter,

--- a/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer.ts
+++ b/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type { PluginImporter } from "../participant-handler/coordination-plugin-loader.js";
+
+/**
+ * ADR-030 Phase 3b (#1420): coordination plugin の実 importer。
+ *
+ * 同 ADR が「動的 load の対象 = レビュー済みカタログ bundle (= S3)」(S1) と定めた通り、 問題が同梱した
+ * coordination plugin を **synth 時に esbuild で self-contained .mjs に bundle → S3 へ upload** したものを、
+ * dispatcher Lambda が runtime に download → `import()` する。 plugin が AWS SDK / fetch / 環境変数に
+ * 触れても本 Lambda は最小 IAM (ADR-030 S2、 PR #1633) で competitor 資格情報・他テナントデータに
+ * 構造的に到達できないため、 in-process 実行の blast radius は coordination state 行に限定される。
+ *
+ * `moduleRef` は problem id (= scope resolver が解決した一意キー)。 S3 key は `coordination/<id>.mjs`。
+ * 同 Lambda 実行内では module-level cache で再 download / 再 import を避ける (= plugin は event 中 immutable)。
+ */
+export interface S3PluginImporterDeps {
+  readonly s3: Pick<S3Client, "send">;
+  readonly bucket: string;
+}
+
+export function coordinationPluginS3Key(moduleRef: string): string {
+  return `coordination/${moduleRef}.mjs`;
+}
+
+/** 本番用 factory: 既定 S3Client を構築して importer を返す (= handler から SDK を直接触らせない seam)。 */
+export function defaultS3PluginImporter(bucket: string): PluginImporter {
+  return createS3PluginImporter({ s3: new S3Client({}), bucket });
+}
+
+export function createS3PluginImporter(deps: S3PluginImporterDeps): PluginImporter {
+  const cache = new Map<string, Promise<unknown>>();
+  return (moduleRef) => {
+    const cached = cache.get(moduleRef);
+    if (cached) return cached;
+    const loaded = loadFromS3(deps, moduleRef);
+    cache.set(moduleRef, loaded);
+    // download / import が失敗したら cache から外し、 次回 invoke で再試行できるようにする。
+    loaded.catch(() => cache.delete(moduleRef));
+    return loaded;
+  };
+}
+
+async function loadFromS3(deps: S3PluginImporterDeps, moduleRef: string): Promise<unknown> {
+  const out = await deps.s3.send(
+    new GetObjectCommand({ Bucket: deps.bucket, Key: coordinationPluginS3Key(moduleRef) }),
+  );
+  const body = await out.Body?.transformToString();
+  if (!body) throw new Error(`coordination plugin not found or empty: ${moduleRef}`);
+  // /tmp に書き出して file URL で dynamic import (ESM)。 unique dir で他 ref と衝突させない。
+  const dir = await mkdtemp(join(tmpdir(), "coord-plugin-"));
+  const file = join(dir, `${moduleRef}.mjs`);
+  await writeFile(file, body, "utf8");
+  return import(pathToFileURL(file).href);
+}

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-handler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/coordination-handler.ts
@@ -129,14 +129,17 @@ export function makeCoordinationScopeResolver(
   return async (teamLoginKey) => {
     const items = await queryTeamItems(shared, teamLoginKey);
     for (const item of items) {
-      const plugin = item.problemId ? config[item.problemId]?.plugin : undefined;
-      if (item.tenantId && item.eventId && item.teamId && plugin) {
+      const problemId = item.problemId;
+      const plugin = problemId ? config[problemId]?.plugin : undefined;
+      if (problemId && item.tenantId && item.eventId && item.teamId && plugin) {
         return {
           tenantId: item.tenantId,
           eventId: item.eventId,
           teamId: item.teamId,
           ctx: { eventId: item.eventId, teamIds: [item.teamId] },
-          moduleRef: plugin,
+          // ADR-030 Phase 3b: moduleRef は problemId (= importer の S3 key `coordination/<id>.mjs`)。
+          // plugin path は宣言の有無判定にのみ使い、 実 load は problemId-keyed bundle を引く。
+          moduleRef: problemId,
           fallbackProjection: {},
         };
       }

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -3,7 +3,7 @@ import { CfnOutput } from "aws-cdk-lib";
 import type { Table } from "aws-cdk-lib/aws-dynamodb";
 import { EventBus } from "aws-cdk-lib/aws-events";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
-import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
+import { BlockPublicAccess, Bucket, BucketEncryption, type IBucket } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
 import { AdminAuditLogTable } from "./admin-audit-log-table.js";
 import { BulkDeployCreateStateMachine } from "./bulk-deploy-create-state-machine.js";
@@ -11,6 +11,7 @@ import { CompetitorAccountsApiLambda } from "./competitor-accounts-api-lambda.js
 import { CompetitorAccountsTable } from "./competitor-accounts-table.js";
 import { CompetitorBootstrapHosting } from "./competitor-bootstrap-hosting.js";
 import { CoordinationDispatcherLambda } from "./coordination-dispatcher-lambda.js";
+import { CoordinationPluginBundle } from "./coordination-plugin-bundle.js";
 import { DeployApiLambda } from "./deploy-api-lambda.js";
 import { DeployCodeBuildProject } from "./deploy-codebuild-project.js";
 import { DeployCreateStateMachine } from "./deploy-create-state-machine.js";
@@ -99,6 +100,12 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * scope resolver が team→moduleRef を解決するのに使う。 未宣言の問題はキーが無い。
    */
   readonly problemsCoordination?: Readonly<Record<string, unknown>>;
+  /**
+   * ADR-030 Phase 3b (#1420): `problemId → bundledMjs`。 `bundleCoordinationPlugins` が synth 時に
+   * 各 coordination plugin を SDK inline 済み self-contained ESM に bundle したもの。 宣言問題がある時
+   * のみ専用 S3 bucket に配置し、 dispatcher が runtime に import() する。 未宣言なら空。
+   */
+  readonly problemsCoordinationBundles?: Readonly<Record<string, string>>;
   /**
    * Issue #910 (#895 Phase 2.C.2.b): bulk batch deploy を Distributed Map 経路で実行するか
    * (= EventApiLambda の \`BULK_DEPLOY_VIA_DISTRIBUTED_MAP\` env で切替)。 default=false で
@@ -464,8 +471,14 @@ export class ProblemDeployBackendStack extends cdk.Stack {
 
       // ADR-030 Phase 2 (#1420): inter-team coordination dispatch を participant-portal Lambda
       // (sts:AssumeRole / ssm / kms 保持) から分離し、 coordination state 行しか触れない最小 IAM の
-      // 専用 Lambda で動かす。 未信頼の問題同梱 plugin を将来 in-process 実行しても competitor
-      // 資格情報・他テナントデータに到達できない (ADR-030 S2)。 plugin の実 import は Phase 3 の seam。
+      // 専用 Lambda で動かす。 未信頼の問題同梱 plugin を in-process 実行しても competitor 資格情報・
+      // 他テナントデータに到達できない (ADR-030 S2)。
+      // Phase 3b: coordination plugin を宣言した問題があれば、 synth-bundle 済み .mjs を専用 S3 bucket に
+      // 配置し、 dispatcher が runtime に download → import() する (= S1 動的 load)。 0 件なら bucket 不要。
+      const coordinationBucket = coordinationPluginBucket(
+        this,
+        (props.problemsCoordinationBundles ?? {}) as Record<string, string>,
+      );
       const coordinationDispatcher = new CoordinationDispatcherLambda(
         this,
         "CoordinationDispatcher",
@@ -475,6 +488,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
           environmentName: props.environmentName,
           // ADR-030 Phase 3 config layer: 問題の coordination plugin path を scope resolver へ渡す。
           problemsCoordination: props.problemsCoordination ?? {},
+          // ADR-030 Phase 3b: plugin .mjs を materialize する S3 bucket (宣言問題がある時のみ)。
+          ...(coordinationBucket ? { pluginBucket: coordinationBucket } : {}),
         },
       );
       new CfnOutput(this, "CoordinationDispatcherApiUrl", {
@@ -527,4 +542,17 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         "ADR-012 Phase 3.A Endpoint registry table 名 (per (tenant, team, problem, slot) の override 行)。",
     });
   }
+}
+
+/**
+ * #1420 ADR-030 Phase 3b: coordination plugin を宣言した問題がある時だけ bundle bucket を作る
+ * (= 0 件なら undefined を返し、 dispatcher は importer 未配線で全 route not_configured)。
+ * constructor から分離して認知的複雑度を抑える。
+ */
+function coordinationPluginBucket(
+  scope: Construct,
+  bundles: Record<string, string>,
+): IBucket | undefined {
+  if (Object.keys(bundles).length === 0) return undefined;
+  return new CoordinationPluginBundle(scope, "CoordinationPluginBundle", { bundles }).bucket;
 }

--- a/infrastructure/lib/utils/bundle-coordination-plugins.ts
+++ b/infrastructure/lib/utils/bundle-coordination-plugins.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { buildSync } from "esbuild";
+import {
+  discoverProblemsCatalog,
+  discoverProblemsCoordination,
+} from "./discover-problems-catalog.js";
+
+/**
+ * ADR-030 Phase 3b (#1420): synth 時に各問題の coordination plugin を **self-contained ESM .mjs** に
+ * bundle する。 plugin が import する `@tenkacloud/coordination-plugin-sdk` を inline し、 dispatcher
+ * Lambda が S3 から download → `import()` するだけで実行できる形にする (= 動的 load、 platform 再
+ * デプロイ不要、 ADR-030 S1)。
+ *
+ * 返り値は `{ [problemId]: bundledJs }`。 CoordinationPluginBundle 構築子が staging dir に書き出し
+ * BucketDeployment で S3 へ上げる。 bundle 失敗 (= plugin の構文/依存エラー) は throw して synth を
+ * 止める (= 壊れた plugin を catalog に載せたまま deploy させない)。
+ */
+export function bundleCoordinationPlugins(problemsRoot: string): Record<string, string> {
+  const catalog = discoverProblemsCatalog(problemsRoot);
+  const coordination = discoverProblemsCoordination(problemsRoot);
+  const out: Record<string, string> = {};
+  for (const [problemId, { plugin }] of Object.entries(coordination)) {
+    const dir = catalog[problemId];
+    if (!dir) continue;
+    // discoverProblemsCatalog は repo-root 相対の `problems/<category>/<dir>` を返すため、
+    // 先頭の `problems/` を外して problemsRoot 配下へ join する (= problemsRoot の basename 非依存)。
+    const relToRoot = dir.replace(/^problems\//, "");
+    const entry = join(problemsRoot, relToRoot, plugin);
+    if (!existsSync(entry)) continue;
+    const result = buildSync({
+      entryPoints: [entry],
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      // 純 reducer 規約 (ADR-030 S3、 validate-problems で enforce 済) のため外部依存は SDK のみ。
+      // SDK を inline して self-contained にする (= Lambda の module graph に依存しない)。
+      write: false,
+      logLevel: "silent",
+      legalComments: "none",
+    });
+    out[problemId] = result.outputFiles[0].text;
+  }
+  return out;
+}

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -60,6 +60,7 @@
     "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "dotenv": "^17.4.2",
+    "esbuild": "^0.27.7",
     "http-status-codes": "^2.3.0",
     "winston": "^3.19.0"
   }

--- a/infrastructure/test/problem-deploy/bundle-coordination-plugins.test.ts
+++ b/infrastructure/test/problem-deploy/bundle-coordination-plugins.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bundleCoordinationPlugins } from "../../lib/utils/bundle-coordination-plugins";
+
+/**
+ * ADR-030 Phase 3b (#1420): synth 時の coordination plugin bundler。 SDK 解決を要しない
+ * self-contained plugin で iteration + esbuild 出力を pin する (= 実 SDK inline は s3-plugin-importer
+ * 側 + reference 問題で検証)。
+ */
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "bundle-test-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function writeProblem(category: string, dir: string, body: object, pluginSrc?: string): void {
+  const pdir = join(root, category, dir);
+  mkdirSync(join(pdir, "coordination"), { recursive: true });
+  writeFileSync(join(pdir, "metadata.json"), JSON.stringify(body));
+  if (pluginSrc !== undefined) writeFileSync(join(pdir, "coordination", "router.ts"), pluginSrc);
+}
+
+describe("bundleCoordinationPlugins", () => {
+  it("should esbuild-bundle a declared plugin into self-contained ESM keyed by problemId", () => {
+    writeProblem(
+      "battles",
+      "router-battle",
+      { id: "router-battle", interTeamCoordination: { plugin: "coordination/router.ts" } },
+      "const p = { initialState: () => ({}), validateOp: () => ({ ok: true }), applyOp: (s) => s, projectForTeam: (s) => s };\nexport default p;\n",
+    );
+    const out = bundleCoordinationPlugins(root);
+    expect(Object.keys(out)).toEqual(["router-battle"]);
+    expect(out["router-battle"]).toContain("export");
+    expect(out["router-battle"]).toContain("validateOp");
+  });
+
+  it("should omit problems that do not declare coordination", () => {
+    writeProblem("challenges", "plain", { id: "plain" });
+    expect(bundleCoordinationPlugins(root)).toEqual({});
+  });
+
+  it("should skip a declared plugin whose file is missing (no throw)", () => {
+    writeProblem("battles", "ghost", {
+      id: "ghost",
+      interTeamCoordination: { plugin: "coordination/router.ts" },
+    });
+    rmSync(join(root, "battles", "ghost", "coordination", "router.ts"), { force: true });
+    expect(bundleCoordinationPlugins(root)).toEqual({});
+  });
+});

--- a/infrastructure/test/problem-deploy/coordination-handler.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-handler.test.ts
@@ -156,7 +156,8 @@ describe("makeCoordinationScopeResolver", () => {
       eventId: "e1",
       teamId: "t1",
       ctx: { eventId: "e1", teamIds: ["t1"] },
-      moduleRef: "coordination/alliance.ts",
+      // ADR-030 Phase 3b: moduleRef は problemId (= importer の S3 key `coordination/<id>.mjs`)。
+      moduleRef: "p1",
       fallbackProjection: {},
     });
   });

--- a/infrastructure/test/problem-deploy/coordination-plugin-bundle.test.ts
+++ b/infrastructure/test/problem-deploy/coordination-plugin-bundle.test.ts
@@ -1,0 +1,100 @@
+import * as cdk from "aws-cdk-lib";
+import { Match, type Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { CoordinationDispatcherLambda } from "../../lib/problem-deploy/coordination-dispatcher-lambda";
+import { CoordinationPluginBundle } from "../../lib/problem-deploy/coordination-plugin-bundle";
+import { SYNTH_TIMEOUT_MS } from "../problem-deploy-backend-stack.test-helpers";
+
+const SAMPLE_PLUGIN =
+  "export default { initialState: () => ({}), validateOp: () => ({ ok: true }), " +
+  "applyOp: (s) => s, projectForTeam: (s) => s };\n";
+
+function synthBundle(): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack");
+  new CoordinationPluginBundle(stack, "Bundle", { bundles: { p1: SAMPLE_PLUGIN } });
+  return cdk.assertions.Template.fromStack(stack);
+}
+
+function synthDispatcherWithBucket(): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "TestStack");
+  const tableProps = {
+    partitionKey: { name: "PK", type: cdk.aws_dynamodb.AttributeType.STRING },
+    sortKey: { name: "SK", type: cdk.aws_dynamodb.AttributeType.STRING },
+  };
+  const deployments = new cdk.aws_dynamodb.Table(stack, "Deployments", tableProps);
+  const events = new cdk.aws_dynamodb.Table(stack, "Events", tableProps);
+  const bucket = new cdk.aws_s3.Bucket(stack, "PluginBucket");
+  new CoordinationDispatcherLambda(stack, "Dispatcher", {
+    deploymentsTable: deployments,
+    eventsTable: events,
+    environmentName: "development",
+    pluginBucket: bucket,
+  });
+  return cdk.assertions.Template.fromStack(stack);
+}
+
+// Role の inline Policies (= Properties.Policies) と grantRead が足す AWS::IAM::Policy の双方から
+// action を集める (trust policy は除外)。
+function allActions(tpl: Template): string[] {
+  const fromRoles = Object.values(tpl.findResources("AWS::IAM::Role")).flatMap((r) =>
+    (
+      (r as { Properties?: { Policies?: Array<{ PolicyDocument?: { Statement?: unknown[] } }> } })
+        .Properties?.Policies ?? []
+    ).flatMap((p) => p.PolicyDocument?.Statement ?? []),
+  );
+  const fromPolicies = Object.values(tpl.findResources("AWS::IAM::Policy")).flatMap(
+    (p) =>
+      (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } }).Properties
+        ?.PolicyDocument?.Statement ?? [],
+  );
+  return [...fromRoles, ...fromPolicies].flatMap((s) => {
+    const a = (s as { Action?: string | string[] }).Action;
+    return Array.isArray(a) ? a : typeof a === "string" ? [a] : [];
+  });
+}
+
+describe("CoordinationPluginBundle (ADR-030 Phase 3b)", () => {
+  it(
+    "should provision a private S3 bucket and a BucketDeployment",
+    () => {
+      const tpl = synthBundle();
+      tpl.hasResourceProperties(
+        "AWS::S3::Bucket",
+        Match.objectLike({
+          PublicAccessBlockConfiguration: Match.objectLike({ BlockPublicAcls: true }),
+        }),
+      );
+      // BucketDeployment は Custom::CDKBucketDeployment custom resource を出す。
+      expect(Object.keys(tpl.findResources("Custom::CDKBucketDeployment")).length).toBeGreaterThan(
+        0,
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+});
+
+describe("CoordinationDispatcherLambda with pluginBucket (ADR-030 Phase 3b)", () => {
+  it(
+    "should set COORDINATION_PLUGIN_BUCKET env + grant S3 read, still WITHOUT sts/ssm/kms",
+    () => {
+      const tpl = synthDispatcherWithBucket();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({ COORDINATION_PLUGIN_BUCKET: Match.anyValue() }),
+          }),
+        }),
+      );
+      const actions = allActions(tpl);
+      expect(actions.some((a) => a.startsWith("s3:Get"))).toBe(true);
+      expect(actions).toContain("dynamodb:Query");
+      expect(actions).not.toContain("sts:AssumeRole");
+      expect(actions).not.toContain("ssm:GetParameter");
+      expect(actions).not.toContain("kms:Decrypt");
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+});

--- a/infrastructure/test/problem-deploy/s3-plugin-importer.test.ts
+++ b/infrastructure/test/problem-deploy/s3-plugin-importer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  coordinationPluginS3Key,
+  createS3PluginImporter,
+} from "../../lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer";
+import { loadCoordinationPlugin } from "../../lib/problem-deploy/handlers/participant-handler/coordination-plugin-loader";
+
+/**
+ * ADR-030 Phase 3b (#1420): S3 plugin importer。 mock S3 が返す self-contained .mjs を /tmp に
+ * 書き出して dynamic import し、 純 reducer の contract を満たすことを e2e で pin する。
+ */
+const PLUGIN_JS =
+  "export default { initialState: () => ({ count: 0 }), " +
+  "validateOp: () => ({ ok: true }), applyOp: (s) => s, projectForTeam: (s) => s };\n";
+
+function mockS3(body: string | undefined) {
+  return {
+    send: vi
+      .fn()
+      .mockResolvedValue(
+        body === undefined ? {} : { Body: { transformToString: async () => body } },
+      ),
+  };
+}
+
+describe("coordinationPluginS3Key", () => {
+  it("should key by coordination/<moduleRef>.mjs", () => {
+    expect(coordinationPluginS3Key("ms-battle")).toBe("coordination/ms-battle.mjs");
+  });
+});
+
+describe("createS3PluginImporter", () => {
+  it("should download, write, and dynamically import a valid plugin", async () => {
+    const s3 = mockS3(PLUGIN_JS);
+    const importer = createS3PluginImporter({ s3, bucket: "B" });
+    const plugin = await loadCoordinationPlugin(importer, "ms-battle");
+    expect(plugin).not.toBeNull();
+    expect(typeof plugin?.initialState).toBe("function");
+    const cmd = s3.send.mock.calls[0][0] as { input: { Bucket: string; Key: string } };
+    expect(cmd.input).toMatchObject({ Bucket: "B", Key: "coordination/ms-battle.mjs" });
+  });
+
+  it("should cache per moduleRef (no re-download on a warm invoke)", async () => {
+    const s3 = mockS3(PLUGIN_JS);
+    const importer = createS3PluginImporter({ s3, bucket: "B" });
+    await importer("p1");
+    await importer("p1");
+    expect(s3.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw and evict the cache when the object is empty (next invoke retries)", async () => {
+    const s3 = mockS3("");
+    const importer = createS3PluginImporter({ s3, bucket: "B" });
+    await expect(importer("p1")).rejects.toThrow(/not found or empty/);
+    await expect(importer("p1")).rejects.toThrow();
+    expect(s3.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("should throw when S3 returns no Body", async () => {
+    const s3 = mockS3(undefined);
+    const importer = createS3PluginImporter({ s3, bucket: "B" });
+    await expect(importer("p1")).rejects.toThrow(/not found or empty/);
+  });
+});


### PR DESCRIPTION
## Summary

**#1420 完了。** coordination plugin を S3 から runtime に動的 `import()` する実 importer + synth-time transpile/upload pipeline を実装し、 dispatcher の seam に差す。 これで reference 問題 (`microservice-migration-battle`) の inter-team interaction が **end-to-end** で動く。

ADR-030 の三層防御が全層 landed:
- **S1** (レビュー済みカタログ / pure-reducer 監査): `validate-problems` で機械 enforce (#1634)
- **S2** (最小 IAM dispatcher): coordination は競技者資格情報を持たない専用 Lambda (#1633)
- **S3** (純 reducer 契約): SDK contract + `safeProjectForTeam` fail-safe (既存)

### 実装
- `bundle-coordination-plugins.ts`: synth 時に各 plugin を esbuild で **SDK inline 済み self-contained ESM .mjs** に bundle（動的 load 用、platform 再デプロイ不要）。
- `coordination-plugin-bundle.ts` (CDK): bundle を private S3 bucket に `BucketDeployment` で配置。
- `s3-plugin-importer.ts`: dispatcher が `coordination/<problemId>.mjs` を download → /tmp → `import()` → 契約検証。 module-level cache、 失敗は evict。
- dispatcher: `COORDINATION_PLUGIN_BUCKET` 配線時に実 importer を使い S3 read IAM を付与（**sts/ssm/kms は依然なし = S2 維持**）。 scope resolver の `moduleRef` を problemId に変更（一意 S3 key）。
- `esbuild` を直接依存に追加（transitive で既に baseline 済 → audit 差分なし）。
- config 配線（resolveAppConfig → wire.ts / tenkacloud-lite.ts → backend stack）。 宣言問題 0 件なら bucket 不要。

## Test plan
- `s3-plugin-importer.test.ts`: mock S3 が返す実 .mjs を /tmp で dynamic import → 契約検証（cache / evict / 空 body も）
- `bundle-coordination-plugins.test.ts`: esbuild bundle の iteration + 出力（+ reference 問題で SDK inline 検証済み）
- `coordination-plugin-bundle.test.ts` (CDK): private bucket + BucketDeployment、 dispatcher の `COORDINATION_PLUGIN_BUCKET` env + S3 read かつ **sts/ssm/kms 無し**
- infra 全 **2375 test** green、 tsc / biome / `make harness`(error 0) / **`cdk synth`**(実 esbuild bundle + BucketDeployment) / 全 gate pass

## Regression analysis
- coordination は frontend 未呼び出しの inert 機能。 宣言問題が無い deploy では bundle bucket を作らず（→ not_configured）、 既存挙動・CFn 差分なし。
- `moduleRef` を plugin path → problemId に変更（S3 key 一意性）。 resolver 単体 test 更新。
- S2 不変: S3 read を足すが sts/ssm/kms は付与しない（CDK template test で固定）。 未信頼 plugin の到達範囲は coordination state 行 + 自 bundle のみ。

## Physical impact
- `CoordinationPluginBundle`: private S3 Bucket + BucketDeployment（custom resource）→ **CREATE**（coordination 宣言問題がある時のみ。 reference 1 件）。
- `CoordinationDispatcher` Lambda: `COORDINATION_PLUGIN_BUCKET` env + S3 read IAM + handler bundle 差分 → **UPDATE**。
- 既存 deployed resource の REPLACE/DELETE なし。

Relates #1420 (backend e2e 完了。 残り = competitor-facing portal UI: dispatcher URL を runtime-config に載せ、 reference 問題の portal slot から coordination API を叩く frontend + submodule slice)
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)