### PR TITLE
feat(problem-deploy): wire executable sakura/apprun deploy — AppRun REST client + deps.sakura [#1412]

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -13,6 +13,7 @@ import {
   LAMBDA_SOURCE_MAP_ENABLED,
 } from "../utils/lambda-runtime.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
+import { buildSakuraCredentialParameterArnPattern } from "./handlers/shared/sakura-credential-store.js";
 
 export interface DeployApiLambdaProps {
   readonly deploymentsTable: Table;
@@ -147,11 +148,18 @@ export class DeployApiLambda extends Construct {
       stack.account,
       props.environmentName,
     );
+    // [ADR-026 / #1412] per-team Sakura API key (SSM SecureString) も同 Lambda が deploy 時に decrypt
+    // 取得する。 ExternalId と同じ prefix-scope + AWS managed key 復号で最小権限を保つ。
+    const sakuraSsmArn = buildSakuraCredentialParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["ssm:GetParameter"],
-        resources: [ssmArn],
+        resources: [ssmArn, sakuraSsmArn],
       }),
     );
     this.fn.addToRolePolicy(
@@ -160,7 +168,7 @@ export class DeployApiLambda extends Construct {
         actions: ["kms:Decrypt"],
         resources: ["*"],
         conditions: {
-          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": ssmArn },
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": [ssmArn, sakuraSsmArn] },
         },
       }),
     );

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -1,18 +1,24 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
 import { S3Client } from "@aws-sdk/client-s3";
+import { SSMClient } from "@aws-sdk/client-ssm";
 import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
+import { createSakuraAppRunRestClient } from "../../runtime-clients/sakura-apprun-rest-client.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
 import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
+  type AdapterDependencies,
   EXECUTABLE_ENGINE,
   EXECUTABLE_PROVIDER,
   type ProblemRuntime,
+  SAKURA_ENGINE,
+  SAKURA_PROVIDER,
   selectAdapter,
 } from "../shared/runtime/index.js";
