### PR TITLE
feat(disruption): executor Lambda entry + CDK construct — Phase B deployable (ADR-031) [#1419]

### DIFF
--- a/.claude/harness/baselines/handler-no-direct-sdk-import.json
+++ b/.claude/harness/baselines/handler-no-direct-sdk-import.json
@@ -29,6 +29,48 @@
       "filePath": "infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts",
       "line": 7,
       "match": "@aws-sdk/lib-dynamodb"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 15,
+      "match": "@aws-sdk/client-cloudformation"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 16,
+      "match": "@aws-sdk/client-dynamodb"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 17,
+      "match": "@aws-sdk/client-lambda"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 18,
+      "match": "@aws-sdk/client-scheduler"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 19,
+      "match": "@aws-sdk/client-ssm"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 20,
+      "match": "@aws-sdk/client-sts"
+    },
+    {
+      "ruleId": "handler-no-direct-sdk-import",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts",
+      "line": 21,
+      "match": "@aws-sdk/lib-dynamodb"
     }
   ]
 }

--- a/infrastructure/lib/problem-deploy/disruption-executor-lambda.ts
+++ b/infrastructure/lib/problem-deploy/disruption-executor-lambda.ts
@@ -1,0 +1,176 @@
+import * as path from "node:path";
+import { ArnFormat, Duration, Stack } from "aws-cdk-lib";
+import type { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { type IEventBus, Rule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Construct } from "constructs";
+import {
+  LAMBDA_NODEJS_BUNDLING_TARGET,
+  LAMBDA_NODEJS_RUNTIME,
+  LAMBDA_SOURCE_MAP_ENABLED,
+} from "../utils/lambda-runtime.js";
+import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
+
+export interface DisruptionExecutorLambdaProps {
+  readonly environmentName: string;
+  /** disruption-fire が `*DisruptionFired` を publish する EventBus。 本 Lambda がその rule の target。 */
+  readonly eventBus: IEventBus;
+  /** team deployment 解決 (GSI1 Query) 用。 */
+  readonly deploymentsTable: ITable;
+  /** EXEC# 冪等行 (conditional Put) 用。 fire の REQUEST#/AUDIT# と同居。 */
+  readonly disruptionsTable: ITable;
+  /** `{ [problemId]: ProblemDisruptionEntry[] }` (action 込)。 build 時 literal 置換で env 4KB を回避。 */
+  readonly problemsDisruptions?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * [ADR-031 / Issue #1419] cross-account disruption executor Lambda (Phase B)。
+ *
+ * EventBridge `tenantcloud.disruptions` source の `*DisruptionFired` を拾い、 該当 team deployment へ
+ * AssumeRole して実障害を注入し、 ADR-029 INV-2 のため revert を aws-scheduler に予約する。 注入の破壊力は
+ * **競技者側 CompetitorDeployRole (AdministratorAccess)** に由来し、 本 Lambda 自身の IAM は最小:
+ *   - sts:AssumeRole は `TenkaCloud-*` ロールのみ (= deploy worker / describe-stack と同 scope)
+ *   - ssm:GetParameter + kms:Decrypt は tenant ExternalId の SecureString のみ (describe-stack と同パターン)
+ *   - DDB は deployments の Query (GSI1) + disruptions の PutItem (EXEC# 冪等) のみ
+ *   - scheduler:CreateSchedule + iam:PassRole は revert scheduler role のみ
+ * SDK の SendCommand / Invoke / UpdateStack 権限は **本 Lambda の role には無い** (= 注入は assumed
+ * credentials で行う)。 = blast radius を IAM で封じつつ、 破壊操作は competitor の同意済 role に閉じる。
+ *
+ * revert は scheduler が本 Lambda 自身を `mode:"revert"` payload で呼び戻す one-shot (= EXEC# 冪等 name)。
+ */
+export class DisruptionExecutorLambda extends Construct {
+  public readonly fn: NodejsFunction;
+  public readonly schedulerRole: iam.Role;
+
+  constructor(scope: Construct, id: string, props: DisruptionExecutorLambdaProps) {
+    super(scope, id);
+    const stack = Stack.of(this);
+
+    // self-invoke (scheduler → executor) の ARN を循環なしで得るため functionName を固定し、 ARN を構築する。
+    const functionName = `${stack.stackName}-disruption-executor`.slice(0, 64);
+    const executorArn = stack.formatArn({
+      service: "lambda",
+      resource: "function",
+      resourceName: functionName,
+      arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+    });
+
+    // scheduler が executor を起動するために assume する role (= revert 予約の Target.RoleArn)。
+    this.schedulerRole = new iam.Role(this, "RevertSchedulerRole", {
+      assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
+      inlinePolicies: {
+        InvokeExecutor: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ["lambda:InvokeFunction"],
+              resources: [executorArn],
+            }),
+          ],
+        }),
+      },
+    });
+
+    this.fn = new NodejsFunction(this, "Function", {
+      functionName,
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(import.meta.dirname, "handlers/disruption-executor-handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.seconds(60),
+      memorySize: 512,
+      environment: {
+        DEPLOYMENTS_TABLE_NAME: props.deploymentsTable.tableName,
+        DISRUPTIONS_TABLE_NAME: props.disruptionsTable.tableName,
+        REVERT_SCHEDULER_ROLE_ARN: this.schedulerRole.roleArn,
+        EXECUTOR_FUNCTION_ARN: executorArn,
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: {
+        minify: true,
+        target: LAMBDA_NODEJS_BUNDLING_TARGET,
+        sourceMap: LAMBDA_SOURCE_MAP_ENABLED,
+        externalModules: [],
+        // disruptions catalog (action 込) を build 時 literal 置換 (env 4KB 回避、 fire と同 catalog)。
+        define: {
+          "process.env.BATTLE_PROBLEMS_DISRUPTIONS": JSON.stringify(
+            JSON.stringify(props.problemsDisruptions ?? {}),
+          ),
+        },
+      },
+    });
+
+    // --- 最小 IAM ---
+    const ssmArn = buildExternalIdParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: [ssmArn],
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: { StringLike: { "kms:EncryptionContext:PARAMETER_ARN": ssmArn } },
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sts:AssumeRole"],
+        resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
+      }),
+    );
+    // deployments: team deployment 解決は GSI1 Query のみ。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:Query"],
+        resources: [
+          props.deploymentsTable.tableArn,
+          `${props.deploymentsTable.tableArn}/index/GSI1`,
+        ],
+      }),
+    );
+    // disruptions: EXEC# 冪等 claim は conditional PutItem のみ。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem"],
+        resources: [props.disruptionsTable.tableArn],
+      }),
+    );
+    // revert 予約 (scheduler) + その実行 role を渡す PassRole。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["scheduler:CreateSchedule"],
+        resources: ["*"],
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["iam:PassRole"],
+        resources: [this.schedulerRole.roleArn],
+        conditions: { StringEquals: { "iam:PassedToService": "scheduler.amazonaws.com" } },
+      }),
+    );
+
+    // `*DisruptionFired` (= disruption-fire の publish) を拾って executor を起動する。
+    new Rule(this, "FiredRule", {
+      eventBus: props.eventBus,
+      eventPattern: { source: ["tenkacloud.disruptions"] },
+      targets: [new LambdaFunction(this.fn)],
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/describe-stack-handler/index.ts
@@ -1,7 +1,7 @@
 import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
-import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
-import type { Credentials } from "@aws-sdk/client-sts";
-import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { type Credentials, STSClient } from "@aws-sdk/client-sts";
+import { assumeCompetitorRole } from "../shared/assume-competitor-role.js";
 import { errorDeployTrace, logDeployTrace } from "../shared/trace-log.js";
 
 export interface DescribeStackStateMachineInput {
@@ -30,147 +30,6 @@ function requireString(value: unknown, field: string): string {
     throw new Error(`missing required field: ${field}`);
   }
   return value;
-}
-
-function assertCompleteCredentials(credentials: Credentials | undefined): Credentials {
-  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey || !credentials.SessionToken) {
-    throw new Error("AssumeRole returned incomplete credentials");
-  }
-  return credentials;
-}
-
-/**
- * Issue #1245 + #856: rotation race の AssumeRole 失敗のうち、 ExternalId mismatch に起因する
- * 4xx だけを 1 generation 前で retry する。 Network / Throttling / 5xx 系は retry せず即 fail。
- *
- * `verify.ts` 側の `shouldRetryWithPreviousVersion` と同じ error name 集合を共有し、
- * blanket-catch (= 全 error で previous version を試す) のような band-aid を避ける。
- */
-const ASSUME_ROLE_FALLBACK_ERROR_NAMES: ReadonlySet<string> = new Set([
-  "AccessDenied",
-  "AccessDeniedException",
-  "Forbidden",
-]);
-
-function shouldRetryWithPreviousVersion(err: unknown): boolean {
-  const name = err instanceof Error ? err.name : "";
-  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(name);
-}
-
-async function assumeCompetitorRole(
-  deps: DescribeStackDeps,
-  params: {
-    readonly region: string;
-    readonly jobId: string;
-    readonly competitorRoleArn?: string;
-    readonly externalIdParameterName?: string;
-  },
-): Promise<Credentials | undefined> {
-  const hasRole =
-    typeof params.competitorRoleArn === "string" && params.competitorRoleArn.length > 0;
-  const hasExternalId =
-    typeof params.externalIdParameterName === "string" && params.externalIdParameterName.length > 0;
-  if (!hasRole && !hasExternalId) return undefined;
-  if (!hasRole || !hasExternalId) {
-    throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
-  }
-  // 上の 2 guard で competitorRoleArn / externalIdParameterName が string であることは確定。
-  const competitorRoleArn = params.competitorRoleArn as string;
-  const externalIdParameterName = params.externalIdParameterName as string;
-
-  const externalIdOut = await deps.ssm.send(
-    new GetParameterCommand({
-      Name: externalIdParameterName,
-      WithDecryption: true,
-    }),
-  );
-  const externalId = externalIdOut.Parameter?.Value;
-  if (!externalId) {
-    throw new Error(`ExternalId not found in SSM SecureString: ${externalIdParameterName}`);
-  }
-
-  try {
-    return await assumeRoleWithExternalId(deps, competitorRoleArn, params.jobId, externalId);
-  } catch (currentErr) {
-    return await retryWithPreviousExternalId(deps, {
-      region: params.region,
-      jobId: params.jobId,
-      competitorRoleArn,
-      externalIdParameterName,
-      currentVersion: Number(externalIdOut.Parameter?.Version ?? 0),
-      currentErr,
-    });
-  }
-}
-
-/**
- * Issue #1245: rotation race の retry path を 1 関数に切り出す。
- *
- * 旧 implementation の問題点:
- *   - 全 error class で blanket fallback (= Throttling / Network 系も前 version で retry していた)
- *   - 成功時の log が `console.warn` の自由 string であり、 metrics filter が当てづらく silent
- *
- * 修正後:
- *   - `shouldRetryWithPreviousVersion` で AccessDenied 系 (= ExternalId mismatch) に絞る
- *   - 1 generation 前 SSM version が無ければ original error を rethrow (= silent skip しない)
- *   - 成功時は `errorDeployTrace` で `deploy.describe-stack.assume-role.grace-fallback` を発火し、
- *     operator alarm に pick up させる (= grace 多発 = rotation pipeline のバグ可視化)
- *   - retry でも ExternalId は必ず渡される (= 「ExternalId 無し AssumeRole」は禁止)
- */
-async function retryWithPreviousExternalId(
-  deps: DescribeStackDeps,
-  args: {
-    readonly region: string;
-    readonly jobId: string;
-    readonly competitorRoleArn: string;
-    readonly externalIdParameterName: string;
-    readonly currentVersion: number;
-    readonly currentErr: unknown;
-  },
-): Promise<Credentials> {
-  const { currentErr } = args;
-  if (!shouldRetryWithPreviousVersion(currentErr)) throw currentErr;
-  const previousVersion = args.currentVersion - 1;
-  if (previousVersion <= 0) throw currentErr;
-  const previousExternalIdOut = await deps.ssm.send(
-    new GetParameterCommand({
-      Name: `${args.externalIdParameterName}:${previousVersion}`,
-      WithDecryption: true,
-    }),
-  );
-  const previousExternalId = previousExternalIdOut.Parameter?.Value;
-  if (!previousExternalId) throw currentErr;
-  const credentials = await assumeRoleWithExternalId(
-    deps,
-    args.competitorRoleArn,
-    args.jobId,
-    previousExternalId,
-  );
-  errorDeployTrace("deploy.describe-stack.assume-role.grace-fallback", {
-    jobId: args.jobId,
-    correlationId: args.jobId,
-    region: args.region,
-    externalIdVersion: previousVersion,
-    reason: currentErr instanceof Error ? currentErr.name : "Unknown",
-  });
-  return credentials;
-}
-
-async function assumeRoleWithExternalId(
-  deps: DescribeStackDeps,
-  roleArn: string,
-  jobId: string,
-  externalId: string,
-): Promise<Credentials> {
-  const assumeOut = await deps.sts.send(
-    new AssumeRoleCommand({
-      RoleArn: roleArn,
-      RoleSessionName: `tenkacloud-describe-stack-${jobId.slice(0, 24)}`,
-      ExternalId: externalId,
-      DurationSeconds: 900,
-    }),
-  );
-  return assertCompleteCredentials(assumeOut.Credentials);
 }
 
 /**
@@ -230,6 +89,8 @@ export async function describeStackForDeployment(
     jobId,
     competitorRoleArn: detail.competitorRoleArn,
     externalIdParameterName: detail.externalIdParameterName,
+    sessionNamePrefix: "tenkacloud-describe-stack-",
+    graceFallbackTraceEvent: "deploy.describe-stack.assume-role.grace-fallback",
   });
   const cfn = deps.cfnClient({ region, credentials });
   const out = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -60,8 +60,13 @@ export interface ExecutorDeps {
   ) => Promise<DeploymentTarget | undefined>;
   /** dispatch を競技者アカウントで実行 (= AssumeRole + SDK send は具体実装側)。 */
   readonly sendDispatch: (dispatch: DisruptionDispatch, target: DeploymentTarget) => Promise<void>;
-  /** revert を afterSeconds 後に予約 (ADR-029 INV-2)。 scheduler 機構は具体実装側。 */
+  /**
+   * revert を afterSeconds 後に予約 (ADR-029 INV-2)。 scheduler 機構は具体実装側。
+   * `detail` は冪等な schedule 名 (= EXEC# と対の requestId/teamId) と revert invocation payload の
+   * 組み立てに必要なため渡す (= 具体実装 scheduleRevert がそれらを使う)。
+   */
   readonly scheduleRevert: (
+    detail: DisruptionFiredDetail,
     dispatch: DisruptionDispatch,
     target: DeploymentTarget,
     afterSeconds: number,
@@ -111,7 +116,7 @@ export async function executeDisruptionAction(
 
   // ADR-029 INV-2: 注入したら必ず復旧を予約する (revert は schema 必須)。
   const revert = buildRevertDispatch(action, detail.parameters, target.stackOutputs);
-  await deps.scheduleRevert(revert, target, action.revert.afterSeconds);
+  await deps.scheduleRevert(detail, revert, target, action.revert.afterSeconds);
 
   return { kind: "ok", jobId: target.jobId };
 }

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
@@ -1,0 +1,108 @@
+/**
+ * [ADR-031 / Issue #1419] cross-account disruption executor Lambda の entry。
+ *
+ * 実 client / AssumeRole を組み立てて `routeDisruptionInvocation` (= 純粋 router) に注入するだけの
+ * 薄い glue (= describe-stack-handler/index.ts と同じ「testable service + real-deps entry」分離)。
+ * 判断ロジック・dispatch mapping・scheduler 呼び出し・DDB アクセスはすべて test 済の module 側にあり、
+ * ここは AWS SDK の構築と env 読取に閉じる。
+ *
+ * 2 経路で起動される (route が判別):
+ *   - EventBridge `*DisruptionFired` rule → `{ detail }` envelope (= 注入)
+ *   - aws-scheduler one-shot → `{ mode:"revert", dispatch, target }` (= 復旧)
+ * revert / inject とも `wiredSendDispatch` が target から都度 AssumeRole する (= 注入時 creds は永続しない)。
+ */
+
+import { CloudFormationClient } from "@aws-sdk/client-cloudformation";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { LambdaClient } from "@aws-sdk/client-lambda";
+import { SchedulerClient } from "@aws-sdk/client-scheduler";
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { STSClient } from "@aws-sdk/client-sts";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { parseDisruptionsCatalogEnv } from "../../../utils/discover-problems-catalog.js";
+import { assumeCompetitorRole } from "../shared/assume-competitor-role.js";
+import { logDeployTrace } from "../shared/trace-log.js";
+import type { DeploymentTarget, ExecutorDeps } from "./execute.js";
+import { claimExecution, type ExecutorResources, resolveDeployment } from "./executor-store.js";
+import { type RouteOutcome, routeDisruptionInvocation } from "./route.js";
+import { scheduleRevert } from "./schedule-revert.js";
+import { type DispatchTarget, sendDispatch } from "./send-dispatch.js";
+
+const SESSION_NAME_PREFIX = "tc-disruption-";
+const GRACE_FALLBACK_TRACE = "deploy.disruption-executor.assume-role.grace-fallback";
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const ssm = new SSMClient({});
+const sts = new STSClient({});
+const scheduler = new SchedulerClient({});
+
+const resources: ExecutorResources = {
+  ddb,
+  deploymentsTableName: process.env.DEPLOYMENTS_TABLE_NAME ?? "",
+  disruptionsTableName: process.env.DISRUPTIONS_TABLE_NAME ?? "",
+};
+
+const problemsDisruptions = parseDisruptionsCatalogEnv(process.env.BATTLE_PROBLEMS_DISRUPTIONS);
+const schedulerRoleArn = process.env.REVERT_SCHEDULER_ROLE_ARN ?? "";
+const revertTargetArn = process.env.EXECUTOR_FUNCTION_ARN ?? "";
+
+/** target から都度 AssumeRole して competitor account 内で dispatch を送る (= inject / revert 共通)。 */
+async function wiredSendDispatch(
+  dispatch: Parameters<ExecutorDeps["sendDispatch"]>[0],
+  target: DeploymentTarget,
+): Promise<void> {
+  const credentials = await assumeCompetitorRole(
+    { ssm, sts },
+    {
+      region: target.region,
+      jobId: target.jobId,
+      competitorRoleArn: target.competitorRoleArn,
+      externalIdParameterName: target.externalIdParameterName,
+      sessionNamePrefix: SESSION_NAME_PREFIX,
+      graceFallbackTraceEvent: GRACE_FALLBACK_TRACE,
+    },
+  );
+  const dispatchTarget: DispatchTarget = { region: target.region, credentials };
+  await sendDispatch(dispatch, dispatchTarget, {
+    ssmClient: (t) => new SSMClient(sdkClientConfig(t)),
+    lambdaClient: (t) => new LambdaClient(sdkClientConfig(t)),
+    cfnClient: (t) => new CloudFormationClient(sdkClientConfig(t)),
+  });
+}
+
+/** STS Credentials (PascalCase) を SDK client config の camelCase credentials に写す (describe-stack と同方針)。 */
+function sdkClientConfig(target: DispatchTarget) {
+  const creds = target.credentials;
+  return {
+    region: target.region,
+    ...(creds
+      ? {
+          credentials: {
+            accessKeyId: creds.AccessKeyId ?? "",
+            secretAccessKey: creds.SecretAccessKey ?? "",
+            sessionToken: creds.SessionToken,
+          },
+        }
+      : {}),
+  };
+}
+
+const deps: ExecutorDeps = {
+  problemsDisruptions,
+  claimExecution: (detail) => claimExecution(resources, detail, Date.now()),
+  resolveDeployment: (detail) => resolveDeployment(resources, detail),
+  sendDispatch: wiredSendDispatch,
+  scheduleRevert: (detail, dispatch, target, afterSeconds) =>
+    scheduleRevert(dispatch, detail, target, afterSeconds, {
+      scheduler,
+      schedulerRoleArn,
+      revertTargetArn,
+    }),
+};
+
+/** Lambda handler。 inject / revert を route が判別し dispatch する。 outcome は observability の trace に出す。 */
+export async function handler(event: unknown): Promise<RouteOutcome> {
+  const outcome = await routeDisruptionInvocation(event, deps);
+  logDeployTrace("deploy.disruption-executor.outcome", { kind: outcome.kind });
+  return outcome;
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/assume-competitor-role.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/assume-competitor-role.ts
@@ -1,0 +1,169 @@
+/**
+ * Cross-account AssumeRole into the competitor's `CompetitorDeployRole`, shared across handlers.
+ *
+ * 以前は describe-stack-handler が自前で持ち、 verify.ts / participant SSO も類似ロジックを別個に
+ * 抱えていた (= rotation-race retry / ExternalId mismatch fallback の error name 集合がコメントで
+ * 「同じものを共有」 と書かれつつ実体は重複していた)。 ここに 1 本化して **単一の監査点** にする
+ * (= 資格情報経路の重複は security リスク。 #856 / #1245 で hardening した retry を 1 箇所に集約)。
+ *
+ * caller 固有の cosmetic だけを param 化する (= 振る舞いは不変):
+ *   - `sessionNamePrefix`: RoleSessionName の prefix (例: describe-stack / disruption-executor)
+ *   - `graceFallbackTraceEvent`: grace-fallback 成功時に発火する trace event 名 (operator alarm が key にする)
+ *
+ * Issue #1245 + #856 の方針はそのまま:
+ *   - ExternalId は SSM SecureString から都度 decrypt (= コードに埋め込まない)
+ *   - AssumeRole 失敗のうち AccessDenied 系 (= ExternalId mismatch) だけ 1 generation 前で 1 度 retry
+ *   - Network / Throttling / 5xx は retry せず即 rethrow (= blanket fallback band-aid を避ける)
+ *   - grace-fallback 成功は errorDeployTrace で発火し operator alarm に拾わせる
+ *   - retry でも ExternalId は必ず渡す (= 「ExternalId 無し AssumeRole」 は禁止)
+ */
+
+import { GetParameterCommand, type SSMClient } from "@aws-sdk/client-ssm";
+import { AssumeRoleCommand, type Credentials, type STSClient } from "@aws-sdk/client-sts";
+import { errorDeployTrace } from "./trace-log.js";
+
+export interface AssumeCompetitorRoleDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly sts: Pick<STSClient, "send">;
+}
+
+export interface AssumeCompetitorRoleParams {
+  readonly region: string;
+  readonly jobId: string;
+  readonly competitorRoleArn?: string;
+  readonly externalIdParameterName?: string;
+  /** RoleSessionName prefix (caller 識別)。 例: "tenkacloud-describe-stack-" / "tc-disruption-"。 */
+  readonly sessionNamePrefix: string;
+  /** grace-fallback 成功時の trace event 名 (= operator alarm の key)。 */
+  readonly graceFallbackTraceEvent: string;
+}
+
+const ASSUME_ROLE_FALLBACK_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "AccessDenied",
+  "AccessDeniedException",
+  "Forbidden",
+]);
+
+/** AccessDenied 系 (= ExternalId mismatch) のみ 1 generation 前での retry 対象。 */
+export function shouldRetryWithPreviousExternalIdVersion(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : "";
+  return ASSUME_ROLE_FALLBACK_ERROR_NAMES.has(name);
+}
+
+function assertCompleteCredentials(credentials: Credentials | undefined): Credentials {
+  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey || !credentials.SessionToken) {
+    throw new Error("AssumeRole returned incomplete credentials");
+  }
+  return credentials;
+}
+
+async function assumeRoleWithExternalId(
+  deps: AssumeCompetitorRoleDeps,
+  args: {
+    readonly roleArn: string;
+    readonly jobId: string;
+    readonly externalId: string;
+    readonly sessionNamePrefix: string;
+  },
+): Promise<Credentials> {
+  const assumeOut = await deps.sts.send(
+    new AssumeRoleCommand({
+      RoleArn: args.roleArn,
+      RoleSessionName: `${args.sessionNamePrefix}${args.jobId.slice(0, 24)}`,
+      ExternalId: args.externalId,
+      DurationSeconds: 900,
+    }),
+  );
+  return assertCompleteCredentials(assumeOut.Credentials);
+}
+
+async function retryWithPreviousExternalId(
+  deps: AssumeCompetitorRoleDeps,
+  args: {
+    readonly region: string;
+    readonly jobId: string;
+    readonly competitorRoleArn: string;
+    readonly externalIdParameterName: string;
+    readonly currentVersion: number;
+    readonly currentErr: unknown;
+    readonly sessionNamePrefix: string;
+    readonly graceFallbackTraceEvent: string;
+  },
+): Promise<Credentials> {
+  const { currentErr } = args;
+  if (!shouldRetryWithPreviousExternalIdVersion(currentErr)) throw currentErr;
+  const previousVersion = args.currentVersion - 1;
+  if (previousVersion <= 0) throw currentErr;
+  const previousExternalIdOut = await deps.ssm.send(
+    new GetParameterCommand({
+      Name: `${args.externalIdParameterName}:${previousVersion}`,
+      WithDecryption: true,
+    }),
+  );
+  const previousExternalId = previousExternalIdOut.Parameter?.Value;
+  if (!previousExternalId) throw currentErr;
+  const credentials = await assumeRoleWithExternalId(deps, {
+    roleArn: args.competitorRoleArn,
+    jobId: args.jobId,
+    externalId: previousExternalId,
+    sessionNamePrefix: args.sessionNamePrefix,
+  });
+  errorDeployTrace(args.graceFallbackTraceEvent, {
+    jobId: args.jobId,
+    correlationId: args.jobId,
+    region: args.region,
+    externalIdVersion: previousVersion,
+    reason: currentErr instanceof Error ? currentErr.name : "Unknown",
+  });
+  return credentials;
+}
+
+/**
+ * competitor account の `CompetitorDeployRole` を ExternalId 付きで AssumeRole する。
+ * competitorRoleArn / externalIdParameterName の双方が無ければ undefined (= same-account 経路)、
+ * 片方だけは config error。 ExternalId mismatch (rotation race) は 1 generation 前で 1 度 retry。
+ */
+export async function assumeCompetitorRole(
+  deps: AssumeCompetitorRoleDeps,
+  params: AssumeCompetitorRoleParams,
+): Promise<Credentials | undefined> {
+  const hasRole =
+    typeof params.competitorRoleArn === "string" && params.competitorRoleArn.length > 0;
+  const hasExternalId =
+    typeof params.externalIdParameterName === "string" && params.externalIdParameterName.length > 0;
+  if (!hasRole && !hasExternalId) return undefined;
+  if (!hasRole || !hasExternalId) {
+    throw new Error("competitorRoleArn and externalIdParameterName must be provided together");
+  }
+  // 上の 2 guard で competitorRoleArn / externalIdParameterName が string であることは確定。
+  const competitorRoleArn = params.competitorRoleArn as string;
+  const externalIdParameterName = params.externalIdParameterName as string;
+
+  const externalIdOut = await deps.ssm.send(
+    new GetParameterCommand({ Name: externalIdParameterName, WithDecryption: true }),
+  );
+  const externalId = externalIdOut.Parameter?.Value;
+  if (!externalId) {
+    throw new Error(`ExternalId not found in SSM SecureString: ${externalIdParameterName}`);
+  }
+
+  try {
+    return await assumeRoleWithExternalId(deps, {
+      roleArn: competitorRoleArn,
+      jobId: params.jobId,
+      externalId,
+      sessionNamePrefix: params.sessionNamePrefix,
+    });
+  } catch (currentErr) {
+    return await retryWithPreviousExternalId(deps, {
+      region: params.region,
+      jobId: params.jobId,
+      competitorRoleArn,
+      externalIdParameterName,
+      currentVersion: Number(externalIdOut.Parameter?.Version ?? 0),
+      currentErr,
+      sessionNamePrefix: params.sessionNamePrefix,
+      graceFallbackTraceEvent: params.graceFallbackTraceEvent,
+    });
+  }
+}

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -22,6 +22,7 @@ import {
 } from "./deploy-event-rule.js";
 import { DeploymentsTable } from "./deployments-table.js";
 import { DescribeStackLambda } from "./describe-stack-lambda.js";
