### PR TITLE
feat(competitor-accounts): per-team cloud credential onboarding routes (sakura/azure/gcp) [#1413]

### DIFF
--- a/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/competitor-accounts-api-lambda.ts
@@ -10,7 +10,10 @@ import {
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
 } from "../utils/lambda-runtime.js";
+import { buildAzureCredentialParameterArnPattern } from "./handlers/shared/azure-credential-store.js";
 import { buildExternalIdParameterArnPattern } from "./handlers/shared/external-id-store.js";
+import { buildGcpCredentialParameterArnPattern } from "./handlers/shared/gcp-credential-store.js";
+import { buildSakuraCredentialParameterArnPattern } from "./handlers/shared/sakura-credential-store.js";
 
 export interface CompetitorAccountsApiLambdaProps {
   readonly competitorAccountsTable: Table;
@@ -86,11 +89,20 @@ export class CompetitorAccountsApiLambda extends Construct {
       stack.account,
       props.environmentName,
     );
+    // [ADR-026/027/032 / #1413] per-team cloud credential onboarding。 同 Lambda が TenantAdmin の
+    // register/rotate/revoke で sakura/azure/gcp の SecureString を Put/Delete/Get する。 ExternalId と
+    // 同じ prefix-scope (tenantId / teamSlug は wildcard) で最小権限を保つ。
+    const credentialSsmArns = [
+      ssmArn,
+      buildSakuraCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+      buildAzureCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+      buildGcpCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+    ];
     this.fn.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["ssm:GetParameter", "ssm:PutParameter", "ssm:DeleteParameter"],
-        resources: [ssmArn],
+        resources: credentialSsmArns,
       }),
     );
     // SSM SecureString は AWS managed key (alias/aws/ssm) で暗号化される。
@@ -108,7 +120,7 @@ export class CompetitorAccountsApiLambda extends Construct {
         resources: ["*"],
         conditions: {
           StringLike: {
-            "kms:EncryptionContext:PARAMETER_ARN": ssmArn,
+            "kms:EncryptionContext:PARAMETER_ARN": credentialSsmArns,
           },
         },
       }),

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { cors } from "hono/cors";
@@ -22,6 +22,12 @@ import {
   deleteCompetitorAccount,
   listCompetitorAccounts,
 } from "./store.js";
