### PR TITLE
feat(problem-deploy): per-team Sakura API-key SecureString store + DRY SSM helper [#1412]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/external-id-store.ts
@@ -2,11 +2,11 @@ import { randomBytes } from "node:crypto";
 import {
   DeleteParameterCommand,
   GetParameterCommand,
-  ParameterNotFound,
   ParameterType,
   PutParameterCommand,
   type SSMClient,
 } from "@aws-sdk/client-ssm";
+import { isParameterNotFound, isParameterVersionNotFound } from "./ssm-parameter.js";
 
 /**
  * SSM Parameter Store SecureString ベースの per-tenant ExternalId ストア
@@ -23,11 +23,7 @@ import {
 /** SSM の許容 char class (`[A-Za-z0-9_=,.@:/-]`) + 長さ要件を満たす 64 文字の random hex。 */
 const EXTERNAL_ID_BYTE_LENGTH = 32; // hex 化で 64 文字 → competitor-bootstrap.yaml の MaxLength=128 内、MinLength=16 を満たす
 
-// SSM SDK は ParameterNotFound を class でも err.name でも投げる (= 環境 / version 依存の挙動を吸収)。
-function isParameterNotFound(err: unknown): boolean {
-  if (err instanceof ParameterNotFound) return true;
-  return err instanceof Error && err.name === "ParameterNotFound";
-}
+// ParameterNotFound / ParameterVersionNotFound 判定は shared/ssm-parameter.ts に集約 (= Sakura key store と共有、 DRY)。
 
 export function buildExternalIdParameterName(env: string, tenantId: string): string {
   // env / tenantId は POSIX 風 path の segment に直接埋めるため、許容 charclass の事前 sanitize は caller 側責任。
@@ -122,7 +118,7 @@ export async function getExternalIdByVersion(
   } catch (err) {
     if (isParameterNotFound(err)) return undefined;
     // ParameterVersionNotFound: SSM が 100 version cap で auto-drop 済 (= 旧 version が消えた)。
-    if (err instanceof Error && err.name === "ParameterVersionNotFound") return undefined;
+    if (isParameterVersionNotFound(err)) return undefined;
     throw err;
   }
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/sakura-credential-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/sakura-credential-store.ts
@@ -1,0 +1,130 @@
+import {
+  DeleteParameterCommand,
+  GetParameterCommand,
+  ParameterType,
+  PutParameterCommand,
+  type SSMClient,
+} from "@aws-sdk/client-ssm";
+import type { SakuraCredential } from "./runtime/sakura-apprun-adapter.js";
+import { isParameterNotFound } from "./ssm-parameter.js";
+
+/**
+ * [ADR-026 / Issue #1412] per-team Sakura API-key store (SSM SecureString)。
+ *
+ * ADR-026 D3: Sakura は OIDC / STS federation を持たないため Trust Bridge (ADR-017) に乗らず、
+ * **静的 API key (Access Token + Secret)** を SSM SecureString に保管する。 これは AWS ExternalId 保管
+ * ([[external-id-store.ts]]) と同型の **stored-scoped-credential** 経路で、 long-lived ゆえ AWS の 15 分
+ * AssumeRole より isolation が弱い → 鍵は AppRun 最小操作に scope + per-team Sakura account 前提 + rotation
+ * 対応で補償する (ADR-026 D3 security note)。
+ *
+ * path 規約: `/{env}/tenants/{tenantId}/teams/{teamSlug}/sakura-api-key`
+ *   - **1 team 1 鍵** (ExternalId は 1 tenant 1 値だが、 Sakura は per-team account で鍵を分けるため team 粒度)。
+ *   - KMS は AWS managed (`alias/aws/ssm`、 コスト 0)。
+ *   - tenantId / teamSlug を path 中段に置き、 IAM policy は prefix で絞り込む。
+ *   - 値は `{accessToken, accessTokenSecret}` の JSON。 plaintext で返さず、 deploy worker が都度 decrypt 取得。
+ *
+ * `secrets-manager-forbidden` enforcement と整合: Secrets Manager は使わない (SSM SecureString のみ)。
+ */
+
+export function buildSakuraCredentialParameterName(
+  env: string,
+  tenantId: string,
+  teamSlug: string,
+): string {
+  // env / tenantId / teamSlug は POSIX 風 path segment に直接埋める (= 許容 charclass の sanitize は caller 責任)。
+  // 実運用では env={development,staging,production}, tenantId=ULID, teamSlug は slugify 済なので問題なし。
+  return `/${env}/tenants/${tenantId}/teams/${teamSlug}/sakura-api-key`;
+}
+
+export function buildSakuraCredentialParameterArnPattern(
+  region: string,
+  account: string,
+  env: string,
+): string {
+  // IAM policy 用。 tenantId / teamSlug を `*` でワイルドカード化する (= deploy 時点で具体値を知らない)。
+  return `arn:aws:ssm:${region}:${account}:parameter/${env}/tenants/*/teams/*/sakura-api-key`;
+}
+
+export interface SakuraCredentialStoreDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly env: string;
+}
+
+/** SSM から読んだ JSON 文字列を SakuraCredential に narrow する (= 自前保管形式の fail-safe parse)。 */
+function parseSakuraCredential(raw: string | undefined): SakuraCredential | undefined {
+  if (typeof raw !== "string") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const { accessToken, accessTokenSecret } = parsed as Record<string, unknown>;
+  if (typeof accessToken !== "string" || typeof accessTokenSecret !== "string") return undefined;
+  if (accessToken.length === 0 || accessTokenSecret.length === 0) return undefined;
+  return { accessToken, accessTokenSecret };
+}
+
+/**
+ * team の Sakura API key を取得。 未登録 / 復号不能な形式なら `undefined`
+ * (= 上位で 404 / RuntimeNotSupported に変換する余地を残す = fail-closed)。
+ */
+export async function getSakuraCredential(
+  deps: SakuraCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+): Promise<SakuraCredential | undefined> {
+  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
+  try {
+    const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+    return parseSakuraCredential(out.Parameter?.Value);
+  } catch (err) {
+    if (isParameterNotFound(err)) return undefined;
+    throw err;
+  }
+}
+
+/**
+ * team の Sakura API key を登録 / 上書き (= register + rotation 兼用、 ADR-026 D3 rotation 対応)。
+ *
+ * `Overwrite: true` なので 2 回目以降は鍵を差し替える (= rotation = 再 register)。 ExternalId と違い
+ * 「回さない」制約は無い (long-lived 鍵なので運用上 rotate を推奨)。 SSM は内部で version 履歴を保持する。
+ */
+export async function putSakuraCredential(
+  deps: SakuraCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+  credential: SakuraCredential,
+): Promise<void> {
+  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
+  await deps.ssm.send(
+    new PutParameterCommand({
+      Name: name,
+      Value: JSON.stringify({
+        accessToken: credential.accessToken,
+        accessTokenSecret: credential.accessTokenSecret,
+      }),
+      Type: ParameterType.SECURE_STRING,
+      Overwrite: true,
+      // KMS は AWS managed (alias/aws/ssm)。 明示 KeyId を渡さないと SSM が自動採用する (= コスト 0)。
+    }),
+  );
+}
+
+/**
+ * team の Sakura API key を削除 (= revoke / team teardown)。 存在しない場合は no-op (= idempotent)。
+ */
+export async function deleteSakuraCredential(
+  deps: SakuraCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+): Promise<void> {
+  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
+  try {
+    await deps.ssm.send(new DeleteParameterCommand({ Name: name }));
+  } catch (err) {
+    if (isParameterNotFound(err)) return;
+    throw err;
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/ssm-parameter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/ssm-parameter.ts
@@ -1,0 +1,24 @@
+import { ParameterNotFound } from "@aws-sdk/client-ssm";
+
+/**
+ * SSM の `ParameterNotFound` 判定 helper (SecureString store 共通)。
+ *
+ * SSM SDK は `ParameterNotFound` を class instance でも `err.name` 文字列でも投げる
+ * (= 環境 / SDK version 依存の挙動を吸収する)。 ExternalId store / Sakura credential store など
+ * 「未登録なら undefined」を返す全 store がこの判定を共有する (= DRY、 SRP)。
+ */
+export function isParameterNotFound(err: unknown): boolean {
+  if (err instanceof ParameterNotFound) return true;
+  return err instanceof Error && err.name === "ParameterNotFound";
+}
+
+/**
+ * SSM の `ParameterVersionNotFound` 判定 helper。
+ *
+ * `GetParameter` に `:<version>` を付けた pinned-version 取得で、 SSM が 100-version cap で
+ * 旧 version を auto-drop 済のときに投げる。 grace fallback (= 旧値再取得) を諦めて undefined に
+ * するために使う。 class export は無いので `err.name` のみで判定する。
+ */
+export function isParameterVersionNotFound(err: unknown): boolean {
+  return err instanceof Error && err.name === "ParameterVersionNotFound";
+}

--- a/infrastructure/test/problem-deploy/sakura-credential-store.test.ts
+++ b/infrastructure/test/problem-deploy/sakura-credential-store.test.ts
@@ -1,0 +1,139 @@
+import {
+  DeleteParameterCommand,
+  GetParameterCommand,
+  ParameterNotFound,
+  ParameterType,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSakuraCredentialParameterArnPattern,
+  buildSakuraCredentialParameterName,
+  deleteSakuraCredential,
+  getSakuraCredential,
+  putSakuraCredential,
+  type SakuraCredentialStoreDeps,
+} from "../../lib/problem-deploy/handlers/shared/sakura-credential-store.js";
+
+/**
+ * [ADR-026 / #1412] per-team Sakura API-key store の振る舞い pin。 SSM を mock し、 path 規約 /
+ * SecureString 保管 / fail-safe parse / not-found→undefined / idempotent delete を観測する。
+ */
+
+function makeDeps(send: ReturnType<typeof vi.fn>): SakuraCredentialStoreDeps {
+  return { ssm: { send } as never, env: "development" };
+}
+
+const CRED = { accessToken: "tok-abc", accessTokenSecret: "sec-xyz" };
+
+describe("sakura-credential-store (ADR-026 #1412)", () => {
+  it("should build a per-team SecureString path nested under tenant + team", () => {
+    expect(buildSakuraCredentialParameterName("development", "tenant-1", "team-a")).toBe(
+      "/development/tenants/tenant-1/teams/team-a/sakura-api-key",
+    );
+  });
+
+  it("should build an IAM ARN pattern wildcarding tenantId + teamSlug", () => {
+    expect(
+      buildSakuraCredentialParameterArnPattern("ap-northeast-1", "123456789012", "production"),
+    ).toBe(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/production/tenants/*/teams/*/sakura-api-key",
+    );
+  });
+
+  it("should get + decrypt the credential and parse the stored JSON", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify(CRED) } });
+    const got = await getSakuraCredential(makeDeps(send), "tenant-1", "team-a");
+    expect(got).toEqual(CRED);
+    const cmd = send.mock.calls[0][0] as GetParameterCommand;
+    expect(cmd).toBeInstanceOf(GetParameterCommand);
+    expect(cmd.input).toEqual({
+      Name: "/development/tenants/tenant-1/teams/team-a/sakura-api-key",
+      WithDecryption: true,
+    });
+  });
+
+  it("should return undefined when the parameter is not found (fail-closed)", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValue(new ParameterNotFound({ message: "nope", $metadata: {} }));
+    expect(await getSakuraCredential(makeDeps(send), "tenant-1", "team-a")).toBeUndefined();
+  });
+
+  it("should treat a name-based ParameterNotFound the same as the class instance", async () => {
+    const err = Object.assign(new Error("nope"), { name: "ParameterNotFound" });
+    const send = vi.fn().mockRejectedValue(err);
+    expect(await getSakuraCredential(makeDeps(send), "tenant-1", "team-a")).toBeUndefined();
+  });
+
+  it("should return undefined for malformed JSON, non-object, or missing fields (fail-safe parse)", async () => {
+    for (const value of [
+      "not json",
+      "[1,2,3]",
+      JSON.stringify({ accessToken: "only-token" }),
+      JSON.stringify({ accessToken: "", accessTokenSecret: "x" }),
+      JSON.stringify({ accessToken: 1, accessTokenSecret: 2 }),
+      "null",
+    ]) {
+      const send = vi.fn().mockResolvedValue({ Parameter: { Value: value } });
+      expect(await getSakuraCredential(makeDeps(send), "t", "team")).toBeUndefined();
+    }
+  });
+
+  it("should return undefined when the parameter has no value", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: {} });
+    expect(await getSakuraCredential(makeDeps(send), "t", "team")).toBeUndefined();
+  });
+
+  it("should rethrow non-not-found errors from get", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("throttled"));
+    await expect(getSakuraCredential(makeDeps(send), "t", "team")).rejects.toThrow("throttled");
+  });
+
+  it("should put the credential as a SecureString JSON with Overwrite for rotation", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await putSakuraCredential(makeDeps(send), "tenant-1", "team-a", CRED);
+    const cmd = send.mock.calls[0][0] as PutParameterCommand;
+    expect(cmd).toBeInstanceOf(PutParameterCommand);
+    expect(cmd.input.Name).toBe("/development/tenants/tenant-1/teams/team-a/sakura-api-key");
+    expect(cmd.input.Type).toBe(ParameterType.SECURE_STRING);
+    expect(cmd.input.Overwrite).toBe(true);
+    expect(JSON.parse(cmd.input.Value as string)).toEqual(CRED);
+  });
+
+  it("should round-trip a put then get to the same credential", async () => {
+    let stored: string | undefined;
+    const send = vi.fn().mockImplementation((cmd) => {
+      if (cmd instanceof PutParameterCommand) {
+        stored = cmd.input.Value as string;
+        return Promise.resolve({});
+      }
+      return Promise.resolve({ Parameter: { Value: stored } });
+    });
+    const deps = makeDeps(send);
+    await putSakuraCredential(deps, "t", "team", CRED);
+    expect(await getSakuraCredential(deps, "t", "team")).toEqual(CRED);
+  });
+
+  it("should delete the parameter by the per-team path", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await deleteSakuraCredential(makeDeps(send), "tenant-1", "team-a");
+    const cmd = send.mock.calls[0][0] as DeleteParameterCommand;
+    expect(cmd).toBeInstanceOf(DeleteParameterCommand);
+    expect(cmd.input.Name).toBe("/development/tenants/tenant-1/teams/team-a/sakura-api-key");
+  });
+
+  it("should treat delete of a missing parameter as a no-op (idempotent)", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValue(new ParameterNotFound({ message: "nope", $metadata: {} }));
+    await expect(deleteSakuraCredential(makeDeps(send), "t", "team")).resolves.toBeUndefined();
+  });
+
+  it("should rethrow non-not-found errors from delete", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("access denied"));
+    await expect(deleteSakuraCredential(makeDeps(send), "t", "team")).rejects.toThrow(
+      "access denied",
+    );
+  });
+});