+import { DisruptionExecutorLambda } from "./disruption-executor-lambda.js";
 import { DisruptionsTable } from "./disruptions-table.js";
 import { EventApiLambda } from "./event-api-lambda.js";
 import { EventsTable } from "./events-table.js";
@@ -348,6 +349,17 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       adminAuditLogTable: adminAuditLog.table,
     });
     this.eventApiLambda = eventApi.fn;
+
+    // [ADR-031 / Issue #1419] Disruption Phase B: operator fire が publish した `*DisruptionFired` を
+    // 拾い、 team deployment へ AssumeRole して実障害を注入し、 revert を予約する cross-account executor。
+    // action 未宣言の disruption は no-op (= Phase A 監査のみ、 後方互換)。
+    new DisruptionExecutorLambda(this, "DisruptionExecutor", {
+      environmentName: props.environmentName,
+      eventBus,
+      deploymentsTable: deployments.table,
+      disruptionsTable: disruptions.table,
+      problemsDisruptions: (props.problemsDisruptions ?? {}) as Readonly<Record<string, unknown>>,
+    });
 
     // Issue #459 / ADR-002 Phase 2.1: Competitor Accounts CRUD + STS verify Lambda。
     // 独立 Lambda にする理由: SSM SecureString R/W + STS AssumeRole の IAM scope を最小化するため。