+import {
+  handleDeleteTeamCredential,
+  handleGetTeamCredentialStatus,
+  handleRegisterTeamCredential,
+  isTeamCredentialProvider,
+} from "./team-credentials-routes.js";
 import { CreateCompetitorAccountRequestSchema } from "./types.js";
 import {
   AssumeRoleSanityCheckFailedError,
@@ -303,6 +309,114 @@ app.delete("/admin/competitor-accounts/:awsAccountId", async (c) => {
     }
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[competitor-accounts] delete failed", { awsAccountId, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+// [ADR-026/027/032 / Issue #1413] per-team cloud credential onboarding (sakura/azure/gcp)。
+// TenantAdmin が非 AWS 問題の deploy 前に per-team 認証情報を SSM SecureString store に登録 / 失効する。
+// path: /admin/team-cloud-credentials/{provider}/{teamSlug}。 tenantId は JWT claim (body 非信頼)。
+const TEAM_SLUG_RE = /^[a-z0-9-]+$/;
+
+function resolveTeamCredentialParams(
+  c: Context,
+): { provider: "sakura" | "azure" | "gcp"; teamSlug: string } | { error: string } {
+  const provider = c.req.param("provider");
+  const teamSlug = c.req.param("teamSlug");
+  if (!provider || !isTeamCredentialProvider(provider)) return { error: "unknown_provider" };
+  if (!teamSlug || !TEAM_SLUG_RE.test(teamSlug)) return { error: "invalid_team_slug" };
+  return { provider, teamSlug };
+}
+
+app.put("/admin/team-cloud-credentials/:provider/:teamSlug", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
+  const params = resolveTeamCredentialParams(c);
+  if ("error" in params) return c.json({ error: params.error }, StatusCodes.BAD_REQUEST);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_body" }, StatusCodes.BAD_REQUEST);
+  }
+  const tenantId = resolveTenantId(c);
+  const audit = extractAuditContext(c);
+  try {
+    const result = await handleRegisterTeamCredential(
+      { shared },
+      params.provider,
+      tenantId,
+      params.teamSlug,
+      body,
+    );
+    void writeAuditEvent({
+      tenantId,
+      actor: audit.actor,
+      actorUsername: audit.actorUsername,
+      action: "register_team_cloud_credential",
+      outcome: result.status === StatusCodes.CREATED ? "success" : "error",
+      target: `${params.provider}:${params.teamSlug}`,
+      ipAddress: audit.ipAddress,
+      userAgent: audit.userAgent,
+      occurredAtMs: Date.now(),
+    });
+    return c.json(result.body as never, result.status as 201 | 400);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[team-credentials] register failed", {
+      provider: params.provider,
+      message,
+    });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.delete("/admin/team-cloud-credentials/:provider/:teamSlug", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
+  const params = resolveTeamCredentialParams(c);
+  if ("error" in params) return c.json({ error: params.error }, StatusCodes.BAD_REQUEST);
+  const tenantId = resolveTenantId(c);
+  const audit = extractAuditContext(c);
+  try {
+    const result = await handleDeleteTeamCredential(
+      { shared },
+      params.provider,
+      tenantId,
+      params.teamSlug,
+    );
+    void writeAuditEvent({
+      tenantId,
+      actor: audit.actor,
+      actorUsername: audit.actorUsername,
+      action: "revoke_team_cloud_credential",
+      outcome: "success",
+      target: `${params.provider}:${params.teamSlug}`,
+      ipAddress: audit.ipAddress,
+      userAgent: audit.userAgent,
+      occurredAtMs: Date.now(),
+    });
+    return c.json(result.body as never, result.status as 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[team-credentials] revoke failed", { provider: params.provider, message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/team-cloud-credentials/:provider/:teamSlug", async (c) => {
+  requireRole(c, [TENANT_ADMIN_ROLE]);
+  const params = resolveTeamCredentialParams(c);
+  if ("error" in params) return c.json({ error: params.error }, StatusCodes.BAD_REQUEST);
+  try {
+    const result = await handleGetTeamCredentialStatus(
+      { shared },
+      params.provider,
+      resolveTenantId(c),
+      params.teamSlug,
+    );
+    return c.json(result.body as never, result.status as 200);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[team-credentials] status failed", { provider: params.provider, message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/team-credentials-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/team-credentials-routes.ts
@@ -1,0 +1,141 @@
+import { StatusCodes } from "http-status-codes";
+import { z } from "zod";
+import {
+  type AzureDeployCredential,
+  deleteAzureCredential,
+  getAzureCredential,
+  putAzureCredential,
+} from "../shared/azure-credential-store.js";
+import {
+  deleteGcpCredential,
+  type GcpDeployCredential,
+  getGcpCredential,
+  putGcpCredential,
+} from "../shared/gcp-credential-store.js";
+import type { SakuraCredential } from "../shared/runtime/sakura-apprun-adapter.js";
+import {
+  deleteSakuraCredential,
+  getSakuraCredential,
+  putSakuraCredential,
+} from "../shared/sakura-credential-store.js";
+import type { SecureJsonStoreDeps } from "../shared/secure-json-store.js";
+
+/**
+ * [ADR-026/027/032 / Issue #1413] per-team cloud credential onboarding routes。
+ *
+ * 非 AWS の問題 (sakura/azure/gcp) を deploy する前に、 TenantAdmin が per-team の認証情報を SSM SecureString
+ * store ([[sakura-credential-store.ts]] / [[azure-credential-store.ts]] / [[gcp-credential-store.ts]]) に登録する
+ * 経路。 deploy worker の `getCredential` がこの store を引く ([[adapter-dependencies.ts]])。 本 module は
+ * provider 別の Zod 検証 + store 呼び出しだけを担い、 **secret は決して response に echo しない** (register は
+ * `{registered:true}`、 status は `{registered:boolean}` のみ)。 register は Overwrite なので rotation 兼用。
+ */
+
+const SakuraCredentialSchema = z
+  .object({ accessToken: z.string().min(1), accessTokenSecret: z.string().min(1) })
+  .strict();
+
+const AzureCredentialSchema = z
+  .object({
+    azureTenantId: z.string().min(1),
+    clientId: z.string().min(1),
+    clientSecret: z.string().min(1),
+    subscriptionId: z.string().min(1),
+    resourceGroup: z.string().min(1),
+    location: z.string().min(1).optional(),
+  })
+  .strict();
+
+const GcpCredentialSchema = z
+  .object({
+    wifAudience: z.string().min(1),
+    serviceAccountEmail: z.string().min(1),
+    projectId: z.string().min(1),
+    location: z.string().min(1),
+  })
+  .strict();
+
+export const TEAM_CREDENTIAL_PROVIDERS = ["sakura", "azure", "gcp"] as const;
+export type TeamCredentialProvider = (typeof TEAM_CREDENTIAL_PROVIDERS)[number];
+
+export function isTeamCredentialProvider(value: string): value is TeamCredentialProvider {
+  return (TEAM_CREDENTIAL_PROVIDERS as readonly string[]).includes(value);
+}
+
+export interface TeamCredentialDeps {
+  readonly shared: SecureJsonStoreDeps;
+}
+
+export interface TeamCredentialRouteResult {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+/**
+ * provider の credential を登録 / 上書き (= register + rotation)。 secret は response に含めない。
+ */
+export async function handleRegisterTeamCredential(
+  deps: TeamCredentialDeps,
+  provider: TeamCredentialProvider,
+  tenantId: string,
+  teamSlug: string,
+  rawBody: unknown,
+): Promise<TeamCredentialRouteResult> {
+  const store = deps.shared;
+  if (provider === "sakura") {
+    const parsed = SakuraCredentialSchema.safeParse(rawBody);
+    if (!parsed.success) return validationFailed(parsed.error.issues);
+    await putSakuraCredential(store, tenantId, teamSlug, parsed.data satisfies SakuraCredential);
+  } else if (provider === "azure") {
+    const parsed = AzureCredentialSchema.safeParse(rawBody);
+    if (!parsed.success) return validationFailed(parsed.error.issues);
+    await putAzureCredential(
+      store,
+      tenantId,
+      teamSlug,
+      parsed.data satisfies AzureDeployCredential,
+    );
+  } else {
+    const parsed = GcpCredentialSchema.safeParse(rawBody);
+    if (!parsed.success) return validationFailed(parsed.error.issues);
+    await putGcpCredential(store, tenantId, teamSlug, parsed.data satisfies GcpDeployCredential);
+  }
+  return { status: StatusCodes.CREATED, body: { registered: true, provider, teamSlug } };
+}
+
+/** provider の credential を削除 (= revoke / teardown)。 不在でも idempotent に 200。 */
+export async function handleDeleteTeamCredential(
+  deps: TeamCredentialDeps,
+  provider: TeamCredentialProvider,
+  tenantId: string,
+  teamSlug: string,
+): Promise<TeamCredentialRouteResult> {
+  const store = deps.shared;
+  if (provider === "sakura") await deleteSakuraCredential(store, tenantId, teamSlug);
+  else if (provider === "azure") await deleteAzureCredential(store, tenantId, teamSlug);
+  else await deleteGcpCredential(store, tenantId, teamSlug);
+  return { status: StatusCodes.OK, body: { deleted: true, provider, teamSlug } };
+}
+
+/**
+ * provider の credential が登録済かを返す。 **secret / config は返さず** `{registered}` だけ
+ * (= TenantAdmin が登録の有無を確認する用途、 値の漏洩を作らない)。
+ */
+export async function handleGetTeamCredentialStatus(
+  deps: TeamCredentialDeps,
+  provider: TeamCredentialProvider,
+  tenantId: string,
+  teamSlug: string,
+): Promise<TeamCredentialRouteResult> {
+  const store = deps.shared;
+  const registered =
+    provider === "sakura"
+      ? (await getSakuraCredential(store, tenantId, teamSlug)) !== undefined
+      : provider === "azure"
+        ? (await getAzureCredential(store, tenantId, teamSlug)) !== undefined
+        : (await getGcpCredential(store, tenantId, teamSlug)) !== undefined;
+  return { status: StatusCodes.OK, body: { provider, teamSlug, registered } };
+}
+
+function validationFailed(issues: unknown): TeamCredentialRouteResult {
+  return { status: StatusCodes.BAD_REQUEST, body: { error: "validation_failed", issues } };
+}

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -284,6 +284,15 @@ describe("ProblemDeployBackendStack (MVP-1) — Competitor Accounts API Lambda (
     );
   });
 
+  // [ADR-026/027/032 / #1413] per-team cloud credential onboarding は同 Lambda が sakura/azure/gcp の
+  // SecureString を Put/Delete/Get する。 3 provider 分の path prefix ARN が policy に乗っていること。
+  it("should grant SSM access on the per-team sakura/azure/gcp credential SecureString paths (#1413)", () => {
+    const serialized = JSON.stringify(tpl.findResources("AWS::IAM::Policy"));
+    expect(serialized).toContain("tenants/*/teams/*/sakura-api-key");
+    expect(serialized).toContain("tenants/*/teams/*/azure-credential");
+    expect(serialized).toContain("tenants/*/teams/*/gcp-credential");
+  });
+
   it("Phase 3.2 / Issue #603: ExternalIdAudit Lambda should run on rate(1 day) and have PutMetricData (namespace-scoped)", () => {
     // rate(1 day) schedule は Events rules test でも assert 済だが、ここでは
     // ExternalIdAudit 経路の代表 evidence (COMPETITOR_ACCOUNTS_TABLE_NAME env + namespace 絞り込み IAM) を pin する。

--- a/infrastructure/test/problem-deploy/team-credentials-routes.test.ts
+++ b/infrastructure/test/problem-deploy/team-credentials-routes.test.ts
@@ -1,0 +1,113 @@
+import { GetParameterCommand, ParameterNotFound, PutParameterCommand } from "@aws-sdk/client-ssm";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleDeleteTeamCredential,
+  handleGetTeamCredentialStatus,
+  handleRegisterTeamCredential,
+  isTeamCredentialProvider,
+} from "../../lib/problem-deploy/handlers/competitor-accounts-handler/team-credentials-routes.js";
+
+/**
+ * [ADR-032 / #1413] per-team cloud credential onboarding routes の振る舞い pin。 provider 別 Zod 検証 /
+ * store への SecureString Put / status は secret を echo しない / 不正 body は 400 / delete idempotent。
+ */
+
+function deps(send: ReturnType<typeof vi.fn>) {
+  return { shared: { ssm: { send } as never, env: "development" } };
+}
+
+const SAKURA = { accessToken: "tok", accessTokenSecret: "sec" };
+const AZURE = {
+  azureTenantId: "dir",
+  clientId: "app",
+  clientSecret: "shh",
+  subscriptionId: "sub",
+  resourceGroup: "rg",
+};
+const GCP = {
+  wifAudience: "//iam.googleapis.com/x/providers/aws",
+  serviceAccountEmail: "d@p.iam.gserviceaccount.com",
+  projectId: "proj",
+  location: "asia-northeast1",
+};
+
+describe("team-credentials-routes (ADR-032 #1413)", () => {
+  it("should recognize only sakura/azure/gcp as valid providers", () => {
+    expect(isTeamCredentialProvider("sakura")).toBe(true);
+    expect(isTeamCredentialProvider("azure")).toBe(true);
+    expect(isTeamCredentialProvider("gcp")).toBe(true);
+    expect(isTeamCredentialProvider("aws")).toBe(false);
+    expect(isTeamCredentialProvider("nope")).toBe(false);
+  });
+
+  it("should register a sakura credential as a SecureString at the per-team path", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const res = await handleRegisterTeamCredential(deps(send), "sakura", "t1", "team-a", SAKURA);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ registered: true, provider: "sakura", teamSlug: "team-a" });
+    const cmd = send.mock.calls[0][0] as PutParameterCommand;
+    expect(cmd).toBeInstanceOf(PutParameterCommand);
+    expect(cmd.input.Name).toBe("/development/tenants/t1/teams/team-a/sakura-api-key");
+    expect(cmd.input.Type).toBe("SecureString");
+  });
+
+  it("should register azure + gcp credentials at their own paths", async () => {
+    const sendA = vi.fn().mockResolvedValue({});
+    await handleRegisterTeamCredential(deps(sendA), "azure", "t1", "team-a", AZURE);
+    expect((sendA.mock.calls[0][0] as PutParameterCommand).input.Name).toBe(
+      "/development/tenants/t1/teams/team-a/azure-credential",
+    );
+    const sendG = vi.fn().mockResolvedValue({});
+    await handleRegisterTeamCredential(deps(sendG), "gcp", "t1", "team-a", GCP);
+    expect((sendG.mock.calls[0][0] as PutParameterCommand).input.Name).toBe(
+      "/development/tenants/t1/teams/team-a/gcp-credential",
+    );
+  });
+
+  it("should reject an invalid / incomplete body with 400 and never Put", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const res = await handleRegisterTeamCredential(
+      deps(send),
+      "sakura",
+      "t1",
+      "team-a",
+      { accessToken: "only" }, // missing accessTokenSecret
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toBe("validation_failed");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should reject unknown extra fields (strict schema)", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const res = await handleRegisterTeamCredential(deps(send), "sakura", "t1", "team-a", {
+      ...SAKURA,
+      injected: "x",
+    });
+    expect(res.status).toBe(400);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should report registered=true WITHOUT echoing the secret in status", async () => {
+    const send = vi.fn().mockResolvedValue({ Parameter: { Value: JSON.stringify(SAKURA) } });
+    const res = await handleGetTeamCredentialStatus(deps(send), "sakura", "t1", "team-a");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ provider: "sakura", teamSlug: "team-a", registered: true });
+    // secret は body に絶対出さない
+    expect(JSON.stringify(res.body)).not.toContain("sec");
+    expect(send.mock.calls[0][0]).toBeInstanceOf(GetParameterCommand);
+  });
+
+  it("should report registered=false when the credential is absent", async () => {
+    const send = vi.fn().mockRejectedValue(new ParameterNotFound({ message: "x", $metadata: {} }));
+    const res = await handleGetTeamCredentialStatus(deps(send), "azure", "t1", "team-a");
+    expect(res.body).toEqual({ provider: "azure", teamSlug: "team-a", registered: false });
+  });
+
+  it("should delete the credential idempotently", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const res = await handleDeleteTeamCredential(deps(send), "gcp", "t1", "team-a");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ deleted: true, provider: "gcp", teamSlug: "team-a" });
+  });
+});


