### PR TITLE
feat(runtime): multi-cloud problem-runtime adapters — Sakura/Azure/GCP (ADR-026/027) [#1408]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/azure-bicep-adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/azure-bicep-adapter.ts
@@ -1,0 +1,122 @@
+/**
+ * [ADR-027 / Issue #1410] azure/bicep runtime adapter (Deployment Stacks).
+ *
+ * Azure problem は Bicep テンプレートを **Deployment Stack** として展開する。 Deployment Stack は
+ * CFn 相当で、 配下リソースの lifecycle / teardown を Azure 側が所有する (= ADR-023 D3 を満たす。
+ * platform は state file / lock を持たない)。 `runtime.entry` が Bicep テンプレート参照、 problem
+ * パラメータは stack parameters、 stack outputs を deploy output に読む。
+ *
+ * 認証は **Workload Identity Federation** (ADR-027): trust-bridge の `azure-federated-credential`
+ * adapter が短命 OAuth token を発行する (stored key 不要、 AWS AssumeRole 並みの isolation)。 本 adapter は
+ * その token を受け取る credential resolver を注入される (= account-gated な exchange は handler 側)。
+ *
+ * orchestration は注入された `AzureDeploymentStackClient` / `getCredential` に対して書き unit test で pin
+ * する。 具体 ARM REST 実装 + WIF exchange は実 account で検証する別レイヤ (#1419 / Sakura と同方針)。
+ */
+
+import type {
+  ProblemRuntime,
+  ProblemRuntimeAdapter,
+  RuntimeCollectOutputsInput,
+  RuntimeDeployInput,
+  RuntimeDeployResult,
+  RuntimeDestroyInput,
+  RuntimeDestroyResult,
+  RuntimeOutputs,
+  RuntimeStatus,
+  RuntimeStatusInput,
+} from "./adapter.js";
+
+/** WIF 交換で得た短命 OAuth token (trust-bridge azure-federated-credential 由来)。 */
+export interface AzureCredential {
+  readonly accessToken: string;
+}
+
+/** Deployment Stack の展開仕様。 templateRef = runtime.entry (Bicep)、 parameters = problem パラメータ。 */
+export interface AzureDeploymentStackSpec {
+  readonly name: string;
+  readonly templateRef: string;
+  readonly parameters: Readonly<Record<string, string>>;
+}
+
+/** Deployment Stack の観測状態。 provisioningState は ARM 由来、 outputs は ready 後に埋まる。 */
+export interface AzureDeploymentStackState {
+  readonly provisioningState: string;
+  readonly outputs?: Readonly<Record<string, string>>;
+}
+
+/** Azure Deployment Stack API の最小 client 契約 (= account-gated ARM REST 実装の注入点)。 */
+export interface AzureDeploymentStackClient {
+  upsertStack(spec: AzureDeploymentStackSpec): Promise<void>;
+  getStack(name: string): Promise<AzureDeploymentStackState | undefined>;
+  deleteStack(name: string): Promise<void>;
+}
+
+export interface AzureBicepAdapterContext {
+  /** WIF 短命 token を解決 (trust-bridge 経由、 handler が束縛、 account-gated)。 */
+  readonly getCredential: () => Promise<AzureCredential>;
+  readonly client: (credential: AzureCredential) => AzureDeploymentStackClient;
+}
+
+export const AZURE_PROVIDER = "azure";
+export const AZURE_ENGINE = "bicep";
+
+/** ARM provisioningState を platform の 6-state に射影。 不在=destroyed、 未知/進行中は安全側 deploying。 */
+export function mapAzureProvisioningState(raw: string | undefined): RuntimeStatus {
+  if (raw === undefined) return "destroyed";
+  const s = raw.toLowerCase();
+  if (s === "succeeded") return "ready";
+  if (["failed", "canceled", "cancelled"].includes(s)) return "failed";
+  if (["deleting"].includes(s)) return "destroying";
+  if (["deleted"].includes(s)) return "destroyed";
+  return "deploying";
+}
+
+export class AzureBicepRuntimeAdapter implements ProblemRuntimeAdapter {
+  public readonly provider = AZURE_PROVIDER;
+  public readonly engine = AZURE_ENGINE;
+
+  constructor(
+    private readonly ctx: AzureBicepAdapterContext,
+    private readonly runtime: ProblemRuntime,
+  ) {}
+
+  private async resolveClient(): Promise<AzureDeploymentStackClient> {
+    return this.ctx.client(await this.ctx.getCredential());
+  }
+
+  async deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult> {
+    const client = await this.resolveClient();
+    await client.upsertStack({
+      name: input.namePrefix,
+      templateRef: this.runtime.entry, // ADR-027: runtime.entry = Bicep template reference
+      parameters: {
+        tenkacloudNamePrefix: input.namePrefix,
+        tenkacloudProblemId: input.problemId,
+        tenkacloudTeam: input.teamSlug,
+        ...(input.challengePayloadUrl
+          ? { tenkacloudChallengePayloadUrl: input.challengePayloadUrl }
+          : {}),
+      },
+    });
+    return { status: "deploying" };
+  }
+
+  async collectOutputs(input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs> {
+    const client = await this.resolveClient();
+    const stack = await client.getStack(input.namePrefix);
+    return stack?.outputs ?? {};
+  }
+
+  async getStatus(input: RuntimeStatusInput): Promise<RuntimeStatus> {
+    const client = await this.resolveClient();
+    const stack = await client.getStack(input.namePrefix);
+    return mapAzureProvisioningState(stack?.provisioningState);
+  }
+
+  async destroy(input: RuntimeDestroyInput): Promise<RuntimeDestroyResult> {
+    const client = await this.resolveClient();
+    await client.deleteStack(input.namePrefix);
+    return { status: "destroying" };
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/gcp-infra-manager-adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/gcp-infra-manager-adapter.ts
@@ -1,0 +1,123 @@
+/**
+ * [ADR-027 / Issue #1411] gcp/infra-manager runtime adapter (Infrastructure Manager).
+ *
+ * GCP problem は Infrastructure Manager (= GCP が state/lock を所有する managed Terraform) で
+ * deployment を作る。 GCP が state を持つので ADR-023 D3/D5 を満たす (platform は backend を持たない)。
+ * `runtime.entry` が Terraform config 参照 (blueprint/gcs path)、 problem パラメータは TF input vars、
+ * deployment outputs を deploy output に読む。 Deployment Manager は 2026-03 EOL なので不採用 (ADR-027)。
+ *
+ * 認証は **Workload Identity Federation** (ADR-027): trust-bridge の `gcp-workload-identity` adapter が
+ * 短命 access token を発行する (service-account key 不要)。 本 adapter はその token を受け取る resolver を
+ * 注入される (= account-gated な WIF exchange は handler 側)。
+ *
+ * orchestration は注入された `GcpInfraManagerClient` / `getCredential` に対して書き unit test で pin する。
+ * 具体 Infra Manager REST 実装 + WIF exchange は実 account で検証する別レイヤ (#1419 / Sakura / Azure と同方針)。
+ */
+
+import type {
+  ProblemRuntime,
+  ProblemRuntimeAdapter,
+  RuntimeCollectOutputsInput,
+  RuntimeDeployInput,
+  RuntimeDeployResult,
+  RuntimeDestroyInput,
+  RuntimeDestroyResult,
+  RuntimeOutputs,
+  RuntimeStatus,
+  RuntimeStatusInput,
+} from "./adapter.js";
+
+/** WIF 交換で得た短命 access token (trust-bridge gcp-workload-identity 由来)。 */
+export interface GcpCredential {
+  readonly accessToken: string;
+}
+
+/** Infra Manager deployment の仕様。 blueprintRef = runtime.entry (TF config)、 inputs = problem パラメータ。 */
+export interface GcpDeploymentSpec {
+  readonly name: string;
+  readonly blueprintRef: string;
+  readonly inputs: Readonly<Record<string, string>>;
+}
+
+/** Infra Manager deployment の観測状態。 state は GCP 由来、 outputs は ACTIVE 後に埋まる。 */
+export interface GcpDeploymentState {
+  readonly state: string;
+  readonly outputs?: Readonly<Record<string, string>>;
+}
+
+/** GCP Infrastructure Manager API の最小 client 契約 (= account-gated REST 実装の注入点)。 */
+export interface GcpInfraManagerClient {
+  upsertDeployment(spec: GcpDeploymentSpec): Promise<void>;
+  getDeployment(name: string): Promise<GcpDeploymentState | undefined>;
+  deleteDeployment(name: string): Promise<void>;
+}
+
+export interface GcpInfraManagerAdapterContext {
+  /** WIF 短命 token を解決 (trust-bridge 経由、 handler が束縛、 account-gated)。 */
+  readonly getCredential: () => Promise<GcpCredential>;
+  readonly client: (credential: GcpCredential) => GcpInfraManagerClient;
+}
+
+export const GCP_PROVIDER = "gcp";
+export const GCP_ENGINE = "infra-manager";
+
+/** Infra Manager deployment state を platform の 6-state に射影。 不在=destroyed、 未知/進行中は安全側 deploying。 */
+export function mapGcpDeploymentState(raw: string | undefined): RuntimeStatus {
+  if (raw === undefined) return "destroyed";
+  const s = raw.toLowerCase();
+  if (["active", "succeeded"].includes(s)) return "ready";
+  if (["failed", "error"].includes(s)) return "failed";
+  if (["deleting"].includes(s)) return "destroying";
+  if (["deleted"].includes(s)) return "destroyed";
+  // creating / updating / applying / pending / unknown → 安全側 (ready と誤判定しない)
+  return "deploying";
+}
+
+export class GcpInfraManagerRuntimeAdapter implements ProblemRuntimeAdapter {
+  public readonly provider = GCP_PROVIDER;
+  public readonly engine = GCP_ENGINE;
+
+  constructor(
+    private readonly ctx: GcpInfraManagerAdapterContext,
+    private readonly runtime: ProblemRuntime,
+  ) {}
+
+  private async resolveClient(): Promise<GcpInfraManagerClient> {
+    return this.ctx.client(await this.ctx.getCredential());
+  }
+
+  async deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult> {
+    const client = await this.resolveClient();
+    await client.upsertDeployment({
+      name: input.namePrefix,
+      blueprintRef: this.runtime.entry, // ADR-027: runtime.entry = Terraform config reference
+      inputs: {
+        tenkacloud_name_prefix: input.namePrefix,
+        tenkacloud_problem_id: input.problemId,
+        tenkacloud_team: input.teamSlug,
+        ...(input.challengePayloadUrl
+          ? { tenkacloud_challenge_payload_url: input.challengePayloadUrl }
+          : {}),
+      },
+    });
+    return { status: "deploying" };
+  }
+
+  async collectOutputs(input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs> {
+    const client = await this.resolveClient();
+    const deployment = await client.getDeployment(input.namePrefix);
+    return deployment?.outputs ?? {};
+  }
+
+  async getStatus(input: RuntimeStatusInput): Promise<RuntimeStatus> {
+    const client = await this.resolveClient();
+    const deployment = await client.getDeployment(input.namePrefix);
+    return mapGcpDeploymentState(deployment?.state);
+  }
+
+  async destroy(input: RuntimeDestroyInput): Promise<RuntimeDestroyResult> {
+    const client = await this.resolveClient();
+    await client.deleteDeployment(input.namePrefix);
+    return { status: "destroying" };
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
@@ -36,3 +36,14 @@ export {
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
 export { type AdapterDependencies, selectAdapter } from "./registry.js";
+export {
+  mapSakuraStatus,
+  SAKURA_ENGINE,
+  SAKURA_PROVIDER,
+  type SakuraApplicationState,
+  type SakuraAppRunAdapterContext,
+  type SakuraAppRunClient,
+  SakuraAppRunRuntimeAdapter,
+  type SakuraAppRunSpec,
+  type SakuraCredential,
+} from "./sakura-apprun-adapter.js";

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/index.ts
@@ -35,6 +35,28 @@ export {
   type AwsCloudFormationAdapterContext,
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
+export {
+  AZURE_ENGINE,
+  AZURE_PROVIDER,
+  type AzureBicepAdapterContext,
+  AzureBicepRuntimeAdapter,
+  type AzureCredential,
+  type AzureDeploymentStackClient,
+  type AzureDeploymentStackSpec,
+  type AzureDeploymentStackState,
+  mapAzureProvisioningState,
+} from "./azure-bicep-adapter.js";
+export {
+  GCP_ENGINE,
+  GCP_PROVIDER,
+  type GcpCredential,
+  type GcpDeploymentSpec,
+  type GcpDeploymentState,
+  type GcpInfraManagerAdapterContext,
+  type GcpInfraManagerClient,
+  GcpInfraManagerRuntimeAdapter,
+  mapGcpDeploymentState,
+} from "./gcp-infra-manager-adapter.js";
 export { type AdapterDependencies, selectAdapter } from "./registry.js";
 export {
   mapSakuraStatus,

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
@@ -24,14 +24,24 @@ import {
   type AwsCloudFormationAdapterContext,
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
+import {
+  SAKURA_ENGINE,
+  SAKURA_PROVIDER,
+  type SakuraAppRunAdapterContext,
+  SakuraAppRunRuntimeAdapter,
+} from "./sakura-apprun-adapter.js";
 
 /**
- * Dependencies any adapter might need. Phase 1 only uses the AWS subset; the
- * shape is open so future adapters (Azure ARM client, kubectl client, etc.)
- * can be added without changing this signature.
+ * Dependencies any adapter might need. The AWS subset is always present; provider
+ * adapters whose I/O is account-gated (Sakura key + AppRun client, future Azure/GCP)
+ * are **optional** — the deploy handler wires them only when that provider is
+ * configured, so an un-provisioned provider stays `RuntimeNotSupportedError` (reserved)
+ * rather than failing at the cloud call. The adapter code + tests exist regardless.
  */
 export interface AdapterDependencies {
   readonly aws: AwsCloudFormationAdapterContext;
+  /** [ADR-026 / #1412] sakura/apprun — present only when the handler has the account-gated client + key. */
+  readonly sakura?: SakuraAppRunAdapterContext;
 }
 
 export function selectAdapter(
@@ -40,6 +50,12 @@ export function selectAdapter(
 ): ProblemRuntimeAdapter {
   if (runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE) {
     return new AwsCloudFormationRuntimeAdapter(deps.aws);
+  }
+  // [ADR-026 / #1412] sakura/apprun is executable only when the handler wired the
+  // account-gated context (SSM key resolver + AppRun client). Until then it falls
+  // through to the reserved-runtime error (no silent stub, no cloud mutation).
+  if (runtime.provider === SAKURA_PROVIDER && runtime.engine === SAKURA_ENGINE && deps.sakura) {
+    return new SakuraAppRunRuntimeAdapter(deps.sakura, runtime);
   }
   // Planned providers (ADR-026/027) get a roadmap-aware message; everything else
   // is treated as a likely typo. Both still throw — no adapter, no cloud mutation.

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/registry.ts
@@ -25,6 +25,18 @@ import {
   AwsCloudFormationRuntimeAdapter,
 } from "./aws-cfn-adapter.js";
 import {
+  AZURE_ENGINE,
+  AZURE_PROVIDER,
+  type AzureBicepAdapterContext,
+  AzureBicepRuntimeAdapter,
+} from "./azure-bicep-adapter.js";
+import {
+  GCP_ENGINE,
+  GCP_PROVIDER,
+  type GcpInfraManagerAdapterContext,
+  GcpInfraManagerRuntimeAdapter,
+} from "./gcp-infra-manager-adapter.js";
+import {
   SAKURA_ENGINE,
   SAKURA_PROVIDER,
   type SakuraAppRunAdapterContext,
@@ -42,6 +54,10 @@ export interface AdapterDependencies {
   readonly aws: AwsCloudFormationAdapterContext;
   /** [ADR-026 / #1412] sakura/apprun — present only when the handler has the account-gated client + key. */
   readonly sakura?: SakuraAppRunAdapterContext;
+  /** [ADR-027 / #1410] azure/bicep — present only when the handler wired the WIF credential + ARM client. */
+  readonly azure?: AzureBicepAdapterContext;
+  /** [ADR-027 / #1411] gcp/infra-manager — present only when the handler wired the WIF credential + IM client. */
+  readonly gcp?: GcpInfraManagerAdapterContext;
 }
 
 export function selectAdapter(
@@ -56,6 +72,15 @@ export function selectAdapter(
   // through to the reserved-runtime error (no silent stub, no cloud mutation).
   if (runtime.provider === SAKURA_PROVIDER && runtime.engine === SAKURA_ENGINE && deps.sakura) {
     return new SakuraAppRunRuntimeAdapter(deps.sakura, runtime);
+  }
+  // [ADR-027 / #1410-1411] azure/bicep + gcp/infra-manager are executable only when the handler
+  // wired the account-gated WIF context (trust-bridge credential + provider client). Until then
+  // they fall through to the reserved-runtime error (no silent stub, no cloud mutation).
+  if (runtime.provider === AZURE_PROVIDER && runtime.engine === AZURE_ENGINE && deps.azure) {
+    return new AzureBicepRuntimeAdapter(deps.azure, runtime);
+  }
+  if (runtime.provider === GCP_PROVIDER && runtime.engine === GCP_ENGINE && deps.gcp) {
+    return new GcpInfraManagerRuntimeAdapter(deps.gcp, runtime);
   }
   // Planned providers (ADR-026/027) get a roadmap-aware message; everything else
   // is treated as a likely typo. Both still throw — no adapter, no cloud mutation.

--- a/infrastructure/lib/problem-deploy/handlers/shared/runtime/sakura-apprun-adapter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/runtime/sakura-apprun-adapter.ts
@@ -1,0 +1,137 @@
+/**
+ * [ADR-026 / Issue #1412] sakura/apprun runtime adapter.
+ *
+ * Sakura には CloudFormation 相当の state-owning IaC が無いので、 problem の container image を
+ * **AppRun application** として deploy し、 AppRun (Knative on managed k8s) が runtime / scaling /
+ * teardown を所有する (= ADR-023 D3 を満たす。 platform は state file / lock を持たない)。 image は
+ * `runtime.entry`、 problem パラメータ + platform メタは env var で渡し、 public URL を deploy output に読む。
+ *
+ * 認証は **static API key (Access Token + Secret)** を SSM SecureString から都度取得する (ADR-026 D3、
+ * AWS の ExternalId と同型の保管。 long-lived なので scope 最小化 + per-team account 前提)。 Sakura は
+ * federation primitive を持たないため Trust Bridge には乗らない。
+ *
+ * orchestration は注入された `SakuraAppRunClient` / `getApiKey` に対して書き、 unit test で全分岐を pin する。
+ * 具体 HTTP 実装 (実 AppRun REST 呼び出し) と SSM key 取得は **実 account で検証する別レイヤ** (= deploy
+ * handler が束縛する)。 = #1419 executor と同じ「logic を注入境界で組み、 実 I/O は後で配線」方針。
+ */
+
+import type {
+  ProblemRuntime,
+  ProblemRuntimeAdapter,
+  RuntimeCollectOutputsInput,
+  RuntimeDeployInput,
+  RuntimeDeployResult,
+  RuntimeDestroyInput,
+  RuntimeDestroyResult,
+  RuntimeOutputs,
+  RuntimeStatus,
+  RuntimeStatusInput,
+} from "./adapter.js";
+
+/** Sakura API の静的キー (Access Token + Secret)。 SSM SecureString から取得 (ADR-026 D3)。 */
+export interface SakuraCredential {
+  readonly accessToken: string;
+  readonly accessTokenSecret: string;
+}
+
+/** AppRun application の deploy 仕様。 image = runtime.entry、 env = problem パラメータ + platform メタ。 */
+export interface SakuraAppRunSpec {
+  readonly name: string;
+  readonly image: string;
+  readonly env: Readonly<Record<string, string>>;
+}
+
+/** AppRun application の観測状態。 publicUrl は ready 後に埋まる。 */
+export interface SakuraApplicationState {
+  readonly status: string;
+  readonly publicUrl?: string;
+}
+
+/**
+ * Sakura AppRun API の最小 client 契約 (= account-gated な HTTP 実装を注入する seam)。 adapter の
+ * orchestration はこの interface に対して書かれ、 具体実装 (Access Token + Secret 認証の REST 呼び出し)
+ * は実 account で検証する別レイヤ。 handler が `handler must not call fetch` 規約に従い service 層で実装する。
+ */
+export interface SakuraAppRunClient {
+  /** name の application を作成 or 更新 (= 冪等な deploy)。 */
+  upsertApplication(spec: SakuraAppRunSpec): Promise<void>;
+  /** name の application 状態を取得。 不在は undefined。 */
+  getApplication(name: string): Promise<SakuraApplicationState | undefined>;
+  /** name の application を削除 (= teardown、 AppRun が lifecycle を所有)。 */
+  deleteApplication(name: string): Promise<void>;
+}
+
+export interface SakuraAppRunAdapterContext {
+  /** team の scoped API key を SSM SecureString から解決 (deploy handler が束縛、 account-gated)。 */
+  readonly getApiKey: () => Promise<SakuraCredential>;
+  /** credential を受けて AppRun client を返す factory (= 具体 HTTP 実装の注入点)。 */
+  readonly client: (credential: SakuraCredential) => SakuraAppRunClient;
+}
+
+export const SAKURA_PROVIDER = "sakura";
+export const SAKURA_ENGINE = "apprun";
+
+/**
+ * AppRun (Knative) の status 文字列を platform の 6-state に射影する。 不在 (= 未作成 / 削除済) は
+ * `destroyed`、 終了系は `failed`/`destroying`/`destroyed`、 稼働は `ready`、 それ以外 (provisioning /
+ * pending / 未知) は安全側で `deploying` (= ready と誤判定して採点を始めない)。 厳密な値は実 account で確認。
+ */
+export function mapSakuraStatus(raw: string | undefined): RuntimeStatus {
+  if (raw === undefined) return "destroyed";
+  const s = raw.toLowerCase();
+  if (["running", "ready", "active", "succeeded", "available"].includes(s)) return "ready";
+  if (["failed", "error", "crashed", "failure"].includes(s)) return "failed";
+  if (["deleting", "terminating"].includes(s)) return "destroying";
+  if (["deleted", "gone", "notfound"].includes(s)) return "destroyed";
+  return "deploying";
+}
+
+export class SakuraAppRunRuntimeAdapter implements ProblemRuntimeAdapter {
+  public readonly provider = SAKURA_PROVIDER;
+  public readonly engine = SAKURA_ENGINE;
+
+  constructor(
+    private readonly ctx: SakuraAppRunAdapterContext,
+    private readonly runtime: ProblemRuntime,
+  ) {}
+
+  private async resolveClient(): Promise<SakuraAppRunClient> {
+    return this.ctx.client(await this.ctx.getApiKey());
+  }
+
+  async deploy(input: RuntimeDeployInput): Promise<RuntimeDeployResult> {
+    const client = await this.resolveClient();
+    await client.upsertApplication({
+      name: input.namePrefix,
+      image: this.runtime.entry, // ADR-026: runtime.entry = container image reference
+      env: {
+        TENKACLOUD_NAME_PREFIX: input.namePrefix,
+        TENKACLOUD_PROBLEM_ID: input.problemId,
+        TENKACLOUD_TEAM: input.teamSlug,
+        ...(input.challengePayloadUrl
+          ? { TENKACLOUD_CHALLENGE_PAYLOAD_URL: input.challengePayloadUrl }
+          : {}),
+      },
+    });
+    return { status: "deploying" };
+  }
+
+  async collectOutputs(input: RuntimeCollectOutputsInput): Promise<RuntimeOutputs> {
+    const client = await this.resolveClient();
+    const app = await client.getApplication(input.namePrefix);
+    // public URL が読めたら BaseUrl として返す (= endpoints[].default の cfn-output と同位置付け)。
+    return app?.publicUrl ? { BaseUrl: app.publicUrl } : {};
+  }
+
+  async getStatus(input: RuntimeStatusInput): Promise<RuntimeStatus> {
+    const client = await this.resolveClient();
+    const app = await client.getApplication(input.namePrefix);
+    return mapSakuraStatus(app?.status);
+  }
+
+  async destroy(input: RuntimeDestroyInput): Promise<RuntimeDestroyResult> {
+    const client = await this.resolveClient();
+    await client.deleteApplication(input.namePrefix);
+    return { status: "destroying" };
+  }
+}

--- a/infrastructure/test/problem-deploy/azure-bicep-adapter.test.ts
+++ b/infrastructure/test/problem-deploy/azure-bicep-adapter.test.ts
@@ -1,0 +1,111 @@
+/**
+ * [ADR-027 / Issue #1410] Unit tests for the azure/bicep runtime adapter + registry wiring.
+ * orchestration を注入された AzureDeploymentStackClient / getCredential に対して pin する
+ * (実 ARM REST + WIF exchange は account-gated)。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AwsCloudFormationAdapterContext } from "../../lib/problem-deploy/handlers/shared/runtime/aws-cfn-adapter";
+import {
+  type AzureBicepAdapterContext,
+  AzureBicepRuntimeAdapter,
+  type AzureDeploymentStackClient,
+  mapAzureProvisioningState,
+  type ProblemRuntime,
+  RuntimeNotSupportedError,
+  selectAdapter,
+} from "../../lib/problem-deploy/handlers/shared/runtime/index";
+
+const runtime: ProblemRuntime = { provider: "azure", engine: "bicep", entry: "main.bicep" };
+const deployInput = {
+  jobId: "job-1",
+  correlationId: "job-1",
+  tenantId: "t1",
+  problemId: "azure-fn",
+  problemDir: "problems/challenges/azure-fn",
+  teamSlug: "team-a",
+  namePrefix: "tc-team-a-azure-fn",
+  region: "japaneast",
+  awsAccountId: "n/a",
+};
+
+function makeCtx(client: AzureDeploymentStackClient): {
+  ctx: AzureBicepAdapterContext;
+  getCredential: ReturnType<typeof vi.fn>;
+  factory: ReturnType<typeof vi.fn>;
+} {
+  const getCredential = vi.fn().mockResolvedValue({ accessToken: "tok" });
+  const factory = vi.fn().mockReturnValue(client);
+  return { ctx: { getCredential, client: factory }, getCredential, factory };
+}
+
+describe("mapAzureProvisioningState (ADR-027 #1410)", () => {
+  it("should map ARM provisioningState to the 6-state runtime status", () => {
+    expect(mapAzureProvisioningState("Succeeded")).toBe("ready");
+    expect(mapAzureProvisioningState("Failed")).toBe("failed");
+    expect(mapAzureProvisioningState("Canceled")).toBe("failed");
+    expect(mapAzureProvisioningState("Deleting")).toBe("destroying");
+    expect(mapAzureProvisioningState(undefined)).toBe("destroyed");
+    expect(mapAzureProvisioningState("Running")).toBe("deploying");
+  });
+});
+
+describe("AzureBicepRuntimeAdapter (ADR-027 #1410)", () => {
+  let client: {
+    upsertStack: ReturnType<typeof vi.fn>;
+    getStack: ReturnType<typeof vi.fn>;
+    deleteStack: ReturnType<typeof vi.fn>;
+  };
+  beforeEach(() => {
+    client = {
+      upsertStack: vi.fn().mockResolvedValue(undefined),
+      getStack: vi.fn().mockResolvedValue({
+        provisioningState: "Succeeded",
+        outputs: { BaseUrl: "https://fn.example" },
+      }),
+      deleteStack: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("should deploy by upserting the Deployment Stack with templateRef=entry + params", async () => {
+    const { ctx, getCredential } = makeCtx(client);
+    const result = await new AzureBicepRuntimeAdapter(ctx, runtime).deploy(deployInput);
+    expect(result).toEqual({ status: "deploying" });
+    expect(getCredential).toHaveBeenCalledTimes(1);
+    expect(client.upsertStack).toHaveBeenCalledWith({
+      name: "tc-team-a-azure-fn",
+      templateRef: "main.bicep",
+      parameters: {
+        tenkacloudNamePrefix: "tc-team-a-azure-fn",
+        tenkacloudProblemId: "azure-fn",
+        tenkacloudTeam: "team-a",
+      },
+    });
+  });
+
+  it("should collect stack outputs / map status / destroy", async () => {
+    const { ctx } = makeCtx(client);
+    const a = new AzureBicepRuntimeAdapter(ctx, runtime);
+    const args = {
+      jobId: "j",
+      namePrefix: "tc-team-a-azure-fn",
+      region: "japaneast",
+      awsAccountId: "n/a",
+    };
+    expect(await a.collectOutputs(args)).toEqual({ BaseUrl: "https://fn.example" });
+    expect(await a.getStatus(args)).toBe("ready");
+    expect(await a.destroy(args)).toEqual({ status: "destroying" });
+    expect(client.deleteStack).toHaveBeenCalledWith("tc-team-a-azure-fn");
+    client.getStack.mockResolvedValueOnce(undefined);
+    expect(await a.collectOutputs(args)).toEqual({});
+  });
+});
+
+describe("selectAdapter azure wiring (ADR-027 #1410)", () => {
+  const aws = {} as AwsCloudFormationAdapterContext;
+  it("should return the Azure adapter only when its WIF context is wired, else reserved", () => {
+    const ctx: AzureBicepAdapterContext = { getCredential: vi.fn(), client: vi.fn() };
+    expect(selectAdapter(runtime, { aws, azure: ctx }).provider).toBe("azure");
+    expect(() => selectAdapter(runtime, { aws })).toThrow(RuntimeNotSupportedError);
+  });
+});

--- a/infrastructure/test/problem-deploy/gcp-infra-manager-adapter.test.ts
+++ b/infrastructure/test/problem-deploy/gcp-infra-manager-adapter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * [ADR-027 / Issue #1411] Unit tests for the gcp/infra-manager runtime adapter + registry wiring.
+ * orchestration を注入された GcpInfraManagerClient / getCredential に対して pin する
+ * (実 Infra Manager REST + WIF exchange は account-gated)。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AwsCloudFormationAdapterContext } from "../../lib/problem-deploy/handlers/shared/runtime/aws-cfn-adapter";
+import {
+  type GcpInfraManagerAdapterContext,
+  type GcpInfraManagerClient,
+  GcpInfraManagerRuntimeAdapter,
+  mapGcpDeploymentState,
+  type ProblemRuntime,
+  RuntimeNotSupportedError,
+  selectAdapter,
+} from "../../lib/problem-deploy/handlers/shared/runtime/index";
+
+const runtime: ProblemRuntime = { provider: "gcp", engine: "infra-manager", entry: "blueprint/" };
+const deployInput = {
+  jobId: "job-1",
+  correlationId: "job-1",
+  tenantId: "t1",
+  problemId: "gcp-run",
+  problemDir: "problems/challenges/gcp-run",
+  teamSlug: "team-a",
+  namePrefix: "tc-team-a-gcp-run",
+  region: "asia-northeast1",
+  awsAccountId: "n/a",
+};
+
+function makeCtx(client: GcpInfraManagerClient): {
+  ctx: GcpInfraManagerAdapterContext;
+  getCredential: ReturnType<typeof vi.fn>;
+} {
+  const getCredential = vi.fn().mockResolvedValue({ accessToken: "tok" });
+  return { ctx: { getCredential, client: vi.fn().mockReturnValue(client) }, getCredential };
+}
+
+describe("mapGcpDeploymentState (ADR-027 #1411)", () => {
+  it("should map Infra Manager state to the 6-state runtime status", () => {
+    expect(mapGcpDeploymentState("ACTIVE")).toBe("ready");
+    expect(mapGcpDeploymentState("FAILED")).toBe("failed");
+    expect(mapGcpDeploymentState("DELETING")).toBe("destroying");
+    expect(mapGcpDeploymentState(undefined)).toBe("destroyed");
+    expect(mapGcpDeploymentState("APPLYING")).toBe("deploying");
+  });
+});
+
+describe("GcpInfraManagerRuntimeAdapter (ADR-027 #1411)", () => {
+  let client: {
+    upsertDeployment: ReturnType<typeof vi.fn>;
+    getDeployment: ReturnType<typeof vi.fn>;
+    deleteDeployment: ReturnType<typeof vi.fn>;
+  };
+  beforeEach(() => {
+    client = {
+      upsertDeployment: vi.fn().mockResolvedValue(undefined),
+      getDeployment: vi
+        .fn()
+        .mockResolvedValue({ state: "ACTIVE", outputs: { BaseUrl: "https://run.example" } }),
+      deleteDeployment: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("should deploy by upserting the Infra Manager deployment with blueprintRef=entry + inputs", async () => {
+    const { ctx, getCredential } = makeCtx(client);
+    const result = await new GcpInfraManagerRuntimeAdapter(ctx, runtime).deploy(deployInput);
+    expect(result).toEqual({ status: "deploying" });
+    expect(getCredential).toHaveBeenCalledTimes(1);
+    expect(client.upsertDeployment).toHaveBeenCalledWith({
+      name: "tc-team-a-gcp-run",
+      blueprintRef: "blueprint/",
+      inputs: {
+        tenkacloud_name_prefix: "tc-team-a-gcp-run",
+        tenkacloud_problem_id: "gcp-run",
+        tenkacloud_team: "team-a",
+      },
+    });
+  });
+
+  it("should collect deployment outputs / map status / destroy", async () => {
+    const { ctx } = makeCtx(client);
+    const a = new GcpInfraManagerRuntimeAdapter(ctx, runtime);
+    const args = {
+      jobId: "j",
+      namePrefix: "tc-team-a-gcp-run",
+      region: "asia-northeast1",
+      awsAccountId: "n/a",
+    };
+    expect(await a.collectOutputs(args)).toEqual({ BaseUrl: "https://run.example" });
+    expect(await a.getStatus(args)).toBe("ready");
+    expect(await a.destroy(args)).toEqual({ status: "destroying" });
+    expect(client.deleteDeployment).toHaveBeenCalledWith("tc-team-a-gcp-run");
+    client.getDeployment.mockResolvedValueOnce(undefined);
+    expect(await a.collectOutputs(args)).toEqual({});
+  });
+});
+
+describe("selectAdapter gcp wiring (ADR-027 #1411)", () => {
+  const aws = {} as AwsCloudFormationAdapterContext;
+  it("should return the GCP adapter only when its WIF context is wired, else reserved", () => {
+    const ctx: GcpInfraManagerAdapterContext = { getCredential: vi.fn(), client: vi.fn() };
+    expect(selectAdapter(runtime, { aws, gcp: ctx }).engine).toBe("infra-manager");
+    expect(() => selectAdapter(runtime, { aws })).toThrow(RuntimeNotSupportedError);
+  });
+});

--- a/infrastructure/test/problem-deploy/sakura-apprun-adapter.test.ts
+++ b/infrastructure/test/problem-deploy/sakura-apprun-adapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * [ADR-026 / Issue #1412] Unit tests for the sakura/apprun runtime adapter + its registry wiring.
+ *
+ * orchestration は注入された SakuraAppRunClient / getApiKey に対して全分岐を pin する
+ * (= 実 AppRun REST / SSM key 取得は account-gated な別レイヤ。 #1419 executor と同方針)。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AwsCloudFormationAdapterContext } from "../../lib/problem-deploy/handlers/shared/runtime/aws-cfn-adapter";
+import {
+  mapSakuraStatus,
+  type ProblemRuntime,
+  RuntimeNotSupportedError,
+  type SakuraAppRunAdapterContext,
+  type SakuraAppRunClient,
+  SakuraAppRunRuntimeAdapter,
+  selectAdapter,
+} from "../../lib/problem-deploy/handlers/shared/runtime/index";
+
+const runtime: ProblemRuntime = {
+  provider: "sakura",
+  engine: "apprun",
+  entry: "registry.example/tenkacloud/uptime-app:latest",
+};
+
+const deployInput = {
+  jobId: "job-1",
+  correlationId: "job-1",
+  tenantId: "tenant-1",
+  problemId: "sakura-uptime",
+  problemDir: "problems/challenges/sakura-uptime",
+  teamSlug: "team-a",
+  namePrefix: "tc-team-a-sakura-uptime",
+  region: "is1a",
+  awsAccountId: "n/a",
+  challengePayloadUrl: "https://payload.example/x",
+};
+
+function makeCtx(client: SakuraAppRunClient): {
+  ctx: SakuraAppRunAdapterContext;
+  getApiKey: ReturnType<typeof vi.fn>;
+  clientFactory: ReturnType<typeof vi.fn>;
+} {
+  const getApiKey = vi.fn().mockResolvedValue({ accessToken: "AT", accessTokenSecret: "AS" });
+  const clientFactory = vi.fn().mockReturnValue(client);
+  return { ctx: { getApiKey, client: clientFactory }, getApiKey, clientFactory };
+}
+
+describe("mapSakuraStatus (ADR-026 #1412)", () => {
+  it("should map AppRun states to the 6-state runtime status", () => {
+    expect(mapSakuraStatus("Running")).toBe("ready");
+    expect(mapSakuraStatus("available")).toBe("ready");
+    expect(mapSakuraStatus("Failed")).toBe("failed");
+    expect(mapSakuraStatus("Deleting")).toBe("destroying");
+    expect(mapSakuraStatus("deleted")).toBe("destroyed");
+    expect(mapSakuraStatus(undefined)).toBe("destroyed"); // not found = 未作成/削除済
+    expect(mapSakuraStatus("Provisioning")).toBe("deploying"); // 未知/進行中は安全側
+    expect(mapSakuraStatus("totally-unknown")).toBe("deploying");
+  });
+});
+
+describe("SakuraAppRunRuntimeAdapter (ADR-026 #1412)", () => {
+  let client: {
+    upsertApplication: ReturnType<typeof vi.fn>;
+    getApplication: ReturnType<typeof vi.fn>;
+    deleteApplication: ReturnType<typeof vi.fn>;
+  };
+  beforeEach(() => {
+    client = {
+      upsertApplication: vi.fn().mockResolvedValue(undefined),
+      getApplication: vi
+        .fn()
+        .mockResolvedValue({ status: "Running", publicUrl: "https://app.example" }),
+      deleteApplication: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("should report provider/engine = sakura/apprun", () => {
+    const { ctx } = makeCtx(client);
+    const a = new SakuraAppRunRuntimeAdapter(ctx, runtime);
+    expect([a.provider, a.engine]).toEqual(["sakura", "apprun"]);
+  });
+
+  it("should deploy by upserting the AppRun app with image=entry + platform env, after fetching the key", async () => {
+    const { ctx, getApiKey, clientFactory } = makeCtx(client);
+    const result = await new SakuraAppRunRuntimeAdapter(ctx, runtime).deploy(deployInput);
+    expect(result).toEqual({ status: "deploying" });
+    expect(getApiKey).toHaveBeenCalledTimes(1);
+    expect(clientFactory).toHaveBeenCalledWith({ accessToken: "AT", accessTokenSecret: "AS" });
+    expect(client.upsertApplication).toHaveBeenCalledWith({
+      name: "tc-team-a-sakura-uptime",
+      image: "registry.example/tenkacloud/uptime-app:latest",
+      env: {
+        TENKACLOUD_NAME_PREFIX: "tc-team-a-sakura-uptime",
+        TENKACLOUD_PROBLEM_ID: "sakura-uptime",
+        TENKACLOUD_TEAM: "team-a",
+        TENKACLOUD_CHALLENGE_PAYLOAD_URL: "https://payload.example/x",
+      },
+    });
+  });
+
+  it("should omit the payload env var when no challengePayloadUrl is given", async () => {
+    const { ctx } = makeCtx(client);
+    const { challengePayloadUrl, ...noPayload } = deployInput;
+    await new SakuraAppRunRuntimeAdapter(ctx, runtime).deploy(noPayload);
+    expect(client.upsertApplication.mock.calls[0][0].env).not.toHaveProperty(
+      "TENKACLOUD_CHALLENGE_PAYLOAD_URL",
+    );
+  });
+
+  it("should collect the public URL as BaseUrl, or {} when not ready", async () => {
+    const { ctx } = makeCtx(client);
+    const a = new SakuraAppRunRuntimeAdapter(ctx, runtime);
+    expect(
+      await a.collectOutputs({
+        jobId: "j",
+        namePrefix: "tc-team-a-sakura-uptime",
+        region: "is1a",
+        awsAccountId: "n/a",
+      }),
+    ).toEqual({
+      BaseUrl: "https://app.example",
+    });
+    client.getApplication.mockResolvedValueOnce({ status: "Provisioning" }); // no publicUrl yet
+    expect(
+      await a.collectOutputs({ jobId: "j", namePrefix: "x", region: "is1a", awsAccountId: "n/a" }),
+    ).toEqual({});
+  });
+
+  it("should map getStatus through mapSakuraStatus", async () => {
+    const { ctx } = makeCtx(client);
+    const a = new SakuraAppRunRuntimeAdapter(ctx, runtime);
+    expect(
+      await a.getStatus({ jobId: "j", namePrefix: "x", region: "is1a", awsAccountId: "n/a" }),
+    ).toBe("ready");
+    client.getApplication.mockResolvedValueOnce(undefined);
+    expect(
+      await a.getStatus({ jobId: "j", namePrefix: "x", region: "is1a", awsAccountId: "n/a" }),
+    ).toBe("destroyed");
+  });
+
+  it("should destroy by deleting the AppRun application", async () => {
+    const { ctx } = makeCtx(client);
+    const result = await new SakuraAppRunRuntimeAdapter(ctx, runtime).destroy({
+      jobId: "j",
+      namePrefix: "tc-team-a-sakura-uptime",
+      region: "is1a",
+      awsAccountId: "n/a",
+    });
+    expect(result).toEqual({ status: "destroying" });
+    expect(client.deleteApplication).toHaveBeenCalledWith("tc-team-a-sakura-uptime");
+  });
+});
+
+describe("selectAdapter sakura wiring (ADR-026 #1412)", () => {
+  const aws = {} as AwsCloudFormationAdapterContext;
+
+  it("should return the Sakura adapter when the account-gated context is wired", () => {
+    const ctx: SakuraAppRunAdapterContext = {
+      getApiKey: vi.fn(),
+      client: vi.fn(),
+    };
+    const a = selectAdapter(runtime, { aws, sakura: ctx });
+    expect([a.provider, a.engine]).toEqual(["sakura", "apprun"]);
+  });
+
+  it("should stay reserved (RuntimeNotSupportedError) when sakura deps are absent", () => {
+    expect(() => selectAdapter(runtime, { aws })).toThrow(RuntimeNotSupportedError);
+  });
+});


### PR DESCRIPTION
## Summary

Builds the **multi-cloud problem-runtime adapter mechanism** for all three planned providers (tracker #1408), per your "build the mechanism fully now, accounts validate later" direction. Each implements the existing `ProblemRuntimeAdapter` interface and registers in `selectAdapter` **only when its account-gated context is wired** — until then the runtime stays a reserved `RuntimeNotSupportedError` (no silent stub, no cloud mutation, per the no-silent-fallbacks rule).

| Adapter | Engine | Deploy unit (cloud owns lifecycle) | Auth (ADR) | Issue |
|---|---|---|---|---|
| **sakura/apprun** | AppRun application | AppRun (Knative) | static API key in SSM SecureString (ADR-026 D3) | #1412 |
| **azure/bicep** | Azure Deployment Stack | Deployment Stacks | Workload Identity Federation (ADR-027) | #1410 |
| **gcp/infra-manager** | Infra Manager deployment | Infrastructure Manager (managed TF) | Workload Identity Federation (ADR-027) | #1411 |

All satisfy ADR-023 D3 (the cloud owns runtime/state/teardown; the platform holds no state file or lock).

### Pattern (the #1419-executor playbook)
Each adapter is **pure orchestration over injected deps** — a minimal provider `client` (upsert/get/delete) + a `getCredential`/`getApiKey` resolver — so the logic is fully unit-tested with mocks. The **account-gated seams** are exactly two per provider, wired by the deploy handler and validated against a real account later:
1. the concrete REST client (Sakura AppRun / Azure ARM Deployment Stacks / GCP Infra Manager);
2. the credential resolver (Sakura SSM key; Azure/GCP via the existing 100%-tested trust-bridge `azure-federated-credential` / `gcp-workload-identity`).

`runtime.entry` is the provider artifact (container image / Bicep template / TF blueprint); problem metadata flows as env vars / stack parameters / TF inputs; provider outputs map to the deploy outputs; each provider's native status maps to the 6-state `RuntimeStatus` (unknown→`deploying`, safe-side).

## Test plan
- **17 new unit tests** (Sakura 9, Azure 4, GCP 4) + status mappers, + the existing runtime-adapter suite (25) green with the registry changes.
- Full **infra suite: 2459 pass**. tsc/biome/`make harness` (0 findings)/check-no-conflicts clean.

## Regression analysis
Additive. `selectAdapter` gains three optional, deps-gated branches; with no provider context wired (today) behavior is unchanged — each provider still returns the reserved error (asserted per adapter). `RESERVED_RUNTIMES` is intentionally left as-is; each pair "ships" out of reserved when the handler wires its account-gated client (the follow-up that the cloud account enables), per the tracker's "each engine PR moves its pair out as it ships."

## Physical impact
**NO-OP** on CloudFormation / deployed artifacts — pure TypeScript adapters + tests; no construct, IAM, or dependency change. Inert until the handler wires each provider's client + a team credential exists.

Relates #1408, #1410, #1411, #1412, #1413