--- a/infrastructure/test/problem-deploy-backend-stack-events.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-events.test.ts
@@ -5,14 +5,15 @@ import { synthDefault } from "./problem-deploy-backend-stack.test-helpers";
 describe("ProblemDeployBackendStack (MVP-1) — EventBridge Rules", () => {
   const tpl = synthDefault();
 
-  it("should have 7 EventBridge Rules (Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) / CodeBuildFailure (Issue #1029))", () => {
+  it("should have 8 EventBridge Rules (Create / Delete / BulkCreate / GenericScoring / ExternalIdAudit schedule / SystemAuditWriter (Issue #1034) / CodeBuildFailure (Issue #1029) / DisruptionExecutor (ADR-031 #1419))", () => {
     // 旧 2 (Create / Delete state-machine event rules)
     //   + BulkCreate (Issue #910 Phase 2.C: BulkDeployCreateRequested → Distributed Map)
     //   + GenericScoring schedule rate(1 minute) (= ADR-012 Phase 3.B、 旧 HealthCheck 後継)
     //   + ExternalIdAudit schedule rate(1 day) (= Phase 3.2 / Issue #603 で追加)
     // = 5。GenericScoring は scoring 問題が無い tenant でも reconcile 用に常時 instantiate される。
     // 旧 5 + Issue #1034 SystemAuditWriter (SBT bus) + Issue #1029 CodeBuildFailure (default bus)
-    tpl.resourceCountIs("AWS::Events::Rule", 7);
+    //   + ADR-031 #1419 DisruptionExecutor (tenkacloud.disruptions → cross-account fault executor)
+    tpl.resourceCountIs("AWS::Events::Rule", 8);
     tpl.hasResourceProperties(
       "AWS::Events::Rule",
       Match.objectLike({

--- a/infrastructure/test/problem-deploy/assume-competitor-role.test.ts
+++ b/infrastructure/test/problem-deploy/assume-competitor-role.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const errorDeployTrace = vi.fn();
+vi.mock("../../lib/problem-deploy/handlers/shared/trace-log", () => ({
+  errorDeployTrace: (...args: unknown[]) => errorDeployTrace(...args),
+  logDeployTrace: vi.fn(),
+}));
+
+import {
+  type AssumeCompetitorRoleDeps,
+  assumeCompetitorRole,
+  shouldRetryWithPreviousExternalIdVersion,
+} from "../../lib/problem-deploy/handlers/shared/assume-competitor-role";
+
+/**
+ * 共有 assumeCompetitorRole の挙動 pin。 describe-stack-handler の既存 test が回帰網だが、 ここでは
+ * 共有契約 + parameterize した cosmetic (sessionNamePrefix / graceFallbackTraceEvent) を直接確認する。
+ */
+
+const CREDS = { AccessKeyId: "AK", SecretAccessKey: "SK", SessionToken: "ST" };
+
+function makeDeps(
+  ssmSend: ReturnType<typeof vi.fn>,
+  stsSend: ReturnType<typeof vi.fn>,
+): AssumeCompetitorRoleDeps {
+  return {
+    ssm: { send: ssmSend } as unknown as AssumeCompetitorRoleDeps["ssm"],
+    sts: { send: stsSend } as unknown as AssumeCompetitorRoleDeps["sts"],
+  };
+}
+
+const baseParams = {
+  region: "ap-northeast-1",
+  jobId: "job-1234567890123456789012345678",
+  competitorRoleArn: "arn:aws:iam::111122223333:role/TenkaCloud-CompetitorDeploy-Role",
+  externalIdParameterName: "/tenkacloud/tenant-1/external-id",
+  sessionNamePrefix: "tc-disruption-",
+  graceFallbackTraceEvent: "deploy.disruption-executor.assume-role.grace-fallback",
+};
+
+describe("assumeCompetitorRole (shared)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return undefined when neither competitorRoleArn nor externalIdParameterName is given", async () => {
+    const deps = makeDeps(vi.fn(), vi.fn());
+    expect(
+      await assumeCompetitorRole(deps, {
+        ...baseParams,
+        competitorRoleArn: undefined,
+        externalIdParameterName: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should throw when only one side of the cross-account metadata is present", async () => {
+    const deps = makeDeps(vi.fn(), vi.fn());
+    await expect(
+      assumeCompetitorRole(deps, { ...baseParams, externalIdParameterName: undefined }),
+    ).rejects.toThrow("must be provided together");
+  });
+
+  it("should throw when the SSM ExternalId parameter has no value", async () => {
+    const deps = makeDeps(vi.fn().mockResolvedValue({ Parameter: {} }), vi.fn());
+    await expect(assumeCompetitorRole(deps, baseParams)).rejects.toThrow(
+      "ExternalId not found in SSM SecureString",
+    );
+  });
+
+  it("should AssumeRole with the caller's session-name prefix (truncated jobId) and return the creds", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "ext-id", Version: 3 } });
+    const sts = vi.fn().mockResolvedValue({ Credentials: CREDS });
+    expect(await assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).toEqual(CREDS);
+    const input = sts.mock.calls[0][0].input;
+    expect(input.RoleSessionName).toBe(`tc-disruption-${baseParams.jobId.slice(0, 24)}`);
+    expect(input.ExternalId).toBe("ext-id");
+    expect(input.DurationSeconds).toBe(900);
+  });
+
+  it("should throw when AssumeRole returns incomplete credentials", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "ext-id", Version: 1 } });
+    const sts = vi.fn().mockResolvedValue({ Credentials: { AccessKeyId: "AK" } });
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow(
+      "incomplete credentials",
+    );
+  });
+
+  it("should grace-fallback to the previous ExternalId version on AccessDenied and fire the caller's trace event", async () => {
+    const ssm = vi
+      .fn()
+      .mockResolvedValueOnce({ Parameter: { Value: "new-id", Version: 4 } })
+      .mockResolvedValueOnce({ Parameter: { Value: "old-id", Version: 3 } });
+    const denied = Object.assign(new Error("denied"), { name: "AccessDenied" });
+    const sts = vi.fn().mockRejectedValueOnce(denied).mockResolvedValueOnce({ Credentials: CREDS });
+    expect(await assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).toEqual(CREDS);
+    expect(ssm.mock.calls[1][0].input.Name).toBe(`${baseParams.externalIdParameterName}:3`);
+    expect(errorDeployTrace).toHaveBeenCalledWith(
+      "deploy.disruption-executor.assume-role.grace-fallback",
+      expect.objectContaining({ externalIdVersion: 3, reason: "AccessDenied" }),
+    );
+  });
+
+  it("should rethrow immediately on a non-AccessDenied error (no blanket band-aid)", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "id", Version: 2 } });
+    const sts = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("slow"), { name: "ThrottlingException" }));
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow("slow");
+    expect(errorDeployTrace).not.toHaveBeenCalled();
+  });
+
+  it("should rethrow the original error when there is no previous version to fall back to", async () => {
+    const ssm = vi.fn().mockResolvedValue({ Parameter: { Value: "id", Version: 1 } });
+    const denied = Object.assign(new Error("denied"), { name: "AccessDenied" });
+    const sts = vi.fn().mockRejectedValue(denied);
+    await expect(assumeCompetitorRole(makeDeps(ssm, sts), baseParams)).rejects.toThrow("denied");
+  });
+});
+
+describe("shouldRetryWithPreviousExternalIdVersion", () => {
+  it("should retry only on the AccessDenied family", () => {
+    for (const name of ["AccessDenied", "AccessDeniedException", "Forbidden"]) {
+      expect(shouldRetryWithPreviousExternalIdVersion(Object.assign(new Error(), { name }))).toBe(
+        true,
+      );
+    }
+    expect(
+      shouldRetryWithPreviousExternalIdVersion(
+        Object.assign(new Error(), { name: "ThrottlingException" }),
+      ),
+    ).toBe(false);
+    expect(shouldRetryWithPreviousExternalIdVersion("not-an-error")).toBe(false);
+  });
+});