+import { getSakuraCredential } from "../shared/sakura-credential-store.js";
 import { logDeployTrace } from "../shared/trace-log.js";
 import { emitShadowAudit } from "../shared/trust-bridge-shadow.js";
 import {
@@ -56,6 +62,13 @@ export interface DeployContext {
   readonly challengePayloadBucket?: string;
   readonly s3?: S3Client;
   /**
+   * [ADR-026 / Issue #1412] sakura/apprun deploy の account-gated 配線。 `ssm` は per-team Sakura
+   * API key store (SSM SecureString) の読取、 `sakuraAppRunBaseUrl` は AppRun REST base URL の override。
+   * 未配線 (= ssm undefined) なら sakura/apprun 問題は selectAdapter で reserved error のまま (= 従来動作)。
+   */
+  readonly ssm?: Pick<SSMClient, "send">;
+  readonly sakuraAppRunBaseUrl?: string;
+  /**
    * [ADR-023 / Issue #1268] Optional per-problemId runtime resolver. If
    * undefined OR if it returns undefined for a given problemId, the deploy
    * worker assumes `aws/cloudformation` — which preserves pre-#1268 behavior
@@ -95,6 +108,63 @@ export class UnverifiedCompetitorAccountError extends Error {
 }
 
 /**
+ * [ADR-026 / #1412] sakura/apprun の adapter context を組む。 getApiKey は per-team SSM SecureString
+ * store を引き、 未登録なら loud に throw (= silent fallback 禁止)。 client は実 AppRun REST 実装を
+ * credential で束ねる factory。 SSM が配線されていない (= ctx.ssm undefined) ときは呼ばれない。
+ */
+function buildSakuraAdapterContext(
+  ssm: Pick<SSMClient, "send">,
+  env: string,
+  tenantId: string,
+  teamSlug: string,
+  sakuraAppRunBaseUrl: string | undefined,
+): NonNullable<AdapterDependencies["sakura"]> {
+  return {
+    getApiKey: async () => {
+      const credential = await getSakuraCredential({ ssm, env }, tenantId, teamSlug);
+      if (!credential) {
+        throw new Error(
+          `no Sakura API key registered for tenant ${tenantId} team ${teamSlug} ` +
+            "(register it in the per-team SSM SecureString store before deploying a sakura/apprun problem)",
+        );
+      }
+      return credential;
+    },
+    client: (credential) =>
+      createSakuraAppRunRestClient(
+        credential,
+        sakuraAppRunBaseUrl ? { baseUrl: sakuraAppRunBaseUrl } : {},
+      ),
+  };
+}
+
+/**
+ * runtime に応じた adapter 依存を組む。 aws は常に存在し、 sakura/apprun は SSM (per-team key store) が
+ * 配線されたときだけ追加する (= 未配線なら selectAdapter が reserved error)。 deps を組む条件分岐を
+ * startDeployment から切り出して責務を分離する (SRP)。
+ */
+function buildAdapterDependencies(
+  ctx: DeployContext,
+  runtime: ProblemRuntime,
+  teamSlug: string,
+): AdapterDependencies {
+  const aws = { events: ctx.events, eventBusName: ctx.eventBusName };
+  if (ctx.ssm && runtime.provider === SAKURA_PROVIDER && runtime.engine === SAKURA_ENGINE) {
+    return {
+      aws,
+      sakura: buildSakuraAdapterContext(
+        ctx.ssm,
+        ctx.env,
+        ctx.tenantId,
+        teamSlug,
+        ctx.sakuraAppRunBaseUrl,
+      ),
+    };
+  }
+  return { aws };
+}
+
+/**
  * 1 件の deploy job を起動する。
  *
  * DDB Put → EventBridge Publish の順序は失敗セマンティクスが要求する: PutEvents が
@@ -118,9 +188,9 @@ export async function startDeployment(
     engine: EXECUTABLE_ENGINE,
     entry: "template.yaml",
   };
-  const adapter = selectAdapter(runtime, {
-    aws: { events: ctx.events, eventBusName: ctx.eventBusName },
-  });
+  // teamSlug は sakura の per-team key 解決にも使うので runtime 解決直後に確定する。
+  const teamSlug = slugify(request.teamName);
+  const adapter = selectAdapter(runtime, buildAdapterDependencies(ctx, runtime, teamSlug));
 
   // Phase 2.2 (Issue #459): verified=true な行が無ければ deploy しない (= fail-closed)。
   // 同 account deploy の dev fallback も廃止 — 全 deploy は verified なれた account のみ。
@@ -138,7 +208,6 @@ export async function startDeployment(
   const jobId = ulid();
   const teamLoginKey = generateTeamLoginKey();
   const namePrefix = buildStackPrefix(request.problemId, request.teamName);
-  const teamSlug = slugify(request.teamName);
   const nowMs = ctx.now();
   const expiresAt = toEpochSeconds(nowMs + (ctx.ttlMs ?? DEFAULT_TTL_MS));
   const createdAt = new Date(nowMs).toISOString();
@@ -303,6 +372,10 @@ export interface DeploySharedResources {
   readonly problemsVisibility: Readonly<Record<string, PrivateVisibility>>;
   readonly challengePayloadBucket: string | undefined;
   readonly s3: S3Client;
+  /** [ADR-026 / #1412] per-team Sakura API key store の読取 client。 */
+  readonly ssm: SSMClient;
+  /** [ADR-026 / #1412] AppRun REST base URL の override (env)。 未設定なら本番 AppRun 共用型。 */
+  readonly sakuraAppRunBaseUrl: string | undefined;
 }
 
 export function buildSharedResources(): DeploySharedResources {
@@ -319,6 +392,8 @@ export function buildSharedResources(): DeploySharedResources {
     problemsVisibility: parseProblemsVisibility(process.env.BATTLE_PROBLEMS_VISIBILITY),
     challengePayloadBucket,
     s3: new S3Client({}),
+    ssm: new SSMClient({}),
+    sakuraAppRunBaseUrl: process.env.SAKURA_APPRUN_BASE_URL || undefined,
   };
 }
 

--- a/infrastructure/lib/problem-deploy/runtime-clients/sakura-apprun-rest-client.ts
+++ b/infrastructure/lib/problem-deploy/runtime-clients/sakura-apprun-rest-client.ts
@@ -1,0 +1,148 @@
+/**
+ * [ADR-026 / Issue #1412] Concrete Sakura AppRun REST client.
+ *
+ * `SakuraAppRunClient` interface (= `handlers/shared/runtime/sakura-apprun-adapter.ts` の注入境界) を
+ * 実 AppRun 共用型 REST API に対して実装する。 adapter は orchestration (= image/env の組立、 status の
+ * 6-state 射影) を持ち、 本 client は **wire 層** (= endpoint / Basic auth / JSON 整形 / name↔id 解決) だけを担う。
+ *
+ * 配置: `handlers/` の外 (= service / repository 層) に置く。 `handler-must-not-call-fetch` 規約どおり
+ * `fetch` は handler に書かず本 client に閉じ込め、 composition root (deploy worker) が factory を注入する。
+ *
+ * API (https://manual.sakura.ad.jp/api/cloud/apprun/、 sacloud/apprun-api-go と整合):
+ *   - base: `https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api`
+ *   - auth: HTTP Basic (user = Access Token, password = Access Token Secret)
+ *   - applications は **id ベース** (create が id を返し、 read/delete は id 指定)。 本 client の interface は
+ *     name ベースなので、 list → name 一致で id を解決してから id ベース API を叩く (= name↔id mapping)。
+ *
+ * 実 account onboarding で確認する余地 (= waterfall の integration 相): list envelope (`data`/`meta`) の
+ * 正確な形、 public URL の field 名 (`public_url` を仮定)、 deploy body の必須 default (port / scale /
+ * cpu / memory)。 いずれも本 client の 1 箇所に局所化し、 unit test は **request 整形 + response 射影** を pin する。
+ */
+
+import { StatusCodes } from "http-status-codes";
+import type {
+  SakuraApplicationState,
+  SakuraAppRunClient,
+  SakuraAppRunSpec,
+  SakuraCredential,
+} from "../handlers/shared/runtime/sakura-apprun-adapter.js";
+
+/** AppRun 共用型 REST API の base path。 */
+const DEFAULT_BASE_URL = "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api";
+
+/**
+ * SakuraAppRunSpec が運ばない deploy body の必須 field の default。 競技問題の container は HTTP を
+ * 単一 port で serve し、 1 team 1 インスタンスで足りる前提 (= 最小コスト)。 実 account で調整する。
+ */
+const DEFAULT_PORT = 8080;
+const DEFAULT_MIN_SCALE = 0; // scale-to-zero でアイドルコストを抑える
+const DEFAULT_MAX_SCALE = 1;
+const DEFAULT_MAX_CPU = "0.1";
+const DEFAULT_MAX_MEMORY = "256Mi";
+const DEFAULT_TIMEOUT_SECONDS = 60;
+/** component 名は AppRun 内部の識別子。 1 component 構成なので固定名で十分。 */
+const DEFAULT_COMPONENT_NAME = "main";
+
+export interface SakuraAppRunRestClientOptions {
+  /** base URL override (= test / 環境別)。 省略時は本番 AppRun 共用型。 */
+  readonly baseUrl?: string;
+  /** fetch 実装の注入 (= unit test で mock、 本番は global fetch)。 */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** AppRun list / read が返す application の最小形 (本 client が依存する field のみ)。 */
+interface SakuraApiApplication {
+  readonly id: string;
+  readonly name: string;
+  readonly status?: string;
+  readonly public_url?: string;
+}
+
+/**
+ * credential を束ねた `SakuraAppRunClient` を返す factory。 deploy worker (composition root) が
+ * `SakuraAppRunAdapterContext.client` としてこれを渡す。
+ */
+export function createSakuraAppRunRestClient(
+  credential: SakuraCredential,
+  options: SakuraAppRunRestClientOptions = {},
+): SakuraAppRunClient {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const doFetch = options.fetchImpl ?? fetch;
+  // Basic 認証: Access Token : Secret を base64。 ADR-026 D3 (静的 API key)。
+  const authHeader = `Basic ${Buffer.from(`${credential.accessToken}:${credential.accessTokenSecret}`).toString("base64")}`;
+
+  async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await doFetch(`${baseUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: authHeader,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Sakura AppRun API ${method} ${path} failed: ${res.status} ${text}`.trim());
+    }
+    // No Content (delete) は body 無し。
+    if (res.status === StatusCodes.NO_CONTENT) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  /** name で application を 1 件解決 (= name↔id mapping)。 不在は undefined。 */
+  async function findByName(name: string): Promise<SakuraApiApplication | undefined> {
+    const listed = await request<{ data?: SakuraApiApplication[] }>("GET", "/applications");
+    return (listed.data ?? []).find((app) => app.name === name);
+  }
+
+  /** spec → AppRun PostApplicationBody。 env(record) → [{key,value}]、 image → component。 */
+  function buildBody(spec: SakuraAppRunSpec) {
+    return {
+      name: spec.name,
+      timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+      port: DEFAULT_PORT,
+      min_scale: DEFAULT_MIN_SCALE,
+      max_scale: DEFAULT_MAX_SCALE,
+      components: [
+        {
+          name: DEFAULT_COMPONENT_NAME,
+          max_cpu: DEFAULT_MAX_CPU,
+          max_memory: DEFAULT_MAX_MEMORY,
+          deploy_source: { container_registry: { image: spec.image } },
+          env: Object.entries(spec.env).map(([key, value]) => ({ key, value })),
+        },
+      ],
+    };
+  }
+
+  return {
+    async upsertApplication(spec: SakuraAppRunSpec): Promise<void> {
+      const existing = await findByName(spec.name);
+      const body = buildBody(spec);
+      if (existing) {
+        // 既存は id 指定で PUT 更新 (= 冪等 deploy)。
+        await request("PUT", `/applications/${existing.id}`, body);
+        return;
+      }
+      await request("POST", "/applications", body);
+    },
+
+    async getApplication(name: string): Promise<SakuraApplicationState | undefined> {
+      const existing = await findByName(name);
+      if (!existing) return undefined;
+      // list の time-of-check と read の time-of-use の間に消えていれば不在扱い。
+      const app = await request<SakuraApiApplication>("GET", `/applications/${existing.id}`);
+      return {
+        status: app.status ?? "unknown",
+        ...(app.public_url ? { publicUrl: app.public_url } : {}),
+      };
+    },
+
+    async deleteApplication(name: string): Promise<void> {
+      const existing = await findByName(name);
+      if (!existing) return; // idempotent
+      await request("DELETE", `/applications/${existing.id}`);
+    },
+  };
+}

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -89,6 +89,13 @@ describe("ProblemDeployBackendStack (MVP-1) — Deploy API Lambda (invoked from 
       }),
     );
   });
