### PR TITLE
feat(problem-deploy): wire executable azure/bicep deploy + DRY secure-json store [#1410]

### DIFF
--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -12,6 +12,7 @@ import {
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
 } from "../utils/lambda-runtime.js";
+import { buildAzureCredentialParameterArnPattern } from "./handlers/shared/azure-credential-store.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
 import { buildSakuraCredentialParameterArnPattern } from "./handlers/shared/sakura-credential-store.js";
 
@@ -148,18 +149,25 @@ export class DeployApiLambda extends Construct {
       stack.account,
       props.environmentName,
     );
-    // [ADR-026 / #1412] per-team Sakura API key (SSM SecureString) も同 Lambda が deploy 時に decrypt
-    // 取得する。 ExternalId と同じ prefix-scope + AWS managed key 復号で最小権限を保つ。
+    // [ADR-026/027/032 / #1412 #1410] per-team の Sakura API key / Azure deploy credential (SSM SecureString)
+    // も同 Lambda が deploy 時に decrypt 取得する。 ExternalId と同じ prefix-scope + AWS managed key 復号で
+    // 最小権限を保つ。
     const sakuraSsmArn = buildSakuraCredentialParameterArnPattern(
       stack.region,
       stack.account,
       props.environmentName,
     );
+    const azureSsmArn = buildAzureCredentialParameterArnPattern(
+      stack.region,
+      stack.account,
+      props.environmentName,
+    );
+    const credentialSsmArns = [ssmArn, sakuraSsmArn, azureSsmArn];
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["ssm:GetParameter"],
-        resources: [ssmArn, sakuraSsmArn],
+        resources: credentialSsmArns,
       }),
     );
     this.fn.addToRolePolicy(
@@ -168,7 +176,7 @@ export class DeployApiLambda extends Construct {
         actions: ["kms:Decrypt"],
         resources: ["*"],
         conditions: {
-          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": [ssmArn, sakuraSsmArn] },
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": credentialSsmArns },
         },
       }),
     );

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -5,12 +5,23 @@ import { SSMClient } from "@aws-sdk/client-ssm";
 import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { ulid } from "ulid";
 import { getEnv } from "../../../helper-functions.js";
+import { createAzureDeploymentStacksRestClient } from "../../runtime-clients/azure-deployment-stacks-rest-client.js";
+import {
+  type AzureEntraTokenClient,
+  createAzureEntraTokenClient,
+} from "../../runtime-clients/azure-entra-token-client.js";
 import { createSakuraAppRunRestClient } from "../../runtime-clients/sakura-apprun-rest-client.js";