--- a/infrastructure/test/problem-deploy/disruption-execute.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-execute.test.ts
@@ -78,8 +78,9 @@ describe("executeDisruptionAction (ADR-031 #1419)", () => {
     expect(sentTarget).toBe(target);
 
     expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
-    const [revert, , afterSeconds] = (deps.scheduleRevert as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const [detailArg, revert, , afterSeconds] = (deps.scheduleRevert as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    expect(detailArg).toBe(detail); // revert payload / idempotent schedule name 用に detail を渡す
     expect(revert).toEqual({
       kind: "ssm-run-command",
       target: "i-aaa,i-bbb",

--- a/infrastructure/test/problem-deploy/disruption-executor-lambda.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-lambda.test.ts
@@ -1,0 +1,136 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { EventBus } from "aws-cdk-lib/aws-events";
+import { describe, expect, it } from "vitest";
+import { DisruptionExecutorLambda } from "../../lib/problem-deploy/disruption-executor-lambda";
+
+/**
+ * [ADR-031 / #1419] cross-account disruption executor の CDK 境界を pin する。 核心は
+ * 「自前 role は最小 (sts:AssumeRole は TenkaCloud-* のみ、 SendCommand/Invoke/UpdateStack は **持たない**)」
+ * = 破壊力は assumed の CompetitorDeployRole に閉じ、 executor 自身の blast radius は IAM で封じる。
+ */
+
+const SYNTH_TIMEOUT_MS = 120_000;
+
+function synth(): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  const deployments = new Table(stack, "Deployments", {
+    partitionKey: { name: "PK", type: AttributeType.STRING },
+  });
+  const disruptions = new Table(stack, "Disruptions", {
+    partitionKey: { name: "PK", type: AttributeType.STRING },
+    sortKey: { name: "SK", type: AttributeType.STRING },
+  });
+  new DisruptionExecutorLambda(stack, "Executor", {
+    environmentName: "development",
+    eventBus: new EventBus(stack, "Bus"),
+    deploymentsTable: deployments,
+    disruptionsTable: disruptions,
+    problemsDisruptions: { "microservice-migration-battle": [{ id: "x" }] },
+  });
+  return Template.fromStack(stack);
+}
+
+/** 全 IAM Role の inline policy (= 権限境界。 trust policy は除外) の action を集める。 */
+function inlineActions(tpl: Template): string[] {
+  return Object.values(tpl.findResources("AWS::IAM::Policy")).flatMap((p) =>
+    (
+      (p as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } }).Properties
+        ?.PolicyDocument?.Statement ?? []
+    ).flatMap((s) => {
+      const a = (s as { Action?: string | string[] }).Action;
+      return Array.isArray(a) ? a : typeof a === "string" ? [a] : [];
+    }),
+  );
+}
+
+describe("DisruptionExecutorLambda (ADR-031 #1419)", () => {
+  it(
+    "should provision a Node.js / arm64 executor Lambda with the wiring env",
+    () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::Lambda::Function",
+        Match.objectLike({
+          Runtime: "nodejs22.x",
+          Architectures: ["arm64"],
+          Environment: Match.objectLike({
+            Variables: Match.objectLike({
+              DEPLOYMENTS_TABLE_NAME: Match.anyValue(),
+              DISRUPTIONS_TABLE_NAME: Match.anyValue(),
+              REVERT_SCHEDULER_ROLE_ARN: Match.anyValue(),
+              EXECUTOR_FUNCTION_ARN: Match.anyValue(),
+            }),
+          }),
+        }),
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "should scope sts:AssumeRole to TenkaCloud-* roles (not a wildcard)",
+    () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Action: "sts:AssumeRole",
+                Resource: "arn:aws:iam::*:role/TenkaCloud-*",
+              }),
+            ]),
+          }),
+        }),
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "should NOT grant the executor's own role the destructive cross-account actions (they ride the assumed role)",
+    () => {
+      const actions = inlineActions(synth());
+      // 注入/復旧の破壊操作は assumed CompetitorDeployRole 経由。 executor 自身の role には付けない。
+      expect(actions).not.toContain("ssm:SendCommand");
+      expect(actions).not.toContain("lambda:InvokeFunction"); // 自前 role には無い (= scheduler role 側のみ)
+      expect(actions).not.toContain("cloudformation:UpdateStack");
+      // 最小権限は揃っている。
+      expect(actions).toContain("dynamodb:Query");
+      expect(actions).toContain("dynamodb:PutItem");
+      expect(actions).toContain("scheduler:CreateSchedule");
+      expect(actions).toContain("iam:PassRole");
+      expect(actions).toContain("ssm:GetParameter");
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "should route tenkacloud.disruptions events to the executor and provision a scheduler-assumable revert role",
+    () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::Events::Rule",
+        Match.objectLike({ EventPattern: { source: ["tenkacloud.disruptions"] } }),
+      );
+      // revert scheduler role: scheduler.amazonaws.com が assume + lambda:InvokeFunction を持つ。
+      tpl.hasResourceProperties(
+        "AWS::IAM::Role",
+        Match.objectLike({
+          AssumeRolePolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Principal: { Service: "scheduler.amazonaws.com" },
+              }),
+            ]),
+          }),
+        }),
+      );
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## Summary