+
+  // [ADR-026 / #1412] sakura/apprun deploy 用に per-team Sakura API-key SecureString を decrypt 取得する
+  // grant が必要。 ExternalId path と同様 prefix-scope された ARN が deploy Lambda の policy に乗っていること。
+  it("should grant ssm:GetParameter on the per-team Sakura API-key SecureString path (#1412)", () => {
+    const serialized = JSON.stringify(tpl.findResources("AWS::IAM::Policy"));
+    expect(serialized).toContain("tenants/*/teams/*/sakura-api-key");
+  });
 });
 
 describe("ProblemDeployBackendStack (MVP-1) — GenericScoring Lambda", () => {

--- a/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
@@ -11,8 +11,9 @@
  *      BEFORE any DDB Put or EventBridge publish — = no cloud mutation.
  */
 
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
 import { GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type DeployContext,
   type DeployInvocation,
@@ -153,5 +154,83 @@ describe("startDeployment with runtime-aware dispatch (ADR-023 / Issue #1268)", 
       RuntimeNotSupportedError,
     );
     expect(ddbSendSpy).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * [ADR-026 / Issue #1412] sakura/apprun dispatch wiring。 SSM (per-team key store) が配線されたときだけ
+ * executable になり、 AppRun REST へ deploy する (EventBridge は使わない)。 鍵未登録は loud に throw、
+ * SSM 未配線では reserved のまま。 注: 現状の verified-AWS-account gate は provider 非依存なので test では
+ * verified account を mock で満たす (= gate の provider 対応は follow-up)。
+ */
+describe("startDeployment sakura/apprun dispatch (ADR-026 / Issue #1412)", () => {
+  const sakuraRuntime: ProblemRuntime = { provider: "sakura", engine: "apprun", entry: "img:1" };
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  function ssmReturning(value: string | undefined): {
+    ssm: { send: ReturnType<typeof vi.fn> };
+    ssmSend: ReturnType<typeof vi.fn>;
+  } {
+    const ssmSend = vi.fn(async (cmd: unknown) => {
+      if (cmd instanceof GetParameterCommand) {
+        return value === undefined
+          ? Promise.reject(Object.assign(new Error("nope"), { name: "ParameterNotFound" }))
+          : { Parameter: { Value: value } };
+      }
+      return {};
+    });
+    return { ssm: { send: ssmSend }, ssmSend };
+  }
+
+  it("should deploy via AppRun (not EventBridge) and resolve the key from SSM when wired", async () => {
+    const appRunFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "app-1" }), { status: 201 }));
+    vi.stubGlobal("fetch", appRunFetch);
+    const { ssm, ssmSend } = ssmReturning(
+      JSON.stringify({ accessToken: "tok", accessTokenSecret: "sec" }),
+    );
+    const { ctx, putSend, eventsSend } = buildContext({
+      ssm: ssm as unknown as DeployContext["ssm"],
+      resolveProblemRuntime: () => sakuraRuntime,
+    });
+    const res = await startDeployment(ctx, sampleRequest());
+    expect(res.status).toBe("PENDING");
+    // SSM から鍵を decrypt 取得した
+    expect(ssmSend.mock.calls.some((c) => c[0] instanceof GetParameterCommand)).toBe(true);
+    // AppRun REST を叩いた (list → create)、 EventBridge は使わない
+    expect(appRunFetch).toHaveBeenCalledTimes(2);
+    expect(appRunFetch.mock.calls[1][1].method).toBe("POST");
+    expect(eventsSend).not.toHaveBeenCalled();
+    // deployment 行は Put 済 (= AWS と同じ enqueue セマンティクス)
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(true);
+  });
+
+  it("should throw loudly (no silent fallback) when no Sakura API key is registered", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+    const { ssm } = ssmReturning(undefined); // ParameterNotFound
+    const { ctx } = buildContext({
+      ssm: ssm as unknown as DeployContext["ssm"],
+      resolveProblemRuntime: () => sakuraRuntime,
+    });
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(/no Sakura API key/);
+  });
+
+  it("should stay reserved (RuntimeNotSupportedError) for sakura/apprun when SSM is not wired", async () => {
+    const { ctx, putSend, eventsSend } = buildContext({
+      // ssm omitted → deps.sakura is never built
+      resolveProblemRuntime: () => sakuraRuntime,
+    });
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toBeInstanceOf(
+      RuntimeNotSupportedError,
+    );
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(false);
+    expect(eventsSend).not.toHaveBeenCalled();
   });
 });