### PR DESCRIPTION
## Summary

ADR-026/027/032: 非 AWS 問題 (sakura/azure/gcp) を deploy する前に、 TenantAdmin が **per-team の認証情報を SSM SecureString store に登録 / 失効する onboarding 経路**。 deploy worker の `getCredential` (`adapter-dependencies.ts`) がこの store を引くので、 これで「クラウドアカウント調達 → 鍵登録 → 非 AWS 問題 deploy」が API/画面から完結する (= 3 provider 実行可能化の最後の接続)。

### 変更
- **`handlers/competitor-accounts-handler/team-credentials-routes.ts` (新)** — provider 別 Zod 検証 + `put`/`delete`/`get{Sakura,Azure,Gcp}Credential` 呼び出し。 register/rotate (`Overwrite`) / revoke / status。 **secret は response に echo しない** (register=`{registered:true}`、 status=`{registered:boolean}` のみ = 値の漏洩を作らない)。
- **`index.ts`** — `PUT`/`DELETE`/`GET /admin/team-cloud-credentials/:provider/:teamSlug` を配線。 `TENANT_ADMIN_ROLE` 限定、 tenantId は JWT claim (body 非信頼)、 provider/teamSlug を validate、 register/revoke を audit log に記録。 unknown provider / invalid slug は 400。
- **`competitor-accounts-api-lambda.ts`** — IAM の `ssm:Get/Put/DeleteParameter` + `kms:Decrypt/GenerateDataKey` を sakura/azure/gcp の credential path に拡張 (ExternalId と同じ prefix-scope、 tenantId/teamSlug は wildcard、 最小権限)。

