### PR TITLE
feat(problem-deploy): Azure ARM + GCP Infra Manager REST client-halves [#1410 #1411]

### DIFF
--- a/infrastructure/lib/problem-deploy/runtime-clients/azure-deployment-stacks-rest-client.ts
+++ b/infrastructure/lib/problem-deploy/runtime-clients/azure-deployment-stacks-rest-client.ts
@@ -1,0 +1,154 @@
+/**
+ * [ADR-027 / Issue #1410] Concrete Azure Deployment Stacks REST client.
+ *
+ * `AzureDeploymentStackClient` interface (= `handlers/shared/runtime/azure-bicep-adapter.ts` の注入境界)
+ * を実 ARM Deployment Stacks REST API に実装する。 adapter は orchestration (= parameters / status 射影)
+ * を持ち、 本 client は **wire 層** (= endpoint / Bearer auth / ARM body 整形) だけを担う。 Sakura REST
+ * client と同方針で `handlers/` の外 (service 層) に置き `fetch` を閉じ込める (`handler-must-not-call-fetch`)。
+ *
+ * 認証は短命 Bearer token (= trust-bridge azure-federated-credential が WIF 交換で得た access token を
+ * `AzureCredential.accessToken` で受け取る)。 本 client は token を貰うだけで federation はしない。
+ *
+ * API (https://learn.microsoft.com/en-us/rest/api/resources/deployment-stacks、 resource-group scope):
+ *   - PUT/GET/DELETE `https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}/providers/
+ *     Microsoft.Resources/deploymentStacks/{name}?api-version=2024-03-01`
+ *   - body: `{location, properties: {templateLink|template, parameters, actionOnUnmanage, denySettings}}`
+ *   - GET response: `properties.provisioningState` + `properties.outputs` ({name:{type,value}})
+ *
+ * spec が運ばない subscription / resourceGroup / location / api-version は options で注入する
+ * (= per-team Azure account の onboarding が供給、 account-gated)。 実 account で照合する余地は body の
+ * actionOnUnmanage / denySettings の既定と outputs の正確な形 (= integration 相、 waterfall)。
+ */
+
+import { StatusCodes } from "http-status-codes";
+import type {
+  AzureCredential,
+  AzureDeploymentStackClient,
+  AzureDeploymentStackSpec,
+  AzureDeploymentStackState,
+} from "../handlers/shared/runtime/azure-bicep-adapter.js";
+
+const DEFAULT_BASE_URL = "https://management.azure.com";
+const DEFAULT_API_VERSION = "2024-03-01";
+const DEFAULT_LOCATION = "japaneast";
+
+export interface AzureDeploymentStacksRestClientOptions {
+  /** Deployment Stack を置く subscription GUID (= per-team Azure account)。 */
+  readonly subscriptionId: string;
+  /** Deployment Stack を置く resource group 名。 */
+  readonly resourceGroup: string;
+  /** ARM region (= stack の location)。 省略時 japaneast。 */
+  readonly location?: string;
+  /** ARM api-version。 省略時 2024-03-01 (GA)。 */
+  readonly apiVersion?: string;
+  /** base URL override (= test / sovereign cloud)。 */
+  readonly baseUrl?: string;
+  /** fetch 実装の注入 (= unit test で mock)。 */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** ARM Deployment Stack GET レスポンスの最小形 (本 client が依存する field のみ)。 */
+interface ArmDeploymentStack {
+  readonly properties?: {
+    readonly provisioningState?: string;
+    readonly outputs?: Record<string, { readonly value?: unknown }>;
+  };
+}
+
+export function createAzureDeploymentStacksRestClient(
+  credential: AzureCredential,
+  options: AzureDeploymentStacksRestClientOptions,
+): AzureDeploymentStackClient {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const apiVersion = options.apiVersion ?? DEFAULT_API_VERSION;
+  const location = options.location ?? DEFAULT_LOCATION;
+  const doFetch = options.fetchImpl ?? fetch;
+
+  function stackPath(name: string): string {
+    return (
+      `${baseUrl}/subscriptions/${options.subscriptionId}/resourceGroups/${options.resourceGroup}` +
+      `/providers/Microsoft.Resources/deploymentStacks/${name}?api-version=${apiVersion}`
+    );
+  }
+
+  async function request<T>(
+    method: string,
+    url: string,
+    body?: unknown,
+  ): Promise<Response & { parsed?: T }> {
+    const res = await doFetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${credential.accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Azure ARM ${method} deploymentStacks failed: ${res.status} ${text}`.trim());
+    }
+    return res;
+  }
+
+  return {
+    async upsertStack(spec: AzureDeploymentStackSpec): Promise<void> {
+      // ARM parameters は {name: {value}} 形。 actionOnUnmanage=deleteAll で teardown 時に resource も削除、
+      // denySettings=none で competitor の操作を妨げない (= 競技環境)。 templateRef は Bicep を ARM 化した
+      // templateLink URI として渡す前提。
+      await request("PUT", stackPath(spec.name), {
+        location,
+        properties: {
+          templateLink: { uri: spec.templateRef },
+          parameters: Object.fromEntries(
+            Object.entries(spec.parameters).map(([key, value]) => [key, { value }]),
+          ),
+          actionOnUnmanage: {
+            resources: "delete",
+            resourceGroups: "delete",
+            managementGroups: "delete",
+          },
+          denySettings: { mode: "none" },
+        },
+      });
+    },
+
+    async getStack(name: string): Promise<AzureDeploymentStackState | undefined> {
+      const res = await doFetch(stackPath(name), {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${credential.accessToken}`,
+          Accept: "application/json",
+        },
+      });
+      if (res.status === StatusCodes.NOT_FOUND) return undefined;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Azure ARM GET deploymentStacks failed: ${res.status} ${text}`.trim());
+      }
+      const stack = (await res.json()) as ArmDeploymentStack;
+      const provisioningState = stack.properties?.provisioningState ?? "unknown";
+      const outputs = stack.properties?.outputs;
+      const flattened = outputs
+        ? Object.fromEntries(
+            Object.entries(outputs).map(([key, out]) => [key, String(out.value ?? "")]),
+          )
+        : undefined;
+      return { provisioningState, ...(flattened ? { outputs: flattened } : {}) };
+    },
+
+    async deleteStack(name: string): Promise<void> {
+      const res = await doFetch(stackPath(name), {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${credential.accessToken}` },
+      });
+      // 既に無ければ idempotent に成功扱い。
+      if (res.status === StatusCodes.NOT_FOUND) return;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Azure ARM DELETE deploymentStacks failed: ${res.status} ${text}`.trim());
+      }
+    },
+  };
+}

--- a/infrastructure/lib/problem-deploy/runtime-clients/gcp-infra-manager-rest-client.ts
+++ b/infrastructure/lib/problem-deploy/runtime-clients/gcp-infra-manager-rest-client.ts
@@ -1,0 +1,150 @@
+/**
+ * [ADR-027 / Issue #1411] Concrete GCP Infrastructure Manager REST client.
+ *
+ * `GcpInfraManagerClient` interface (= `handlers/shared/runtime/gcp-infra-manager-adapter.ts` の注入境界)
+ * を実 Infrastructure Manager REST API に実装する。 adapter は orchestration (= inputs / state 射影) を
+ * 持ち、 本 client は **wire 層** (= endpoint / Bearer auth / Terraform blueprint 整形) だけを担う。 Sakura /
+ * Azure REST client と同方針で `handlers/` の外 (service 層) に置き `fetch` を閉じ込める。
+ *
+ * 認証は短命 Bearer token (= trust-bridge gcp-workload-identity が WIF 交換で得た access token を
+ * `GcpCredential.accessToken` で受け取る)。 本 client は token を貰うだけで federation はしない。
+ *
+ * API (https://cloud.google.com/infrastructure-manager/docs/reference/rest):
+ *   - base `https://config.googleapis.com/v1`
+ *   - create: POST `/projects/{p}/locations/{l}/deployments?deploymentId={name}` (LRO)
+ *   - get:    GET  `/projects/{p}/locations/{l}/deployments/{name}` → `{state, ...}`
+ *   - update: PATCH `/projects/{p}/locations/{l}/deployments/{name}` (LRO)
+ *   - delete: DELETE `/projects/{p}/locations/{l}/deployments/{name}` (LRO)
+ *   - body: `{terraformBlueprint: {gcsSource, inputValues: {key: {inputValue}}}}`
+ *
+ * spec が運ばない project / location は options で注入する (= per-team GCP account の onboarding が供給、
+ * account-gated)。 実 account で照合する余地は outputs の正確な参照 (= revision 配下) と LRO の完了待ち
+ * (= 本 client は enqueue まで、 完了は status polling で観測) — integration 相 (waterfall)。
+ */
+
+import { StatusCodes } from "http-status-codes";
+import type {
+  GcpCredential,
+  GcpDeploymentSpec,
+  GcpDeploymentState,
+  GcpInfraManagerClient,
+} from "../handlers/shared/runtime/gcp-infra-manager-adapter.js";
+
+const DEFAULT_BASE_URL = "https://config.googleapis.com/v1";
+
+export interface GcpInfraManagerRestClientOptions {
+  /** deployment を置く GCP project ID (= per-team account)。 */
+  readonly projectId: string;
+  /** Infra Manager の location (= region、 例 asia-northeast1)。 */
+  readonly location: string;
+  /** base URL override (= test)。 */
+  readonly baseUrl?: string;
+  /** fetch 実装の注入 (= unit test で mock)。 */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** Infra Manager deployment GET レスポンスの最小形 (本 client が依存する field のみ)。 */
+interface InfraManagerDeployment {
+  readonly state?: string;
+  readonly terraformBlueprint?: { readonly inputValues?: Record<string, unknown> };
+  readonly outputs?: Record<string, { readonly value?: unknown }>;
+}
+
+export function createGcpInfraManagerRestClient(
+  credential: GcpCredential,
+  options: GcpInfraManagerRestClientOptions,
+): GcpInfraManagerClient {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const doFetch = options.fetchImpl ?? fetch;
+  const parent = `projects/${options.projectId}/locations/${options.location}`;
+
+  function authHeaders(json: boolean): Record<string, string> {
+    return {
+      Authorization: `Bearer ${credential.accessToken}`,
+      Accept: "application/json",
+      ...(json ? { "Content-Type": "application/json" } : {}),
+    };
+  }
+
+  function blueprintBody(spec: GcpDeploymentSpec) {
+    return {
+      terraformBlueprint: {
+        // blueprintRef = TF config の GCS URI (gs://...)。
+        gcsSource: spec.blueprintRef,
+        inputValues: Object.fromEntries(
+          Object.entries(spec.inputs).map(([key, value]) => [key, { inputValue: value }]),
+        ),
+      },
+    };
+  }
+
+  async function getRaw(name: string): Promise<InfraManagerDeployment | undefined> {
+    const res = await doFetch(`${baseUrl}/${parent}/deployments/${name}`, {
+      method: "GET",
+      headers: authHeaders(false),
+    });
+    if (res.status === StatusCodes.NOT_FOUND) return undefined;
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`GCP Infra Manager GET deployment failed: ${res.status} ${text}`.trim());
+    }
+    return (await res.json()) as InfraManagerDeployment;
+  }
+
+  async function mutate(method: string, url: string, body: unknown): Promise<void> {
+    const res = await doFetch(url, {
+      method,
+      headers: authHeaders(true),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `GCP Infra Manager ${method} deployment failed: ${res.status} ${text}`.trim(),
+      );
+    }
+  }
+
+  return {
+    async upsertDeployment(spec: GcpDeploymentSpec): Promise<void> {
+      const existing = await getRaw(spec.name);
+      if (existing) {
+        // 既存は PATCH 更新 (LRO)。
+        await mutate("PATCH", `${baseUrl}/${parent}/deployments/${spec.name}`, blueprintBody(spec));
+        return;
+      }
+      // 新規は POST + ?deploymentId= (LRO)。
+      await mutate(
+        "POST",
+        `${baseUrl}/${parent}/deployments?deploymentId=${encodeURIComponent(spec.name)}`,
+        blueprintBody(spec),
+      );
+    },
+
+    async getDeployment(name: string): Promise<GcpDeploymentState | undefined> {
+      const deployment = await getRaw(name);
+      if (!deployment) return undefined;
+      const outputs = deployment.outputs
+        ? Object.fromEntries(
+            Object.entries(deployment.outputs).map(([key, out]) => [key, String(out.value ?? "")]),
+          )
+        : undefined;
+      return {
+        state: deployment.state ?? "unknown",
+        ...(outputs ? { outputs } : {}),
+      };
+    },
+
+    async deleteDeployment(name: string): Promise<void> {
+      const res = await doFetch(`${baseUrl}/${parent}/deployments/${name}`, {
+        method: "DELETE",
+        headers: authHeaders(false),
+      });
+      if (res.status === StatusCodes.NOT_FOUND) return; // idempotent
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`GCP Infra Manager DELETE deployment failed: ${res.status} ${text}`.trim());
+      }
+    },
+  };
+}

