### PR TITLE
feat(disruption): executor core — builders + orchestration + DDB deps (ADR-031) [#1419]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/dispatch-command.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/dispatch-command.ts
@@ -1,0 +1,126 @@
+/**
+ * [ADR-031 / Issue #1419] cross-account disruption executor の **純粋な dispatch core**。
+ *
+ * fired event (= `*DisruptionFired`) が持つ `action` 宣言 + 既に fold 済の `parameters` +
+ * team の `stackOutputs` を受け取り、 競技者アカウントで実行すべき 1 アクションを **SDK 非依存の
+ * 正規化記述子** に落とす。 ここでは AWS を一切呼ばない (= AssumeRole / SendCommand 等は handler の
+ * 責務)。 純関数なので unit test で全分岐を pin できる。
+ *
+ * 設計判断:
+ *   - `targetRef` / `functionRef` は **stackOutputs の key** からのみ解決する (= 任意 resource id を
+ *     直接実行させない、 ADR-031 の injection 縮小)。 解決できなければ loud に throw (silent fallback 禁止)。
+ *   - `paramTemplate` の `{{key}}` は fired `parameters` の値でのみ置換する。 値が無い placeholder は
+ *     literal `{{key}}` を競技者アカウントへ送らないよう throw する (= validate-problems の宣言時 allow-list と
+ *     runtime の二重防御)。
+ *   - revert は注入と同じ kind / target を使い、 `action.revert` の documentName / paramTemplate で
+ *     上書きする。 `afterSeconds` は scheduling metadata なので記述子には含めない (handler が scheduler に渡す)。
+ */
+
+import type {
+  DisruptionAction,
+  DisruptionActionKind,
+} from "../../../utils/discover-problems-catalog.js";
+
+/** 競技者アカウントで実行する 1 アクションの正規化記述子 (SDK 非依存)。 */
+export interface DisruptionDispatch {
+  readonly kind: DisruptionActionKind;
+  /** 解決済の実行対象 (= ssm: instance ids 文字列 / lambda: function 名 ARN / cfn: stack 名)。 */
+  readonly target: string;
+  /** ssm-run-command の SSM Document 名 (他 kind では undefined)。 */
+  readonly documentName?: string;
+  /** placeholder 置換済の API 引数 (= SSM Parameters / Lambda payload / CFn Parameters の素材)。 */
+  readonly params: Record<string, unknown>;
+}
+
+const PLACEHOLDER_RE = /\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g;
+
+function substituteString(value: string, params: Readonly<Record<string, unknown>>): string {
+  return value.replace(PLACEHOLDER_RE, (_match, key: string) => {
+    if (!(key in params)) {
+      throw new Error(
+        `disruption action placeholder {{${key}}} has no value in the fired parameters`,
+      );
+    }
+    return String(params[key]);
+  });
+}
+
+/** paramTemplate を再帰的に walk して string 中の `{{key}}` を fired parameters で置換する。 */
+function substituteValue(value: unknown, params: Readonly<Record<string, unknown>>): unknown {
+  if (typeof value === "string") return substituteString(value, params);
+  if (Array.isArray(value)) return value.map((v) => substituteValue(v, params));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = substituteValue(v, params);
+    return out;
+  }
+  return value;
+}
+
+function substituteTemplate(
+  template: Readonly<Record<string, unknown>> | undefined,
+  params: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  if (!template) return {};
+  return substituteValue(template, params) as Record<string, unknown>;
+}
+
+/** stackOutputs[ref] を解決する。 未宣言 / 空は loud に throw (= 注入対象が無いのに送らない)。 */
+function resolveOutput(
+  ref: string,
+  stackOutputs: Readonly<Record<string, string>>,
+  label: string,
+): string {
+  const value = stackOutputs[ref];
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`disruption action ${label}="${ref}" not found in team stackOutputs`);
+  }
+  return value;
+}
+
+/**
+ * 注入アクションの記述子を組み立てる。 lambda-invoke は `functionRef ?? targetRef` を、 それ以外は
+ * `targetRef` を stackOutputs から解決する。
+ */
+export function buildDisruptionDispatch(
+  action: DisruptionAction,
+  parameters: Readonly<Record<string, unknown>>,
+  stackOutputs: Readonly<Record<string, string>>,
+): DisruptionDispatch {
+  const targetRef =
+    action.kind === "lambda-invoke" ? (action.functionRef ?? action.targetRef) : action.targetRef;
+  const target = resolveOutput(
+    targetRef,
+    stackOutputs,
+    action.kind === "lambda-invoke" ? "functionRef/targetRef" : "targetRef",
+  );
+  return {
+    kind: action.kind,
+    target,
+    ...(action.documentName ? { documentName: action.documentName } : {}),
+    params: substituteTemplate(action.paramTemplate, parameters),
+  };
+}
+
+/**
+ * 復旧アクションの記述子。 注入と同じ kind / target を使い、 `action.revert` の documentName /
+ * paramTemplate で上書きする。 `afterSeconds` は記述子に含めない (= handler が scheduler に渡す)。
+ */
+export function buildRevertDispatch(
+  action: DisruptionAction,
+  parameters: Readonly<Record<string, unknown>>,
+  stackOutputs: Readonly<Record<string, string>>,
+): DisruptionDispatch {
+  const injected = buildDisruptionDispatch(action, parameters, stackOutputs);
+  const revert = action.revert;
+  return {
+    kind: injected.kind,
+    target: injected.target,
+    ...(revert.documentName
+      ? { documentName: revert.documentName }
+      : injected.documentName
+        ? { documentName: injected.documentName }
+        : {}),
+    params: substituteTemplate(revert.paramTemplate, parameters),
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -1,0 +1,117 @@
+/**
+ * [ADR-031 / Issue #1419] cross-account disruption executor の orchestration。
+ *
+ * `*DisruptionFired` event (= disruption-fire が operator account の bus に publish したもの) を 1 件受け、
+ * 該当 team の deployment へ実障害を注入し、 ADR-029 INV-2 のため復旧を予約する。 流れ:
+ *
+ *   1. catalog で `(problemId, disruptionId)` の `action` を解決。 action 未宣言 = Phase A (監査のみ) で no-op。
+ *   2. `EXEC#{requestId}#{teamId}` の conditional claim で per-team 冪等性を取る (= EventBridge at-least-once 対策)。
+ *   3. team の deployment row (jobId / region / competitorRoleArn / externalId / stackOutputs) を解決。
+ *      未 deploy / 未完了 = 注入対象が無いので no-op (loud にせず skip、 監査は claim 済)。
+ *   4. competitor account へ AssumeRole (ExternalId) し、 inject dispatch を送る。
+ *   5. revert dispatch を `afterSeconds` 後に予約 (= 必ず復旧する。 永続障害の禁止)。
+ *
+ * I/O 境界 (catalog 解決 / 冪等 claim / deployment 解決 / AssumeRole / 送信 / 予約) はすべて deps として注入し、
+ * 本 orchestration は **判断 (順序 / 分岐) だけ** を持つ純粋な関数にする (= describe-stack-handler と同じ DI 方針、
+ * unit test で全分岐を mock で pin できる)。 各 dep の具体実装 (SDK mapping / scheduler / DDB query) と
+ * Lambda + IAM の CDK 配線は、 競技者アカウントへ実 fault を deploy する判断を伴うため別途。
+ */
+
+import type {
+  DisruptionAction,
+  ProblemDisruptionEntry,
+} from "../../../utils/discover-problems-catalog.js";
+import {
+  buildDisruptionDispatch,
+  buildRevertDispatch,
+  type DisruptionDispatch,
+} from "./dispatch-command.js";
+
+/** fired event の Detail (= disruption-fire.publishEntries が JSON.stringify する形)。 */
+export interface DisruptionFiredDetail {
+  readonly disruptionId: string;
+  readonly eventId: string;
+  readonly problemId: string;
+  readonly tenantId: string;
+  readonly teamId: string;
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly requestId: string;
+  readonly firedAt: string;
+}
+
+/** 注入対象 team deployment の解決結果。 */
+export interface DeploymentTarget {
+  readonly jobId: string;
+  readonly region: string;
+  readonly competitorRoleArn: string;
+  readonly externalIdParameterName: string;
+  /** CFn Outputs (= deployment row の stackOutputs JSON を parse 済)。 */
+  readonly stackOutputs: Readonly<Record<string, string>>;
+}
+
+export interface ExecutorDeps {
+  /** problemsDisruptions catalog (= fire と同じ env 由来)。 */
+  readonly problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>;
+  /** `EXEC#{requestId}#{teamId}` の conditional claim。 claimed=winner / duplicate=既処理。 */
+  readonly claimExecution: (detail: DisruptionFiredDetail) => Promise<"claimed" | "duplicate">;
+  /** team+problem deployment を解決。 未 deploy / 未完了 / stackOutputs 無しは undefined。 */
+  readonly resolveDeployment: (
+    detail: DisruptionFiredDetail,
+  ) => Promise<DeploymentTarget | undefined>;
+  /** dispatch を競技者アカウントで実行 (= AssumeRole + SDK send は具体実装側)。 */
+  readonly sendDispatch: (dispatch: DisruptionDispatch, target: DeploymentTarget) => Promise<void>;
+  /** revert を afterSeconds 後に予約 (ADR-029 INV-2)。 scheduler 機構は具体実装側。 */
+  readonly scheduleRevert: (
+    dispatch: DisruptionDispatch,
+    target: DeploymentTarget,
+    afterSeconds: number,
+  ) => Promise<void>;
+}
+
+export type DisruptionExecuteOutcome =
+  | { readonly kind: "ok"; readonly jobId: string }
+  | { readonly kind: "no_action" }
+  | { readonly kind: "duplicate" }
+  | { readonly kind: "unknown_disruption" }
+  | { readonly kind: "no_deployment" };
+
+function resolveAction(
+  catalog: ExecutorDeps["problemsDisruptions"],
+  problemId: string,
+  disruptionId: string,
+): DisruptionAction | undefined | "unknown" {
+  const entries = catalog[problemId];
+  if (!entries) return "unknown";
+  const declaration = entries.find((d) => d.id === disruptionId);
+  if (!declaration) return "unknown";
+  return declaration.action;
+}
+
+/**
+ * 1 件の fired disruption を実行する。 副作用は deps 経由のみ。 戻り値で結果を表す
+ * (= caller の handler が log / metric に使う)。
+ */
+export async function executeDisruptionAction(
+  detail: DisruptionFiredDetail,
+  deps: ExecutorDeps,
+): Promise<DisruptionExecuteOutcome> {
+  const action = resolveAction(deps.problemsDisruptions, detail.problemId, detail.disruptionId);
+  if (action === "unknown") return { kind: "unknown_disruption" };
+  // action 未宣言 = Phase A 監査のみ。 注入は起こさない (= 後方互換)。
+  if (!action) return { kind: "no_action" };
+
+  // EventBridge at-least-once の再配送を per-team 冪等で弾く。 claim は注入の前に取る。
+  if ((await deps.claimExecution(detail)) === "duplicate") return { kind: "duplicate" };
+
+  const target = await deps.resolveDeployment(detail);
+  if (!target) return { kind: "no_deployment" };
+
+  const inject = buildDisruptionDispatch(action, detail.parameters, target.stackOutputs);
+  await deps.sendDispatch(inject, target);
+
+  // ADR-029 INV-2: 注入したら必ず復旧を予約する (revert は schema 必須)。
+  const revert = buildRevertDispatch(action, detail.parameters, target.stackOutputs);
+  await deps.scheduleRevert(revert, target, action.revert.afterSeconds);
+
+  return { kind: "ok", jobId: target.jobId };
+}

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -60,8 +60,13 @@ export interface ExecutorDeps {
   ) => Promise<DeploymentTarget | undefined>;
   /** dispatch を競技者アカウントで実行 (= AssumeRole + SDK send は具体実装側)。 */
   readonly sendDispatch: (dispatch: DisruptionDispatch, target: DeploymentTarget) => Promise<void>;
-  /** revert を afterSeconds 後に予約 (ADR-029 INV-2)。 scheduler 機構は具体実装側。 */
+  /**
+   * revert を afterSeconds 後に予約 (ADR-029 INV-2)。 scheduler 機構は具体実装側。
+   * `detail` は冪等な schedule 名 (= EXEC# と対の requestId/teamId) と revert invocation payload の
+   * 組み立てに必要なため渡す (= 具体実装 scheduleRevert がそれらを使う)。
+   */
   readonly scheduleRevert: (
+    detail: DisruptionFiredDetail,
     dispatch: DisruptionDispatch,
     target: DeploymentTarget,
     afterSeconds: number,
@@ -111,7 +116,7 @@ export async function executeDisruptionAction(
 
   // ADR-029 INV-2: 注入したら必ず復旧を予約する (revert は schema 必須)。
   const revert = buildRevertDispatch(action, detail.parameters, target.stackOutputs);
-  await deps.scheduleRevert(revert, target, action.revert.afterSeconds);
+  await deps.scheduleRevert(detail, revert, target, action.revert.afterSeconds);
 
   return { kind: "ok", jobId: target.jobId };
 }

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
@@ -1,0 +1,105 @@
+/**
+ * [ADR-031 / Issue #1419] executor の DDB 副作用 dep 実装 (= `executeDisruptionAction` の
+ * `claimExecution` / `resolveDeployment` の具体実装)。 既存 pattern を踏襲し新 SDK 依存を増やさない:
+ *   - claim: disruption-fire の REQUEST# 冪等 claim と同型 (conditional Put + CCF=duplicate)
+ *   - resolve: leaderboard-score-events の GSI1(TENANT#)+eventId filter query と同型
+ *
+ * AssumeRole / SDK 送信 / scheduler は別 dep (= deploy 判断を伴うため owner)。 ここは DDB のみ。
+ */
+
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { type DynamoDBDocumentClient, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeploymentItem } from "../deploy-handler/types.js";
+import { parseStackOutputs } from "../shared/cfn-status.js";
+import type { DeploymentTarget, DisruptionFiredDetail } from "./execute.js";
+
+export interface ExecutorResources {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  /** Deployments テーブル (= deploy-handler が書く row)。 GSI1 = TENANT#。 */
+  readonly deploymentsTableName: string;
+  /** Disruptions テーブル (= fire の REQUEST#/AUDIT# と同居、 EXEC# 冪等行を置く)。 */
+  readonly disruptionsTableName: string;
+  /** EXEC# 行の TTL 秒数 (省略時 7 日)。 */
+  readonly execTtlSeconds?: number;
+}
+
+const DEFAULT_EXEC_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * `EXEC#{requestId}#{teamId}` を conditional Put で奪う。 EventBridge at-least-once の再配送に対する
+ * per-team 冪等性。 ConditionalCheckFailed = 既に処理済 (duplicate)、 それ以外の error は伝播。
+ */
+export async function claimExecution(
+  resources: ExecutorResources,
+  detail: DisruptionFiredDetail,
+  nowMs: number,
+): Promise<"claimed" | "duplicate"> {
+  const pk = `EXEC#${detail.requestId}#${detail.teamId}`;
+  try {
+    await resources.ddb.send(
+      new PutCommand({
+        TableName: resources.disruptionsTableName,
+        Item: {
+          PK: pk,
+          SK: "METADATA",
+          disruptionId: detail.disruptionId,
+          eventId: detail.eventId,
+          problemId: detail.problemId,
+          tenantId: detail.tenantId,
+          teamId: detail.teamId,
+          requestId: detail.requestId,
+          firedAt: detail.firedAt,
+          expiresAt:
+            Math.floor(nowMs / 1000) + (resources.execTtlSeconds ?? DEFAULT_EXEC_TTL_SECONDS),
+        },
+        ConditionExpression: "attribute_not_exists(PK)",
+      }),
+    );
+    return "claimed";
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) return "duplicate";
+    throw err;
+  }
+}
+
+/**
+ * fired `(tenantId, eventId, teamId, problemId)` の **COMPLETE** deployment を GSI1 query で解決し、
+ * cross-account 注入に必要な情報が揃った行のみ返す。 未 deploy / 未完了 / cross-account 情報や
+ * stackOutputs 欠落は undefined (= 注入対象なし、 caller が no-op にする)。
+ */
+export async function resolveDeployment(
+  resources: ExecutorResources,
+  detail: DisruptionFiredDetail,
+): Promise<DeploymentTarget | undefined> {
+  const out = await resources.ddb.send(
+    new QueryCommand({
+      TableName: resources.deploymentsTableName,
+      IndexName: "GSI1",
+      KeyConditionExpression: "GSI1PK = :pk",
+      FilterExpression: "eventId = :ev AND teamId = :tid AND problemId = :pid",
+      ExpressionAttributeValues: {
+        ":pk": `TENANT#${detail.tenantId}`,
+        ":ev": detail.eventId,
+        ":tid": detail.teamId,
+        ":pid": detail.problemId,
+      },
+    }),
+  );
+  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  const ready = items.find(
+    (d) =>
+      d.status === "COMPLETE" &&
+      typeof d.jobId === "string" &&
+      typeof d.region === "string" &&
+      typeof d.competitorRoleArn === "string" &&
+      typeof d.externalIdParameterName === "string",
+  );
+  if (!ready) return undefined;
+  return {
+    jobId: ready.jobId as string,
+    region: ready.region as string,
+    competitorRoleArn: ready.competitorRoleArn as string,
+    externalIdParameterName: ready.externalIdParameterName as string,
+    stackOutputs: parseStackOutputs(ready.stackOutputs),
+  };
+}

--- a/infrastructure/test/problem-deploy/disruption-dispatch-command.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-dispatch-command.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDisruptionDispatch,
+  buildRevertDispatch,
+} from "../../lib/problem-deploy/handlers/disruption-executor-handler/dispatch-command";
+import type { DisruptionAction } from "../../lib/utils/discover-problems-catalog";
+
+/**
+ * [ADR-031 / #1419] executor の純粋 dispatch core を pin する。
+ * - targetRef / functionRef を stackOutputs から解決 (未解決は throw)
+ * - paramTemplate の {{key}} を fired parameters で置換 (値無しは throw)
+ * - revert は同 kind/target + revert.paramTemplate/documentName で上書き
+ */
+
+const ssmAction: DisruptionAction = {
+  kind: "ssm-run-command",
+  targetRef: "WorkerInstanceIds",
+  documentName: "AWS-RunShellScript",
+  paramTemplate: { commands: ["tc qdisc add dev {{device}} root netem delay {{delayMs}}ms"] },
+  revert: {
+    afterSeconds: 600,
+    documentName: "AWS-RunShellScript",
+    paramTemplate: { commands: ["tc qdisc del dev {{device}} root"] },
+  },
+};
+
+const stackOutputs = { WorkerInstanceIds: "i-aaa,i-bbb", FaultFn: "tc-fault-fn" };
+const parameters = { device: "eth0", delayMs: 200 };
+
+describe("buildDisruptionDispatch (ADR-031 #1419)", () => {
+  it("should resolve targetRef from stackOutputs and substitute placeholders from fired parameters", () => {
+    expect(buildDisruptionDispatch(ssmAction, parameters, stackOutputs)).toEqual({
+      kind: "ssm-run-command",
+      target: "i-aaa,i-bbb",
+      documentName: "AWS-RunShellScript",
+      params: { commands: ["tc qdisc add dev eth0 root netem delay 200ms"] },
+    });
+  });
+
+  it("should resolve a lambda-invoke functionRef (preferred over targetRef) from stackOutputs", () => {
+    const action: DisruptionAction = {
+      kind: "lambda-invoke",
+      targetRef: "WorkerInstanceIds",
+      functionRef: "FaultFn",
+      paramTemplate: { mode: "fail", device: "{{device}}" },
+      revert: { afterSeconds: 30 },
+    };
+    expect(buildDisruptionDispatch(action, parameters, stackOutputs)).toEqual({
+      kind: "lambda-invoke",
+      target: "tc-fault-fn",
+      params: { mode: "fail", device: "eth0" },
+    });
+  });
+
+  it("should fall back to targetRef for lambda-invoke when functionRef is absent", () => {
+    const action: DisruptionAction = {
+      kind: "lambda-invoke",
+      targetRef: "FaultFn",
+      revert: { afterSeconds: 30 },
+    };
+    expect(buildDisruptionDispatch(action, parameters, stackOutputs).target).toBe("tc-fault-fn");
+  });
+
+  it("should return empty params when no paramTemplate is declared", () => {
+    const action: DisruptionAction = {
+      kind: "cfn-stack-update",
+      targetRef: "WorkerInstanceIds",
+      revert: { afterSeconds: 30 },
+    };
+    const dispatch = buildDisruptionDispatch(action, parameters, stackOutputs);
+    expect(dispatch.params).toEqual({});
+    expect(dispatch.documentName).toBeUndefined();
+  });
+
+  it("should throw when targetRef cannot be resolved from stackOutputs", () => {
+    expect(() => buildDisruptionDispatch(ssmAction, parameters, { Other: "x" })).toThrow(
+      /targetRef="WorkerInstanceIds" not found/,
+    );
+  });
+
+  it("should throw when a placeholder has no value in the fired parameters", () => {
+    expect(() => buildDisruptionDispatch(ssmAction, { device: "eth0" }, stackOutputs)).toThrow(
+      /\{\{delayMs\}\} has no value/,
+    );
+  });
+
+  it("should substitute placeholders nested inside arrays and objects", () => {
+    const action: DisruptionAction = {
+      kind: "ssm-run-command",
+      targetRef: "WorkerInstanceIds",
+      paramTemplate: { nested: { list: ["{{device}}", { deep: "delay-{{delayMs}}" }] } },
+      revert: { afterSeconds: 1 },
+    };
+    expect(buildDisruptionDispatch(action, parameters, stackOutputs).params).toEqual({
+      nested: { list: ["eth0", { deep: "delay-200" }] },
+    });
+  });
+
+  it("should pass non-string leaves (number / boolean / null) through unchanged", () => {
+    const action: DisruptionAction = {
+      kind: "lambda-invoke",
+      targetRef: "FaultFn",
+      paramTemplate: { count: 3, enabled: true, note: null, label: "{{device}}" },
+      revert: { afterSeconds: 1 },
+    };
+    expect(buildDisruptionDispatch(action, parameters, stackOutputs).params).toEqual({
+      count: 3,
+      enabled: true,
+      note: null,
+      label: "eth0",
+    });
+  });
+});
+
+describe("buildRevertDispatch (ADR-031 #1419, ADR-029 INV-2)", () => {
+  it("should reuse the inject target/kind and apply the revert paramTemplate + documentName", () => {
+    expect(buildRevertDispatch(ssmAction, parameters, stackOutputs)).toEqual({
+      kind: "ssm-run-command",
+      target: "i-aaa,i-bbb",
+      documentName: "AWS-RunShellScript",
+      params: { commands: ["tc qdisc del dev eth0 root"] },
+    });
+  });
+
+  it("should inherit the inject documentName when the revert omits it, and yield empty params with no revert template", () => {
+    const action: DisruptionAction = {
+      kind: "ssm-run-command",
+      targetRef: "WorkerInstanceIds",
+      documentName: "AWS-RunShellScript",
+      revert: { afterSeconds: 60 },
+    };
+    expect(buildRevertDispatch(action, parameters, stackOutputs)).toEqual({
+      kind: "ssm-run-command",
+      target: "i-aaa,i-bbb",
+      documentName: "AWS-RunShellScript",
+      params: {},
+    });
+  });
+
+  it("should yield no documentName when neither inject nor revert declares one", () => {
+    const action: DisruptionAction = {
+      kind: "lambda-invoke",
+      targetRef: "FaultFn",
+      revert: { afterSeconds: 60, paramTemplate: { mode: "recover" } },
+    };
+    const revert = buildRevertDispatch(action, parameters, stackOutputs);
+    expect(revert.documentName).toBeUndefined();
+    expect(revert.params).toEqual({ mode: "recover" });
+  });
+});

--- a/infrastructure/test/problem-deploy/disruption-execute.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-execute.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DeploymentTarget,
+  type DisruptionFiredDetail,
+  type ExecutorDeps,
+  executeDisruptionAction,
+} from "../../lib/problem-deploy/handlers/disruption-executor-handler/execute";
+import type { ProblemDisruptionEntry } from "../../lib/utils/discover-problems-catalog";
+
+/**
+ * [ADR-031 / #1419] executor orchestration を pin する。 副作用は deps 経由のみなので、
+ * 各 dep を mock して分岐 (no_action / duplicate / no_deployment / ok + 順序) を観察する。
+ */
+
+const withAction: ProblemDisruptionEntry = {
+  id: "ec2-latency-injection",
+  name: "latency",
+  eventDetailType: "DegradedDisruptionFired",
+  parameters: { delayMs: 200, device: "eth0" },
+  action: {
+    kind: "ssm-run-command",
+    targetRef: "WorkerInstanceIds",
+    documentName: "AWS-RunShellScript",
+    paramTemplate: { commands: ["tc qdisc add dev {{device}} root netem delay {{delayMs}}ms"] },
+    revert: {
+      afterSeconds: 600,
+      paramTemplate: { commands: ["tc qdisc del dev {{device}} root"] },
+    },
+  },
+};
+
+const detail: DisruptionFiredDetail = {
+  disruptionId: "ec2-latency-injection",
+  eventId: "evt-1",
+  problemId: "microservice-migration-battle",
+  tenantId: "tenant-1",
+  teamId: "team-1",
+  parameters: { delayMs: 200, device: "eth0" },
+  requestId: "req-1",
+  firedAt: "2026-06-02T00:00:00.000Z",
+};
+
+const target: DeploymentTarget = {
+  jobId: "job-1",
+  region: "ap-northeast-1",
+  competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+  externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+  stackOutputs: { WorkerInstanceIds: "i-aaa,i-bbb" },
+};
+
+function makeDeps(over: Partial<ExecutorDeps> = {}): ExecutorDeps {
+  return {
+    problemsDisruptions: { "microservice-migration-battle": [withAction] },
+    claimExecution: vi.fn().mockResolvedValue("claimed"),
+    resolveDeployment: vi.fn().mockResolvedValue(target),
+    sendDispatch: vi.fn().mockResolvedValue(undefined),
+    scheduleRevert: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  };
+}
+
+describe("executeDisruptionAction (ADR-031 #1419)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should inject the built dispatch then schedule the revert on the happy path", async () => {
+    const deps = makeDeps();
+    const outcome = await executeDisruptionAction(detail, deps);
+    expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
+
+    expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
+    const [injected, sentTarget] = (deps.sendDispatch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(injected).toEqual({
+      kind: "ssm-run-command",
+      target: "i-aaa,i-bbb",
+      documentName: "AWS-RunShellScript",
+      params: { commands: ["tc qdisc add dev eth0 root netem delay 200ms"] },
+    });
+    expect(sentTarget).toBe(target);
+
+    expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
+    const [revert, , afterSeconds] = (deps.scheduleRevert as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(revert).toEqual({
+      kind: "ssm-run-command",
+      target: "i-aaa,i-bbb",
+      documentName: "AWS-RunShellScript",
+      params: { commands: ["tc qdisc del dev eth0 root"] },
+    });
+    expect(afterSeconds).toBe(600);
+  });
+
+  it("should be a no-op (no_action) when the disruption declares no action (Phase A)", async () => {
+    const noAction: ProblemDisruptionEntry = { ...withAction, action: undefined };
+    const deps = makeDeps({
+      problemsDisruptions: { "microservice-migration-battle": [noAction] },
+    });
+    expect(await executeDisruptionAction(detail, deps)).toEqual({ kind: "no_action" });
+    expect(deps.claimExecution).not.toHaveBeenCalled();
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+  });
+
+  it("should return unknown_disruption when the problem / disruption is not in the catalog", async () => {
+    expect(await executeDisruptionAction(detail, makeDeps({ problemsDisruptions: {} }))).toEqual({
+      kind: "unknown_disruption",
+    });
+    const otherId = makeDeps({
+      problemsDisruptions: { "microservice-migration-battle": [{ ...withAction, id: "other" }] },
+    });
+    expect(await executeDisruptionAction(detail, otherId)).toEqual({ kind: "unknown_disruption" });
+  });
+
+  it("should stop at the idempotency claim when the execution is a duplicate", async () => {
+    const deps = makeDeps({ claimExecution: vi.fn().mockResolvedValue("duplicate") });
+    expect(await executeDisruptionAction(detail, deps)).toEqual({ kind: "duplicate" });
+    expect(deps.resolveDeployment).not.toHaveBeenCalled();
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  it("should be a no-op (no_deployment) when the team has no resolvable deployment", async () => {
+    const deps = makeDeps({ resolveDeployment: vi.fn().mockResolvedValue(undefined) });
+    expect(await executeDisruptionAction(detail, deps)).toEqual({ kind: "no_deployment" });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  it("should not schedule the revert when the inject send fails (error propagates)", async () => {
+    const deps = makeDeps({
+      sendDispatch: vi.fn().mockRejectedValue(new Error("SendCommand denied")),
+    });
+    await expect(executeDisruptionAction(detail, deps)).rejects.toThrow("SendCommand denied");
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+});

--- a/infrastructure/test/problem-deploy/disruption-execute.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-execute.test.ts
@@ -78,8 +78,9 @@ describe("executeDisruptionAction (ADR-031 #1419)", () => {
     expect(sentTarget).toBe(target);
 
     expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
-    const [revert, , afterSeconds] = (deps.scheduleRevert as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const [detailArg, revert, , afterSeconds] = (deps.scheduleRevert as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    expect(detailArg).toBe(detail); // revert payload / idempotent schedule name 用に detail を渡す
     expect(revert).toEqual({
       kind: "ssm-run-command",
       target: "i-aaa,i-bbb",

--- a/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
@@ -1,0 +1,125 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DisruptionFiredDetail } from "../../lib/problem-deploy/handlers/disruption-executor-handler/execute";
+import {
+  claimExecution,
+  type ExecutorResources,
+  resolveDeployment,
+} from "../../lib/problem-deploy/handlers/disruption-executor-handler/executor-store";
+
+/**
+ * [ADR-031 / #1419] executor の DDB dep 実装。 claimExecution (冪等 Put) と resolveDeployment
+ * (GSI1 query + COMPLETE filter + stackOutputs parse) を mocked ddb で pin する。
+ */
+
+const detail: DisruptionFiredDetail = {
+  disruptionId: "ec2-latency-injection",
+  eventId: "evt-1",
+  problemId: "microservice-migration-battle",
+  tenantId: "tenant-1",
+  teamId: "team-1",
+  parameters: { delayMs: 200 },
+  requestId: "req-1",
+  firedAt: "2026-06-02T00:00:00.000Z",
+};
+
+function makeResources(send: ReturnType<typeof vi.fn>): ExecutorResources {
+  return {
+    ddb: { send } as unknown as ExecutorResources["ddb"],
+    deploymentsTableName: "Deployments",
+    disruptionsTableName: "Disruptions",
+  };
+}
+
+describe("claimExecution (ADR-031 #1419)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should Put the EXEC# row with attribute_not_exists and return claimed", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    expect(await claimExecution(makeResources(send), detail, 1_000_000)).toBe("claimed");
+    const put = send.mock.calls[0][0];
+    expect(put.input.TableName).toBe("Disruptions");
+    expect(put.input.Item.PK).toBe("EXEC#req-1#team-1");
+    expect(put.input.ConditionExpression).toBe("attribute_not_exists(PK)");
+    expect(put.input.Item.expiresAt).toBe(Math.floor(1_000_000 / 1000) + 7 * 24 * 60 * 60);
+  });
+
+  it("should return duplicate on ConditionalCheckFailed", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValue(new ConditionalCheckFailedException({ message: "exists", $metadata: {} }));
+    expect(await claimExecution(makeResources(send), detail, 0)).toBe("duplicate");
+  });
+
+  it("should propagate non-conditional errors", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("throttled"));
+    await expect(claimExecution(makeResources(send), detail, 0)).rejects.toThrow("throttled");
+  });
+
+  it("should honor a custom execTtlSeconds", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const resources = { ...makeResources(send), execTtlSeconds: 60 };
+    await claimExecution(resources, detail, 5000);
+    expect(send.mock.calls[0][0].input.Item.expiresAt).toBe(Math.floor(5000 / 1000) + 60);
+  });
+});
+
+describe("resolveDeployment (ADR-031 #1419)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const completeRow = {
+    status: "COMPLETE",
+    jobId: "job-1",
+    region: "ap-northeast-1",
+    competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+    externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+    teamId: "team-1",
+    problemId: "microservice-migration-battle",
+    eventId: "evt-1",
+    stackOutputs: JSON.stringify({ WorkerInstanceIds: "i-aaa,i-bbb" }),
+  };
+
+  it("should query GSI1 by tenant + filter event/team/problem and return the parsed target", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [completeRow] });
+    const target = await resolveDeployment(makeResources(send), detail);
+    expect(target).toEqual({
+      jobId: "job-1",
+      region: "ap-northeast-1",
+      competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+      externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+      stackOutputs: { WorkerInstanceIds: "i-aaa,i-bbb" },
+    });
+    const query = send.mock.calls[0][0];
+    expect(query.input.IndexName).toBe("GSI1");
+    expect(query.input.ExpressionAttributeValues).toMatchObject({
+      ":pk": "TENANT#tenant-1",
+      ":ev": "evt-1",
+      ":tid": "team-1",
+      ":pid": "microservice-migration-battle",
+    });
+  });
+
+  it("should return undefined when no row is COMPLETE", async () => {
+    const send = vi.fn().mockResolvedValue({ Items: [{ ...completeRow, status: "IN_PROGRESS" }] });
+    expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
+  });
+
+  it("should skip a COMPLETE row missing cross-account fields", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValue({ Items: [{ ...completeRow, competitorRoleArn: undefined }] });
+    expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
+  });
+
+  it("should default stackOutputs to {} when the row has no stackOutputs", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValue({ Items: [{ ...completeRow, stackOutputs: undefined }] });
+    expect((await resolveDeployment(makeResources(send), detail))?.stackOutputs).toEqual({});
+  });
+
+  it("should return undefined on an empty result set", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The complete **non-deploy core** of the ADR-031 cross-account disruption executor (#1419). Three pure/testable modules under `disruption-executor-handler/` — **no deploy, no new SDK dependency**. The only remaining pieces all *deploy real fault injection into competitor accounts*, so they stay your review/deploy decision.

> Stacked on #1639 (`DisruptionAction` type). Base `feat/1419-action-schema-validate`; retarget to `main` after #1639 merges.

### Modules

1. **`dispatch-command.ts`** — pure builders. `buildDisruptionDispatch` / `buildRevertDispatch` → `{ kind, target, documentName?, params }`. `targetRef`/`functionRef` resolved only from `stackOutputs` keys (loud throw if unresolved); `{{key}}` substituted only from fired `parameters` (value-less placeholder throws — runtime twin of #1639's allow-list); revert reuses inject kind/target with `action.revert` overrides (ADR-029 INV-2).
2. **`execute.ts`** — orchestration. `executeDisruptionAction(detail, deps)`: resolve action (`unknown_disruption`/`no_action` passthrough) → claim `EXEC#{requestId}#{teamId}` (`duplicate` short-circuit) → resolve deployment (`no_deployment` no-op) → inject → **schedule revert**. Every I/O boundary injected (describe-stack-handler DI), so it's a pure decision function.
3. **`executor-store.ts`** — the DDB deps (no new SDK dep): `claimExecution` (conditional Put, mirrors disruption-fire's REQUEST# claim) + `resolveDeployment` (GSI1 `TENANT#` + event/team/problem filter, COMPLETE rows only, parsed stackOutputs — mirrors leaderboard-score-events).

### Owner-gated remainder (deploys real fault injection)

- `sendDispatch` — `DisruptionDispatch` → SSM SendCommand / Lambda Invoke / CFn UpdateStack via assumed creds (needs `@aws-sdk/client-lambda`).
- `scheduleRevert` — `aws-scheduler` one-shot (new IAM).
- the Lambda + EventBridge rule + scoped `sts:AssumeRole` CDK construct, + reference-problem E2E.

Building those is fine; **deploying** them (AdministratorAccess fault injection into third-party accounts) is your call. Precedent for shipping core ahead of wiring: #1606.

## Test plan

- **26 new unit tests**, infra full suite green: dispatch builders (11), orchestration (6: ok ordering / no_action / unknown / duplicate / no_deployment / send-fails-no-revert), DDB deps (9: claimed / duplicate / error / TTL / GSI shape / non-COMPLETE / missing-field / empty outputs / empty result).
- `tsc --noEmit`, biome, `make harness` (no findings), `check-no-conflicts`: all clean.

## Regression analysis

Net-new, **zero production call sites** — three new modules in a new dir; nothing imports them at runtime yet (the entry + CDK construct are the owner-reviewed deploy step). No Lambda/IAM/event/existing-file change. Type-only dep on #1639; rebases onto `main` cleanly after it merges. Throw paths are fail-loud by design and covered.

## Physical impact

**NO-OP** on CloudFormation / deployed artifacts. Pure TypeScript + tests; no construct, Lambda, IAM, DynamoDB, or EventBridge change. Nothing deployed or invocable until the handler entry + construct land.

Relates #1419