### PR TITLE
feat(disruption): executor invocation router — inject vs revert (ADR-031) [#1419]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/route.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/route.ts
@@ -1,0 +1,90 @@
+/**
+ * [ADR-031 / Issue #1419] executor Lambda の invocation router (= handler entry の純粋ロジック)。
+ *
+ * 同じ executor Lambda が 2 経路で起動される:
+ *   1. EventBridge `*DisruptionFired` rule → `{ ..., detail: DisruptionFiredDetail }` envelope (= 注入)
+ *   2. aws-scheduler の one-shot → `{ mode: "revert", dispatch, target }` payload (= 復旧、 scheduleRevert が積む)
+ *
+ * router は両者を判別し、 注入は `executeDisruptionAction`、 復旧は `sendDispatch` dep をそのまま再利用する
+ * (= revert の credentials は wired sendDispatch dep が target から都度 AssumeRole する前提なので、 inject と
+ * 同じ dep で送れる)。 不正 envelope は `invalid_event` (= loud に落とさず handler が log/metric にできる形)。
+ *
+ * 実 client / AssumeRole の組み立ては index.ts (= 別途、 deploy 判断を伴う) が deps として注入する。
+ * 本 module は純粋で、 unit test で全分岐を mock で pin できる。
+ */
+
+import type { DisruptionDispatch } from "./dispatch-command.js";
+import {
+  type DeploymentTarget,
+  type DisruptionExecuteOutcome,
+  type DisruptionFiredDetail,
+  type ExecutorDeps,
+  executeDisruptionAction,
+} from "./execute.js";
+
+interface RevertInvocation {
+  readonly mode: "revert";
+  readonly dispatch: DisruptionDispatch;
+  readonly target: DeploymentTarget;
+}
+
+export type RouteOutcome =
+  | DisruptionExecuteOutcome
+  | { readonly kind: "reverted" }
+  | { readonly kind: "invalid_event" };
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** EventBridge envelope の `detail` を DisruptionFiredDetail へ narrow。 必須 string 欠落は undefined。 */
+export function parseDisruptionFiredDetail(event: unknown): DisruptionFiredDetail | undefined {
+  if (!isObject(event) || !isObject(event.detail)) return undefined;
+  const d = event.detail;
+  const disruptionId = asNonEmptyString(d.disruptionId);
+  const eventId = asNonEmptyString(d.eventId);
+  const problemId = asNonEmptyString(d.problemId);
+  const tenantId = asNonEmptyString(d.tenantId);
+  const teamId = asNonEmptyString(d.teamId);
+  const requestId = asNonEmptyString(d.requestId);
+  const firedAt = asNonEmptyString(d.firedAt);
+  if (!disruptionId || !eventId || !problemId || !tenantId || !teamId || !requestId || !firedAt) {
+    return undefined;
+  }
+  return {
+    disruptionId,
+    eventId,
+    problemId,
+    tenantId,
+    teamId,
+    requestId,
+    firedAt,
+    parameters: isObject(d.parameters) ? d.parameters : {},
+  };
+}
+
+function isRevertInvocation(event: unknown): event is RevertInvocation {
+  return (
+    isObject(event) && event.mode === "revert" && isObject(event.dispatch) && isObject(event.target)
+  );
+}
+
+/** executor Lambda の 1 invocation を inject / revert に振り分けて実行する。 */
+export async function routeDisruptionInvocation(
+  event: unknown,
+  deps: ExecutorDeps,
+): Promise<RouteOutcome> {
+  if (isRevertInvocation(event)) {
+    // revert: scheduleRevert が積んだ構築済 dispatch を、 inject と同じ sendDispatch dep で送る
+    // (= dep が target から都度 AssumeRole する。 注入時 creds は永続しない)。
+    await deps.sendDispatch(event.dispatch, event.target);
+    return { kind: "reverted" };
+  }
+  const detail = parseDisruptionFiredDetail(event);
+  if (!detail) return { kind: "invalid_event" };
+  return executeDisruptionAction(detail, deps);
+}

--- a/infrastructure/test/problem-deploy/disruption-route.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecutorDeps } from "../../lib/problem-deploy/handlers/disruption-executor-handler/execute";
+import {
+  parseDisruptionFiredDetail,
+  routeDisruptionInvocation,
+} from "../../lib/problem-deploy/handlers/disruption-executor-handler/route";
+import type { ProblemDisruptionEntry } from "../../lib/utils/discover-problems-catalog";
+
+/**
+ * [ADR-031 / #1419] executor router: EventBridge inject envelope と scheduler revert payload を
+ * 判別し、 それぞれ executeDisruptionAction / sendDispatch dep に振り分けることを pin する。
+ */
+
+const action = {
+  kind: "ssm-run-command" as const,
+  targetRef: "WorkerInstanceIds",
+  paramTemplate: { commands: ["delay {{delayMs}}"] },
+  revert: { afterSeconds: 600 },
+};
+const withAction: ProblemDisruptionEntry = {
+  id: "ec2-latency-injection",
+  name: "latency",
+  eventDetailType: "DegradedDisruptionFired",
+  parameters: { delayMs: 200 },
+  action,
+};
+
+const firedDetail = {
+  disruptionId: "ec2-latency-injection",
+  eventId: "evt-1",
+  problemId: "microservice-migration-battle",
+  tenantId: "tenant-1",
+  teamId: "team-1",
+  parameters: { delayMs: 200 },
+  requestId: "req-1",
+  firedAt: "2026-06-02T00:00:00.000Z",
+};
+
+const deploymentTarget = {
+  jobId: "job-1",
+  region: "ap-northeast-1",
+  competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+  externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+  stackOutputs: { WorkerInstanceIds: "i-aaa" },
+};
+
+function makeDeps(over: Partial<ExecutorDeps> = {}): ExecutorDeps {
+  return {
+    problemsDisruptions: { "microservice-migration-battle": [withAction] },
+    claimExecution: vi.fn().mockResolvedValue("claimed"),
+    resolveDeployment: vi.fn().mockResolvedValue(deploymentTarget),
+    sendDispatch: vi.fn().mockResolvedValue(undefined),
+    scheduleRevert: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  };
+}
+
+describe("parseDisruptionFiredDetail", () => {
+  it("should narrow a valid EventBridge envelope detail", () => {
+    expect(parseDisruptionFiredDetail({ "detail-type": "X", detail: firedDetail })).toEqual(
+      firedDetail,
+    );
+  });
+
+  it("should default parameters to {} when absent / non-object", () => {
+    const { parameters, ...rest } = firedDetail;
+    expect(parseDisruptionFiredDetail({ detail: rest })?.parameters).toEqual({});
+    expect(
+      parseDisruptionFiredDetail({ detail: { ...rest, parameters: ["x"] } })?.parameters,
+    ).toEqual({});
+  });
+
+  it("should return undefined for a missing detail or a missing required field", () => {
+    expect(parseDisruptionFiredDetail(undefined)).toBeUndefined();
+    expect(parseDisruptionFiredDetail({})).toBeUndefined();
+    expect(parseDisruptionFiredDetail({ detail: { ...firedDetail, teamId: "" } })).toBeUndefined();
+  });
+});
+
+describe("routeDisruptionInvocation (ADR-031 #1419)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should route an EventBridge fired envelope to executeDisruptionAction (inject)", async () => {
+    const deps = makeDeps();
+    const outcome = await routeDisruptionInvocation(
+      { "detail-type": "DegradedDisruptionFired", detail: firedDetail },
+      deps,
+    );
+    expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
+    expect(deps.sendDispatch).toHaveBeenCalledTimes(1); // the inject send
+    expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
+  });
+
+  it("should route a scheduler revert payload straight to sendDispatch (no re-execution)", async () => {
+    const deps = makeDeps();
+    const revertDispatch = {
+      kind: "ssm-run-command" as const,
+      target: "i-aaa",
+      params: { commands: ["undo"] },
+    };
+    const outcome = await routeDisruptionInvocation(
+      { mode: "revert", dispatch: revertDispatch, target: deploymentTarget },
+      deps,
+    );
+    expect(outcome).toEqual({ kind: "reverted" });
+    expect(deps.sendDispatch).toHaveBeenCalledWith(revertDispatch, deploymentTarget);
+    expect(deps.claimExecution).not.toHaveBeenCalled();
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  it("should return invalid_event for a malformed envelope (neither revert nor a valid detail)", async () => {
+    const deps = makeDeps();
+    expect(await routeDisruptionInvocation({ detail: { teamId: "team-1" } }, deps)).toEqual({
+      kind: "invalid_event",
+    });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+  });
+
+  it("should treat a revert payload missing dispatch/target as a (failing) inject parse", async () => {
+    const deps = makeDeps();
+    expect(await routeDisruptionInvocation({ mode: "revert" }, deps)).toEqual({
+      kind: "invalid_event",
+    });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The last piece of executor **logic**: `routeDisruptionInvocation` distinguishes the two ways the single executor Lambda is invoked and dispatches each.

> Stacked on #1642 → #1641 → #1640 → #1639. Base `feat/1419-executor-schedule-revert`.

- **EventBridge `*DisruptionFired`** envelope → `parseDisruptionFiredDetail` → `executeDisruptionAction` (inject path).
- **aws-scheduler one-shot** `{ mode:"revert", dispatch, target }` → reuse the `sendDispatch` dep directly (the wired dep re-AssumeRoles from `target`, so inject-time credentials are never persisted; the pre-built revert dispatch just gets sent).
- **malformed** envelope → `invalid_event` (the handler logs/metrics; no crash).

`parseDisruptionFiredDetail` narrows the EventBridge `detail` (all required strings present; `parameters` defaults to `{}` for absent/non-object). Pure module with DI — `index.ts` (the real-client + AssumeRole wiring) is the deploy step.

## Test plan

- **9 new tests** (`disruption-route.test.ts`): parse (valid / default-params / missing-field), route (inject → execute, revert → sendDispatch only, malformed → invalid_event, revert-missing-fields → invalid_event).
- `tsc --noEmit`, biome, `make harness` (no findings), `check-no-conflicts`: clean. Infra suite green.

## Executor logic — now complete

With this PR the executor's entire **logic** is built + tested (≈39 tests), all pure / DI, no deploy:

| module | PR |
|---|---|
| dispatch builders | #1640 |
| orchestration (`executeDisruptionAction`) | #1640 |
| DDB store (`claimExecution` / `resolveDeployment`) | #1640 |
| `sendDispatch` (SSM/Lambda/CFn) | #1641 |
| `scheduleRevert` (aws-scheduler) | #1642 |
| **invocation router** | **this PR** |

## Regression analysis

Net-new, **zero production call sites** (the `index.ts` real-deps wiring + CDK construct are the owner-reviewed deploy step). No Lambda/IAM/event/existing-file change. Pure functions over injected deps; the `invalid_event` / not-called branches are asserted.

## Physical impact

**NO-OP** on CloudFormation / deployed artifacts. A TypeScript module + tests. Nothing invocable until `index.ts` + the construct land.

## Remaining for #1419 (deploy boundary, owner)

- `index.ts` — construct the real clients + `assumeCompetitorRole` (describe-stack pattern) + wire `sendDispatch`/`scheduleRevert`/store deps, export the Lambda handler over `routeDisruptionInvocation`.
- **CDK construct** — Lambda + EventBridge rule (`*DisruptionFired`) + scoped `sts:AssumeRole` IAM + the scheduler execution role + env (table names, catalog, scheduler role ARN, self ARN).

These **deploy real fault injection into competitor accounts on the AdministratorAccess role** — your review/deploy decision.

Relates #1419