### PR TITLE
feat(generic-scoring): non-AWS runtime status reconciler (status/outputs) [#1410 #1411 #1412]

### DIFF
--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -1,8 +1,9 @@
 import * as path from "node:path";
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import type { ITable } from "aws-cdk-lib/aws-dynamodb";
 import { type IEventBus, Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -11,6 +12,9 @@ import {
   LAMBDA_NODEJS_RUNTIME,
   LAMBDA_SOURCE_MAP_ENABLED,
 } from "../utils/lambda-runtime.js";
+import { buildAzureCredentialParameterArnPattern } from "./handlers/shared/azure-credential-store.js";
+import { buildGcpCredentialParameterArnPattern } from "./handlers/shared/gcp-credential-store.js";
+import { buildSakuraCredentialParameterArnPattern } from "./handlers/shared/sakura-credential-store.js";
 
 export interface GenericScoringLambdaProps {
   readonly deploymentsTable: ITable;
@@ -51,6 +55,11 @@ export interface GenericScoringLambdaProps {
    * scoring Lambda に `events:PutEvents` を least-privilege で付与する。
    */
   readonly eventBus: IEventBus;
+  /**
+   * [ADR-026/027/032 / #1410-1412] SSM SecureString path 構築 + 非 AWS runtime status reconciler の
+   * credential 解決用の environment 名 (`/<env>/tenants/.../{sakura-api-key|azure-credential|gcp-credential}`)。
+   */
+  readonly environmentName: string;
 }
 
 /**
@@ -100,6 +109,8 @@ export class GenericScoringLambda extends Construct {
         PROBLEM_ENDPOINTS_TABLE_NAME: props.endpointsTable.tableName,
         // #1422: condition-triggered disruption の publish 先 (手動 fire と同じ deploy bus)。
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
+        // [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler の credential path 構築用。
+        DEPLOY_ENVIRONMENT: props.environmentName,
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -139,6 +150,32 @@ export class GenericScoringLambda extends Construct {
     // #1422: condition-triggered disruption を event bus に publish する (= events:PutEvents、
     // 当該 bus に scope された least-privilege)。
     props.eventBus.grantPutEventsTo(this.fn);
+
+    // [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler が per-team credential
+    // (sakura/azure/gcp SecureString) を decrypt 取得する。 deploy-api-lambda と同じ prefix-scope。
+    const stack = Stack.of(this);
+    const credentialSsmArns = [
+      buildSakuraCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+      buildAzureCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+      buildGcpCredentialParameterArnPattern(stack.region, stack.account, props.environmentName),
+    ];
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: credentialSsmArns,
+      }),
+    );
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: {
+          StringLike: { "kms:EncryptionContext:PARAMETER_ARN": credentialSsmArns },
+        },
+      }),
+    );
 
     // EventBridge `rate(1 minute)`. Lambda 自身の invoke 権限は LambdaFunction target が自動付与。
     new Rule(this, "Schedule", {

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -15,6 +15,7 @@ import { runAttackDetectionKind } from "./kinds/attack-detection.js";
 import { runPhasedPollingKind } from "./kinds/phased-polling.js";
 import { runUptimeFlatKind } from "./kinds/uptime-flat.js";
 import { runUptimeMultiKind } from "./kinds/uptime-multi.js";
+import { reconcileRuntimeStatuses } from "./runtime-status-reconciler.js";
 import { isScoringActive } from "./scoring-active.js";
 import {
   buildSharedResources,
@@ -66,6 +67,14 @@ export async function handler(): Promise<void> {
     });
   });
 
+  // [ADR-026/027/032 / #1410-1412] 非 AWS runtime (sakura/azure/gcp) deployment の status / outputs を
+  // adapter.getStatus / collectOutputs で reconcile (= State Machine が無いので tick が進める)。 採点と並列。
+  const runtimeReconcilePromise = reconcileRuntimeStatuses(shared, nowIso).catch((err) => {
+    console.warn("[generic-scoring] reconcileRuntimeStatuses failed", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+  });
+
   // metadata.json の `phases[]` は scoring とは別 field なので、 dispatcher で per-problemId
   // に展開する。Phase 3.B では `BATTLE_PROBLEMS_PHASES` env で渡す (= Lambda 配線で
   // discoverProblemsPhases から JSON 化)。env が無い場合は空 (= phases 無し)。
@@ -102,7 +111,7 @@ export async function handler(): Promise<void> {
     exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
 
-  await reconcilePromise;
+  await Promise.all([reconcilePromise, runtimeReconcilePromise]);
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/runtime-status-reconciler.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/runtime-status-reconciler.ts
@@ -1,0 +1,222 @@
+import type { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import type { SSMClient } from "@aws-sdk/client-ssm";
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  type AdapterDependencyConfig,
+  buildAdapterDependencies,
+} from "../deploy-handler/adapter-dependencies.js";
+import { slugify } from "../deploy-handler/naming.js";
+import type { DeploymentItem, DeploymentStatus } from "../deploy-handler/types.js";
+import {
+  EXECUTABLE_ENGINE,
+  EXECUTABLE_PROVIDER,
+  type ProblemRuntime,
+  type RuntimeStatus,
+  selectAdapter,
+} from "../shared/runtime/index.js";
+
+/**
+ * [ADR-026/027/032 / #1410-1412] 非 AWS runtime (sakura/azure/gcp) deployment の status reconciler。
+ *
+ * AWS は Step Functions State Machine が deploy 進捗を CFn から読み status / stackOutputs を書き戻すが、
+ * 非 AWS は同期 adapter.deploy で enqueue するだけなので status を進める主体が無い。 本 reconciler は
+ * generic-scoring の 1-min tick に相乗りし、 **active な非 AWS 行** (= runtimeProvider あり + status が
+ * 非終端) を scan して adapter.getStatus で cloud 状態を読み、 DeploymentStatus に射影して書き戻す。
+ * ready になったら adapter.collectOutputs で endpoint を stackOutputs に書き、 scoring が probe できるようにする。
+ *
+ * 既存行 (runtimeProvider 無し) / AWS 行は scan filter で除外され完全に従来どおり。 conditional update で
+ * 並行 teardown 等との race を弾く (= 期待 status と一致するときだけ書く)。
+ */
+
+/** 非終端の status (= reconcile 対象)。 終端 (DELETED/EXPIRED/AUTO_DELETED) は触らない。 */
+const RECONCILABLE_STATUSES: readonly DeploymentStatus[] = [
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "DELETING",
+];
+
+/** RuntimeStatus (adapter の 6-state) を DeploymentStatus に射影する。 */
+export function mapRuntimeStatus(status: RuntimeStatus): DeploymentStatus {
+  switch (status) {
+    case "ready":
+      return "COMPLETE";
+    case "failed":
+      return "FAILED";
+    case "destroying":
+      return "DELETING";
+    case "destroyed":
+      return "DELETED";
+    default:
+      // pending / deploying は IN_PROGRESS に倒す (= 採点 gate 前)。
+      return "IN_PROGRESS";
+  }
+}
+
+export interface RuntimeReconcileDeps {
+  readonly ddb: DynamoDBDocumentClient;
+  readonly deploymentsTableName: string;
+  readonly env: string;
+  readonly events: EventBridgeClient;
+  readonly eventBusName: string;
+  readonly ssm: Pick<SSMClient, "send">;
+  readonly sakuraAppRunBaseUrl?: string;
+}
+
+/** 行から runtime を復元 (= non-AWS のみ呼ばれる前提だが entry 欠落は undefined で skip)。 */
+function runtimeFromItem(item: Partial<DeploymentItem>): ProblemRuntime | undefined {
+  if (item.runtimeProvider && item.runtimeEngine && item.runtimeEntry) {
+    return {
+      provider: item.runtimeProvider,
+      engine: item.runtimeEngine,
+      entry: item.runtimeEntry,
+    };
+  }
+  return undefined;
+}
+
+function adapterConfig(deps: RuntimeReconcileDeps, tenantId: string): AdapterDependencyConfig {
+  return {
+    env: deps.env,
+    tenantId,
+    events: deps.events,
+    eventBusName: deps.eventBusName,
+    ssm: deps.ssm,
+    ...(deps.sakuraAppRunBaseUrl ? { sakuraAppRunBaseUrl: deps.sakuraAppRunBaseUrl } : {}),
+  };
+}
+
+/**
+ * 1 行を reconcile する。 getStatus で cloud 状態を読み、 変化があれば status を書き戻す。 ready なら
+ * collectOutputs で endpoint を stackOutputs に書く。 conditional update で並行更新との race を弾く。
+ */
+export async function reconcileRuntimeDeployment(
+  deps: RuntimeReconcileDeps,
+  item: Partial<DeploymentItem>,
+  nowIso: string,
+): Promise<void> {
+  const runtime = runtimeFromItem(item);
+  if (!runtime) return;
+  if (runtime.provider === EXECUTABLE_PROVIDER && runtime.engine === EXECUTABLE_ENGINE) return;
+  const jobId = item.jobId;
+  const tenantId = item.tenantId;
+  const currentStatus = item.status;
+  if (!jobId || !tenantId || !currentStatus) return;
+
+  const adapter = selectAdapter(
+    runtime,
+    buildAdapterDependencies(
+      adapterConfig(deps, tenantId),
+      runtime,
+      slugify(String(item.teamName ?? "")),
+    ),
+  );
+  const statusInput = {
+    jobId,
+    namePrefix: String(item.namePrefix ?? ""),
+    region: String(item.region ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
+  };
+  const runtimeStatus = await adapter.getStatus(statusInput);
+  const nextStatus = mapRuntimeStatus(runtimeStatus);
+
+  // ready のときは endpoint を集めて stackOutputs に書く (= scoring が probe できる)。
+  const outputs = runtimeStatus === "ready" ? await adapter.collectOutputs(statusInput) : undefined;
+  const stackOutputs = outputs ? JSON.stringify(outputs) : undefined;
+
+  // status も outputs も変化が無ければ書かない (= DDB write を抑える)。
+  if (nextStatus === currentStatus && stackOutputs === undefined) return;
+
+  await applyReconcileUpdate(deps, {
+    jobId,
+    tenantId,
+    currentStatus,
+    nextStatus,
+    stackOutputs,
+    nowIso,
+  });
+}
+
+interface ReconcileUpdate {
+  readonly jobId: string;
+  readonly tenantId: string;
+  readonly currentStatus: DeploymentStatus;
+  readonly nextStatus: DeploymentStatus;
+  readonly stackOutputs: string | undefined;
+  readonly nowIso: string;
+}
+
+/**
+ * status (+ ready なら stackOutputs) を conditional update で書き戻す。 並行 teardown / 他 tick との race は
+ * 読み取り時 status と一致する condition で弾き、 ConditionalCheckFailed は次 tick へ委ねて throw しない。
+ */
+async function applyReconcileUpdate(deps: RuntimeReconcileDeps, u: ReconcileUpdate): Promise<void> {
+  const sets = ["#s = :next", "updatedAt = :now"];
+  const values: Record<string, unknown> = {
+    ":next": u.nextStatus,
+    ":now": u.nowIso,
+    ":cur": u.currentStatus,
+    ":tenant": u.tenantId,
+  };
+  if (u.stackOutputs !== undefined) {
+    sets.push("stackOutputs = :outputs");
+    values[":outputs"] = u.stackOutputs;
+  }
+  try {
+    await deps.ddb.send(
+      new UpdateCommand({
+        TableName: deps.deploymentsTableName,
+        Key: { PK: `DEPLOYMENT#${u.jobId}`, SK: "META" },
+        UpdateExpression: `SET ${sets.join(", ")}`,
+        ConditionExpression: "tenantId = :tenant AND #s = :cur",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: values,
+      }),
+    );
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ConditionalCheckFailedException") return;
+    throw err;
+  }
+}
+
+/**
+ * active な非 AWS deployment を scan して 1 件ずつ reconcile する。 generic-scoring の tick に相乗り。
+ * 1 件の失敗は全体を止めない (= 次 tick で再評価)。 AWS 行 / runtimeProvider 無し行は filter で除外。
+ */
+export async function reconcileRuntimeStatuses(
+  deps: RuntimeReconcileDeps,
+  nowIso: string,
+): Promise<void> {
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await deps.ddb.send(
+      new ScanCommand({
+        TableName: deps.deploymentsTableName,
+        FilterExpression: "attribute_exists(runtimeProvider) AND #s IN (:p, :i, :c, :d)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":p": RECONCILABLE_STATUSES[0],
+          ":i": RECONCILABLE_STATUSES[1],
+          ":c": RECONCILABLE_STATUSES[2],
+          ":d": RECONCILABLE_STATUSES[3],
+        },
+        Limit: 200,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+    await Promise.all(
+      items.map((item) =>
+        reconcileRuntimeDeployment(deps, item, nowIso).catch((err) => {
+          console.warn("[runtime-reconciler] reconcile failed", {
+            jobId: item.jobId,
+            provider: item.runtimeProvider,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }),
+      ),
+    );
+    exclusiveStartKey = out.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { EventBridgeClient } from "@aws-sdk/client-eventbridge";
+import { SSMClient } from "@aws-sdk/client-ssm";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { getEnv } from "../../../helper-functions.js";
 import {
@@ -31,6 +32,13 @@ export interface GenericScoringSharedResources {
   /** [#1422] condition-triggered fire の publish 先 event bus (= 空なら発火 skip)。 */
   readonly eventBusName: string;
   readonly events: EventBridgeClient;
+  /**
+   * [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler が per-team credential を解決し
+   * adapter を組むための env / SSM client / AppRun base URL override。 absent runtime (= AWS) では未使用。
+   */
+  readonly env: string;
+  readonly ssm: SSMClient;
+  readonly sakuraAppRunBaseUrl?: string;
 }
 
 export function buildSharedResources(): GenericScoringSharedResources {
@@ -44,6 +52,11 @@ export function buildSharedResources(): GenericScoringSharedResources {
     problemsDisruptions: parseDisruptionsCatalogEnv(process.env.BATTLE_PROBLEMS_DISRUPTIONS),
     eventBusName: process.env.DEPLOY_EVENT_BUS_NAME ?? "",
     events: new EventBridgeClient({}),
+    // 非 AWS reconciler 専用 (= AWS only の運用では未使用)。 unset でも throw させず空文字に倒す
+    // (= 既存 scoring tick / test を壊さない)。 本番 Lambda は DEPLOY_ENVIRONMENT を必ず注入する。
+    env: process.env.DEPLOY_ENVIRONMENT ?? "",
+    ssm: new SSMClient({}),
+    sakuraAppRunBaseUrl: process.env.SAKURA_APPRUN_BASE_URL || undefined,
   };
 }
 

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -452,6 +452,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       // #1422 (ADR-013 Phase 2): condition-triggered disruption の eval + in-account 発火。
       problemsDisruptions: props.problemsDisruptions ?? {},
       eventBus,
+      // [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler の credential path 構築用。
+      environmentName: props.environmentName,
     });
     this.genericScoringLambda = genericScoring.fn;
 

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -170,6 +170,25 @@ describe("ProblemDeployBackendStack (MVP-1) — GenericScoring Lambda", () => {
     });
     expect(hasPutEvents).toBe(true);
   });
+
+  // [ADR-026/027/032 / #1410-1412] runtime status reconciler が非 AWS credential を decrypt 取得する。
+  it("should grant ssm:GetParameter on the per-team credential paths + DEPLOY_ENVIRONMENT env (#1410-1412)", () => {
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const genericScoring = Object.entries(functions).find(
+      ([name]) => name.includes("GenericScoring") && name.includes("Function"),
+    );
+    const vars =
+      (
+        genericScoring?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    expect(vars.DEPLOY_ENVIRONMENT).toBeDefined();
+    const policies = JSON.stringify(tpl.findResources("AWS::IAM::Policy"));
+    expect(policies).toContain("tenants/*/teams/*/sakura-api-key");
+    expect(policies).toContain("tenants/*/teams/*/azure-credential");
+    expect(policies).toContain("tenants/*/teams/*/gcp-credential");
+  });
 });
 
 describe("ProblemDeployBackendStack (MVP-1) — SystemAuditWriter Lambda (Issue #1034)", () => {

--- a/infrastructure/test/problem-deploy/generic-scoring-index.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-index.test.ts
@@ -16,6 +16,7 @@ const EVENTS_TABLE = "TestEvents";
 const mocks = vi.hoisted(() => ({
   buildSharedResources: vi.fn(),
   reconcileEventStatuses: vi.fn(),
+  reconcileRuntimeStatuses: vi.fn(),
   isScoringActive: vi.fn(),
   runUptimeFlatKind: vi.fn(),
   runUptimeMultiKind: vi.fn(),
@@ -31,6 +32,12 @@ vi.mock("../../lib/problem-deploy/handlers/generic-scoring-handler/event-reconci
   reconcileEventStatuses: mocks.reconcileEventStatuses,
   resolveEventStatusTransition: vi.fn(),
 }));
+vi.mock(
+  "../../lib/problem-deploy/handlers/generic-scoring-handler/runtime-status-reconciler",
+  () => ({
+    reconcileRuntimeStatuses: mocks.reconcileRuntimeStatuses,
+  }),
+);
 vi.mock("../../lib/problem-deploy/handlers/generic-scoring-handler/scoring-active", () => ({
   isScoringActive: mocks.isScoringActive,
 }));
@@ -121,6 +128,7 @@ beforeEach(() => {
   cfg.queryThrows = false;
   mocks.isScoringActive.mockReturnValue(true);
   mocks.reconcileEventStatuses.mockResolvedValue(undefined);
+  mocks.reconcileRuntimeStatuses.mockResolvedValue(undefined);
   mocks.runUptimeFlatKind.mockResolvedValue(EMPTY_RESULT);
   mocks.runUptimeMultiKind.mockResolvedValue(EMPTY_RESULT);
   mocks.runPhasedPollingKind.mockResolvedValue(EMPTY_RESULT);
@@ -151,6 +159,8 @@ describe("handler scan loop", () => {
     const scans = ddb.send.mock.calls.filter((c) => c[0] instanceof ScanCommand);
     expect(scans).toHaveLength(2);
     expect(mocks.reconcileEventStatuses).toHaveBeenCalledTimes(1);
+    // [#1410-1412] 非 AWS runtime reconciler も 1 tick で 1 回 await される。
+    expect(mocks.reconcileRuntimeStatuses).toHaveBeenCalledTimes(1);
   });
 
   it("should swallow a reconcile failure without throwing", async () => {

--- a/infrastructure/test/problem-deploy/runtime-status-reconciler.test.ts
+++ b/infrastructure/test/problem-deploy/runtime-status-reconciler.test.ts
@@ -1,0 +1,151 @@
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mapRuntimeStatus,
+  type RuntimeReconcileDeps,
+  reconcileRuntimeDeployment,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/runtime-status-reconciler.js";
+
+/**
+ * [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler の振る舞い pin。 RuntimeStatus→
+ * DeploymentStatus 射影 / sakura 行の getStatus→ready→COMPLETE + collectOutputs→stackOutputs /
+ * 無変化 skip / AWS・runtime 欠落 skip / race(ConditionalCheckFailed) を観測する。
+ */
+
+const NOW = "2026-06-03T00:00:00.000Z";
+const BASE = "https://apprun.test/api";
+
+function deps(
+  ddbSend: ReturnType<typeof vi.fn>,
+  ssmSend: ReturnType<typeof vi.fn>,
+): RuntimeReconcileDeps {
+  return {
+    ddb: { send: ddbSend } as never,
+    deploymentsTableName: "TestDeployments",
+    env: "development",
+    events: {} as never, // sakura adapter は aws field を使わない
+    eventBusName: "bus",
+    ssm: { send: ssmSend } as never,
+    sakuraAppRunBaseUrl: BASE,
+  };
+}
+
+const sakuraRow = (over: Record<string, unknown> = {}) => ({
+  PK: "DEPLOYMENT#J1",
+  SK: "META",
+  jobId: "J1",
+  tenantId: "t1",
+  teamName: "Team A",
+  namePrefix: "tc-p-team-a",
+  region: "ap-northeast-1",
+  awsAccountId: "999999999999",
+  status: "IN_PROGRESS",
+  runtimeProvider: "sakura",
+  runtimeEngine: "apprun",
+  runtimeEntry: "registry/img:1",
+  ...over,
+});
+
+describe("runtime-status-reconciler — mapRuntimeStatus", () => {
+  it("should map the 6 RuntimeStatus values to DeploymentStatus", () => {
+    expect(mapRuntimeStatus("ready")).toBe("COMPLETE");
+    expect(mapRuntimeStatus("failed")).toBe("FAILED");
+    expect(mapRuntimeStatus("destroying")).toBe("DELETING");
+    expect(mapRuntimeStatus("destroyed")).toBe("DELETED");
+    expect(mapRuntimeStatus("deploying")).toBe("IN_PROGRESS");
+    expect(mapRuntimeStatus("pending")).toBe("IN_PROGRESS");
+  });
+});
+
+describe("runtime-status-reconciler — reconcileRuntimeDeployment", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubSakuraFetch(status: string, publicUrl?: string) {
+    const app = {
+      id: "a1",
+      name: "tc-p-team-a",
+      status,
+      ...(publicUrl ? { public_url: publicUrl } : {}),
+    };
+    const fetchMock = vi.fn(async (url: string) =>
+      url.endsWith("/applications")
+        ? new Response(JSON.stringify({ data: [{ id: "a1", name: "tc-p-team-a" }] }), {
+            status: 200,
+          })
+        : new Response(JSON.stringify(app), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  const ssmCredential = () =>
+    vi.fn(async () => ({
+      Parameter: { Value: JSON.stringify({ accessToken: "tok", accessTokenSecret: "sec" }) },
+    }));
+
+  it("should write COMPLETE + stackOutputs when a sakura deployment becomes ready", async () => {
+    stubSakuraFetch("running", "https://app.apprun");
+    const ddbSend = vi.fn().mockResolvedValue({});
+    await reconcileRuntimeDeployment(deps(ddbSend, ssmCredential()), sakuraRow(), NOW);
+    const cmd = ddbSend.mock.calls[0]?.[0] as UpdateCommand;
+    expect(cmd).toBeInstanceOf(UpdateCommand);
+    expect(cmd.input.ExpressionAttributeValues?.[":next"]).toBe("COMPLETE");
+    expect(cmd.input.ExpressionAttributeValues?.[":cur"]).toBe("IN_PROGRESS");
+    expect(JSON.parse(cmd.input.ExpressionAttributeValues?.[":outputs"] as string)).toEqual({
+      BaseUrl: "https://app.apprun",
+    });
+    // race ガード: 読み取り時 status と一致する条件
+    expect(cmd.input.ConditionExpression).toContain("#s = :cur");
+  });
+
+  it("should NOT write when status is unchanged and not ready (deploying → IN_PROGRESS, same)", async () => {
+    stubSakuraFetch("provisioning"); // → deploying → IN_PROGRESS (= current)、 ready でないので outputs 無し
+    const ddbSend = vi.fn().mockResolvedValue({});
+    await reconcileRuntimeDeployment(deps(ddbSend, ssmCredential()), sakuraRow(), NOW);
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("should swallow ConditionalCheckFailed (concurrent teardown/tick race) without throwing", async () => {
+    stubSakuraFetch("running", "https://app.apprun");
+    const ddbSend = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("race"), { name: "ConditionalCheckFailedException" }),
+      );
+    await expect(
+      reconcileRuntimeDeployment(deps(ddbSend, ssmCredential()), sakuraRow(), NOW),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should skip AWS / runtime-less rows without calling the cloud (no fetch, no Update)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const ddbSend = vi.fn();
+    const ssmSend = vi.fn();
+    // runtimeProvider 無し (= legacy AWS 行)
+    await reconcileRuntimeDeployment(
+      deps(ddbSend, ssmSend),
+      {
+        ...sakuraRow(),
+        runtimeProvider: undefined,
+        runtimeEngine: undefined,
+        runtimeEntry: undefined,
+      },
+      NOW,
+    );
+    // 明示 aws/cloudformation
+    await reconcileRuntimeDeployment(
+      deps(ddbSend, ssmSend),
+      {
+        ...sakuraRow(),
+        runtimeProvider: "aws",
+        runtimeEngine: "cloudformation",
+        runtimeEntry: "template.yaml",
+      },
+      NOW,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

非 AWS runtime (sakura/azure/gcp) deployment は State Machine が無いので **status を進める主体が無かった**（deploy は同期 `adapter.deploy` で enqueue するだけ）。 generic-scoring の 1-min tick に相乗りする reconciler を追加し、 deploy 実行可能 → **scorable** まで完成させる（teardown は #1659 で完了済）。

### 変更
- **`runtime-status-reconciler.ts` (新)** — active な非 AWS 行（`runtimeProvider` あり + status 非終端）を scan し、 `adapter.getStatus` → `mapRuntimeStatus`（6-state → DeploymentStatus）で status を、 ready なら `adapter.collectOutputs` で endpoint を `stackOutputs` に書き戻す（= scoring が probe できる）。 conditional update で並行 teardown / 他 tick との race を弾き、 `ConditionalCheckFailed` は次 tick へ委ねて throw しない。
- **`shared.ts`** — `env` / `ssm` / `sakuraAppRunBaseUrl` を追加（`DEPLOY_ENVIRONMENT` は unset でも空文字に倒し、 既存 scoring tick / test を不変に保つ）。
- **`index.ts`** — `reconcileRuntimeStatuses` を `reconcileEventStatuses` と並列に `Promise.all` で await。
- **`generic-scoring-lambda.ts`** — `environmentName` prop + `DEPLOY_ENVIRONMENT` env + 非 AWS credential path への `ssm:GetParameter` + `kms:Decrypt`（deploy-api-lambda と同型の prefix-scope）。 stack が `environmentName` を配線。

## Test plan
- `runtime-status-reconciler.test.ts` (5): `mapRuntimeStatus` 6-state / sakura 行 ready→COMPLETE + collectOutputs→stackOutputs / 無変化 skip / `ConditionalCheckFailed` swallow / AWS・runtime 欠落 skip（fetch も Update も呼ばない）。
- `generic-scoring-index.test.ts` に runtime reconciler を mock + 1 tick で 1 回 await を pin。
- `problem-deploy-backend-stack-lambdas.test.ts` に IAM 1: scoring Lambda policy に 3 credential path + `DEPLOY_ENVIRONMENT` env。
- infra 全体 2562 tests 緑、 typecheck / biome / harness (exit 0) / check-http-status / cdk synth / audit-deps 緑。

## Regression analysis
- `runtimeProvider` 無し / AWS 行は scan FilterExpression（`attribute_exists(runtimeProvider)`）+ 早期 return で除外 → 従来 scoring tick は完全不変。 既存 scoring / dispatcher テスト全緑（reconciler を mock して隔離）。
- `DEPLOY_ENVIRONMENT` unset → 空文字（既存 tick/test を壊さない）。 本番 Lambda は env を必ず注入。
- conditional update（status = 読み取り時値）で teardown(#1659) / event-reconciler との並行更新を fail-safe に弾く。

## Physical impact
- **UPDATE** (GenericScoring Lambda): IAM policy が 3 credential SSM path への `ssm:GetParameter` + `kms:Decrypt` を取得、 `DEPLOY_ENVIRONMENT` env 追加、 bundle に reconciler 同梱。 新規 CFn resource の CREATE/REPLACE/DELETE は無し。

## 既知事項
- SigV4 / 実 cloud API の status mapping 正当性は実 account onboarding で照合（integration 相、 ADR-032）。
- `problem-deploy-backend-stack.ts` の file-too-large (575行) は本 PR 以前からの非 failing warning（別 SOLID 分割 issue）。

Relates #1410
Relates #1411
Relates #1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for non-AWS runtime provider credentials (Sakura, Azure, GCP) with secure encrypted parameter storage and fine-grained KMS-based access control.
  * Implemented status reconciliation for multi-cloud deployments to automatically track and sync runtime state changes.

* **Tests**
  * Added comprehensive test coverage for runtime status reconciliation and IAM credential access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->