+import {
+  type AzureDeployCredential,
+  getAzureCredential,
+} from "../shared/azure-credential-store.js";
 import { parseProblemsCatalog } from "../shared/catalog.js";
 import { resolveVerifiedCompetitorAccount } from "../shared/competitor-account-lookup.js";
 import { deploymentTerminalExpiresAt } from "../shared/deployment-retention.js";
 import {
   type AdapterDependencies,
+  AZURE_ENGINE,
+  AZURE_PROVIDER,
   EXECUTABLE_ENGINE,
   EXECUTABLE_PROVIDER,
   type ProblemRuntime,
@@ -68,6 +79,11 @@ export interface DeployContext {
    */
   readonly ssm?: Pick<SSMClient, "send">;
   readonly sakuraAppRunBaseUrl?: string;
+  /**
+   * [ADR-032 / Issue #1410] azure/bicep deploy 用の Entra ID client_credentials token client。
+   * 省略時は本番 authority (login.microsoftonline.com) の実装を使う (= test では fake 注入)。
+   */
+  readonly azureEntraTokenClient?: AzureEntraTokenClient;
   /**
    * [ADR-023 / Issue #1268] Optional per-problemId runtime resolver. If
    * undefined OR if it returns undefined for a given problemId, the deploy
@@ -139,9 +155,55 @@ function buildSakuraAdapterContext(
 }
 
 /**
- * runtime に応じた adapter 依存を組む。 aws は常に存在し、 sakura/apprun は SSM (per-team key store) が
- * 配線されたときだけ追加する (= 未配線なら selectAdapter が reserved error)。 deps を組む条件分岐を
- * startDeployment から切り出して責務を分離する (SRP)。
+ * [ADR-027 / ADR-032 / #1410] azure/bicep の adapter context を組む。 getCredential は per-team の
+ * Azure deploy 設定 (app registration secret + subscription/RG) を SSM SecureString から引き、 未登録なら
+ * loud に throw、 client_credentials grant で ARM token を得る。 client は同 config の subscription/RG で
+ * Deployment Stacks REST client を束ねる。 adapter は必ず getCredential → client の順で呼ぶので、 解決した
+ * config を closure に保持して client factory が subscription/RG を読む (= AzureCredential は accessToken のみ運ぶ)。
+ */
+function buildAzureAdapterContext(
+  ssm: Pick<SSMClient, "send">,
+  env: string,
+  tenantId: string,
+  teamSlug: string,
+  tokenClient: AzureEntraTokenClient,
+): NonNullable<AdapterDependencies["azure"]> {
+  let resolved: AzureDeployCredential | undefined;
+  return {
+    getCredential: async () => {
+      const config = await getAzureCredential({ ssm, env }, tenantId, teamSlug);
+      if (!config) {
+        throw new Error(
+          `no Azure credential registered for tenant ${tenantId} team ${teamSlug} ` +
+            "(register the app registration secret + subscription/resourceGroup in the per-team SSM SecureString store)",
+        );
+      }
+      resolved = config;
+      const accessToken = await tokenClient.getToken({
+        azureTenantId: config.azureTenantId,
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+      });
+      return { accessToken };
+    },
+    client: (credential) => {
+      // adapter は resolveClient で getCredential を await してから client を呼ぶので resolved は必ず埋まる。
+      if (!resolved) {
+        throw new Error("Azure adapter context: getCredential must resolve before client");
+      }
+      return createAzureDeploymentStacksRestClient(credential, {
+        subscriptionId: resolved.subscriptionId,
+        resourceGroup: resolved.resourceGroup,
+        ...(resolved.location ? { location: resolved.location } : {}),
+      });
+    },
+  };
+}
+
+/**
+ * runtime に応じた adapter 依存を組む。 aws は常に存在し、 sakura/apprun・azure/bicep は SSM (per-team
+ * credential store) が配線されたときだけ追加する (= 未配線なら selectAdapter が reserved error)。 deps を
+ * 組む条件分岐を startDeployment から切り出して責務を分離する (SRP)。
  */
 function buildAdapterDependencies(
   ctx: DeployContext,
@@ -149,7 +211,8 @@ function buildAdapterDependencies(
   teamSlug: string,
 ): AdapterDependencies {
   const aws = { events: ctx.events, eventBusName: ctx.eventBusName };
-  if (ctx.ssm && runtime.provider === SAKURA_PROVIDER && runtime.engine === SAKURA_ENGINE) {
+  if (!ctx.ssm) return { aws };
+  if (runtime.provider === SAKURA_PROVIDER && runtime.engine === SAKURA_ENGINE) {
     return {
       aws,
       sakura: buildSakuraAdapterContext(
@@ -158,6 +221,18 @@ function buildAdapterDependencies(
         ctx.tenantId,
         teamSlug,
         ctx.sakuraAppRunBaseUrl,
+      ),
+    };
+  }
+  if (runtime.provider === AZURE_PROVIDER && runtime.engine === AZURE_ENGINE) {
+    return {
+      aws,
+      azure: buildAzureAdapterContext(
+        ctx.ssm,
+        ctx.env,
+        ctx.tenantId,
+        teamSlug,
+        ctx.azureEntraTokenClient ?? createAzureEntraTokenClient(),
       ),
     };
   }

--- a/infrastructure/lib/problem-deploy/handlers/shared/azure-credential-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/azure-credential-store.ts
@@ -1,0 +1,116 @@
+import { createSecureJsonStore, type SecureJsonStoreDeps } from "./secure-json-store.js";
+
+/**
+ * [ADR-027 / ADR-032 / Issue #1410] per-team Azure deploy credential store (SSM SecureString)。
+ *
+ * ADR-032: Microsoft Entra ID は AWS-native の federation 経路を持たない (federated credential は OIDC
+ * issuer のみ受付) ため、 AWS Lambda の deploy worker から鍵レスにするには platform-as-OIDC-issuer という
+ * 重いサブシステムが要る。 deployable v1 ではこれを避け、 **per-team app registration の client secret を
+ * SSM SecureString に保管** (= ADR-026 Sakura stored-key と同型) し `client_credentials` grant で ARM token を
+ * 得る。 long-lived secret なので Sakura 同等の補償 (per-team app + 最小 ARM ロール + SecureString のみ + rotation) を課す。
+ *
+ * path 規約: `/{env}/tenants/{tenantId}/teams/{teamSlug}/azure-credential`。 値は app registration の認証情報 +
+ * deploy 先 (subscription / resourceGroup / location) をまとめた JSON。 plaintext で返さず都度 decrypt 取得。
+ * SSM 機構は [[secure-json-store.ts]] を共有 (= Sakura store と DRY)。 `secrets-manager-forbidden` 準拠。
+ */
+
+/** per-team の Azure deploy 設定 (= app registration の認証情報 + Deployment Stack の置き場所)。 */
+export interface AzureDeployCredential {
+  /** Entra ID directory (tenant) GUID。 client_credentials の token endpoint path に使う。 */
+  readonly azureTenantId: string;
+  /** app registration の client ID。 */
+  readonly clientId: string;
+  /** app registration の client secret (= long-lived、 SecureString 保管)。 */
+  readonly clientSecret: string;
+  /** Deployment Stack を置く subscription GUID。 */
+  readonly subscriptionId: string;
+  /** Deployment Stack を置く resource group 名。 */
+  readonly resourceGroup: string;
+  /** ARM region (省略時は REST client の default)。 */
+  readonly location?: string;
+}
+
+export type AzureCredentialStoreDeps = SecureJsonStoreDeps;
+
+export function buildAzureCredentialParameterName(
+  env: string,
+  tenantId: string,
+  teamSlug: string,
+): string {
+  return `/${env}/tenants/${tenantId}/teams/${teamSlug}/azure-credential`;
+}
+
+export function buildAzureCredentialParameterArnPattern(
+  region: string,
+  account: string,
+  env: string,
+): string {
+  // IAM policy 用。 tenantId / teamSlug を `*` でワイルドカード化する。
+  return `arn:aws:ssm:${region}:${account}:parameter/${env}/tenants/*/teams/*/azure-credential`;
+}
+
+/** SSM から読んだ JSON を AzureDeployCredential に narrow (= fail-safe parse、 必須 string field 欠落は undefined)。 */
+function parseAzureCredential(raw: string | undefined): AzureDeployCredential | undefined {
+  if (typeof raw !== "string") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const required = [
+    "azureTenantId",
+    "clientId",
+    "clientSecret",
+    "subscriptionId",
+    "resourceGroup",
+  ] as const;
+  for (const key of required) {
+    if (typeof obj[key] !== "string" || (obj[key] as string).length === 0) return undefined;
+  }
+  if (obj.location !== undefined && typeof obj.location !== "string") return undefined;
+  return {
+    azureTenantId: obj.azureTenantId as string,
+    clientId: obj.clientId as string,
+    clientSecret: obj.clientSecret as string,
+    subscriptionId: obj.subscriptionId as string,
+    resourceGroup: obj.resourceGroup as string,
+    ...(typeof obj.location === "string" ? { location: obj.location } : {}),
+  };
+}
+
+const store = createSecureJsonStore<AzureDeployCredential>({
+  buildName: buildAzureCredentialParameterName,
+  parse: parseAzureCredential,
+  serialize: (credential) => JSON.stringify(credential),
+});
+
+/** team の Azure deploy 設定を取得。 未登録 / 不正形式は undefined (= fail-closed)。 */
+export function getAzureCredential(
+  deps: AzureCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+): Promise<AzureDeployCredential | undefined> {
+  return store.get(deps, tenantId, teamSlug);
+}
+
+/** team の Azure deploy 設定を登録 / 上書き (= register + rotation)。 */
+export function putAzureCredential(
+  deps: AzureCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+  credential: AzureDeployCredential,
+): Promise<void> {
+  return store.put(deps, tenantId, teamSlug, credential);
+}
+
+/** team の Azure deploy 設定を削除 (= revoke / teardown)。 不在は no-op (idempotent)。 */
+export function deleteAzureCredential(
+  deps: AzureCredentialStoreDeps,
+  tenantId: string,
+  teamSlug: string,
+): Promise<void> {
+  return store.delete(deps, tenantId, teamSlug);
+}

--- a/infrastructure/lib/problem-deploy/handlers/shared/sakura-credential-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/sakura-credential-store.ts
@@ -1,12 +1,5 @@
-import {
-  DeleteParameterCommand,
-  GetParameterCommand,
-  ParameterType,
-  PutParameterCommand,
-  type SSMClient,
-} from "@aws-sdk/client-ssm";
 import type { SakuraCredential } from "./runtime/sakura-apprun-adapter.js";
-import { isParameterNotFound } from "./ssm-parameter.js";
+import { createSecureJsonStore, type SecureJsonStoreDeps } from "./secure-json-store.js";
 
 /**
  * [ADR-026 / Issue #1412] per-team Sakura API-key store (SSM SecureString)。
@@ -19,12 +12,13 @@ import { isParameterNotFound } from "./ssm-parameter.js";
  *
  * path 規約: `/{env}/tenants/{tenantId}/teams/{teamSlug}/sakura-api-key`
  *   - **1 team 1 鍵** (ExternalId は 1 tenant 1 値だが、 Sakura は per-team account で鍵を分けるため team 粒度)。
- *   - KMS は AWS managed (`alias/aws/ssm`、 コスト 0)。
- *   - tenantId / teamSlug を path 中段に置き、 IAM policy は prefix で絞り込む。
  *   - 値は `{accessToken, accessTokenSecret}` の JSON。 plaintext で返さず、 deploy worker が都度 decrypt 取得。
  *
- * `secrets-manager-forbidden` enforcement と整合: Secrets Manager は使わない (SSM SecureString のみ)。
+ * SSM SecureString の get/put/delete 機構は [[secure-json-store.ts]] (汎用) に集約 (= Azure secret store と共有、 DRY)。
+ * 本 module は Sakura 固有の path / parse / 名前付き API だけを持つ。 `secrets-manager-forbidden` 準拠。
  */
+
+export type SakuraCredentialStoreDeps = SecureJsonStoreDeps;
 
 export function buildSakuraCredentialParameterName(
   env: string,
@@ -45,11 +39,6 @@ export function buildSakuraCredentialParameterArnPattern(
   return `arn:aws:ssm:${region}:${account}:parameter/${env}/tenants/*/teams/*/sakura-api-key`;
 }
 
-export interface SakuraCredentialStoreDeps {
-  readonly ssm: Pick<SSMClient, "send">;
-  readonly env: string;
-}
-
 /** SSM から読んだ JSON 文字列を SakuraCredential に narrow する (= 自前保管形式の fail-safe parse)。 */
 function parseSakuraCredential(raw: string | undefined): SakuraCredential | undefined {
   if (typeof raw !== "string") return undefined;
@@ -66,65 +55,48 @@ function parseSakuraCredential(raw: string | undefined): SakuraCredential | unde
   return { accessToken, accessTokenSecret };
 }
 
+const store = createSecureJsonStore<SakuraCredential>({
+  buildName: buildSakuraCredentialParameterName,
+  parse: parseSakuraCredential,
+  serialize: (credential) =>
+    JSON.stringify({
+      accessToken: credential.accessToken,
+      accessTokenSecret: credential.accessTokenSecret,
+    }),
+});
+
 /**
  * team の Sakura API key を取得。 未登録 / 復号不能な形式なら `undefined`
  * (= 上位で 404 / RuntimeNotSupported に変換する余地を残す = fail-closed)。
  */
-export async function getSakuraCredential(
+export function getSakuraCredential(
   deps: SakuraCredentialStoreDeps,
   tenantId: string,
   teamSlug: string,
 ): Promise<SakuraCredential | undefined> {
-  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
-  try {
-    const out = await deps.ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
-    return parseSakuraCredential(out.Parameter?.Value);
-  } catch (err) {
-    if (isParameterNotFound(err)) return undefined;
-    throw err;
-  }
+  return store.get(deps, tenantId, teamSlug);
 }
 
 /**
  * team の Sakura API key を登録 / 上書き (= register + rotation 兼用、 ADR-026 D3 rotation 対応)。
- *
- * `Overwrite: true` なので 2 回目以降は鍵を差し替える (= rotation = 再 register)。 ExternalId と違い
- * 「回さない」制約は無い (long-lived 鍵なので運用上 rotate を推奨)。 SSM は内部で version 履歴を保持する。
+ * `Overwrite: true` なので 2 回目以降は鍵を差し替える (= rotation = 再 register)。
  */
-export async function putSakuraCredential(
+export function putSakuraCredential(
   deps: SakuraCredentialStoreDeps,
   tenantId: string,
   teamSlug: string,
   credential: SakuraCredential,
 ): Promise<void> {
-  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
-  await deps.ssm.send(
-    new PutParameterCommand({
-      Name: name,
-      Value: JSON.stringify({
-        accessToken: credential.accessToken,
-        accessTokenSecret: credential.accessTokenSecret,
-      }),
-      Type: ParameterType.SECURE_STRING,
-      Overwrite: true,
-      // KMS は AWS managed (alias/aws/ssm)。 明示 KeyId を渡さないと SSM が自動採用する (= コスト 0)。
-    }),
-  );
+  return store.put(deps, tenantId, teamSlug, credential);
 }
 
 /**
  * team の Sakura API key を削除 (= revoke / team teardown)。 存在しない場合は no-op (= idempotent)。
  */
-export async function deleteSakuraCredential(
+export function deleteSakuraCredential(
   deps: SakuraCredentialStoreDeps,
   tenantId: string,
   teamSlug: string,
 ): Promise<void> {
-  const name = buildSakuraCredentialParameterName(deps.env, tenantId, teamSlug);
-  try {
-    await deps.ssm.send(new DeleteParameterCommand({ Name: name }));
-  } catch (err) {
-    if (isParameterNotFound(err)) return;
-    throw err;
-  }
+  return store.delete(deps, tenantId, teamSlug);
 }

--- a/infrastructure/lib/problem-deploy/handlers/shared/secure-json-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/secure-json-store.ts
@@ -1,0 +1,81 @@
+import {
+  DeleteParameterCommand,
+  GetParameterCommand,
+  ParameterType,
+  PutParameterCommand,
+  type SSMClient,
+} from "@aws-sdk/client-ssm";
+import { isParameterNotFound } from "./ssm-parameter.js";
+
+/**
+ * [ADR-026/027 / #1412 #1410] per-team の機密設定を SSM SecureString に保管する汎用ストア。
+ *
+ * Sakura API key / Azure client secret など、 provider 別の「per-team な JSON 機密を SecureString で
+ * 保管し、 未登録 / 復号不能なら fail-safe に undefined を返し、 delete は idempotent」という共通形を
+ * 1 箇所に集約する (= DRY / SRP)。 provider 固有なのは path 規約 (`buildName`) と JSON ⇔ 型の
+ * parse / serialize だけなので、 それらを注入する factory にする。
+ *
+ * KMS は AWS managed (`alias/aws/ssm`、 コスト 0)。 `secrets-manager-forbidden` 準拠で Secrets Manager は
+ * 使わない。 `Overwrite: true` で put は register + rotation 兼用。
+ */
+
+export interface SecureJsonStoreDeps {
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly env: string;
+}
+
+export interface SecureJsonStore<T> {
+  /** 未登録 / 復号不能形式なら undefined (= fail-closed)。 */
+  get(deps: SecureJsonStoreDeps, tenantId: string, teamSlug: string): Promise<T | undefined>;
+  /** register + rotation 兼用 (Overwrite: true)。 */
+  put(deps: SecureJsonStoreDeps, tenantId: string, teamSlug: string, value: T): Promise<void>;
+  /** 不在は no-op (= idempotent)。 */
+  delete(deps: SecureJsonStoreDeps, tenantId: string, teamSlug: string): Promise<void>;
+}
+
+export interface SecureJsonStoreConfig<T> {
+  /** `/{env}/tenants/{tenantId}/teams/{teamSlug}/...` 形の SSM path を組む。 */
+  readonly buildName: (env: string, tenantId: string, teamSlug: string) => string;
+  /** SSM から読んだ生文字列を型 T に narrow (= 自前保管形式の fail-safe parse)。 不正なら undefined。 */
+  readonly parse: (raw: string | undefined) => T | undefined;
+  /** 型 T を保管用 JSON 文字列に整形。 */
+  readonly serialize: (value: T) => string;
+}
+
+export function createSecureJsonStore<T>(config: SecureJsonStoreConfig<T>): SecureJsonStore<T> {
+  return {
+    async get(deps, tenantId, teamSlug) {
+      const name = config.buildName(deps.env, tenantId, teamSlug);
+      try {
+        const out = await deps.ssm.send(
+          new GetParameterCommand({ Name: name, WithDecryption: true }),
+        );
+        return config.parse(out.Parameter?.Value);
+      } catch (err) {
+        if (isParameterNotFound(err)) return undefined;
+        throw err;
+      }
+    },
+    async put(deps, tenantId, teamSlug, value) {
+      const name = config.buildName(deps.env, tenantId, teamSlug);
+      await deps.ssm.send(
+        new PutParameterCommand({
+          Name: name,
+          Value: config.serialize(value),
+          Type: ParameterType.SECURE_STRING,
+          Overwrite: true,
+          // KMS は AWS managed (alias/aws/ssm)。 明示 KeyId を渡さないと SSM が自動採用 (= コスト 0)。
+        }),
+      );
+    },
+    async delete(deps, tenantId, teamSlug) {
+      const name = config.buildName(deps.env, tenantId, teamSlug);
+      try {
+        await deps.ssm.send(new DeleteParameterCommand({ Name: name }));
+      } catch (err) {
+        if (isParameterNotFound(err)) return;
+        throw err;
+      }
+    },
+  };
+}

--- a/infrastructure/lib/problem-deploy/runtime-clients/azure-entra-token-client.ts
+++ b/infrastructure/lib/problem-deploy/runtime-clients/azure-entra-token-client.ts
@@ -1,0 +1,70 @@
+/**
+ * [ADR-027 / ADR-032 / Issue #1410] Microsoft Entra ID `client_credentials` token client.
+ *
+ * ADR-032 の決定どおり、 Azure deploy は per-team app registration の client secret で
+ * `client_credentials` grant を行い ARM access token を得る (= WIF/OIDC issuer は将来アップグレード)。
+ * Sakura / ARM REST client と同方針で `handlers/` の外 (service 層) に置き `fetch` を閉じ込める。
+ *
+ * endpoint: `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token`
+ *   body (application/x-www-form-urlencoded): grant_type=client_credentials, client_id, client_secret, scope
+ *   response: `{access_token, token_type, expires_in}`
+ */
+
+const DEFAULT_AUTHORITY = "https://login.microsoftonline.com";
+/** ARM 操作のための既定 scope。 */
+export const ARM_DEFAULT_SCOPE = "https://management.azure.com/.default";
+
+export interface AzureEntraTokenInput {
+  readonly azureTenantId: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  /** OAuth2 scope。 省略時 ARM の `.default`。 */
+  readonly scope?: string;
+}
+
+export interface AzureEntraTokenClient {
+  /** client_credentials grant で access token (文字列) を得る。 */
+  getToken(input: AzureEntraTokenInput): Promise<string>;
+}
+
+export interface AzureEntraTokenClientOptions {
+  /** authority base URL override (= test / sovereign cloud)。 省略時 login.microsoftonline.com。 */
+  readonly authority?: string;
+  /** fetch 実装の注入 (= unit test で mock)。 */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export function createAzureEntraTokenClient(
+  options: AzureEntraTokenClientOptions = {},
+): AzureEntraTokenClient {
+  const authority = (options.authority ?? DEFAULT_AUTHORITY).replace(/\/$/, "");
+  const doFetch = options.fetchImpl ?? fetch;
+
+  return {
+    async getToken(input: AzureEntraTokenInput): Promise<string> {
+      const body = new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: input.clientId,
+        client_secret: input.clientSecret,
+        scope: input.scope ?? ARM_DEFAULT_SCOPE,
+      });
+      const res = await doFetch(`${authority}/${input.azureTenantId}/oauth2/v2.0/token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: body.toString(),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Entra ID client_credentials token failed: ${res.status} ${text}`.trim());
+      }
+      const json = (await res.json()) as { access_token?: unknown };
+      if (typeof json.access_token !== "string" || json.access_token.length === 0) {
+        throw new Error("Entra ID token response missing access_token");
+      }
+      return json.access_token;
+    },
+  };
+}

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -96,6 +96,12 @@ describe("ProblemDeployBackendStack (MVP-1) — Deploy API Lambda (invoked from 
     const serialized = JSON.stringify(tpl.findResources("AWS::IAM::Policy"));
     expect(serialized).toContain("tenants/*/teams/*/sakura-api-key");
   });
+
+  // [ADR-032 / #1410] azure/bicep deploy も per-team Azure credential を decrypt 取得する。
+  it("should grant ssm:GetParameter on the per-team Azure credential SecureString path (#1410)", () => {
+    const serialized = JSON.stringify(tpl.findResources("AWS::IAM::Policy"));
+    expect(serialized).toContain("tenants/*/teams/*/azure-credential");
+  });
 });
 
 describe("ProblemDeployBackendStack (MVP-1) — GenericScoring Lambda", () => {

--- a/infrastructure/test/problem-deploy/azure-credential-store.test.ts
+++ b/infrastructure/test/problem-deploy/azure-credential-store.test.ts
@@ -1,0 +1,97 @@
+import {
+  type GetParameterCommand,
+  ParameterNotFound,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AzureCredentialStoreDeps,
+  buildAzureCredentialParameterArnPattern,
+  buildAzureCredentialParameterName,
+  deleteAzureCredential,
+  getAzureCredential,
+  putAzureCredential,
+} from "../../lib/problem-deploy/handlers/shared/azure-credential-store.js";
+
+/**
+ * [ADR-032 / #1410] per-team Azure deploy credential store の振る舞い pin。 path 規約 / 必須 field の
+ * fail-safe parse / round-trip / not-found→undefined / idempotent delete を観測する (SSM mock)。
+ */
+
+function makeDeps(send: ReturnType<typeof vi.fn>): AzureCredentialStoreDeps {
+  return { ssm: { send } as never, env: "development" };
+}
+
+const CRED = {
+  azureTenantId: "dir-1",
+  clientId: "app-1",
+  clientSecret: "shh",
+  subscriptionId: "sub-1",
+  resourceGroup: "rg-1",
+  location: "japaneast",
+};
+
+describe("azure-credential-store (ADR-032 #1410)", () => {
+  it("should build a per-team SecureString path + IAM ARN pattern", () => {
+    expect(buildAzureCredentialParameterName("development", "t1", "team-a")).toBe(
+      "/development/tenants/t1/teams/team-a/azure-credential",
+    );
+    expect(
+      buildAzureCredentialParameterArnPattern("ap-northeast-1", "123456789012", "production"),
+    ).toBe(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/production/tenants/*/teams/*/azure-credential",
+    );
+  });
+
+  it("should get + decrypt + parse the full deploy config", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify(CRED) } });
+    expect(await getAzureCredential(makeDeps(send), "t1", "team-a")).toEqual(CRED);
+    const cmd = send.mock.calls[0][0] as GetParameterCommand;
+    expect(cmd.input.WithDecryption).toBe(true);
+  });
+
+  it("should accept config without the optional location", async () => {
+    const { location: _omit, ...noLoc } = CRED;
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify(noLoc) } });
+    expect(await getAzureCredential(makeDeps(send), "t1", "team-a")).toEqual(noLoc);
+  });
+
+  it("should return undefined when a required field is missing or malformed (fail-safe)", async () => {
+    for (const value of [
+      "not json",
+      JSON.stringify({ ...CRED, clientSecret: undefined }),
+      JSON.stringify({ ...CRED, subscriptionId: "" }),
+      JSON.stringify({ ...CRED, location: 123 }),
+      "null",
+    ]) {
+      const send = vi.fn().mockResolvedValue({ Parameter: { Value: value } });
+      expect(await getAzureCredential(makeDeps(send), "t", "team")).toBeUndefined();
+    }
+  });
+
+  it("should return undefined on ParameterNotFound (fail-closed)", async () => {
+    const send = vi.fn().mockRejectedValue(new ParameterNotFound({ message: "x", $metadata: {} }));
+    expect(await getAzureCredential(makeDeps(send), "t", "team")).toBeUndefined();
+  });
+
+  it("should put as a SecureString and round-trip", async () => {
+    let stored: string | undefined;
+    const send = vi.fn().mockImplementation((cmd) => {
+      if (cmd instanceof PutParameterCommand) {
+        stored = cmd.input.Value as string;
+        expect(cmd.input.Type).toBe("SecureString");
+        expect(cmd.input.Overwrite).toBe(true);
+        return Promise.resolve({});
+      }
+      return Promise.resolve({ Parameter: { Value: stored } });
+    });
+    const deps = makeDeps(send);
+    await putAzureCredential(deps, "t", "team", CRED);
+    expect(await getAzureCredential(deps, "t", "team")).toEqual(CRED);
+  });
+
+  it("should treat delete of a missing parameter as a no-op (idempotent)", async () => {
+    const send = vi.fn().mockRejectedValue(new ParameterNotFound({ message: "x", $metadata: {} }));
+    await expect(deleteAzureCredential(makeDeps(send), "t", "team")).resolves.toBeUndefined();
+  });
+});

