### PR TITLE
feat(disruption): sendDispatch — descriptor → SSM/Lambda/CFn command (ADR-031) [#1419]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/send-dispatch.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/send-dispatch.ts
@@ -1,0 +1,107 @@
+/**
+ * [ADR-031 / Issue #1419] executor の `sendDispatch` dep 具体実装 = 正規化記述子 (DisruptionDispatch) を
+ * 競技者アカウントの実 SDK command に map して送る。 client は describe-stack-handler と同じ factory dep
+ * (`{ region, credentials }` を受けて assumed-credential client を返す) で注入し、 unit test では mock する。
+ *
+ * 新 SDK 依存は無し (ssm / lambda / cloudformation client は infra に既存)。 SDK の振る舞い選択:
+ *   - ssm-run-command: target = stackOutputs の instance ids (comma 区切り) を SendCommand の InstanceIds に。
+ *     params は SSM Parameters (= Record<string,string[]>) へ coerce。
+ *   - lambda-invoke: InvocationType="Event" の **非同期** 投入 (= fault 注入の完了は待たない、 executor を塞がない)。
+ *   - cfn-stack-update: UsePreviousTemplate=true + params を CFn Parameters に。 既存 stack を parameter 上書き
+ *     だけで degrade させる前提。 IAM capability は competitor stack が named role を含みうるため明示。
+ */
+
+import {
+  Capability,
+  type CloudFormationClient,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { InvokeCommand, type LambdaClient } from "@aws-sdk/client-lambda";
+import { SendCommandCommand, type SSMClient } from "@aws-sdk/client-ssm";
+import type { Credentials } from "@aws-sdk/client-sts";
+import type { DisruptionDispatch } from "./dispatch-command.js";
+
+export interface DispatchTarget {
+  readonly region: string;
+  readonly credentials?: Credentials;
+}
+
+export interface SendDispatchDeps {
+  readonly ssmClient: (target: DispatchTarget) => Pick<SSMClient, "send">;
+  readonly lambdaClient: (target: DispatchTarget) => Pick<LambdaClient, "send">;
+  readonly cfnClient: (target: DispatchTarget) => Pick<CloudFormationClient, "send">;
+}
+
+const DEFAULT_SSM_DOCUMENT = "AWS-RunShellScript";
+const CFN_UPDATE_CAPABILITIES: Capability[] = [
+  Capability.CAPABILITY_IAM,
+  Capability.CAPABILITY_NAMED_IAM,
+  Capability.CAPABILITY_AUTO_EXPAND,
+];
+
+/** dispatch.params の各値を SSM Parameters の Record<string, string[]> へ coerce。 */
+function toSsmParameters(params: Readonly<Record<string, unknown>>): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(params)) {
+    out[key] = Array.isArray(value) ? value.map((v) => String(v)) : [String(value)];
+  }
+  return out;
+}
+
+/** dispatch.params を CFn UpdateStack の Parameters ({ParameterKey, ParameterValue}[]) へ。 */
+function toCfnParameters(
+  params: Readonly<Record<string, unknown>>,
+): { ParameterKey: string; ParameterValue: string }[] {
+  return Object.entries(params).map(([key, value]) => ({
+    ParameterKey: key,
+    ParameterValue: String(value),
+  }));
+}
+
+/** comma 区切りの instance ids 文字列を trim + 空要素除去で配列化。 */
+function toInstanceIds(target: string): string[] {
+  return target
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * 1 つの dispatch 記述子を competitor account で実行する。 AssumeRole 済の credentials は target に乗る
+ * 前提 (= 解決は caller=handler 側)。 SDK error は握り潰さず伝播 (= 注入失敗を loud にする)。
+ */
+export async function sendDispatch(
+  dispatch: DisruptionDispatch,
+  target: DispatchTarget,
+  deps: SendDispatchDeps,
+): Promise<void> {
+  if (dispatch.kind === "ssm-run-command") {
+    await deps.ssmClient(target).send(
+      new SendCommandCommand({
+        DocumentName: dispatch.documentName ?? DEFAULT_SSM_DOCUMENT,
+        InstanceIds: toInstanceIds(dispatch.target),
+        Parameters: toSsmParameters(dispatch.params),
+      }),
+    );
+    return;
+  }
+  if (dispatch.kind === "lambda-invoke") {
+    await deps.lambdaClient(target).send(
+      new InvokeCommand({
+        FunctionName: dispatch.target,
+        InvocationType: "Event",
+        Payload: new TextEncoder().encode(JSON.stringify(dispatch.params)),
+      }),
+    );
+    return;
+  }
+  // cfn-stack-update
+  await deps.cfnClient(target).send(
+    new UpdateStackCommand({
+      StackName: dispatch.target,
+      UsePreviousTemplate: true,
+      Parameters: toCfnParameters(dispatch.params),
+      Capabilities: CFN_UPDATE_CAPABILITIES,
+    }),
+  );
+}

--- a/infrastructure/test/problem-deploy/disruption-send-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-send-dispatch.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DisruptionDispatch } from "../../lib/problem-deploy/handlers/disruption-executor-handler/dispatch-command";
+import {
+  type DispatchTarget,
+  type SendDispatchDeps,
+  sendDispatch,
+} from "../../lib/problem-deploy/handlers/disruption-executor-handler/send-dispatch";
+
+/**
+ * [ADR-031 / #1419] sendDispatch: DisruptionDispatch → 実 SDK command の mapping を mocked client で pin。
+ * client factory は assumed-credential 付きで呼ばれること + 各 kind の command input を観察する。
+ */
+
+const target: DispatchTarget = {
+  region: "ap-northeast-1",
+  credentials: { AccessKeyId: "AK", SecretAccessKey: "SK", SessionToken: "ST" },
+};
+
+function makeDeps(): {
+  deps: SendDispatchDeps;
+  ssm: ReturnType<typeof vi.fn>;
+  lambda: ReturnType<typeof vi.fn>;
+  cfn: ReturnType<typeof vi.fn>;
+  factories: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const ssm = vi.fn().mockResolvedValue({});
+  const lambda = vi.fn().mockResolvedValue({});
+  const cfn = vi.fn().mockResolvedValue({});
+  const ssmFactory = vi.fn().mockReturnValue({ send: ssm });
+  const lambdaFactory = vi.fn().mockReturnValue({ send: lambda });
+  const cfnFactory = vi.fn().mockReturnValue({ send: cfn });
+  return {
+    deps: { ssmClient: ssmFactory, lambdaClient: lambdaFactory, cfnClient: cfnFactory },
+    ssm,
+    lambda,
+    cfn,
+    factories: { ssmFactory, lambdaFactory, cfnFactory },
+  };
+}
+
+describe("sendDispatch (ADR-031 #1419)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should send SSM SendCommand with split InstanceIds and coerced string[] Parameters", async () => {
+    const { deps, ssm, factories } = makeDeps();
+    const dispatch: DisruptionDispatch = {
+      kind: "ssm-run-command",
+      target: "i-aaa, i-bbb ,",
+      documentName: "AWS-RunShellScript",
+      params: { commands: ["echo hi"], timeout: 30 },
+    };
+    await sendDispatch(dispatch, target, deps);
+    expect(factories.ssmFactory).toHaveBeenCalledWith(target);
+    const input = ssm.mock.calls[0][0].input;
+    expect(input.DocumentName).toBe("AWS-RunShellScript");
+    expect(input.InstanceIds).toEqual(["i-aaa", "i-bbb"]);
+    expect(input.Parameters).toEqual({ commands: ["echo hi"], timeout: ["30"] });
+  });
+
+  it("should default the SSM document name when none is declared", async () => {
+    const { deps, ssm } = makeDeps();
+    await sendDispatch({ kind: "ssm-run-command", target: "i-x", params: {} }, target, deps);
+    expect(ssm.mock.calls[0][0].input.DocumentName).toBe("AWS-RunShellScript");
+  });
+
+  it("should invoke Lambda asynchronously (Event) with the params as JSON payload", async () => {
+    const { deps, lambda, factories } = makeDeps();
+    await sendDispatch(
+      { kind: "lambda-invoke", target: "fault-fn", params: { mode: "fail" } },
+      target,
+      deps,
+    );
+    expect(factories.lambdaFactory).toHaveBeenCalledWith(target);
+    const input = lambda.mock.calls[0][0].input;
+    expect(input.FunctionName).toBe("fault-fn");
+    expect(input.InvocationType).toBe("Event");
+    expect(new TextDecoder().decode(input.Payload)).toBe(JSON.stringify({ mode: "fail" }));
+  });
+
+  it("should update the CFn stack with UsePreviousTemplate + mapped Parameters + IAM capabilities", async () => {
+    const { deps, cfn, factories } = makeDeps();
+    await sendDispatch(
+      { kind: "cfn-stack-update", target: "team-stack", params: { DesiredCount: 0 } },
+      target,
+      deps,
+    );
+    expect(factories.cfnFactory).toHaveBeenCalledWith(target);
+    const input = cfn.mock.calls[0][0].input;
+    expect(input.StackName).toBe("team-stack");
+    expect(input.UsePreviousTemplate).toBe(true);
+    expect(input.Parameters).toEqual([{ ParameterKey: "DesiredCount", ParameterValue: "0" }]);
+    expect(input.Capabilities).toContain("CAPABILITY_NAMED_IAM");
+  });
+
+  it("should propagate SDK errors (fault injection failure is loud)", async () => {
+    const { deps, ssm } = makeDeps();
+    ssm.mockRejectedValueOnce(new Error("AccessDenied"));
+    await expect(
+      sendDispatch({ kind: "ssm-run-command", target: "i-x", params: {} }, target, deps),
+    ).rejects.toThrow("AccessDenied");
+  });
+});


