### PR TITLE
feat(portal): coordination API client + dispatcher URL wiring [#1420]

### DIFF
--- a/apps/participant-portal/src/api/coordination-client.ts
+++ b/apps/participant-portal/src/api/coordination-client.ts
@@ -1,0 +1,73 @@
+import { StatusCodes } from "http-status-codes";
+
+/**
+ * ADR-028/030 (#1420): 参加者間 coordination の op 提出 / projection polling client。
+ *
+ * coordination は専用 dispatcher Lambda (= `coordinationApiUrl`、 最小 IAM、 ADR-030 S2) が host する。
+ * portal slot (= 問題が同梱する UI) がこの client で op を送り、 自チーム向け projection を polling する。
+ * backend の {@link CoordinationHandlerOutcome} に対応する discriminated union を返し、 caller (slot)
+ * が `kind` で分岐する。 polling 方針は AGENTS.md (SSE 不使用) に従い、 呼び出し側 setInterval で行う。
+ */
+export type CoordinationOutcome =
+  | { readonly kind: "ok"; readonly projection: unknown }
+  | { readonly kind: "rejected"; readonly error: string }
+  | { readonly kind: "conflict" }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "not_configured" }
+  | { readonly kind: "unauthorized" };
+
+function coordinationUrl(base: string, path: string): string {
+  const root = base.endsWith("/") ? base : `${base}/`;
+  return new URL(path, root).toString();
+}
+
+async function mapResponse(res: Response): Promise<CoordinationOutcome> {
+  switch (res.status) {
+    case StatusCodes.OK: {
+      const body = (await res.json()) as { projection?: unknown };
+      return { kind: "ok", projection: body.projection };
+    }
+    case StatusCodes.UNPROCESSABLE_ENTITY: {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      return { kind: "rejected", error: body.error ?? "rejected" };
+    }
+    case StatusCodes.CONFLICT:
+      return { kind: "conflict" };
+    case StatusCodes.SERVICE_UNAVAILABLE:
+      return { kind: "unavailable" };
+    case StatusCodes.UNAUTHORIZED:
+      return { kind: "unauthorized" };
+    default:
+      // 404 (= coordination 未宣言) その他は not_configured に倒し、 slot は通常表示にフォールバック。
+      return { kind: "not_configured" };
+  }
+}
+
+/** team の op を提出し、 適用後の projection を返す (= write 経路)。 */
+export async function submitCoordinationOp(
+  coordinationApiUrl: string,
+  teamLoginKey: string,
+  op: unknown,
+  signal?: AbortSignal,
+): Promise<CoordinationOutcome> {
+  const res = await fetch(coordinationUrl(coordinationApiUrl, "portal/me/coordination/op"), {
+    method: "POST",
+    headers: { authorization: `Bearer ${teamLoginKey}`, "content-type": "application/json" },
+    body: JSON.stringify({ op }),
+    signal,
+  });
+  return mapResponse(res);
+}
+
+/** 自チームの現在 projection を読む (= 書き込みなし、 polling 用)。 */
+export async function getCoordinationProjection(
+  coordinationApiUrl: string,
+  teamLoginKey: string,
+  signal?: AbortSignal,
+): Promise<CoordinationOutcome> {
+  const res = await fetch(
+    coordinationUrl(coordinationApiUrl, "portal/me/coordination/projection"),
+    { headers: { authorization: `Bearer ${teamLoginKey}` }, signal },
+  );
+  return mapResponse(res);
+}

--- a/apps/participant-portal/src/config.ts
+++ b/apps/participant-portal/src/config.ts
@@ -22,6 +22,11 @@ export interface AppConfig {
   readonly mode: AppMode;
   readonly cloudMode: CloudMode;
   readonly localstackEndpoint?: string;
+  /**
+   * ADR-028/030 (#1420): 参加者間 coordination dispatcher (専用 Lambda) の Function URL。
+   * 未配線 (= coordination 無効 / 旧 deploy) なら undefined。 portal slot が coordination-client で叩く。
+   */
+  readonly coordinationApiUrl?: string;
 }
 
 interface RuntimeConfig {
@@ -31,6 +36,7 @@ interface RuntimeConfig {
   readonly mode?: AppMode;
   readonly cloudMode?: CloudMode;
   readonly localstackEndpoint?: string;
+  readonly coordinationApiUrl?: string;
 }
 
 const DEV_FALLBACK: AppConfig = {
@@ -110,6 +116,12 @@ export async function loadConfig(): Promise<AppConfig> {
       });
       return DEV_FALLBACK;
     }