--- a/infrastructure/test/problem-deploy/azure-entra-token-client.test.ts
+++ b/infrastructure/test/problem-deploy/azure-entra-token-client.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAzureEntraTokenClient } from "../../lib/problem-deploy/runtime-clients/azure-entra-token-client.js";
+
+/**
+ * [ADR-032 / #1410] Entra ID client_credentials token client の wire を pin。 fetch を mock し、
+ * token endpoint / form body (grant_type / client_id / client_secret / scope) / access_token 抽出 /
+ * 非2xx throw / access_token 欠落 throw を観測する。
+ */
+
+function client(fetchImpl: ReturnType<typeof vi.fn>) {
+  return createAzureEntraTokenClient({
+    authority: "https://login.test",
+    fetchImpl: fetchImpl as never,
+  });
+}
+
+const INPUT = { azureTenantId: "dir-1", clientId: "app-1", clientSecret: "shh" };
+
+describe("azure-entra-token-client (ADR-032 #1410)", () => {
+  it("should POST client_credentials to the tenant token endpoint and return the access_token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ access_token: "arm-token", token_type: "Bearer", expires_in: 3600 }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    const token = await client(fetchImpl).getToken(INPUT);
+    expect(token).toBe("arm-token");
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://login.test/dir-1/oauth2/v2.0/token");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    const params = new URLSearchParams(init.body);
+    expect(params.get("grant_type")).toBe("client_credentials");
+    expect(params.get("client_id")).toBe("app-1");
+    expect(params.get("client_secret")).toBe("shh");
+    expect(params.get("scope")).toBe("https://management.azure.com/.default");
+  });
+
+  it("should use a custom scope when provided", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "t" }), { status: 200 }));
+    await client(fetchImpl).getToken({ ...INPUT, scope: "https://graph.microsoft.com/.default" });
+    const params = new URLSearchParams(fetchImpl.mock.calls[0][1].body);
+    expect(params.get("scope")).toBe("https://graph.microsoft.com/.default");
+  });
+
+  it("should throw with the status on a non-2xx response", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("invalid_client", { status: 401 }));
+    await expect(client(fetchImpl).getToken(INPUT)).rejects.toThrow(/401/);
+  });
+
+  it("should throw when the response has no access_token", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token_type: "Bearer" }), { status: 200 }),
+      );
+    await expect(client(fetchImpl).getToken(INPUT)).rejects.toThrow(/missing access_token/);
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-runtime-dispatch.test.ts
@@ -234,3 +234,81 @@ describe("startDeployment sakura/apprun dispatch (ADR-026 / Issue #1412)", () =>
     expect(eventsSend).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * [ADR-032 / Issue #1410] azure/bicep dispatch wiring。 SSM (per-team Azure credential) + Entra token client
+ * が配線されたときだけ executable になり、 ARM Deployment Stacks REST へ deploy する (EventBridge は使わない)。
+ * config 未登録は loud throw、 SSM 未配線では reserved のまま。 verified-AWS-account gate は #1412 同様 follow-up。
+ */
+describe("startDeployment azure/bicep dispatch (ADR-032 / Issue #1410)", () => {
+  const azureRuntime: ProblemRuntime = { provider: "azure", engine: "bicep", entry: "main.json" };
+  const AZURE_CONFIG = {
+    azureTenantId: "dir-1",
+    clientId: "app-1",
+    clientSecret: "shh",
+    subscriptionId: "sub-1",
+    resourceGroup: "rg-1",
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  function ssmReturning(value: string | undefined): { send: ReturnType<typeof vi.fn> } {
+    return {
+      send: vi.fn(async (cmd: unknown) => {
+        if (cmd instanceof GetParameterCommand) {
+          return value === undefined
+            ? Promise.reject(Object.assign(new Error("nope"), { name: "ParameterNotFound" }))
+            : { Parameter: { Value: value } };
+        }
+        return {};
+      }),
+    };
+  }
+
+  it("should deploy via ARM (not EventBridge), resolving config from SSM + ARM token via the Entra client", async () => {
+    const armFetch = vi.fn().mockResolvedValueOnce(new Response("{}", { status: 200 })); // PUT deploymentStacks
+    vi.stubGlobal("fetch", armFetch);
+    const tokenClient = { getToken: vi.fn().mockResolvedValue("arm-token") };
+    const { ctx, putSend, eventsSend } = buildContext({
+      ssm: ssmReturning(JSON.stringify(AZURE_CONFIG)) as unknown as DeployContext["ssm"],
+      azureEntraTokenClient: tokenClient as unknown as DeployContext["azureEntraTokenClient"],
+      resolveProblemRuntime: () => azureRuntime,
+    });
+    const res = await startDeployment(ctx, sampleRequest());
+    expect(res.status).toBe("PENDING");
+    expect(tokenClient.getToken).toHaveBeenCalledWith(
+      expect.objectContaining({ azureTenantId: "dir-1", clientId: "app-1", clientSecret: "shh" }),
+    );
+    expect(armFetch).toHaveBeenCalledTimes(1);
+    expect(armFetch.mock.calls[0][1].method).toBe("PUT");
+    expect(eventsSend).not.toHaveBeenCalled();
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(true);
+  });
+
+  it("should throw loudly when no Azure credential is registered", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+    const tokenClient = { getToken: vi.fn() };
+    const { ctx } = buildContext({
+      ssm: ssmReturning(undefined) as unknown as DeployContext["ssm"],
+      azureEntraTokenClient: tokenClient as unknown as DeployContext["azureEntraTokenClient"],
+      resolveProblemRuntime: () => azureRuntime,
+    });
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(/no Azure credential/);
+    expect(tokenClient.getToken).not.toHaveBeenCalled();
+  });
+
+  it("should stay reserved (RuntimeNotSupportedError) for azure/bicep when SSM is not wired", async () => {
+    const { ctx, putSend, eventsSend } = buildContext({
+      resolveProblemRuntime: () => azureRuntime,
+    });
+    await expect(startDeployment(ctx, sampleRequest())).rejects.toBeInstanceOf(
+      RuntimeNotSupportedError,
+    );
+    expect(putSend.mock.calls.some((c) => c[0] instanceof PutCommand)).toBe(false);
+    expect(eventsSend).not.toHaveBeenCalled();
+  });
+});

--- a/infrastructure/test/problem-deploy/secure-json-store.test.ts
+++ b/infrastructure/test/problem-deploy/secure-json-store.test.ts
@@ -1,0 +1,68 @@
+import {
+  type GetParameterCommand,
+  ParameterNotFound,
+  type PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import { describe, expect, it, vi } from "vitest";
+import { createSecureJsonStore } from "../../lib/problem-deploy/handlers/shared/secure-json-store.js";
+
+/**
+ * [ADR-026/027 / #1412 #1410] 汎用 SecureJsonStore の契約 pin (Sakura / Azure store が共有する DRY 基盤)。
+ * buildName / parse / serialize の注入が正しく get/put/delete に反映され、 not-found→undefined +
+ * idempotent delete + parse 委譲が成り立つことを観測する。
+ */
+
+interface Demo {
+  readonly a: string;
+}
+
+const store = createSecureJsonStore<Demo>({
+  buildName: (env, t, s) => `/${env}/x/${t}/${s}/demo`,
+  parse: (raw) => {
+    if (typeof raw !== "string") return undefined;
+    try {
+      const o = JSON.parse(raw) as { a?: unknown };
+      return typeof o.a === "string" ? { a: o.a } : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+  serialize: (v) => JSON.stringify(v),
+});
+
+const deps = (send: ReturnType<typeof vi.fn>) => ({ ssm: { send } as never, env: "dev" });
+
+describe("secure-json-store (shared)", () => {
+  it("should GET with decryption at the built path and delegate to parse", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify({ a: "hi" }) } });
+    expect(await store.get(deps(send), "t1", "team")).toEqual({ a: "hi" });
+    const cmd = send.mock.calls[0][0] as GetParameterCommand;
+    expect(cmd.input).toEqual({ Name: "/dev/x/t1/team/demo", WithDecryption: true });
+  });
+
+  it("should return undefined when parse rejects the stored value", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify({ a: 1 }) } });
+    expect(await store.get(deps(send), "t1", "team")).toBeUndefined();
+  });
+
+  it("should return undefined on ParameterNotFound (fail-closed)", async () => {
+    const send = vi.fn().mockRejectedValue(new ParameterNotFound({ message: "x", $metadata: {} }));
+    expect(await store.get(deps(send), "t", "team")).toBeUndefined();
+  });
+
+  it("should PUT as a SecureString with Overwrite, serialized", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await store.put(deps(send), "t", "team", { a: "v" });
+    const cmd = send.mock.calls[0][0] as PutParameterCommand;
+    expect(cmd.input.Type).toBe("SecureString");
+    expect(cmd.input.Overwrite).toBe(true);
+    expect(cmd.input.Value).toBe(JSON.stringify({ a: "v" }));
+  });
+
+  it("should treat delete of a missing parameter as idempotent and rethrow other errors", async () => {
+    const gone = vi.fn().mockRejectedValue(new ParameterNotFound({ message: "x", $metadata: {} }));
+    await expect(store.delete(deps(gone), "t", "team")).resolves.toBeUndefined();
+    const boom = vi.fn().mockRejectedValue(new Error("denied"));
+    await expect(store.delete(deps(boom), "t", "team")).rejects.toThrow("denied");
+  });
+});


