### PR TITLE
refactor(participant-portal): adopt shared usePolling + useNowMs [#1418]

### DIFF
--- a/apps/participant-portal/src/auth/TeamViewProvider.tsx
+++ b/apps/participant-portal/src/auth/TeamViewProvider.tsx
@@ -1,4 +1,4 @@
-import { toErrorMessage } from "@tenkacloud/web-kit";
+import { toErrorMessage, usePolling } from "@tenkacloud/web-kit";
 import {
   createContext,
   type ReactNode,
@@ -329,6 +329,9 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
     setNotifications(DEV_MOCK_NOTIFICATIONS);
   }, [isMock, sessionToken, view]);
 
+  // me + leaderboard polling は usePolling に寄せず手書きのまま残す: 全 problem が terminal に
+  // 達したら次 tick を skip する `stopPollingRef` gate (= timer 制御ではなく業務的な停止条件) を
+  // 持ち、 enabled gate だけでは表現できないため (= usePolling の責務範囲外)。
   useEffect(() => {
     if (isMock || !sessionToken) return;
     stopPollingRef.current = false;
@@ -343,12 +346,11 @@ export function TeamViewProvider({ config, children }: { config: AppConfig; chil
     return () => clearInterval(interval);
   }, [isMock, sessionToken, refresh]);
 
-  useEffect(() => {
-    if (isMock || !sessionToken) return;
-    void refreshNotifications();
-    const interval = setInterval(refreshNotifications, NOTIFICATIONS_POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [isMock, sessionToken, refreshNotifications]);
+  // notifications は単純な「即時 + interval + cleanup」 なので usePolling (web-kit) に集約 (#1418 DRY)。
+  // enabled gate により refreshNotifications 冒頭の同条件 guard は不到達のまま (= v8 ignore 維持)。
+  usePolling(refreshNotifications, NOTIFICATIONS_POLL_INTERVAL_MS, {
+    enabled: !isMock && Boolean(sessionToken),
+  });
 
   // codex review P3: page を開いた瞬間の既読化を **localStorage と Context state 両方** に
   // 反映して、TopNav 未読 badge が次の 60s tick を待たず即 0 化する。

--- a/apps/participant-portal/src/components/CliCredentialsPanel.tsx
+++ b/apps/participant-portal/src/components/CliCredentialsPanel.tsx
@@ -4,8 +4,8 @@ import Button from "@cloudscape-design/components/button";
 import ExpandableSection from "@cloudscape-design/components/expandable-section";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
-import { toErrorMessage } from "@tenkacloud/web-kit";
-import { useEffect, useState } from "react";
+import { toErrorMessage, useNowMs } from "@tenkacloud/web-kit";
+import { useState } from "react";
 import {
   type CliCredentialsView,
   getCliCredentials,
@@ -291,10 +291,7 @@ export function describeRemainingTime(expirationIso: string, nowMs: number): Cou
 }
 
 function useCountdown(expirationIso: string): CountdownState {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, []);
+  // 1 秒 tick の時計は web-kit useNowMs に集約 (= credential 失効までの残時間表示用)。
+  const now = useNowMs(1000);
   return describeRemainingTime(expirationIso, now);
 }

--- a/apps/participant-portal/src/components/CountdownTimer.tsx
+++ b/apps/participant-portal/src/components/CountdownTimer.tsx
@@ -1,6 +1,6 @@
 import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
-import { useEffect, useState } from "react";
+import { useNowMs } from "@tenkacloud/web-kit";
 import { useT } from "../i18n";
 
 /**
@@ -56,12 +56,8 @@ export function computeCountdownState(
  */
 export function CountdownTimer({ endsAt }: { endsAt?: string }) {
   const t = useT();
-  const [nowMs, setNowMs] = useState<number>(() => Date.now());
-
-  useEffect(() => {
-    const id = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // 1 秒 tick の時計は web-kit useNowMs に集約 (= 60s data polling とは独立の client-side clock)。
+  const nowMs = useNowMs(1000);
 
   const state = computeCountdownState(endsAt, nowMs);
   if (state.kind === "no-event") return null;

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -8,6 +8,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator, {
   type StatusIndicatorProps,
 } from "@cloudscape-design/components/status-indicator";
+import { useNowMs } from "@tenkacloud/web-kit";
 import { useEffect, useState } from "react";
 import {
   type DeployLogsResponse,
@@ -61,15 +62,6 @@ const DEPLOY_LOG_LEVEL_COLOR: Record<DeploymentLogEntry["level"], string> = {
   error: "#ff9b9b",
 };
 
-function useNowMs(intervalMs: number): number {
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = window.setInterval(() => setNowMs(Date.now()), intervalMs);
-    return () => window.clearInterval(timer);
-  }, [intervalMs]);
-  return nowMs;
-}
-
 export function describeRemainingUntilAutoDelete(t: ProblemPanelT, diffMs: number): string {
   const totalMinutes = Math.max(1, Math.ceil(diffMs / 60_000));
   return t("problem_panel.auto_delete_remaining_minutes", { minutes: totalMinutes });
@@ -111,6 +103,8 @@ function useLiveDeployLog({
 }): DeploymentLogView | null {
   const [liveDeployLog, setLiveDeployLog] = useState<DeploymentLogView | null>(null);
 
+  // この polling は usePolling に寄せない: tick 間で `nextToken` を引き継ぐ paging と、
+  // `response.complete` で自走停止する業務ロジックを持ち、 単純な timer 制御 (usePolling の責務) を超える。
   useEffect(() => {
     setLiveDeployLog(null);
     if (TERMINAL_STATUSES.has(problem.status)) return;

--- a/apps/participant-portal/src/components/ScoreTimelineChart.tsx
+++ b/apps/participant-portal/src/components/ScoreTimelineChart.tsx
@@ -100,6 +100,9 @@ export function ScoreTimelineChart({
   const [data, setData] = useState<LeaderboardScoreEventsResponse | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
 
+  // この polling は usePolling に寄せない: cleanup で in-flight fetch を `AbortController.abort()` で
+  // 中断する必要があり (= unmount 時の stale request 抑止)、 usePolling の cleanup (timer 停止のみ) では
+  // 表現できないため。
   useEffect(() => {
     let mounted = true;
     const controller = new AbortController();

--- a/apps/participant-portal/src/pages/ScoreEvents.tsx
+++ b/apps/participant-portal/src/pages/ScoreEvents.tsx
@@ -5,7 +5,7 @@ import Header from "@cloudscape-design/components/header";
 import LineChart from "@cloudscape-design/components/line-chart";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
-import { toErrorMessage } from "@tenkacloud/web-kit";
+import { toErrorMessage, usePolling } from "@tenkacloud/web-kit";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   getScoreEvents,
@@ -70,12 +70,9 @@ export function ScoreEventsPage({ config }: { config: AppConfig }) {
     }
   }, [isMock, sessionToken, config.apiBaseUrl, auth]);
 
-  useEffect(() => {
-    if (isMock || !sessionToken) return;
-    void tick();
-    const interval = setInterval(tick, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [isMock, sessionToken, tick]);
+  // 即時 fetch + interval + unmount cleanup は usePolling (web-kit) に集約 (#1418 DRY)。
+  // enabled gate (= backend mode かつ session 在り) で tick 内の同条件 guard は不到達のまま。
+  usePolling(tick, POLL_INTERVAL_MS, { enabled: !isMock && Boolean(sessionToken) });
 
   // LP 「モックで試す」 動線: dev-mock mode では backend を叩かないので、 fixture を
   // 1 度だけ seed する (= 競技中のスコア推移 chart + 履歴 table をデモで見せる)。

--- a/packages/web-kit/src/index.ts
+++ b/packages/web-kit/src/index.ts
@@ -20,4 +20,5 @@ export {
 } from "./i18n";
 export { LoadingState, type LoadingStateProps } from "./LoadingState";
 export { StatusBadge, type StatusBadgeProps, type StatusTone, statusToTone } from "./StatusBadge";
+export { useNowMs } from "./useNowMs";
 export { type UsePollingOptions, usePolling } from "./usePolling";

--- a/packages/web-kit/src/useNowMs.ts
+++ b/packages/web-kit/src/useNowMs.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react";
+import { usePolling } from "./usePolling";
+
+/**
+ * 現在時刻 (epoch ms) を `intervalMs` ごとに更新して返す clock hook (3 SPA 共通)。
+ *
+ * countdown / 残時間 / 相対時刻のような「時計を一定間隔で再評価して再描画したい」 UI の
+ * re-render driver。 fetch せず client-side のみで動く (= leaderboard 等の data polling とは別系統)。
+ * participant-portal の CountdownTimer / CliCredentialsPanel / ProblemPanel に
+ * `useState(Date.now) + setInterval(setNow(Date.now())) + clearInterval` が copy-paste されていたのを
+ * 1 箇所へ集約する (DRY / 単一責務)。
+ *
+ * {@link usePolling} の上に薄く乗る: 初期値は mount 時刻 (`useState` initializer)、 以後は
+ * `immediate: false` で「次の周期から」 interval 更新する (= mount 直後に冗長な setState を打たない)。
+ * tick callback は `useCallback([])` で安定化し、 nowMs 更新由来の再描画で interval を張り直さない。
+ *
+ * @param intervalMs 時計を再評価する間隔 (ms)。
+ * @returns 直近の `Date.now()` (epoch ms)。
+ */
+export function useNowMs(intervalMs: number): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const tick = useCallback(() => setNowMs(Date.now()), []);
+  usePolling(tick, intervalMs, { immediate: false });
+  return nowMs;
+}

--- a/packages/web-kit/test/useNowMs.test.tsx
+++ b/packages/web-kit/test/useNowMs.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * useNowMs (web-kit clock hook) の regression test。
+ * 初期値 = mount 時刻 / interval ごとの更新 / immediate を打たないこと / unmount cleanup を pin する。
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNowMs } from "../src/useNowMs";
+
+describe("useNowMs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-02T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return the mount time initially without an immediate extra tick", () => {
+    const start = Date.now();
+    const { result } = renderHook(() => useNowMs(1000));
+    expect(result.current).toBe(start);
+  });
+
+  it("should advance the returned time once per interval", () => {
+    const start = Date.now();
+    const { result } = renderHook(() => useNowMs(1000));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(start + 1000);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(start + 3000);
+  });
+
+  it("should stop updating after unmount", () => {
+    const start = Date.now();
+    const { result, unmount } = renderHook(() => useNowMs(1000));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(start + 1000);
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(start + 1000); // frozen at last value, no further ticks
+  });
+});


### PR DESCRIPTION
## Summary

`participant-portal` was the one SPA left out of the #1418 shared-polling-primitive consolidation (`admin-console` and `application-admin-console` already converged on `usePolling` from `@tenkacloud/web-kit`). It hand-rolled `setInterval` + cleanup in 5 places, and the three "tick `Date.now()` every N ms" clocks were the **same hook copy-pasted 3×**.

This PR closes that gap (DRY / single responsibility), without changing any runtime behavior.

### What changed

- **web-kit**: new `useNowMs(intervalMs)` clock hook — `useState(Date.now)` initial value + `usePolling(tick, intervalMs, { immediate: false })`, `tick` stabilized with `useCallback([])` so nowMs re-renders don't re-arm the interval. Exported from the package index. (new `useNowMs.test.tsx`, 100%).
- **portal clocks adopt `useNowMs`**: `ProblemPanel` (deletes its local `useNowMs` copy), `CountdownTimer`, `CliCredentialsPanel.useCountdown`.
- **portal data polls adopt `usePolling`**: `TeamViewProvider` notifications tick, `ScoreEvents` tick — both with `enabled: !isMock && Boolean(sessionToken)` replacing the manual `if (isMock || !sessionToken) return` guard + `setInterval`/`clearInterval`.
- **3 pollers intentionally left hand-written** (now documented inline so future readers don't "fix" them):
  - `TeamViewProvider` me+leaderboard tick — has a `stopPollingRef` business stop-gate (stop once all problems terminal) beyond `usePolling`'s timer-only responsibility.
  - `ProblemPanel.useLiveDeployLog` — carries `nextToken` across ticks (paging) and self-stops on `response.complete`.
  - `ScoreTimelineChart` — aborts the in-flight `fetch` via `AbortController` on cleanup; `usePolling`'s cleanup only stops the timer.

## Test plan

- `participant-portal`: 592 tests pass; coverage 100% (Stmts 1415/1415, Branches 1087/1087, Funcs 353/353, Lines 1229/1229).
- `web-kit`: 44 tests pass (incl. 3 new `useNowMs`); package coverage gate green (100%).
- `make before-commit`: lint / typecheck / all workspace tests / validate-problems / http-magic-numbers / template checks / **check-no-conflicts** / dependency audit all green. (`check-synth` fails only on the pre-existing environmental gap — fresh worktree without the gitignored `.env`; `CDK_PARAM_SYSTEM_ADMIN_EMAIL=… CDK_SKIP_BUNDLING=1 make synth` exits 0. No infra was touched.)
- `make harness`: 0 errors.

## Regression analysis

- **Behavior-preserving by construction.** `usePolling` performs the identical `setInterval` + immediate run + `clearInterval` cleanup, and `useNowMs` performs the identical `useState(Date.now)` + 1 s interval; the existing component tests (countdown rendering, score-events polling, notifications polling, credential expiry) exercise these paths and remain green unchanged.
- **Hook-order / deps**: migrated callbacks (`refreshNotifications`, `ScoreEvents.tick`) were already `useCallback`-memoized, so the `usePolling` effect re-arms on exactly the same dependency changes as the old `useEffect`. `useNowMs`'s `tick` is `useCallback([])`-stable, so the interval is armed once (no per-tick churn). Confirmed by typecheck + tests.
- **enabled-gate equivalence**: `enabled: !isMock && Boolean(sessionToken)` reproduces the old `if (isMock || !sessionToken) return` early-return; the in-callback guards stay `/* v8 ignore */` (still unreachable) and coverage stays 100%.
- **web-kit `index.ts` is purely additive** (one new export); existing consumers (`admin-console`, `application-admin-console`) are unaffected — their full suites run in `before-commit` and pass.
- The 3 untouched pollers keep their exact prior semantics.

## Physical impact

- **NO-OP** on CloudFormation / deployed artifacts. Frontend-only refactor (`apps/participant-portal/src/**` + `packages/web-kit/src/**`); no CDK construct, Lambda, IAM, or DynamoDB change. The built SPA bundle is functionally identical (same timers, same fetch cadence). `cdk synth` template output is unchanged.

Relates #1418