## Test plan
- `team-credentials-routes.test.ts` (8): provider 判定 / 3 provider の SecureString Put path / 不正 body 400 で Put しない / strict schema (extra field 拒否) / **status は secret を echo しない** / not-found→registered:false / idempotent delete。
- `problem-deploy-backend-stack-lambdas.test.ts` に IAM 1: CompetitorAccounts Lambda policy に sakura/azure/gcp credential path の grant。
- infra 全体 2554 tests 緑、 typecheck / biome / harness (0 findings) / check-http-status / cdk synth / audit-deps 全緑。

## Regression analysis
- 既存 competitor-accounts / SAML route は不変 (新 route + IAM 拡張は加算的)。 既存テスト全緑。
- credential stores (sakura #1651 / azure #1655 / gcp #1656) は既に main に存在。 本 PR はその登録 UX/API 側。
- `resolveTeamCredentialParams` は provider/teamSlug を validate してから dispatch (= 未知 provider / 不正 slug を fail-closed)。

## Physical impact
- **UPDATE** (CompetitorAccounts Lambda): IAM policy が 3 credential SSM path への `ssm:Get/Put/DeleteParameter` + `kms` を取得。 Lambda bundle に onboarding routes 同梱。 新規 CFn resource の CREATE/REPLACE/DELETE は無し。

## Follow-up (本 PR scope 外)
- application-admin-console の登録 UX (本 PR は API = observable slice)。
- verified-AWS-account gate の provider 対応 / 非 AWS の status-destroy adapter 配線 / 実 cloud 照合。

Relates #1413