+    // #1420: coordination dispatcher URL も backend mode では HTTPS 必須 (= teamLoginKey 漏洩防止)。
+    // 非 HTTPS なら coordination だけ無効化し (= undefined)、 portal 本体は通常起動させる。
+    const coordinationApiUrl =
+      runtime.coordinationApiUrl && (mode !== "backend" || isHttpsUrl(runtime.coordinationApiUrl))
+        ? runtime.coordinationApiUrl
+        : undefined;
     return {
       apiBaseUrl,
       eventTitle: runtime.eventTitle ?? DEV_FALLBACK.eventTitle,
@@ -120,6 +132,7 @@ export async function loadConfig(): Promise<AppConfig> {
         cloudMode === "localstack"
           ? normalizeLocalstackEndpoint(runtime.localstackEndpoint)
           : undefined,
+      ...(coordinationApiUrl ? { coordinationApiUrl } : {}),
     };
   } catch {
     return DEV_FALLBACK;

--- a/apps/participant-portal/test/api/coordination-client.test.ts
+++ b/apps/participant-portal/test/api/coordination-client.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCoordinationProjection, submitCoordinationOp } from "../../src/api/coordination-client";
+
+/**
+ * #1420: coordination-client。 dispatcher の各 HTTP status を CoordinationOutcome へ写す mapping と、
+ * op (POST) / projection (GET) の URL / bearer / body を pin する。
+ */
+const URL_BASE = "https://coord.example.com";
+
+function mockFetch(status: number, body?: unknown) {
+  return vi.fn().mockResolvedValue({
+    status,
+    json: async () => body ?? {},
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch(200, { projection: { count: 1 } }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("submitCoordinationOp", () => {
+  it("should POST the op with bearer auth and return the projection on 200", async () => {
+    const f = mockFetch(200, { projection: { allies: ["t2"] } });
+    vi.stubGlobal("fetch", f);
+    const out = await submitCoordinationOp(URL_BASE, "key-1", { kind: "ally" });
+    expect(out).toEqual({ kind: "ok", projection: { allies: ["t2"] } });
+    const [url, init] = f.mock.calls[0];
+    expect(String(url)).toBe("https://coord.example.com/portal/me/coordination/op");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).headers).toMatchObject({ authorization: "Bearer key-1" });
+    expect((init as RequestInit).body).toBe(JSON.stringify({ op: { kind: "ally" } }));
+  });
+
+  it("should map 422 to rejected with the backend error", async () => {
+    vi.stubGlobal("fetch", mockFetch(422, { error: "bad_op" }));
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({
+      kind: "rejected",
+      error: "bad_op",
+    });
+  });
+
+  it("should map 422 to rejected with a default when the body has no error / is unreadable", async () => {
+    vi.stubGlobal("fetch", {
+      // body 読み取り失敗 → catch → {} → error ?? "rejected"
+      ...mockFetch(422),
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 422,
+        json: async () => {
+          throw new Error("bad json");
+        },
+      }),
+    );
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({
+      kind: "rejected",
+      error: "rejected",
+    });
+  });
+
+  it("should map 409 to conflict", async () => {
+    vi.stubGlobal("fetch", mockFetch(409));
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({ kind: "conflict" });
+  });
+
+  it("should map 503 to unavailable", async () => {
+    vi.stubGlobal("fetch", mockFetch(503));
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({ kind: "unavailable" });
+  });
+
+  it("should map 401 to unauthorized", async () => {
+    vi.stubGlobal("fetch", mockFetch(401));
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({ kind: "unauthorized" });
+  });
+
+  it("should map 404 (and other statuses) to not_configured", async () => {
+    vi.stubGlobal("fetch", mockFetch(404));
+    expect(await submitCoordinationOp(URL_BASE, "k", {})).toEqual({ kind: "not_configured" });
+  });
+});
+
+describe("getCoordinationProjection", () => {
+  it("should GET the projection with bearer auth and normalize a trailing-slash base", async () => {
+    const f = mockFetch(200, { projection: { count: 3 } });
+    vi.stubGlobal("fetch", f);
+    const out = await getCoordinationProjection("https://coord.example.com/", "key-2");
+    expect(out).toEqual({ kind: "ok", projection: { count: 3 } });
+    const [url, init] = f.mock.calls[0];
+    expect(String(url)).toBe("https://coord.example.com/portal/me/coordination/projection");
+    expect((init as RequestInit).headers).toMatchObject({ authorization: "Bearer key-2" });
+    expect((init as RequestInit).method ?? "GET").toBe("GET");
+  });
+
+  it("should map not_configured (404) for a team whose problem declares no coordination", async () => {
+    vi.stubGlobal("fetch", mockFetch(404));
+    expect(await getCoordinationProjection(URL_BASE, "k")).toEqual({ kind: "not_configured" });
+  });
+});

--- a/apps/participant-portal/test/config.test.ts
+++ b/apps/participant-portal/test/config.test.ts
@@ -175,4 +175,47 @@ describe("loadConfig", () => {
     expect(cfg.mode).toBe("dev-mock");
     expect(cfg.eventTitle).toBe("No-API Event");
   });
+
+  // #1420: coordination dispatcher URL の parse + HTTPS gate。
+  it("should carry an HTTPS coordinationApiUrl in backend mode", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        mode: "backend",
+        coordinationApiUrl: "https://coord.example.com",
+      }),
+    });
+    expect((await loadConfig()).coordinationApiUrl).toBe("https://coord.example.com");
+  });
+
+  it("should drop a non-HTTPS coordinationApiUrl in backend mode but keep the portal usable", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        apiBaseUrl: "https://api.example.com",
+        mode: "backend",
+        coordinationApiUrl: "http://coord.example.com",
+      }),
+    });
+    const cfg = await loadConfig();
+    expect(cfg.coordinationApiUrl).toBeUndefined();
+    expect(cfg.apiBaseUrl).toBe("https://api.example.com");
+  });
+
+  it("should allow a non-HTTPS coordinationApiUrl in dev-mock mode", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ mode: "dev-mock", coordinationApiUrl: "http://localhost:9100" }),
+    });
+    expect((await loadConfig()).coordinationApiUrl).toBe("http://localhost:9100");
+  });
+
+  it("should leave coordinationApiUrl undefined when the key is omitted", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ apiBaseUrl: "https://api.example.com", mode: "backend" }),
+    });
+    expect((await loadConfig()).coordinationApiUrl).toBeUndefined();
+  });
 });

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -27,6 +27,11 @@ export interface ParticipantPortalRuntimeConfig {
    * "dev-mock": frontend 単体動作 (auth 偽装)。"backend": 実 backend を呼ぶ。
    */
   readonly mode: ParticipantPortalMode;
+  /**
+   * ADR-028/030 (#1420): 参加者間 coordination dispatcher の Function URL。 portal slot が
+   * coordination-client で叩く。 未配線なら省略 (= coordination 無効)。
+   */
+  readonly coordinationApiUrl?: string;
 }
 
 const DEFAULT_DEV_MOCK_RUNTIME_CONFIG = (region: string): ParticipantPortalRuntimeConfig => ({
@@ -124,6 +129,10 @@ export class ParticipantPortalHosting extends Construct {
           eventTitle: config.eventTitle,
           eventRegion: config.eventRegion,
           mode: config.mode,
+          // #1420: coordination dispatcher URL (= 専用 Lambda)。 未配線なら key を出さない。
+          ...(config.coordinationApiUrl
+            ? { coordinationApiUrl: config.coordinationApiUrl.replace(/\/$/, "") }
+            : {}),
         }),
       ],
       destinationBucket: this.bucket,

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -492,6 +492,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
         ...baseConfig,
         apiBaseUrl: portalLambda.url.url,
         mode: "backend",