--- a/infrastructure/test/problem-deploy/sakura-apprun-rest-client.test.ts
+++ b/infrastructure/test/problem-deploy/sakura-apprun-rest-client.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSakuraAppRunRestClient } from "../../lib/problem-deploy/runtime-clients/sakura-apprun-rest-client.js";
+
+/**
+ * [ADR-026 / #1412] AppRun REST client の wire 整形を pin。 fetch を mock し、 endpoint / Basic auth /
+ * body 整形 / name↔id 解決 / status+public_url 射影 / idempotent delete / 非2xx throw を観測する。
+ * 実 API の field 名差は integration 相で吸収する前提 (= waterfall)。
+ */
+
+const CRED = { accessToken: "tok", accessTokenSecret: "sec" };
+const BASE = "https://example.test/apprun/api";
+const EXPECTED_AUTH = `Basic ${Buffer.from("tok:sec").toString("base64")}`;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(fetchImpl: ReturnType<typeof vi.fn>) {
+  return createSakuraAppRunRestClient(CRED, { baseUrl: BASE, fetchImpl: fetchImpl as never });
+}
+
+describe("sakura-apprun-rest-client (ADR-026 #1412)", () => {
+  it("should POST a new application with Basic auth and an image/env component when none exists", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [] })) // list → empty
+      .mockResolvedValueOnce(jsonResponse({ id: "app-1", name: "p-team" }, 201)); // create
+    await makeClient(fetchImpl).upsertApplication({
+      name: "p-team",
+      image: "registry.example/img:latest",
+      env: { TENKACLOUD_TEAM: "team-a" },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const [listUrl, listInit] = fetchImpl.mock.calls[0];
+    expect(listUrl).toBe(`${BASE}/applications`);
+    expect(listInit.method).toBe("GET");
+    expect(listInit.headers.Authorization).toBe(EXPECTED_AUTH);
+    const [createUrl, createInit] = fetchImpl.mock.calls[1];
+    expect(createUrl).toBe(`${BASE}/applications`);
+    expect(createInit.method).toBe("POST");
+    const body = JSON.parse(createInit.body);
+    expect(body.name).toBe("p-team");
+    expect(body.components[0].deploy_source.container_registry.image).toBe(
+      "registry.example/img:latest",
+    );
+    expect(body.components[0].env).toEqual([{ key: "TENKACLOUD_TEAM", value: "team-a" }]);
+    expect(body.port).toBe(8080);
+  });
+
+  it("should PUT to the resolved id when an application with the same name already exists (idempotent deploy)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "app-9", name: "p-team" }] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "app-9", name: "p-team" }));
+    await makeClient(fetchImpl).upsertApplication({ name: "p-team", image: "img:2", env: {} });
+    const [updateUrl, updateInit] = fetchImpl.mock.calls[1];
+    expect(updateUrl).toBe(`${BASE}/applications/app-9`);
+    expect(updateInit.method).toBe("PUT");
+  });
+
+  it("should resolve name→id then read status + public_url for getApplication", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "app-1", name: "p-team" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: "app-1",
+          name: "p-team",
+          status: "running",
+          public_url: "https://x.apprun",
+        }),
+      );
+    const state = await makeClient(fetchImpl).getApplication("p-team");
+    expect(state).toEqual({ status: "running", publicUrl: "https://x.apprun" });
+    expect(fetchImpl.mock.calls[1][0]).toBe(`${BASE}/applications/app-1`);
+  });
+
+  it("should return undefined from getApplication when the name is not in the list", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "x", name: "other" }] }));
+    expect(await makeClient(fetchImpl).getApplication("p-team")).toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // no read when not found
+  });
+
+  it("should omit publicUrl when the application has no public_url yet", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "app-1", name: "p" }] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "app-1", name: "p", status: "provisioning" }));
+    expect(await makeClient(fetchImpl).getApplication("p")).toEqual({ status: "provisioning" });
+  });
+
+  it("should DELETE by resolved id and treat a missing application as a no-op", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "app-1", name: "p" }] }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await makeClient(fetchImpl).deleteApplication("p");
+    expect(fetchImpl.mock.calls[1][0]).toBe(`${BASE}/applications/app-1`);
+    expect(fetchImpl.mock.calls[1][1].method).toBe("DELETE");
+
+    const emptyFetch = vi.fn().mockResolvedValueOnce(jsonResponse({ data: [] }));
+    await expect(makeClient(emptyFetch).deleteApplication("p")).resolves.toBeUndefined();
+    expect(emptyFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw with the status + body on a non-2xx response", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
+    await expect(
+      makeClient(fetchImpl).upsertApplication({ name: "p", image: "img", env: {} }),
+    ).rejects.toThrow(/429/);
+  });
+
+  it("should default to the production AppRun base URL when none is provided", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
+      .mockResolvedValueOnce(jsonResponse({}));
+    const client = createSakuraAppRunRestClient(CRED, { fetchImpl: fetchImpl as never });
+    await client.upsertApplication({ name: "p", image: "img", env: {} });
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      "https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

ADR-026 の `sakura/apprun` を **deploy-executable** にする。 PR #1651 (merged) の per-team credential store (`getApiKey` 側) に、 具体 AppRun REST client + deploy worker への `deps.sakura` 配線を足し、 Sakura adapter (PR #1648) を「reserved」から「実 deploy 可能」へ昇格させる。

### 変更
- **`runtime-clients/sakura-apprun-rest-client.ts` (新)** — `SakuraAppRunClient` を実 AppRun 共用型 REST API に実装。
  - base `https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api`、 HTTP Basic 認証 (Access Token : Secret、 ADR-026 D3)。
  - AppRun applications は **id ベース** なので、 name ベースの interface を満たすため list→name 一致で id 解決してから create(POST) / update(PUT) / read(GET) / delete(DELETE)。
  - `image` → `components[].deploy_source.container_registry.image`、 `env`(record) → `[{key,value}]` (sacloud/apprun-api-go と整合)。
  - `handlers/` の外 (service 層) に置き `fetch` を閉じ込める (`handler-must-not-call-fetch` 規約)。 204 は `StatusCodes.NO_CONTENT`。
- **`deploy.ts`** — `buildAdapterDependencies` で `aws` は常時、 `sakura` は SSM (per-team key store) 配線時かつ runtime が sakura/apprun のときだけ `deps` に組む (= `selectAdapter` が executable adapter を返す)。 `getApiKey` は store を引き、 未登録なら **loud に throw** (silent fallback 禁止)。 `buildSharedResources` に `SSMClient` + `SAKURA_APPRUN_BASE_URL`(override) を追加。
- **`deploy-api-lambda.ts`** — per-team Sakura API-key path に `ssm:GetParameter` + `kms:Decrypt` を付与 (ExternalId path と同型の prefix-scope 最小権限)。

## Test plan
- `sakura-apprun-rest-client.test.ts` (8): endpoint / Basic auth / body 整形 / name↔id 解決 / status+public_url 射影 / idempotent delete / 非2xx throw / default base URL を pin (fetch mock)。
- `deploy-runtime-dispatch.test.ts` に sakura dispatch 3 件: SSM 配線時に AppRun へ deploy (EventBridge は使わない) + SSM から鍵 decrypt / 鍵未登録は loud throw / SSM 未配線は `RuntimeNotSupportedError` (reserved)。
- `problem-deploy-backend-stack-lambdas.test.ts` に IAM 1 件: deploy Lambda policy に `tenants/*/teams/*/sakura-api-key` の grant。
- infra 全体 2498 tests 緑、 typecheck / biome / harness (0 findings) / check-http-status / cdk synth / audit-deps すべて緑 (pre-commit gate)。

## Regression analysis
- AWS path は不変 (`deps.aws` は常時、 sakura 分岐は `ctx.ssm` 配線 **かつ** runtime=sakura/apprun のときのみ)。 既存の runtime-dispatch / deploy テスト全緑。
- `deploy-api-lambda` の IAM 変更は加算的 (既存 `ssm:GetParameter` statement の resources に sakura ARN を追加、 `kms:Decrypt` condition を 2 ARN の配列化)。 既存 CDK テスト全緑。
- `buildAdapterDependencies` 抽出で `startDeployment` の cognitive complexity を 16→15 以下に戻した (SRP)。

## Physical impact
- **UPDATE** (DeployApi Lambda): IAM policy が sakura SSM path への `ssm:GetParameter` + `kms:Decrypt` を取得。 Lambda code (bundle) も REST client 同梱で UPDATE。 新規 CFn resource の CREATE/REPLACE/DELETE は無し。
- 既存 deploy 動作 (AWS 問題) への physical 影響なし。

## 既知の follow-up (本 PR の scope 外、 #1412 内)
- `verified-AWS-account` gate が provider 非依存 → sakura でも AWS account 登録が要る (gate の provider 対応)。
- `getStatus` / `destroy` / `collectOutputs` の adapter 配線 (status polling / teardown / scoring) — 現状 adapter は deploy 時のみ使用。
- 実 account onboarding 時に AppRun の list envelope / `public_url` field 名 / deploy body default (port/scale) を検証。

Relates #1412