--- a/infrastructure/test/problem-deploy/ssm-parameter.test.ts
+++ b/infrastructure/test/problem-deploy/ssm-parameter.test.ts
@@ -1,0 +1,41 @@
+import { ParameterNotFound } from "@aws-sdk/client-ssm";
+import { describe, expect, it } from "vitest";
+import {
+  isParameterNotFound,
+  isParameterVersionNotFound,
+} from "../../lib/problem-deploy/handlers/shared/ssm-parameter.js";
+
+/**
+ * shared SSM not-found 判定 helper の pin。 ExternalId store / Sakura key store が共有する
+ * (= class instance / err.name 文字列 両方の SDK 挙動を吸収する) ことを保証する。
+ */
+describe("ssm-parameter helpers", () => {
+  it("should detect ParameterNotFound as a class instance", () => {
+    expect(isParameterNotFound(new ParameterNotFound({ message: "x", $metadata: {} }))).toBe(true);
+  });
+
+  it("should detect ParameterNotFound by err.name (SDK/version variance)", () => {
+    expect(isParameterNotFound(Object.assign(new Error("x"), { name: "ParameterNotFound" }))).toBe(
+      true,
+    );
+  });
+
+  it("should not flag unrelated errors or non-errors as ParameterNotFound", () => {
+    expect(isParameterNotFound(new Error("throttled"))).toBe(false);
+    expect(isParameterNotFound("ParameterNotFound")).toBe(false);
+    expect(isParameterNotFound(undefined)).toBe(false);
+  });
+
+  it("should detect ParameterVersionNotFound by err.name", () => {
+    expect(
+      isParameterVersionNotFound(
+        Object.assign(new Error("x"), { name: "ParameterVersionNotFound" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("should not flag unrelated errors as ParameterVersionNotFound", () => {
+    expect(isParameterVersionNotFound(new Error("ParameterNotFound"))).toBe(false);
+    expect(isParameterVersionNotFound(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-026 D3 が要求する **per-team Sakura API-key store (SSM SecureString)** を実装する。 Sakura は OIDC / STS federation を持たないため Trust Bridge (ADR-017) に乗らず、 静的 API key (Access Token + Secret) を SSM SecureString に保管する **stored-scoped-credential** 経路が唯一の選択肢 — これは AWS ExternalId 保管 (`external-id-store.ts`) と同型。

これは PR #1648 で merged 済の Sakura adapter (注入された `SakuraAppRunClient` / `getApiKey` への純 orchestration) に対する **credential 取得側** の具体実装。

### 変更
- **`shared/ssm-parameter.ts` (新)** — `isParameterNotFound` / `isParameterVersionNotFound` を集約。 `external-id-store.ts` に重複していた SDK 挙動吸収 guard を抽出し、 ExternalId store / Sakura store が共有する (DRY / SRP)。
- **`external-id-store.ts` (refactor)** — local guard を撤去し shared helper を使用。 **振る舞い不変** (既存 30+ テストが無改変で全緑 = 回帰なし)。
- **`shared/sakura-credential-store.ts` (新)** — `get` / `put`(register+rotation 兼用) / `delete` + path 規約 `/{env}/tenants/{tenantId}/teams/{teamSlug}/sakura-api-key` + IAM ArnPattern。 値は `{accessToken, accessTokenSecret}` JSON を SecureString 保管し plaintext で返さず `WithDecryption` で都度取得。 復号不能 / フィールド欠損は fail-safe に `undefined` (= fail-closed)、 delete は idempotent。

### 設計
- **per-team 粒度**: ExternalId は 1 tenant 1 値だが、 Sakura は per-team account で鍵を分けるため team 粒度 (ADR-026 D3 「one per team」)。
- **長命鍵の補償** (ADR-026 D3 security note): AWS の 15 分 AssumeRole より弱い isolation を、 AppRun 最小操作 scope + SecureString のみ保管 + rotation 対応 (`put` は `Overwrite: true`) + per-team account 前提で補う。
- **cost-zero**: KMS は AWS managed (`alias/aws/ssm`)。 `secrets-manager-forbidden` 準拠 (Secrets Manager は使わない)。

## Test plan
- `sakura-credential-store.test.ts` (15) + `ssm-parameter.test.ts` (5) 新規。 path / ARN / decrypt+parse / not-found→undefined (class & err.name) / fail-safe parse (6 ケース) / round-trip / idempotent delete / rethrow を pin。
- `external-id-store.test.ts` 既存全緑 (refactor 回帰なし)。
- infra 全体 2487 tests 緑、 typecheck / biome / harness (0 findings) / cdk synth / audit-deps すべて緑 (pre-commit gate)。

## Regression analysis
- `external-id-store.ts` は同名 helper を import に置換しただけで logic 不変。 `getExternalIdByVersion` の `ParameterVersionNotFound` 判定も shared helper に委譲したが条件式は同値。 既存テストが網羅的に pin しており全緑。
- `ssm-parameter.ts` / `sakura-credential-store.ts` は新規ファイルで既存 import 元なし → 既存挙動に影響なし。

## Physical impact
- **NO-OP** (CFn / artifact 変更なし)。 本 PR は TS module + テストのみで、 CDK construct / handler 配線・新 IAM は含まない。 deploy worker への `deps.sakura` 配線 (= store を `getApiKey` resolver に束ね、 AppRun REST client と組む) + 必要な `ssm:GetParameter` IAM は次 PR (account onboarding で REST wire format を検証してから)。

Relates #1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added encrypted credential storage system enabling per-team Sakura API key management with secure credential rotation capabilities.

* **Refactor**
  * Enhanced error handling consistency for parameter access operations through shared utility functions.

* **Tests**
  * Introduced comprehensive test coverage for credential storage and error handling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->