### PR TITLE
refactor(problem-deploy): extract shared assumeCompetitorRole (SOLID/DRY) [#1419]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -1,7 +1,7 @@
 import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
-import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
-import type { Credentials } from "@aws-sdk/client-sts";
-import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { type Credentials, STSClient } from "@aws-sdk/client-sts";
+import { assumeCompetitorRole } from "../shared/assume-competitor-role.js";
 import { errorDeployTrace, logDeployTrace } from "../shared/trace-log.js";
 
 export interface DescribeStackStateMachineInput {
@@ -30,147 +30,6 @@ function requireString(value: unknown, field: string): string {
     throw new Error(`missing required field: ${field}`);
   }
   return value;
-}
-
-function assertCompleteCredentials(credentials: Credentials | undefined): Credentials {
-  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey || !credentials.SessionToken) {
-    throw new Error("AssumeRole returned incomplete credentials");
-  }
-  return credentials;
-}
-
-/**
- * Issue #1245 + #856: rotation race の AssumeRole 失敗のうち、 ExternalId mismatch に起因する
- * 4xx だけを 1 generation 前で retry する。 Network / Throttling / 5xx 系は retry せず即 fail。
- *
- * `verify.ts` 側の `shouldRetryWithPreviousVersion` と同じ error name 集合を共有し、
- * blanket-catch (= 全 error で previous version を試す) のような band-aid を避ける。
- */
-const ASSUME_ROLE_FALLBACK_ERROR_NAMES: ReadonlySet<string> = new Set([
-  "AccessDenied",
-  "AccessDeniedException",
-  "Forbidden",
-]);
-
-function shouldRetryWithPreviousVersion(err: unknown): boolean {
-  const name = err instanceof Error ? err.name : "";
-  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(name);
-}
-
-async function assumeCompetitorRole(
-  deps: DescribeStackDeps,
-  params: {
-    readonly region: string;
-    readonly jobId: string;
-    readonly competitorRoleArn?: string;
-    readonly externalIdParameterName?: string;
-  },
-): Promise<Credentials | undefined> {
-  const hasRole =
-    typeof params.competitorRoleArn === "string" && params.competitorRoleArn.length > 0;
-  const hasExternalId =
-    typeof params.externalIdParameterName === "string" && params.externalIdParameterName.length > 0;
-  if (!hasRole && !hasExternalId) return undefined;
-  if (!hasRole || !hasExternalId) {
-    throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
-  }
-  // 上の 2 guard で competitorRoleArn / externalIdParameterName が string であることは確定。
-  const competitorRoleArn = params.competitorRoleArn as string;
-  const externalIdParameterName = params.externalIdParameterName as string;
-
-  const externalIdOut = await deps.ssm.send(
-    new GetParameterCommand({
-      Name: externalIdParameterName,
-      WithDecryption: true,
-    }),
-  );
-  const externalId = externalIdOut.Parameter?.Value;
-  if (!externalId) {
-    throw new Error(`ExternalId not found in SSM SecureString: ${externalIdParameterName}`);
-  }
-
-  try {
-    return await assumeRoleWithExternalId(deps, competitorRoleArn, params.jobId, externalId);
-  } catch (currentErr) {
-    return await retryWithPreviousExternalId(deps, {
-      region: params.region,
-      jobId: params.jobId,
-      competitorRoleArn,
-      externalIdParameterName,
-      currentVersion: Number(externalIdOut.Parameter?.Version ?? 0),
-      currentErr,
-    });
-  }
-}
-
-/**
- * Issue #1245: rotation race の retry path を 1 関数に切り出す。
- *
- * 旧 implementation の問題点:
- *   - 全 error class で blanket fallback (= Throttling / Network 系も前 version で retry していた)
- *   - 成功時の log が `console.warn` の自由 string であり、 metrics filter が当てづらく silent
- *
- * 修正後:
- *   - `shouldRetryWithPreviousVersion` で AccessDenied 系 (= ExternalId mismatch) に絞る
- *   - 1 generation 前 SSM version が無ければ original error を rethrow (= silent skip しない)
- *   - 成功時は `errorDeployTrace` で `deploy.describe-stack.assume-role.grace-fallback` を発火し、
- *     operator alarm に pick up させる (= grace 多発 = rotation pipeline のバグ可視化)
- *   - retry でも ExternalId は必ず渡される (= 「ExternalId 無し AssumeRole」は禁止)
- */
-async function retryWithPreviousExternalId(
-  deps: DescribeStackDeps,
-  args: {
-    readonly region: string;
-    readonly jobId: string;
-    readonly competitorRoleArn: string;
-    readonly externalIdParameterName: string;
-    readonly currentVersion: number;
-    readonly currentErr: unknown;
-  },
-): Promise<Credentials> {
-  const { currentErr } = args;
-  if (!shouldRetryWithPreviousVersion(currentErr)) throw currentErr;
-  const previousVersion = args.currentVersion - 1;
-  if (previousVersion <= 0) throw currentErr;
-  const previousExternalIdOut = await deps.ssm.send(
-    new GetParameterCommand({
-      Name: `${args.externalIdParameterName}:${previousVersion}`,
-      WithDecryption: true,
-    }),
-  );
-  const previousExternalId = previousExternalIdOut.Parameter?.Value;
-  if (!previousExternalId) throw currentErr;
-  const credentials = await assumeRoleWithExternalId(
-    deps,
-    args.competitorRoleArn,
-    args.jobId,
-    previousExternalId,
-  );
-  errorDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
-    jobId: args.jobId,
-    correlationId: args.jobId,
-    region: args.region,
-    externalIdVersion: previousVersion,
-    reason: currentErr instanceof Error ? currentErr.name : "Unknown",
-  });
-  return credentials;
-}
-
-async function assumeRoleWithExternalId(
-  deps: DescribeStackDeps,
-  roleArn: string,
-  jobId: string,
-  externalId: string,
-): Promise<Credentials> {
-  const assumeOut = await deps.sts.send(
-    new AssumeRoleCommand({
-      RoleArn: roleArn,
-      RoleSessionName: `tenkacloud-describe-stack-${jobId.slice(0, 24)}`,
-      ExternalId: externalId,
-      DurationSeconds: 900,
-    }),
-  );
-  return assertCompleteCredentials(assumeOut.Credentials);
 }
 
 /**
@@ -230,6 +89,8 @@ export async function describeStackForDeployment(
     jobId,
     competitorRoleArn: detail.competitorRoleArn,
     externalIdParameterName: detail.externalIdParameterName,
+    sessionNamePrefix: "tenkacloud-describe-stack-",
+    graceFallbackTraceEvent: "deploy.describe-stack.assume-role.grace-fallback",
   });
   const cfn = deps.cfnClient({ region, credentials });
   const out = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));

--- a/infrastructure/lib/problem-deploy/handlers/shared/assume-competitor-role.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/assume-competitor-role.ts
@@ -1,0 +1,169 @@
+/**
+ * Cross-account AssumeRole into the competitor's `CompetitorDeployRole`, shared across handlers.
+ *
+ * 以前は describe-stack-handler が自前で持ち、 verify.ts / participant SSO も類似ロジックを別個に
+ * 抱えていた (= rotation-race retry / ExternalId mismatch fallback の error name 集合がコメントで
+ * 「同じものを共有」 と書かれつつ実体は重複していた)。 ここに 1 本化して **単一の監査点** にする
+ * (= 資格情報経路の重複は security リスク。 #856 / #1245 で hardening した retry を 1 箇所に集約)。
+ *
+ * caller 固有の cosmetic だけを param 化する (= 振る舞いは不変):
+ *   - `sessionNamePrefix`: RoleSessionName の prefix (例: describe-stack / disruption-executor)
+ *   - `graceFallbackTraceEvent`: grace-fallback 成功時に発火する trace event 名 (operator alarm が key にする)
+ *
+ * Issue #1245 + #856 の方針はそのまま:
+ *   - ExternalId は SSM SecureString から都度 decrypt (= コードに埋め込まない)
+ *   - AssumeRole 失敗のうち AccessDenied 系 (= ExternalId mismatch) だけ 1 generation 前で 1 度 retry
+ *   - Network / Throttling / 5xx は retry せず即 rethrow (= blanket fallback band-aid を避ける)
+ *   - grace-fallback 成功は errorDeployTrace で発火し operator alarm に拾わせる
+ *   - retry でも ExternalId は必ず渡す (= 「ExternalId 無し AssumeRole」 は禁止)
+ */
+
+import { GetParameterCommand, type SSMClient } from "@aws-sdk/client-ssm";
+import { AssumeRoleCommand, type Credentials, type STSClient } from "@aws-sdk/client-sts";
+import { errorDeployTrace } from "./trace-log.js";
+
+export interface AssumeCompetitorRoleDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly sts: Pick<STSClient, "send">;
+}
+
+export interface AssumeCompetitorRoleParams {
+  readonly region: string;
+  readonly jobId: string;
+  readonly competitorRoleArn?: string;
+  readonly externalIdParameterName?: string;
+  /** RoleSessionName prefix (caller 識別)。 例: "tenkacloud-describe-stack-" / "tc-disruption-"。 */
+  readonly sessionNamePrefix: string;
+  /** grace-fallback 成功時の trace event 名 (= operator alarm の key)。 */
+  readonly graceFallbackTraceEvent: string;
+}
+
+const ASSUME_ROLE_FALLBACK_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "AccessDenied",
+  "AccessDeniedException",
+  "Forbidden",
+]);
+
+/** AccessDenied 系 (= ExternalId mismatch) のみ 1 generation 前での retry 対象。 */
+export function shouldRetryWithPreviousExternalIdVersion(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : "";
+  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(name);
+}
+
+function assertCompleteCredentials(credentials: Credentials | undefined): Credentials {
+  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey || !credentials.SessionToken) {
+    throw new Error("AssumeRole returned incomplete credentials");
+  }
+  return credentials;
+}
+
+async function assumeRoleWithExternalId(
+  deps: AssumeCompetitorRoleDeps,
+  args: {
+    readonly roleArn: string;
+    readonly jobId: string;
+    readonly externalId: string;
+    readonly sessionNamePrefix: string;
+  },
+): Promise<Credentials> {
+  const assumeOut = await deps.sts.send(
+    new AssumeRoleCommand({
+      RoleArn: args.roleArn,
+      RoleSessionName: `${args.sessionNamePrefix}${args.jobId.slice(0, 24)}`,
+      ExternalId: args.externalId,
+      DurationSeconds: 900,
+    }),
+  );
+  return assertCompleteCredentials(assumeOut.Credentials);
+}
+
+async function retryWithPreviousExternalId(
+  deps: AssumeCompetitorRoleDeps,
+  args: {
+    readonly region: string;
+    readonly jobId: string;
+    readonly competitorRoleArn: string;
+    readonly externalIdParameterName: string;
+    readonly currentVersion: number;
+    readonly currentErr: unknown;
+    readonly sessionNamePrefix: string;
+    readonly graceFallbackTraceEvent: string;
+  },
+): Promise<Credentials> {
+  const { currentErr } = args;
+  if (!shouldRetryWithPreviousExternalIdVersion(currentErr)) throw currentErr;
+  const previousVersion = args.currentVersion - 1;
+  if (previousVersion <= 0) throw currentErr;
+  const previousExternalIdOut = await deps.ssm.send(
+    new GetParameterCommand({
+      Name: `${args.externalIdParameterName}:${previousVersion}`,
+      WithDecryption: true,
+    }),
+  );
+  const previousExternalId = previousExternalIdOut.Parameter?.Value;
+  if (!previousExternalId) throw currentErr;
+  const credentials = await assumeRoleWithExternalId(deps, {
+    roleArn: args.competitorRoleArn,
+    jobId: args.jobId,
+    externalId: previousExternalId,
+    sessionNamePrefix: args.sessionNamePrefix,
+  });
+  errorDeployTrace(args.graceFallbackTraceEvent, {
+    jobId: args.jobId,
+    correlationId: args.jobId,
+    region: args.region,
+    externalIdVersion: previousVersion,
+    reason: currentErr instanceof Error ? currentErr.name : "Unknown",
+  });
+  return credentials;
+}
+
+/**
+ * competitor account の `CompetitorDeployRole` を ExternalId 付きで AssumeRole する。
+ * competitorRoleArn / externalIdParameterName の双方が無ければ undefined (= same-account 経路)、
+ * 片方だけは config error。 ExternalId mismatch (rotation race) は 1 generation 前で 1 度 retry。
+ */
+export async function assumeCompetitorRole(
+  deps: AssumeCompetitorRoleDeps,
+  params: AssumeCompetitorRoleParams,
+): Promise<Credentials | undefined> {
+  const hasRole =
+    typeof params.competitorRoleArn === "string" && params.competitorRoleArn.length > 0;
+  const hasExternalId =
+    typeof params.externalIdParameterName === "string" && params.externalIdParameterName.length > 0;
+  if (!hasRole && !hasExternalId) return undefined;
+  if (!hasRole || !hasExternalId) {
+    throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
+  }
+  // 上の 2 guard で competitorRoleArn / externalIdParameterName が string であることは確定。
+  const competitorRoleArn = params.competitorRoleArn as string;
+  const externalIdParameterName = params.externalIdParameterName as string;
+
+  const externalIdOut = await deps.ssm.send(
+    new GetParameterCommand({ Name: externalIdParameterName, WithDecryption: true }),
+  );
+  const externalId = externalIdOut.Parameter?.Value;
+  if (!externalId) {
+    throw new Error(`ExternalId not found in SSM SecureString: ${externalIdParameterName}`);
+  }
+
+  try {
+    return await assumeRoleWithExternalId(deps, {
+      roleArn: competitorRoleArn,
+      jobId: params.jobId,
+      externalId,
+      sessionNamePrefix: params.sessionNamePrefix,
+    });
+  } catch (currentErr) {
+    return await retryWithPreviousExternalId(deps, {
+      region: params.region,
+      jobId: params.jobId,
+      competitorRoleArn,
+      externalIdParameterName,
+      currentVersion: Number(externalIdOut.Parameter?.Version ?? 0),
+      currentErr,
+      sessionNamePrefix: params.sessionNamePrefix,
+      graceFallbackTraceEvent: params.graceFallbackTraceEvent,
+    });
+  }
+}