--- a/infrastructure/test/problem-deploy/azure-deployment-stacks-rest-client.test.ts
+++ b/infrastructure/test/problem-deploy/azure-deployment-stacks-rest-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAzureDeploymentStacksRestClient } from "../../lib/problem-deploy/runtime-clients/azure-deployment-stacks-rest-client.js";
+
+/**
+ * [ADR-027 / #1410] ARM Deployment Stacks REST client の wire 整形を pin。 fetch を mock し、
+ * endpoint / Bearer auth / ARM body (templateLink + parameters{value} + actionOnUnmanage) /
+ * provisioningState+outputs 射影 / 404→undefined / idempotent delete / 非2xx throw を観測する。
+ */
+
+const CRED = { accessToken: "aad-token" };
+const OPTS = {
+  subscriptionId: "sub-1",
+  resourceGroup: "rg-1",
+  baseUrl: "https://arm.test",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function client(fetchImpl: ReturnType<typeof vi.fn>) {
+  return createAzureDeploymentStacksRestClient(CRED, { ...OPTS, fetchImpl: fetchImpl as never });
+}
+
+const EXPECTED_PATH =
+  "https://arm.test/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Resources/deploymentStacks/p-team?api-version=2024-03-01";
+
+describe("azure-deployment-stacks-rest-client (ADR-027 #1410)", () => {
+  it("should PUT a deployment stack with Bearer auth, templateLink, and ARM-shaped parameters", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonResponse({}, 200));
+    await client(fetchImpl).upsertStack({
+      name: "p-team",
+      templateRef: "https://blob.test/main.json",
+      parameters: { tenkacloudTeam: "team-a" },
+    });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(EXPECTED_PATH);
+    expect(init.method).toBe("PUT");
+    expect(init.headers.Authorization).toBe("Bearer aad-token");
+    const body = JSON.parse(init.body);
+    expect(body.properties.templateLink.uri).toBe("https://blob.test/main.json");
+    expect(body.properties.parameters).toEqual({ tenkacloudTeam: { value: "team-a" } });
+    expect(body.properties.actionOnUnmanage.resources).toBe("delete");
+  });
+
+  it("should GET provisioningState and flatten outputs", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        properties: {
+          provisioningState: "succeeded",
+          outputs: { baseUrl: { type: "String", value: "https://app.test" } },
+        },
+      }),
+    );
+    const state = await client(fetchImpl).getStack("p-team");
+    expect(state).toEqual({
+      provisioningState: "succeeded",
+      outputs: { baseUrl: "https://app.test" },
+    });
+  });
+
+  it("should return undefined from getStack on 404", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(new Response("not found", { status: 404 }));
+    expect(await client(fetchImpl).getStack("p-team")).toBeUndefined();
+  });
+
+  it("should omit outputs when the stack has none", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ properties: { provisioningState: "deploying" } }));
+    expect(await client(fetchImpl).getStack("p")).toEqual({ provisioningState: "deploying" });
+  });
+
+  it("should DELETE the stack and treat 404 as idempotent success", async () => {
+    const ok = vi.fn().mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await client(ok).deleteStack("p-team");
+    expect(ok.mock.calls[0][1].method).toBe("DELETE");
+    const gone = vi.fn().mockResolvedValueOnce(new Response(null, { status: 404 }));
+    await expect(client(gone).deleteStack("p-team")).resolves.toBeUndefined();
+  });
+
+  it("should throw with the status on a non-2xx PUT/GET/DELETE", async () => {
+    const put = vi.fn().mockResolvedValueOnce(new Response("bad", { status: 400 }));
+    await expect(
+      client(put).upsertStack({ name: "p", templateRef: "t", parameters: {} }),
+    ).rejects.toThrow(/400/);
+    const get = vi.fn().mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    await expect(client(get).getStack("p")).rejects.toThrow(/500/);
+  });
+});