### PR DESCRIPTION
## Summary

ADR-032 の決定どおり **azure/bicep を deploy-executable** にする。 Microsoft Entra ID は AWS-native の federation 経路を持たないため、 per-team app registration の **client secret を SSM SecureString 保管**し `client_credentials` grant で ARM token を得る (= ADR-026 Sakura stored-key 経路の再利用、 鍵レス OIDC issuer 化は将来アップグレード)。

### 変更
- **`shared/secure-json-store.ts` (新)** — per-team SecureString JSON store の汎用基盤 (`get`/`put`/`delete` + fail-safe parse + not-found→undefined + idempotent delete)。 `buildName` / `parse` / `serialize` を注入する factory (= Sakura / Azure store の **DRY 基盤**)。
- **`sakura-credential-store.ts` (refactor)** — 上記汎用 store を使うよう変更。 名前付き API + 振る舞い不変 (既存テスト全緑 = 回帰なし)。
- **`shared/azure-credential-store.ts` (新)** — per-team Azure deploy 設定 (`azureTenantId` / `clientId` / `clientSecret` / `subscriptionId` / `resourceGroup` / `location?`) を SecureString 保管。 必須 field 欠落は fail-safe parse で `undefined`。
- **`runtime-clients/azure-entra-token-client.ts` (新)** — `client_credentials` token client (`login.microsoftonline.com/{tenant}/oauth2/v2.0/token`、 form body、 `access_token` 抽出)。
- **`deploy.ts`** — `buildAzureAdapterContext` + `buildAdapterDependencies` の azure 分岐。 `getCredential` は config を SSM から引き未登録は **loud throw** → Entra token、 `client` は同 config の subscription/RG で Deployment Stacks REST client を束ねる (adapter の getCredential→client 順序を closure で活用)。
- **`deploy-api-lambda.ts`** — azure-credential path に `ssm:GetParameter` + `kms:Decrypt` を追加 (3 ARN を集約)。