The **#1419 capstone**: wires the tested executor modules into a deployable Lambda + its CDK construct. With this, ADR-031 **Phase B is code-complete** — the only thing left is `make deploy` + a target-account E2E (yours).

> Top of the stack: #1639 → #1640 → #1641 → #1642 → #1643 (+ the execute.ts compose fix and #1644's shared `assumeCompetitorRole`, carried here so it composes; they dedupe when those merge). Base `feat/1419-executor-route`.

### What it adds

- **`handlers/disruption-executor-handler/index.ts`** — the real-deps entry (DI composition root, exactly like `describe-stack-handler/index.ts`). Constructs the SDK clients + the shared `assumeCompetitorRole`, wires `claimExecution`/`resolveDeployment`/`sendDispatch`/`scheduleRevert`, and exports the Lambda `handler` over `routeDisruptionInvocation`. (SDK imports baselined as a composition root, parity with the describe-stack / generic-scoring entries.)
- **`disruption-executor-lambda.ts`** — the construct: `NodejsFunction` + an EventBridge rule on `tenkacloud.disruptions` + a scheduler execution role. **Least-privilege IAM**:
  - `sts:AssumeRole` only on `arn:aws:iam::*:role/TenkaCloud-*` (not `*`),
  - `ssm:GetParameter` + `kms:Decrypt` only for the tenant ExternalId (describe-stack pattern),
  - `dynamodb:Query` (GSI1) + `dynamodb:PutItem` (EXEC#),
  - `scheduler:CreateSchedule` + scoped `iam:PassRole`.
  - The destructive `SendCommand`/`Invoke`/`UpdateStack` are **not** on the executor's own role — they ride the assumed `CompetitorDeployRole` — **pinned by a Template assertion test**.
- Wired into `ProblemDeployBackendStack`; the EventBridge-rule-count test goes 7→8.

### Security shape

The executor's *own* IAM is minimal and Template-asserted; the destructive power is the pre-existing competitor-account `CompetitorDeployRole` (AdministratorAccess, consented at bootstrap), gated by operator-authenticated fire → problem-author `action` (validated by #1639/#32) → ExternalId-scoped AssumeRole → ADR-029-INV-2 auto-revert. No new IAM danger beyond the describe-stack cross-account pattern.

## Test plan

- **4 Template assertion tests**: Lambda + wiring env; `sts:AssumeRole` scoped to `TenkaCloud-*`; the executor's own role has **no** SendCommand/Invoke/UpdateStack; the `tenkacloud.disruptions` rule + the scheduler-assumable revert role.
- Full **infra suite: 2442 pass** (incl. the 7→8 rule-count update).
- `tsc --noEmit`, biome, `make harness` (**0 errors**), `check-no-conflicts`, **`cdk synth` exit 0** (the construct synthesizes in the real stack): all green.

## Regression analysis

- The new Lambda + rule are **additive**; `action`-less disruptions stay Phase A audit-only (the executor returns `no_action`), so existing disruption behavior is unchanged.
- The only existing-resource delta is the EventBridge rule count (7→8, test updated) and the new construct in `ProblemDeployBackendStack`. `cdk synth` confirms the rest of the template is unchanged.
- The composition fix (`scheduleRevert(detail, …)`) corrects a real defect where the orchestration dep didn't type-compose with the concrete scheduler — now verified end-to-end by the wiring + tsc.
- The shared `assumeCompetitorRole` is behavior-preserving (describe-stack's 20 tests unchanged, from #1644).

## Physical impact

**CFn: CREATE** — one new `AWS::Lambda::Function` (the executor), one `AWS::Events::Rule` (`tenkacloud.disruptions` → executor), two `AWS::IAM::Role`s (the executor's least-privilege role + the scheduler execution role) in `ProblemDeployBackendStack`. No table/capacity change (DynamoDbLowCapacity unaffected). NO-OP on all other stacks. The fault-injection path is **inert until a problem declares an `action`** and an operator fires it.

Relates #1419