### PR TITLE
feat(portal): expose live coordination client to plugin slots (ADR-028) [#1420]

### DIFF
--- a/apps/participant-portal/src/pages/ProblemDetail.tsx
+++ b/apps/participant-portal/src/pages/ProblemDetail.tsx
@@ -183,6 +183,8 @@ export function ProblemDetailPage({ config }: { config: AppConfig }) {
           score={problem.score}
           team={view.team}
           stackOutputs={problem.stackOutputs}
+          coordinationApiUrl={config.coordinationApiUrl}
+          sessionToken={sessionToken ?? undefined}
         />
       )}
     </SpaceBetween>

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.test.tsx
@@ -28,11 +28,23 @@ vi.mock("./props-builder", () => ({
   buildPortalTeam: vi.fn((team) => team),
 }));
 
+// #1420: coordination-client を mock し、 PortalPluginSlots が dispatcher URL + session を束ねた
+// coordinationClient を slot に渡すこと (= op/projection が正しい引数で client を叩く) を観測する。
+vi.mock("../api/coordination-client", () => ({
+  submitCoordinationOp: vi.fn().mockResolvedValue({ kind: "ok", projection: {} }),
+  getCoordinationProjection: vi.fn().mockResolvedValue({ kind: "ok", projection: {} }),
+}));
+
 const { loadPluginSlot } = await import("./loader");
 const { buildPortalCoordination } = await import("./props-builder");
+const { submitCoordinationOp, getCoordinationProjection } = await import(
+  "../api/coordination-client"
+);
 const { PortalPluginSlots } = await import("./PortalPluginSlots");
 const mockLoadPluginSlot = loadPluginSlot as ReturnType<typeof vi.fn>;
 const mockBuildCoordination = buildPortalCoordination as ReturnType<typeof vi.fn>;