## Test plan
- `secure-json-store.test.ts` (5、 汎用基盤) / `azure-credential-store.test.ts` (7、 path/ARN/必須field parse/round-trip/idempotent) / `azure-entra-token-client.test.ts` (4、 form body/access_token/throw)。
- `deploy-runtime-dispatch.test.ts` に azure dispatch 3: SSM+token client 配線時に ARM へ deploy (EventBridge 不使用) + config 未登録は loud throw + SSM 未配線は `RuntimeNotSupportedError`。
- `problem-deploy-backend-stack-lambdas.test.ts` に IAM 1: deploy Lambda policy に `tenants/*/teams/*/azure-credential` grant。
- infra 全体 2531 tests 緑、 typecheck / biome / harness (0 findings) / check-http-status / cdk synth / audit-deps 全緑。

## Regression analysis
- AWS / Sakura path 不変 (azure 分岐は `ctx.ssm` 配線 **かつ** runtime=azure/bicep のときのみ)。 既存テスト全緑。
- `sakura-credential-store` の汎用 store への refactor は名前付き API + 振る舞いを保持 (= 既存 Sakura テスト + deploy dispatch テストが回帰網)。
- `deploy-api-lambda` IAM は加算的 (3 ARN を 1 statement に集約)。

## Physical impact
- **UPDATE** (DeployApi Lambda): IAM policy が azure-credential SSM path への `ssm:GetParameter` + `kms:Decrypt` を取得。 Lambda bundle に Azure client/token-client 同梱。 新規 CFn resource の CREATE/REPLACE/DELETE は無し。

## 残る follow-up (#1410 内 / 別 issue)
- per-team onboarding (#1413): Azure app registration + secret の登録 UX。
- `getStatus`/`destroy`/`collectOutputs` の adapter 配線、 verified-account gate の provider 対応。
- 実 account での wire 照合 (ARM api-version / templateLink 形式)。

Relates #1410