### PR DESCRIPTION
## Summary

The executor's **`sendDispatch`** dep impl: map a `DisruptionDispatch` descriptor (from #1640's builders) to the real competitor-account SDK command, via injected client factories (the `describe-stack-handler` `{region, credentials}` factory pattern). **No new SDK dependency** — `@aws-sdk/client-ssm`, `-lambda`, and `-cloudformation` are all already infra deps (I'd earlier mis-stated Lambda as a gate; it isn't).

> Stacked on #1640 (executor core, for `DisruptionDispatch`). Base `feat/1419-executor-dispatch-core`.

### Mapping (per kind)

- **`ssm-run-command`** → `SendCommand`: `target` comma-split into `InstanceIds`, `params` coerced to SSM `Parameters` (`Record<string,string[]>`), document defaults to `AWS-RunShellScript`.
- **`lambda-invoke`** → `Invoke` `InvocationType=Event` (async fire-and-forget fault, doesn't block the executor), `params` as the JSON payload.
- **`cfn-stack-update`** → `UpdateStack` `UsePreviousTemplate=true` + mapped `Parameters` + IAM capabilities (competitor stacks may declare named roles).
- SDK errors **propagate** (fault-injection failure is loud, no silent swallow).

## Test plan

- **5 unit tests** (mocked client factories): SSM InstanceIds-split + string[] coercion + default document; Lambda async Event + JSON payload; CFn UsePreviousTemplate + Parameters + capabilities; factory called with the assumed-credential target; SDK error propagation.
- `tsc --noEmit`, biome, `make harness` (no findings), `check-no-conflicts`: all clean. Infra suite green.

## Regression analysis

Net-new, **zero production call sites** — a new module; nothing imports it at runtime yet (the handler entry that wires it + the CDK construct are the owner-reviewed deploy step). No Lambda/IAM/event/existing-file change. Pure mapping over injected clients; behavior is exercised entirely through mocks.

## Physical impact

**NO-OP** on CloudFormation / deployed artifacts. A TypeScript module + tests using already-present SDK clients; no construct, IAM, or dependency change. Nothing is invocable until the handler entry + construct land (owner-reviewed).

## Remaining for #1419

`scheduleRevert` (`aws-scheduler` — would add `@aws-sdk/client-scheduler`), the handler entry wiring all deps, and the **CDK construct** (Lambda + EventBridge rule + scoped `sts:AssumeRole` IAM). Those **deploy real fault injection into competitor accounts on the AdministratorAccess role** — your review/deploy decision.

Relates #1419