### PR TITLE
feat(problem-deploy): non-AWS teardown via adapter.destroy + persist runtime on deployment row [#1410 #1411 #1412]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -6,8 +6,16 @@ import {
   EVENT_DETAIL_TYPE_DEPLOY_DELETE_REQUESTED,
   publishProblemEvent,
 } from "../shared/events.js";
+import {
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  type ProblemRuntime,
+  selectAdapter,
+} from "../shared/runtime/index.js";
 import { logDeployTrace } from "../shared/trace-log.js";
+import { buildAdapterDependencies } from "./adapter-dependencies.js";
 import type { DeploySharedResources } from "./deploy.js";
+import { slugify } from "./naming.js";
 import type { DeploymentItem, DeploymentStatus } from "./types.js";
 
 export type TeardownOutcome =
@@ -46,6 +54,13 @@ export async function requestTeardown(
   if (item.tenantId !== tenantId) return { kind: "not_found" };
   const status = (item.status ?? "PENDING") as DeploymentStatus;
   if (status === "DELETING" || status === "DELETED") return { kind: "already_deleted" };
+
+  // [ADR-026/027/032 / #1410-1412] 非 AWS runtime (sakura/azure/gcp) は CFn DeleteStack ではなく
+  // adapter.destroy (cloud REST) で teardown する。 runtimeProvider が無い行は従来どおり AWS/CFn 経路。
+  const runtime = resolveItemRuntime(item);
+  if (runtime.provider !== EXECUTABLE_PROVIDER || runtime.engine !== EXECUTABLE_ENGINE) {
+    return teardownViaAdapter(shared, tenantId, jobId, item, runtime, status, nowMs);
+  }
 
   const region = String(item.region ?? "");
   const awsAccountId = String(item.awsAccountId ?? "");
@@ -89,6 +104,70 @@ export async function requestTeardown(
   await publishTeardown(shared, tenantId, nowMs, detail);
 
   return { kind: "accepted", previousStatus: status };
+}
+
+/** deployment 行から runtime を復元する。 runtimeProvider/Engine/Entry が無ければ aws/cloudformation (legacy)。 */
+function resolveItemRuntime(item: Partial<DeploymentItem>): ProblemRuntime {
+  if (item.runtimeProvider && item.runtimeEngine && item.runtimeEntry) {
+    return {
+      provider: item.runtimeProvider,
+      engine: item.runtimeEngine,
+      entry: item.runtimeEntry,
+    };
+  }
+  return { provider: EXECUTABLE_PROVIDER, engine: EXECUTABLE_ENGINE, entry: "template.yaml" };
+}
+
+/**
+ * [ADR-026/027/032 / #1410-1412] 非 AWS runtime の teardown。 status を DELETING に倒し、 adapter.destroy で
+ * cloud REST 削除を enqueue する (EventBridge / CFn は使わない)。 DELETED への最終遷移は status polling
+ * (adapter.getStatus → destroyed) が確定する想定 (= AWS の State Machine 確定と同じ非同期セマンティクス)。
+ * adapter.destroy 失敗時は DELETING → FAILED に巻き戻す (= AWS publish 失敗時と同じ補償)。
+ */
+async function teardownViaAdapter(
+  shared: DeploySharedResources,
+  tenantId: string,
+  jobId: string,
+  item: Partial<DeploymentItem>,
+  runtime: ProblemRuntime,
+  previousStatus: DeploymentStatus,
+  nowMs: number,
+): Promise<TeardownOutcome> {
+  const updatedAt = new Date(nowMs).toISOString();
+  const transition = await transitionTeardownToDeleting(shared, tenantId, jobId, updatedAt, nowMs);
+  if (transition) return transition;
+
+  const teamSlug = slugify(String(item.teamName ?? ""));
+  const adapter = selectAdapter(
+    runtime,
+    buildAdapterDependencies({ ...shared, tenantId }, runtime, teamSlug),
+  );
+  try {
+    await adapter.destroy({
+      jobId,
+      namePrefix: String(item.namePrefix ?? ""),
+      region: String(item.region ?? ""),
+      awsAccountId: String(item.awsAccountId ?? ""),
+    });
+  } catch (err) {
+    await compensateFailedTeardownPublish(
+      shared,
+      tenantId,
+      jobId,
+      nowMs,
+      `Failed to destroy ${runtime.provider}/${runtime.engine} runtime`,
+    );
+    throw err;
+  }
+  logDeployTrace("deploy.delete.adapter.enqueued", {
+    jobId,
+    correlationId: jobId,
+    tenantId,
+    provider: runtime.provider,
+    engine: runtime.engine,
+    namePrefix: String(item.namePrefix ?? ""),
+  });
+  return { kind: "accepted", previousStatus };
 }
 
 function missingTeardownFields(fields: {
@@ -176,6 +255,7 @@ async function compensateFailedTeardownPublish(
   tenantId: string,
   jobId: string,
   nowMs: number,
+  reason = "Failed to publish DeployDeleteRequested event",
 ): Promise<void> {
   try {
     await shared.ddb.send(
@@ -191,7 +271,7 @@ async function compensateFailedTeardownPublish(
           ":failed": "FAILED",
           ":deleting": "DELETING",
           ":updatedAt": new Date(nowMs).toISOString(),
-          ":reason": "Failed to publish DeployDeleteRequested event",
+          ":reason": reason,
           ":tenantId": tenantId,
           ":expiresAt": deploymentTerminalExpiresAt(nowMs),
         },

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -100,6 +100,23 @@ const DEFAULT_TTL_MS = 8 * 60 * 60 * 1000;
 
 const toEpochSeconds = (ms: number): number => Math.floor(ms / 1000);
 
+/**
+ * [ADR-026/027/032 / #1410-1412] 非 AWS runtime のときだけ provider/engine/entry を DeploymentItem に
+ * 載せる (= teardown / status の adapter 経路判別)。 AWS/CFn は field を載せず従来行と byte-identical。
+ */
+function runtimeItemFields(
+  runtime: ProblemRuntime,
+): Pick<DeploymentItem, "runtimeProvider" | "runtimeEngine" | "runtimeEntry"> {
+  if (runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE) {
+    return {};
+  }
+  return {
+    runtimeProvider: runtime.provider,
+    runtimeEngine: runtime.engine,
+    runtimeEntry: runtime.entry,
+  };
+}
+
 export class UnknownProblemError extends Error {
   constructor(problemId: string) {
     super(`unknown problemId: ${problemId}`);
@@ -190,6 +207,9 @@ export async function startDeployment(
     expiresAt,
     accountGroupId: request.accountGroupId,
     problemSetId: request.problemSetId,
+    // [ADR-026/027/032 / #1410-1412] 非 AWS runtime のときだけ provider/engine/entry を永続化する
+    // (= teardown / status が adapter 経由で動く判別。 AWS 行は従来どおり field なしで byte-identical)。
+    ...runtimeItemFields(runtime),
   };
 
   await ctx.ddb.send(

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -81,6 +81,15 @@ export interface DeploymentItem {
   teamLoginKey: string;
   status: DeploymentStatus;
 
+  /**
+   * [ADR-026/027/032 / #1410-1412] 非 AWS runtime の問題 (sakura/azure/gcp) を deploy したときの
+   * provider / engine / entry。 teardown / status が CFn 経由か adapter 経由かの判別に使う。
+   * **absent = aws/cloudformation** (legacy 行 / 既定。 = 従来どおり CFn 経路)。
+   */
+  runtimeProvider?: string;
+  runtimeEngine?: string;
+  runtimeEntry?: string;
+
   /** worker (CFn 起動側) が埋める */
   stackId?: string;
   /** Step Functions の CodeBuildStartBuild output (= `Build.Id`) から永続化する build ID。 */

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -1,6 +1,6 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requestTeardown } from "../../lib/problem-deploy/handlers/deploy-handler/delete";
 import type { DeploySharedResources } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
 
@@ -230,5 +230,86 @@ describe("requestTeardown", () => {
     const getCmd = ddbSend.mock.calls[0]?.[0] as GetCommand;
     expect(getCmd).toBeInstanceOf(GetCommand);
     expect(getCmd.input.Key).toEqual({ PK: "DEPLOYMENT#JOB42", SK: "META" });
+  });
+});
+
+/**
+ * [ADR-026/027/032 / #1410-1412] 非 AWS runtime (sakura/apprun) の teardown は CFn DeleteStack event を
+ * publish せず adapter.destroy (cloud REST) で削除する。 status は DELETING に倒し、 EventBridge は使わない。
+ */
+describe("requestTeardown (non-AWS runtime via adapter)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  function buildSakuraShared(): {
+    shared: DeploySharedResources;
+    ddbSend: ReturnType<typeof vi.fn>;
+    eventsSend: ReturnType<typeof vi.fn>;
+    ssmSend: ReturnType<typeof vi.fn>;
+  } {
+    const ddbSend = vi.fn();
+    const eventsSend = vi.fn();
+    const ssmSend = vi.fn(async () => ({
+      Parameter: { Value: JSON.stringify({ accessToken: "tok", accessTokenSecret: "sec" }) },
+    }));
+    const shared = {
+      tableName: "TestDeployments",
+      competitorAccountsTableName: "TestCompetitorAccounts",
+      env: "development",
+      eventBusName: "test-bus",
+      ddb: { send: ddbSend } as unknown as DeploySharedResources["ddb"],
+      events: { send: eventsSend } as unknown as DeploySharedResources["events"],
+      problemsCatalog: {},
+      ssm: { send: ssmSend },
+    } as unknown as DeploySharedResources;
+    return { shared, ddbSend, eventsSend, ssmSend };
+  }
+
+  const sakuraRow = (over: Record<string, unknown> = {}) => ({
+    ...sampleRow(),
+    runtimeProvider: "sakura",
+    runtimeEngine: "apprun",
+    runtimeEntry: "registry/img:1",
+    ...over,
+  });
+
+  it("should transition DELETING + call adapter.destroy (AppRun REST) without publishing a CFn delete event", async () => {
+    const { shared, ddbSend, eventsSend, ssmSend } = buildSakuraShared();
+    ddbSend.mockResolvedValueOnce({ Item: sakuraRow() }); // Get row
+    ddbSend.mockResolvedValueOnce({}); // transition → DELETING
+    // AppRun REST: findByName (list) → delete by id
+    const appRunFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ id: "a1", name: "tc-p-t" }] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", appRunFetch);
+
+    const res = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(res).toEqual({ kind: "accepted", previousStatus: "COMPLETE" });
+    // DELETING transition は走る
+    expect(ddbSend.mock.calls.some((c) => c[0] instanceof UpdateCommand)).toBe(true);
+    // CFn delete event は publish しない
+    expect(eventsSend).not.toHaveBeenCalled();
+    // SSM から鍵を引き AppRun REST を叩いた (list + DELETE)
+    expect(ssmSend).toHaveBeenCalled();
+    expect(appRunFetch.mock.calls[1][1].method).toBe("DELETE");
+  });
+
+  it("should compensate to FAILED when adapter.destroy throws", async () => {
+    const { shared, ddbSend, eventsSend } = buildSakuraShared();
+    ddbSend.mockResolvedValueOnce({ Item: sakuraRow() }); // Get
+    ddbSend.mockResolvedValueOnce({}); // DELETING
+    ddbSend.mockResolvedValueOnce({}); // compensation → FAILED
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(new Response("boom", { status: 500 })), // list 失敗
+    );
+    await expect(requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS)).rejects.toThrow();
+    expect(eventsSend).not.toHaveBeenCalled();
+    // 補償 Update (DELETING → FAILED) が走った (= orphan 防止)
+    const updates = ddbSend.mock.calls.filter((c) => c[0] instanceof UpdateCommand);
+    expect(updates.length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

非 AWS runtime (sakura/azure/gcp) の deploy は CFn ではなく adapter 経由なので、 teardown も CFn DeleteStack event ではなく `adapter.destroy` (cloud REST) で削除する必要がある。 lifecycle 配線の最初のスライス (teardown)。

### 変更
- **`types.ts`** — `DeploymentItem` に `runtimeProvider` / `runtimeEngine` / `runtimeEntry` (optional) を追加。 **absent = aws/cloudformation** (legacy 行 / 既定 = 従来どおり CFn 経路)。
- **`deploy.ts`** — 非 AWS runtime のときだけ `runtimeItemFields()` で provider/engine/entry を行に永続化 (AWS 行は field 無しで byte-identical)。 `startDeployment` の complexity を保つため helper に切出し。
- **`delete.ts` `requestTeardown`** — 行から runtime を復元し、 非 AWS なら `teardownViaAdapter` へ分岐: status を DELETING に倒し (既存 transition 再利用)、 `buildAdapterDependencies` + `selectAdapter` で `adapter.destroy({jobId, namePrefix, region, awsAccountId})` を呼ぶ。 **EventBridge / CFn event は使わない**。 DELETED 最終遷移は status polling (`adapter.getStatus`→destroyed) が確定する想定 (= AWS の State Machine 確定と同じ非同期セマンティクス、 status-polling 配線は follow-up)。 `adapter.destroy` 失敗時は DELETING→FAILED に補償 (orphan 防止)。 `compensateFailedTeardownPublish` を reason param 化。

## Test plan
- `deploy-delete.test.ts` に非 AWS 2 件: sakura 行の teardown が DELETING transition + `adapter.destroy` (AppRun REST: list + DELETE) を呼び **CFn delete event を publish しない** / `adapter.destroy` throw 時に DELETING→FAILED 補償。
- 既存 teardown テスト (AWS 経路) 全緑 (= runtimeProvider 無し行は従来どおり)。
- infra 全体 2556 tests 緑、 typecheck / biome / harness (0 findings) / cdk synth / audit-deps 緑 (pre-commit gate)。

## Regression analysis
- 分岐は `runtimeProvider` が非 aws のときのみ。 既存行 (runtimeProvider 無し) / AWS 問題は `resolveItemRuntime` が aws/cloudformation を返し従来の CFn delete event 経路に倒れる (= byte-identical)。
- deploy 行への runtime field 追加は非 AWS のときだけ (AWS 行不変)。 既存 deploy テスト全緑。
- `compensateFailedTeardownPublish` の reason param は default 値で従来挙動を保つ。

## Physical impact
- **NO-OP** (CFn / artifact 変更なし)。 DeploymentItem に optional field 追加 + handler logic のみ。 DDB schema は schemaless なので migration 不要。

## Follow-up
- 非 AWS の `getStatus` (status polling → DELETED 確定 / READY 判定) + `collectOutputs` (scoring) 配線。
- frontend 登録 UX (#1413、 client 層 stash 済)。

Relates #1410
Relates #1411
Relates #1412