--- a/infrastructure/test/problem-deploy/assume-competitor-role.test.ts
+++ b/infrastructure/test/problem-deploy/assume-competitor-role.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const errorDeployTrace = vi.fn();
+vi.mock("../../lib/problem-deploy/handlers/shared/trace-log", () => ({
+  errorDeployTrace: (...args: unknown[]) => errorDeployTrace(...args),
+  logDeployTrace: vi.fn(),
+}));
+
+import {
+  type AssumeCompetitorRoleDeps,
+  assumeCompetitorRole,
+  shouldRetryWithPreviousExternalIdVersion,
+} from "../../lib/problem-deploy/handlers/shared/assume-competitor-role";
+
+/**
+ * 共有 assumeCompetitorRole の挙動 pin。 describe-stack-handler の既存 test が回帰網だが、 ここでは
+ * 共有契約 + parameterize した cosmetic (sessionNamePrefix / graceFallbackTraceEvent) を直接確認する。
+ */
+
+const CREDS = { AccessKeyId: "AK", SecretAccessKey: "SK", SessionToken: "ST" };
+
+function makeDeps(
+  ssmSend: ReturnType<typeof vi.fn>,
+  stsSend: ReturnType<typeof vi.fn>,
+): AssumeCompetitorRoleDeps {
+  return {
+    ssm: { send: ssmSend } as unknown as AssumeCompetitorRoleDeps["ssm"],
+    sts: { send: stsSend } as unknown as AssumeCompetitorRoleDeps["sts"],
+  };
+}
+
+const baseParams = {
+  region: "ap-northeast-1",
+  jobId: "job-1234567890123456789012345678",
+  competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+  externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+  sessionNamePrefix: "tc-disruption-",
+  graceFallbackTraceEvent: "deploy.disruption-executor.assume-role.grace-fallback",
+};
+
+describe("assumeCompetitorRole (shared)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return undefined when neither competitorRoleArn nor externalIdParameterName is given", async () => {
+    const deps = makeDeps(vi.fn(), vi.fn());
+    expect(
+      await assumeCompetitorRole(deps, {
+        ...baseParams,
+        competitorRoleArn: undefined,
+        externalIdParameterName: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should throw when only one side of the cross-account metadata is present", async () => {
+    const deps = makeDeps(vi.fn(), vi.fn());
+    await expect(
+      assumeCompetitorRole(deps, { ...baseParams, externalIdParameterName: undefined }),
+    ).rejects.toThrow("must be provided together");
+  });
+
+  it("should throw when the SSM ExternalId parameter has no value", async () => {
+    const deps = makeDeps(vi.fn().mockResolvedValue({ Parameter: {} }), vi.fn());
+    await expect(assumeCompetitorRole(deps, baseParams)).rejects.toThrow(
+      "ExternalId not found in SSM SecureString",
+    );
+  });
+
+  it("should AssumeRole with the caller's session-name prefix (truncated jobId) and return the creds", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "ext-id", Version: 3 } });
+    const sts = vi.fn().mockResolvedValue({ Credentials: CREDS });
+    expect(await assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).toEqual(CREDS);
+    const input = sts.mock.calls[0][0].input;
+    expect(input.RoleSessionName).toBe(`tc-disruption-${baseParams.jobId.slice(0, 24)}`);
+    expect(input.ExternalId).toBe("ext-id");
+    expect(input.DurationSeconds).toBe(900);
+  });
+
+  it("should throw when AssumeRole returns incomplete credentials", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "ext-id", Version: 1 } });
+    const sts = vi.fn().mockResolvedValue({ Credentials: { AccessKeyId: "AK" } });
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow(
+      "incomplete credentials",
+    );
+  });
+
+  it("should grace-fallback to the previous ExternalId version on AccessDenied and fire the caller's trace event", async () => {
+    const ssm = vi
+      .fn()
+      .mockResolvedValueOnce({ Parameter: { Value: "new-id", Version: 4 } })
+      .mockResolvedValueOnce({ Parameter: { Value: "old-id", Version: 3 } });
+    const denied = Object.assign(new Error("denied"), { name: "AccessDenied" });
+    const sts = vi.fn().mockRejectedValueOnce(denied).mockResolvedValueOnce({ Credentials: CREDS });
+    expect(await assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).toEqual(CREDS);
+    expect(ssm.mock.calls[1][0].input.Name).toBe(`${baseParams.externalIdParameterName}:3`);
+    expect(errorDeployTrace).toHaveBeenCalledWith(
+      "deploy.disruption-executor.assume-role.grace-fallback",
+      expect.objectContaining({ externalIdVersion: 3, reason: "AccessDenied" }),
+    );
+  });
+
+  it("should rethrow immediately on a non-AccessDenied error (no blanket band-aid)", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "id", Version: 2 } });
+    const sts = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("slow"), { name: "ThrottlingException" }));
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow("slow");
+    expect(errorDeployTrace).not.toHaveBeenCalled();
+  });
+
+  it("should rethrow the original error when there is no previous version to fall back to", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "id", Version: 1 } });
+    const denied = Object.assign(new Error("denied"), { name: "AccessDenied" });
+    const sts = vi.fn().mockRejectedValue(denied);
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow("denied");
+  });
+});
+
+describe("shouldRetryWithPreviousExternalIdVersion", () => {
+  it("should retry only on the AccessDenied family", () => {
+    for (const name of ["AccessDenied", "AccessDeniedException", "Forbidden"]) {
+      expect(shouldRetryWithPreviousExternalIdVersion(Object.assign(new Error(), { name }))).toBe(
+        true,
+      );
+    }
+    expect(
+      shouldRetryWithPreviousExternalIdVersion(
+        Object.assign(new Error(), { name: "ThrottlingException" }),
+      ),
+    ).toBe(false);
+    expect(shouldRetryWithPreviousExternalIdVersion("not-an-error")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The directive's **SOLID/DRY** clause applied to the cross-account auth path. The AssumeRole-into-`CompetitorDeployRole` logic — including the #856/#1245 rotation-race ExternalId-mismatch retry + grace-fallback trace — lived inline in `describe-stack-handler` and was near-duplicated in `competitor-accounts/verify.ts` + participant SSO (the code even comments that they "share the same error-name set" while duplicating it).

This extracts the canonical implementation to **`handlers/shared/assume-competitor-role.ts`**, giving credential-path code a **single audited home** (consolidating security-critical auth is a *security improvement*, not just dedup) and letting the upcoming disruption executor (#1419) reuse it instead of copying it.

### Behavior-preserving by construction

Only **caller-cosmetic** bits are parameterized:
- `sessionNamePrefix` — the `RoleSessionName` prefix
- `graceFallbackTraceEvent` — the trace event name operator alarms key on

`describe-stack` passes its **exact prior values** (`"tenkacloud-describe-stack-"` + `"deploy.describe-stack.assume-role.grace-fallback"`), so its session name and trace event name are byte-identical. The retry semantics, ExternalId decryption, incomplete-credential guard, and rethrow rules are a pure relocation.

## Test plan

- **describe-stack's existing 20 tests pass UNCHANGED** — this is the regression proof. They cover: AssumeRole-with-ExternalId, legacy same-account fallback, one-sided-metadata config error, retry-with-previous-generation on AccessDenied, **NO** retry on non-AccessDenied, incomplete-credential throw, SSM-no-value throw, and the assertion that `deploy.describe-stack.assume-role.grace-fallback` fires at error level (the operator-alarm pin).
- **9 new direct tests** of the shared module (`assume-competitor-role.test.ts`): undefined / one-sided / no-value / happy session-name (custom prefix) / incomplete-creds / grace-fallback-fires-the-caller's-trace / non-AccessDenied rethrow / no-previous-version rethrow + the retry predicate family.
- Full infra suite **2377 pass**. `tsc --noEmit`, biome, `make harness` (no findings), `check-no-conflicts`: all clean.

## Regression analysis

- **Pure relocation + parameterization of cosmetics.** describe-stack's behavior (incl. the exact trace event name + session name) is unchanged, proven by its 20 tests passing without edits. No call-signature change for describe-stack beyond the two new cosmetic params it now passes explicitly.
- `verify.ts` / SSO are **untouched** (they keep their own variants — different deps/return shapes; consolidating them is a noted follow-up). So this PR's blast radius is exactly describe-stack + the new shared module.
- The shared module is dependency-light (`@aws-sdk/client-ssm` + `-sts`, already deps) and pure over injected `send`.

## Physical impact

**NO-OP** on CloudFormation / deployed artifacts. Code-move + a new TypeScript module + tests; no construct, IAM, Lambda, or dependency change. The describe-stack Lambda's runtime behavior (including its AssumeRole calls + traces) is identical.

Relates #1419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated cross-account role assumption logic into a shared helper for improved maintainability and consistency.

* **Tests**
  * Added comprehensive test coverage for credential assumption, retry mechanisms, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->