+        // #1420: 専用 coordination dispatcher の Function URL を portal へ配る (slot が叩く)。
+        coordinationApiUrl: coordinationDispatcher.url.url,
       });
       this.participantPortalUrl = portal.distributionUrl;
       new CfnOutput(this, "ParticipantPortalUrl", {


### PR DESCRIPTION
## Summary

ADR-028/030 (#1420) の participant 向け coordination plumbing。 専用 dispatcher Lambda（最小 IAM、#1633）を portal slot から叩くための **client + config + runtime-config 配線**を足す。 これで問題同梱の portal slot が op 提出 / projection polling を行える（= e2e の frontend 基盤）。

- `api/coordination-client.ts`: `submitCoordinationOp` (POST) / `getCoordinationProjection` (GET)。 backend の outcome（ok / rejected / conflict / unavailable / not_configured / unauthorized）に対応する discriminated union。 polling は呼び出し側 setInterval（SSE 不使用、AGENTS.md）。
- `config.ts`: `coordinationApiUrl` を runtime-config から読む。 backend mode は HTTPS 必須（teamLoginKey 漏洩防止、apiBaseUrl と同方針）。 非 HTTPS なら coordination だけ無効化し portal 本体は通常起動。
- CDK: `ParticipantPortalHosting` の runtime-config に `coordinationApiUrl` を追加し、 backend stack が dispatcher の Function URL を配る。 未配線なら key を出さない。

## Test plan
- **portal coverage gate 100%**: `coordination-client.ts` (L15/15 B10/10) + `config.ts` (L29/29 B44/44)
- portal 全 **605 test** green、 infra 全 **2368 test** green、 tsc / biome / `make harness`(error 0) / `cdk synth` / no-conflicts / http-status pass

## Regression analysis
- `coordinationApiUrl` 未配線（旧 deploy / coordination 無効）なら undefined → 既存 portal 起動・API に影響なし。
- 本 client を呼ぶ consumer（reference 問題の portal slot）は submodule 側の最終 slice。 本 PR は platform 基盤のみ（= #1633 Phase 3 config layer と同じ「次段で使う配線」）。

## Physical impact
- participant `runtime-config.json` に `coordinationApiUrl` key 追加 → **UPDATE**（S3 object 内容差分）。 新規 CFn resource なし。
- frontend dist: coordination-client 追加で再ビルド → **UPDATE**（slot が使うまで inert）。

Relates #1420
Relates #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added participant-to-participant coordination capability to the portal
  * Coordination feature is optional and gracefully handles missing configuration

* **Infrastructure**
  * Integrated coordination dispatcher for backend deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->