### PR TITLE
docs(adr): ADR-032 cross-cloud federation subject-token mechanism (resolves ADR-017 OQ#1)

### DIFF
--- a/docs/architecture/adr-032-cross-cloud-federation-subject-token.html
+++ b/docs/architecture/adr-032-cross-cloud-federation-subject-token.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-032: Cross-cloud federation subject-token mechanism</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft { background: #ddf4ff; color: var(--c-link); }
+  .badge.accept { background: #dafbe1; color: var(--c-accept); }
+  .badge.reject { background: #ffe5e5; color: var(--c-reject); }
+  .badge.warn { background: #fff8c5; color: var(--c-warn); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  .risk-high { color: var(--c-reject); font-weight: 600; }
+  .risk-med { color: var(--c-warn); font-weight: 600; }
+  .ok { color: var(--c-accept); font-weight: 600; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-032: Cross-cloud federation subject-token mechanism</h1>
+  <p><em>非 AWS の問題ランタイム (Azure / GCP) へ deploy する際、 AWS Lambda 上の deploy worker が
+  どうやって provider-native の短命クレデンシャルを得るか — ADR-017 OQ#1 の解決</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge accept">Accepted</span> 2026-06-02</div>
+    <div><b>Related:</b>
+      <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> (Trust Bridge / verified intent → credential),
+      <a href="./adr-027-azure-gcp-federated-providers.html">ADR-027</a> (Azure / GCP problem runtimes),
+      <a href="./adr-026-sakura-cloud-problem-provider.html">ADR-026</a> (Sakura stored-key path),
+      <a href="./adr-023-provider-specific-problem-runtime.html">ADR-023</a> (multi-cloud expansion path)
+    </div>
+  </div>
+</header>
+
+<h2>Context</h2>
+
+<p>
+ADR-017 (Trust Bridge) は cross-cloud の権限委譲を「verified intent → short-lived provider-native
+credential」と抽象化し、 provider 別の交換アダプタを規定した。 ADR-027 は Azure / GCP の問題ランタイムを
+<b>Workload Identity Federation (WIF)</b> で扱う方針を採り、 <code>packages/trust-bridge</code> に
+<code>AzureFederatedCredentialExchange</code> / <code>GcpWorkloadIdentityFederationExchange</code> を
+プロトタイプとして実装した。 両アダプタは交換のオーケストレーション (= STS / token endpoint 呼び出し →
+短命トークン) を持つが、 <b>subject token をどう構成するか</b> を caller 注入の
+<code>toClientAssertion</code> / <code>toSubjectToken</code> hook に委ね、 その具体形を未決
+(ADR-017 OQ#1) として残した。
+</p>
+
+<p>
+deploy worker の実体は <b>AWS Lambda</b> (<code>problem-deploy</code> backend) である。 ここから Azure / GCP の
+WIF へ federate する際の subject token には、 前提として無視できない制約がある:
+</p>
+
+<table>
+  <thead><tr><th>制約</th><th>内容</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>プロトタイプの想定が成立しない</td>
+      <td>両アダプタの doc comment は「trust-bridge の JWS (HS256) を subject token としてそのまま乗せる」
+      想定を記す。 だが HS256 は<b>対称鍵</b>であり、 GCP STS / Microsoft Entra ID は subject token を
+      <b>発行者の公開鍵 (JWKS) で検証</b>する OIDC モデルを前提とする。 共有秘密を検証側に渡さない限り
+      HS256 JWS は WIF で<span class="risk-high">検証できない</span>。 = OQ#1 は「wire 整形」ではなく
+      <b>信頼モデルの選択</b>の問題。</td>
+    </tr>
+    <tr>
+      <td>AWS Lambda は OIDC token を native 発行しない</td>
+      <td>GitHub Actions / GitLab CI のような OIDC issuer を AWS Lambda は持たない。 Lambda が持つのは
+      <b>AWS IAM の実行ロール identity</b> (= SigV4 で署名できる) であって、 任意 audience 向けの
+      OIDC JWT ではない。</td>
+    </tr>
+    <tr>
+      <td>provider ごとに federate 元の選択肢が異なる</td>
+      <td>GCP WIF は <b>AWS を first-class の credential source</b> として受け付ける (subject token =
+      署名済 <code>sts:GetCallerIdentity</code> リクエスト)。 Microsoft Entra ID の federated identity
+      credential は <b>OIDC issuer のみ</b>を受け付け、 AWS-native の経路を持たない。</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+したがって OQ#1 は provider 一律には解けない。 「AWS Lambda という発行元から、 各 provider が実際に検証できる
+subject をどう作るか」を provider 別に決める必要がある。
+</p>
+
+<h2>Decision</h2>
+
+<p>
+<b>federate 元として最も強い isolation を、 各 provider が native に受け付ける範囲で採る</b>。 具体的には
+GCP は鍵レスの AWS-native WIF、 Azure は (native AWS 経路が無いため) stored client secret から始め、
+OIDC issuer 化は将来のアップグレードとして留保する。
+</p>
+
+<table>
+  <thead><tr><th>provider</th><th>subject / credential</th><th>署名鍵</th><th>isolation</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><b>GCP</b> (<a href="https://github.com/susumutomita/TenkaCloud/issues/1411">#1411</a>)</td>
+      <td>WIF <b>AWS provider</b>。 subject token = 署名済 <code>sts:GetCallerIdentity</code>
+      (<code>subjectTokenType = urn:ietf:params:aws:token-type:aws4_request</code>)。 GCP STS で federated
+      token に交換し、 <code>iamcredentials.generateAccessToken</code> で per-team service account の
+      短命 access token を得る。</td>
+      <td><span class="ok">不要</span> (deploy Lambda の AWS identity がそのまま subject)</td>
+      <td><span class="ok">短命</span> (federated token + SA token、 stored key なし)</td>
+    </tr>
+    <tr>
+      <td><b>Azure</b> (<a href="https://github.com/susumutomita/TenkaCloud/issues/1410">#1410</a>)</td>
+      <td>per-team の Entra ID app registration の <b>client secret</b> を SSM SecureString に保管し、
+      <code>client_credentials</code> grant で ARM access token を得る (ADR-026 の Sakura stored-key と
+      同型の保管経路)。</td>
+      <td><span class="risk-med">stored secret</span> (long-lived、 SSM SecureString)</td>
+      <td><span class="risk-med">弱め</span> (Sakura と同等。 per-team app + 最小ロール + rotation で補償)</td>
+    </tr>
+    <tr>
+      <td><b>Sakura</b> (<a href="https://github.com/susumutomita/TenkaCloud/issues/1412">#1412</a>)</td>
+      <td>変更なし。 静的 API key (Access Token + Secret) を SSM SecureString 保管 (ADR-026)。</td>
+      <td><span class="risk-med">stored key</span></td>
+      <td><span class="risk-med">弱め</span> (ADR-026 D3 の通り)</td>
+    </tr>
+    <tr>
+      <td>AWS</td>
+      <td>変更なし。 <code>sts:AssumeRole</code> + ExternalId + 1h セッション (ADR-002)。</td>
+      <td><span class="ok">不要</span></td>
+      <td><span class="ok">最短命</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>GCP — 鍵レス AWS-native WIF</h3>
+<p>
+GCP WIF プール (per-team GCP プロジェクト) を、 platform の AWS アカウントを信頼するよう構成する
+(<a href="https://github.com/susumutomita/TenkaCloud/issues/1413">#1413</a> onboarding)。 deploy worker は
+自身の実行ロールで <code>sts:GetCallerIdentity</code> を SigV4 署名し、 GCP の規定形式
+(<code>{url, method, headers}</code> を base64url 化) で subject token を作る。 これを
+<code>GcpWorkloadIdentityFederationExchange</code> に <code>toSubjectToken</code> として渡す。
+プロトタイプの HS256 JWS 前提はこの方式で置き換わる。 <b>platform 側に署名鍵を持たない</b>のが利点
+(鍵の保管 / ローテーション / 漏洩の管理対象が増えない)。
+</p>
+
+<h3>Azure — stored client secret を起点に、 OIDC issuer は留保</h3>
+<p>
+Microsoft Entra ID は AWS-native の credential source を持たないため、 鍵レスにするには platform を
+OIDC issuer 化 (RS256 JWT 発行 + JWKS 公開 + per-team app への federated credential 登録) する新サブシステムが
+要る。 これは JWKS ホスティング・鍵ローテーション・issuer 運用を抱える重い投資であり、 最初の deployable
+バージョンの blocker にするのは過剰である。 そこで Azure は <b>ADR-026 の Sakura stored-key 経路を再利用</b>し、
+per-team app registration の client secret を SSM SecureString に保管して <code>client_credentials</code> grant で
+ARM token を得る。 これは ADR-027 が掲げた「Azure は stored key 不要」を<b>意図的に緩和</b>する判断であり、
+理由は上記の native 経路の欠如である。 OIDC issuer 化は <b>将来のアップグレード</b>として
+<code>AzureFederatedCredentialExchange</code> (既存プロトタイプ) を活かす形で留保する。
+</p>
+
+<details>
+  <summary>なぜ Azure も AWS-native にできないのか (詳細)</summary>
+  <p>
+  Entra ID の federated identity credential は <code>issuer</code> + <code>subject</code> + <code>audience</code> の
+  3 つで OIDC トークンを照合する。 issuer は HTTPS で <code>/.well-known/openid-configuration</code> と JWKS を
+  公開していなければならない。 AWS Lambda はこれを満たす issuer を内蔵しない。 GCP のように
+  「AWS の GetCallerIdentity を信頼する」設定は Entra ID 側に存在しない。 したがって鍵レス化は
+  「platform が OIDC issuer になる」以外に道がなく、 それは独立した設計判断 (本 ADR の scope 外、 将来 ADR) を要する。
+  </p>
+</details>
+
+<h2>Consequences</h2>
+<ul>
+  <li>GCP は stored key を一切持たず、 short-lived credential で deploy できる (= AWS と同等の isolation)。</li>
+  <li>Azure は long-lived な client secret を 1 つ抱える。 これは Sakura と同じ <span class="risk-med">弱い isolation</span> で、
+  同じ補償 (per-team app registration / 最小 ARM ロール / SSM SecureString のみ保管 / rotation 対応) を課す。
+  <code>secrets-manager-forbidden</code> 準拠で Secrets Manager は使わず SSM SecureString に保管する。</li>
+  <li>scoring は provider 非依存の HTTP probe のままで影響を受けない (ADR-026/027)。</li>
+  <li>Control Plane (SBT / Cognito / EventBridge) と deploy worker のホスト (AWS) は不変。 追加されるのは
+  deploy 経路の credential 解決と、 onboarding の per-team 登録 (GCP WIF プール / Azure app secret) のみ。</li>
+</ul>
+
+<h2>Implementation order</h2>
+<ol>
+  <li><b>GCP resolver</b>: SigV4 署名 <code>GetCallerIdentity</code> → subject token、 GCP STS / iamcredentials の
+  REST client、 <code>GcpWorkloadIdentityFederationExchange</code> をオーケストレーションする <code>getCredential</code>、
+  <code>deploy.ts</code> の <code>deps.gcp</code> 配線。 REST client (Infra Manager) は実装済 (#1411)。</li>
+  <li><b>Azure resolver</b>: per-team client secret の SSM SecureString store (Sakura store と同型)、
+  <code>client_credentials</code> token client、 <code>getCredential</code>、 <code>deps.azure</code> 配線。
+  REST client (Deployment Stacks) は実装済 (#1410)。</li>
+  <li><b>onboarding</b> (<a href="https://github.com/susumutomita/TenkaCloud/issues/1413">#1413</a>): per-team の
+  GCP WIF プール / SA mapping と Azure app registration + secret 登録 UX。</li>
+  <li>非 AWS ランタイムの <code>getStatus</code> / <code>destroy</code> / <code>collectOutputs</code> を
+  status / teardown / scoring 経路へ配線。</li>
+</ol>
+
+<h2>Alternatives considered</h2>
+<table>
+  <thead><tr><th>案</th><th>判定</th><th>理由</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>両 provider とも platform-as-OIDC-issuer (RS256 + JWKS)</td>
+      <td><span class="badge reject">却下 (現時点)</span></td>
+      <td>JWKS ホスティング・鍵ローテーション・issuer 運用という独立サブシステムを deployable v1 の blocker にするのは過剰。
+      Azure の将来アップグレードとして留保する。</td>
+    </tr>
+    <tr>
+      <td>GCP も stored key (SA key JSON)</td>
+      <td><span class="badge reject">却下</span></td>
+      <td>GCP WIF の AWS-native 経路が鍵レスで動くため、 long-lived な SA key を持つのは厳密に劣る。 Google も SA key を非推奨とする。</td>
+    </tr>
+    <tr>
+      <td>HS256 JWS をそのまま subject token (プロトタイプの当初想定)</td>
+      <td><span class="badge reject">却下</span></td>
+      <td>対称鍵のため WIF / Entra の OIDC 検証を通らない。 検証側に共有秘密を渡すことになり信頼モデルが破綻する。</td>
+    </tr>
+  </tbody>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

非 AWS ランタイム (Azure / GCP) へ deploy する際、 AWS Lambda 上の deploy worker がどう provider-native の短命クレデンシャルを得るか — **ADR-017 OQ#1 を解決**する ADR。

### なぜ必要か (発見)
`packages/trust-bridge` の WIF プロトタイプは「trust-bridge の JWS (HS256) を subject token に乗せる」想定だが、 HS256 は**対称鍵**のため GCP STS / Microsoft Entra ID の **OIDC 検証 (発行者公開鍵)** を通らない。 さらに AWS Lambda は OIDC token を native 発行しない。 = OQ#1 は wire 整形ではなく **信頼モデルの選択**。 federation の実装を始める前にこの設計判断が要る (Issue→設計→実装)。

### 決定
| provider | subject / credential | 署名鍵 | isolation |
| --- | --- | --- | --- |
| **GCP** #1411 | WIF **AWS provider** = 署名済 `sts:GetCallerIdentity` → GCP STS → `iamcredentials` で per-team SA token | 不要 (Lambda の AWS identity) | 短命 (鍵なし) |
| **Azure** #1410 | per-team app registration の **client secret** を SSM SecureString 保管 + `client_credentials` grant (ADR-026 Sakura 同型) | stored secret | 弱め (Sakura 同等、 補償付き) |
| Sakura #1412 / AWS | 変更なし | — | — |

- **GCP** は鍵レス AWS-native WIF で AWS と同等の isolation。 プロトタイプの HS256-JWS 前提を置き換える。
- **Azure** は Entra ID が AWS-native 経路を持たない (federated credential は OIDC issuer のみ受付) ため、 鍵レス化には platform-as-OIDC-issuer という重いサブシステムが要る。 deployable v1 の blocker にしないため、 まず stored client secret (Sakura 経路の再利用) から始め、 OIDC issuer 化は将来アップグレードとして留保する。 ADR-027 の「Azure stored key 不要」を native 経路欠如のため意図的に緩和する判断を明記。

## Test plan
- 設計ドキュメント (HTML) のみ。 `make harness` 緑 (`adr-must-be-html` / `adr-self-contained` 準拠)、 リンク先 ADR の実ファイル名に整合。
- 既存コードへの変更なし → 全 workspace test / typecheck / cdk synth 緑 (pre-commit gate)。

## Regression analysis
- ドキュメント追加のみ。 コード・CFn・テストへの影響なし。

## Physical impact
- **NO-OP** (HTML ドキュメント 1 ファイル追加)。

Relates #1410
Relates #1411