--- a/infrastructure/test/problem-deploy/gcp-infra-manager-rest-client.test.ts
+++ b/infrastructure/test/problem-deploy/gcp-infra-manager-rest-client.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGcpInfraManagerRestClient } from "../../lib/problem-deploy/runtime-clients/gcp-infra-manager-rest-client.js";
+
+/**
+ * [ADR-027 / #1411] Infrastructure Manager REST client の wire 整形を pin。 fetch を mock し、
+ * endpoint / Bearer auth / terraformBlueprint(gcsSource + inputValues{inputValue}) / create-vs-update /
+ * state+outputs 射影 / 404→undefined / idempotent delete / 非2xx throw を観測する。
+ */
+
+const CRED = { accessToken: "gcp-token" };
+const OPTS = {
+  projectId: "proj-1",
+  location: "asia-northeast1",
+  baseUrl: "https://config.test/v1",
+};
+const PARENT = "https://config.test/v1/projects/proj-1/locations/asia-northeast1";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function client(fetchImpl: ReturnType<typeof vi.fn>) {
+  return createGcpInfraManagerRestClient(CRED, { ...OPTS, fetchImpl: fetchImpl as never });
+}
+
+describe("gcp-infra-manager-rest-client (ADR-027 #1411)", () => {
+  it("should POST a new deployment with ?deploymentId and a terraformBlueprint when none exists", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("not found", { status: 404 })) // get → 404
+      .mockResolvedValueOnce(jsonResponse({ name: "op" })); // create LRO
+    await client(fetchImpl).upsertDeployment({
+      name: "p-team",
+      blueprintRef: "gs://bucket/config",
+      inputs: { team: "team-a" },
+    });
+    const [createUrl, createInit] = fetchImpl.mock.calls[1];
+    expect(createUrl).toBe(`${PARENT}/deployments?deploymentId=p-team`);
+    expect(createInit.method).toBe("POST");
+    expect(createInit.headers.Authorization).toBe("Bearer gcp-token");
+    const body = JSON.parse(createInit.body);
+    expect(body.terraformBlueprint.gcsSource).toBe("gs://bucket/config");
+    expect(body.terraformBlueprint.inputValues).toEqual({ team: { inputValue: "team-a" } });
+  });
+
+  it("should PATCH an existing deployment (idempotent upsert)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ state: "ACTIVE" })) // get → exists
+      .mockResolvedValueOnce(jsonResponse({ name: "op" }));
+    await client(fetchImpl).upsertDeployment({
+      name: "p-team",
+      blueprintRef: "gs://b/c",
+      inputs: {},
+    });
+    const [updateUrl, updateInit] = fetchImpl.mock.calls[1];
+    expect(updateUrl).toBe(`${PARENT}/deployments/p-team`);
+    expect(updateInit.method).toBe("PATCH");
+  });
+
+  it("should GET state and flatten outputs", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ state: "ACTIVE", outputs: { url: { value: "https://x.run.app" } } }),
+      );
+    expect(await client(fetchImpl).getDeployment("p-team")).toEqual({
+      state: "ACTIVE",
+      outputs: { url: "https://x.run.app" },
+    });
+  });
+
+  it("should return undefined from getDeployment on 404", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(new Response("nope", { status: 404 }));
+    expect(await client(fetchImpl).getDeployment("p")).toBeUndefined();
+  });
+
+  it("should DELETE the deployment and treat 404 as idempotent success", async () => {
+    const ok = vi.fn().mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await client(ok).deleteDeployment("p-team");
+    expect(ok.mock.calls[0][0]).toBe(`${PARENT}/deployments/p-team`);
+    expect(ok.mock.calls[0][1].method).toBe("DELETE");
+    const gone = vi.fn().mockResolvedValueOnce(new Response(null, { status: 404 }));
+    await expect(client(gone).deleteDeployment("p")).resolves.toBeUndefined();
+  });
+
+  it("should throw with the status on a non-2xx get/create", async () => {
+    const get = vi.fn().mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    await expect(client(get).getDeployment("p")).rejects.toThrow(/500/);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-027 の `azure/bicep` + `gcp/infra-manager` adapter (PR #1648) の `client` 注入境界を、 実 cloud REST API に実装する。 Sakura REST client (#1652) と同方針: `handlers/` の外 (service 層) に置き `fetch` を閉じ込め、 短命 Bearer token を貰うだけで federation はしない (= adapter context の `getCredential` 側が trust-bridge WIF 交換で供給する)。

### 変更
- **`runtime-clients/azure-deployment-stacks-rest-client.ts` (新)** — ARM Deployment Stacks REST。 `PUT/GET/DELETE .../deploymentStacks/{name}?api-version=2024-03-01`、 `templateRef`→`templateLink`、 `parameters`→`{name:{value}}`、 `actionOnUnmanage=delete` (teardown 時に resource 削除)、 `provisioningState`+`outputs` 射影、 404→undefined / idempotent delete。 subscription / RG / location / api-version は options 注入 (per-team Azure account onboarding が供給)。
- **`runtime-clients/gcp-infra-manager-rest-client.ts` (新)** — Infrastructure Manager REST。 base `config.googleapis.com/v1`、 create=`POST ?deploymentId` / update=`PATCH` / get / delete、 `blueprintRef`→`terraformBlueprint.gcsSource`、 `inputs`→`inputValues{inputValue}`、 `state`+`outputs` 射影、 404→undefined / idempotent delete。 project / location は options 注入。
- 両 client とも `StatusCodes.NOT_FOUND` (magic number 禁止)。

## Test plan
- `azure-deployment-stacks-rest-client.test.ts` (6) + `gcp-infra-manager-rest-client.test.ts` (6): endpoint / Bearer auth / body 整形 (ARM parameters / TF inputValues) / create-vs-update / provisioningState・state + outputs 射影 / 404→undefined / idempotent delete / 非2xx throw を fetch mock で pin。
- infra 全体緑、 typecheck / biome / harness (0 findings) / check-http-status / cdk synth / audit-deps すべて緑 (pre-commit gate)。

## Regression analysis
- 新規ファイル 2 + テスト 2 のみ。 既存 import 元なし → 既存挙動に影響なし (AWS / Sakura path 不変)。
- adapter (#1648) の `client` 契約に正確に一致 (型で保証、 typecheck 緑)。

## Physical impact
- **NO-OP** (CFn / artifact 変更なし)。 service 層 module + テストのみで、 deploy worker への `deps.azure`/`deps.gcp` 配線・IAM・新 dep は含まない。

## 残る seam (本 PR scope 外、 #1410/#1411 内)
- `getCredential` federation resolver: trust-bridge `azure-federated-credential` / `gcp-workload-identity` 交換を呼ぶ orchestration + **署名鍵 / OIDC issuer の設計 (ADR-017 OQ#1)**。 これは静的鍵の Sakura と違い cross-cloud trust の設計判断を含む (= 本当に「大げさ」な唯一の残部)。 設計確定後に resolver + `deploy.ts` deps 配線 + IAM。
- `getStatus`/`destroy`/`collectOutputs` の adapter 配線、 実 account での wire 照合 (LRO 完了待ち / outputs 参照)。

Relates #1410
Relates #1411