+const mockSubmitOp = submitCoordinationOp as ReturnType<typeof vi.fn>;
+const mockGetProjection = getCoordinationProjection as ReturnType<typeof vi.fn>;
 
 const baseProps = {
   problemId: "fake-problem",
@@ -45,6 +57,8 @@ const baseProps = {
 afterEach(() => {
   mockLoadPluginSlot.mockReset();
   mockBuildCoordination.mockReset();
+  mockSubmitOp.mockClear();
+  mockGetProjection.mockClear();
 });
 
 describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
@@ -75,6 +89,49 @@ describe("PortalPluginSlots (ADR-012 Phase 5)", () => {
     );
     render(<PortalPluginSlots {...baseProps} />);
     await waitFor(() => expect(screen.getByTestId("coord")).toHaveTextContent("Router"));
+  });
+
+  it("should bind a live coordination client when coordinationApiUrl + sessionToken are present and route op/projection through it (#1420)", async () => {
+    let captured: { submitOp: (op: unknown) => unknown; getProjection: () => unknown } | undefined;
+    function CoordClientPanel(props: {
+      coordinationClient?: { submitOp: (op: unknown) => unknown; getProjection: () => unknown };
+    }) {
+      captured = props.coordinationClient;
+      return <div data-testid="cc">{props.coordinationClient ? "bound" : "none"}</div>;
+    }
+    mockLoadPluginSlot.mockImplementation((_p, slotName) =>
+      slotName === "StatusPanel" ? CoordClientPanel : undefined,
+    );
+    render(
+      <PortalPluginSlots
+        {...baseProps}
+        coordinationApiUrl="https://coord.example"
+        sessionToken="key-1"
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId("cc")).toHaveTextContent("bound"));
+    // biome-ignore lint/style/noNonNullAssertion: render asserted the client is bound
+    await captured!.submitOp({ kind: "register-route", url: "https://svc" });
+    // biome-ignore lint/style/noNonNullAssertion: render asserted the client is bound
+    await captured!.getProjection();
+    expect(mockSubmitOp).toHaveBeenCalledWith("https://coord.example", "key-1", {
+      kind: "register-route",
+      url: "https://svc",
+    });
+    expect(mockGetProjection).toHaveBeenCalledWith("https://coord.example", "key-1");
+  });
+
+  it("should NOT bind a coordination client when the dispatcher URL or session is missing (#1420)", async () => {
+    function Panel(props: { coordinationClient?: unknown }) {
+      return <div data-testid="cc">{props.coordinationClient ? "bound" : "none"}</div>;
+    }
+    mockLoadPluginSlot.mockImplementation((_p, slotName) =>
+      slotName === "StatusPanel" ? Panel : undefined,
+    );
+    // dispatcher URL あり / session なし → 束縛しない (= 認証無しで coordination を叩かせない)
+    render(<PortalPluginSlots {...baseProps} coordinationApiUrl="https://coord.example" />);
+    await waitFor(() => expect(screen.getByTestId("cc")).toHaveTextContent("none"));
+    expect(mockSubmitOp).not.toHaveBeenCalled();
   });
 
   it("should let ErrorBoundary fall back to an Alert when a plugin throws (= the whole portal does not crash) and elevate the log to console.error (Issue #1251)", async () => {

--- a/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
+++ b/apps/participant-portal/src/plugins/PortalPluginSlots.tsx
@@ -14,9 +14,14 @@
 
 import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
-import { PORTAL_SLOT_NAMES, type PortalSlotProps } from "@tenkacloud/portal-plugin-sdk";
+import {
+  PORTAL_SLOT_NAMES,
+  type PortalCoordinationClient,
+  type PortalSlotProps,
+} from "@tenkacloud/portal-plugin-sdk";
 import { toErrorMessage } from "@tenkacloud/web-kit";
 import { Component, type ErrorInfo, type ReactNode, Suspense, useMemo } from "react";
+import { getCoordinationProjection, submitCoordinationOp } from "../api/coordination-client";
 import { loadPluginSlot } from "./loader";
 import {
   buildPortalCoordination,
@@ -36,6 +41,10 @@ interface PortalPluginSlotsProps {
     readonly eventId?: string;
   };
   readonly stackOutputs: Record<string, string>;
+  /** [#1420] coordination dispatcher の Function URL (= config.coordinationApiUrl)。 未配線なら省略。 */
+  readonly coordinationApiUrl?: string;
+  /** [#1420] team の session token (= bearer)。 coordinationClient の束縛に使う。 */
+  readonly sessionToken?: string;
 }
 
 export function PortalPluginSlots({
@@ -44,6 +53,8 @@ export function PortalPluginSlots({
   score,
   team,
   stackOutputs,
+  coordinationApiUrl,
+  sessionToken,
 }: PortalPluginSlotsProps) {
   // problemId が変わらない限り phases / disruptions / slot 検索結果は不変 (= build-time catalog
   // から narrowed)。 endpoints は stackOutputs 依存なので別 memo に切る。
@@ -55,6 +66,15 @@ export function PortalPluginSlots({
     [problemId, stackOutputs],
   );
   const teamProp = useMemo(() => buildPortalTeam(team), [team]);
+  // [#1420] dispatcher URL + session が揃ったときだけ live coordination client を束縛する
+  // (= plugin は URL/token を知らず op 投入 + projection 取得できる)。 どちらか無ければ undefined。
+  const coordinationClient = useMemo<PortalCoordinationClient | undefined>(() => {
+    if (!coordinationApiUrl || !sessionToken) return undefined;
+    return {
+      submitOp: (op: unknown) => submitCoordinationOp(coordinationApiUrl, sessionToken, op),
+      getProjection: () => getCoordinationProjection(coordinationApiUrl, sessionToken),
+    };
+  }, [coordinationApiUrl, sessionToken]);
   // mount 時刻を pin (= 5s polling 由来の re-render で plugin が clock change を見ない方が
   // surprise が少ない、 「nowIso が動く」 ことに依存した plugin は plugin 内で自前
   // setInterval を持つべき)。 [] で intentional mount-pin。 problemId / jobId が変われば
@@ -71,9 +91,21 @@ export function PortalPluginSlots({
       phases,
       disruptions,
       ...(coordination ? { coordination } : {}),
+      ...(coordinationClient ? { coordinationClient } : {}),
       nowIso,
     }),
-    [teamProp, problemId, jobId, score, endpoints, phases, disruptions, coordination, nowIso],
+    [
+      teamProp,
+      problemId,
+      jobId,
+      score,
+      endpoints,
+      phases,
+      disruptions,
+      coordination,
+      coordinationClient,
+      nowIso,
+    ],
   );
 
   const slotsToRender = useMemo(

--- a/packages/portal-plugin-sdk/src/index.ts
+++ b/packages/portal-plugin-sdk/src/index.ts
@@ -47,7 +47,35 @@ export interface PortalSlotProps {
    * 未宣言 / non-public な問題では undefined (= plugin 側で `props.coordination?.` で安全に扱う)。
    */
   readonly coordination?: PortalCoordinationEntry;
+  /**
+   * ADR-028/030 / Issue #1420: coordination dispatcher を team の credential で叩く **live** client。
+   * portal が `coordinationApiUrl` (= dispatcher URL) + session を持つときだけ束縛される (= 未配線 /
+   * coordination 無効の問題では undefined)。 plugin は `props.coordinationClient?.submitOp(op)` で op を
+   * 投げ、 `getProjection()` で自チーム視点の projection を読む (= live route directory 等)。
+   */
+  readonly coordinationClient?: PortalCoordinationClient;
   readonly nowIso: string;
+}
+
+/**
+ * coordination op の結果 (= dispatcher の HTTP status を写した discriminated union)。 plugin は
+ * `kind` で分岐する (ok=projection 反映 / rejected=理由表示 / not_configured・unavailable=機能オフ表示)。
+ */
+export type PortalCoordinationOutcome =
+  | { readonly kind: "ok"; readonly projection: unknown }
+  | { readonly kind: "rejected"; readonly error: string }
+  | { readonly kind: "conflict" }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "not_configured" }
+  | { readonly kind: "unauthorized" };
+
+/**
+ * team の credential に束縛済の coordination client (portal が注入)。 plugin は URL / token を知らずに
+ * op 投入 + projection 取得ができる (= 認証は infra 層、 INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER 準拠)。
+ */
+export interface PortalCoordinationClient {
+  readonly submitOp: (op: unknown) => Promise<PortalCoordinationOutcome>;
+  readonly getProjection: () => Promise<PortalCoordinationOutcome>;
 }
 
 /**


### PR DESCRIPTION
## Summary

The competitor-facing seam for **live inter-team coordination** (#1420). `PortalSlotProps` gains an optional `coordinationClient` so a problem's portal plugin can submit coordination ops + read its team's projection **without knowing the dispatcher URL or the team token** — auth stays injected at the infra layer (`INVARIANT_AUTH_INJECTED_AT_INFRA_LAYER`).

This is the bridge between the merged backend (dispatcher #1633, importer #1635, portal coordination-client #1636) and the reference problem's portal slots.

- **portal-plugin-sdk**: `PortalCoordinationClient` (`submitOp` / `getProjection` → `PortalCoordinationOutcome`) + `coordinationClient?` on `PortalSlotProps` (type-only contract for problem plugins).
- **participant-portal `PortalPluginSlots`**: binds `coordinationClient` from the merged `coordination-client` (#1636) using `config.coordinationApiUrl` + `sessionToken` — **only when both are present** (else `undefined`, so no auth-less coordination calls).
- **`ProblemDetail`**: threads `coordinationApiUrl` + `sessionToken` in.

## Test plan
- **2 new tests** (`PortalPluginSlots.test`): client bound → `submitOp`/`getProjection` route through `coordination-client` with the right args; **not** bound when URL/session missing.
- Full **participant-portal suite: 607 pass, coverage 100%**. tsc/biome/`make harness` (0 findings)/check-no-conflicts clean. (`portal-plugin-sdk` is type-only, not coverage-gated.)

## Regression analysis
Additive + optional. `coordinationClient` is only present when `coordinationApiUrl` (added in #1636) + a session exist; problems that don't opt in see `undefined` and use `props.coordinationClient?.` safely. No change to existing slot behavior (the existing 10 PortalPluginSlots tests pass unchanged).

## Physical impact
**NO-OP** on CloudFormation / deployed artifacts. Frontend-only (SDK type + portal binding). The client only does anything once a deployed dispatcher URL is in `runtime-config.json` and a problem plugin calls it.

## Remaining for #1420
The reference problem's `RegistrationPanel`/`StatusPanel` (submodule) consuming `props.coordinationClient` to register a service URL + render the live route directory — the e2e acceptance. Follow-up submodule PR.

Relates #1420