### PR TITLE
feat(app-admin): per-team cloud credential onboarding UX [#1413]

### DIFF
--- a/apps/application-admin-console/src/api/client.ts
+++ b/apps/application-admin-console/src/api/client.ts
@@ -11,6 +11,7 @@ import type { AppConfig } from "../config";
 export interface ApiClient {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body: unknown): Promise<T>;
+  put<T>(path: string, body: unknown): Promise<T>;
   patch<T>(path: string, body: unknown): Promise<T>;
   del(path: string): Promise<void>;
   /** 削除系で JSON body を返す経路 (例: bulk teardown の集計結果)。 */
@@ -58,6 +59,11 @@ export function createApiClient(baseUrl: string, idToken: string): ApiClient {
     async post<T>(path: string, body: unknown): Promise<T> {
       return (
         await request(path, { method: "POST", body: JSON.stringify(body) })
+      ).json() as Promise<T>;
+    },
+    async put<T>(path: string, body: unknown): Promise<T> {
+      return (
+        await request(path, { method: "PUT", body: JSON.stringify(body) })
       ).json() as Promise<T>;
     },
     async patch<T>(path: string, body: unknown): Promise<T> {

--- a/apps/application-admin-console/src/api/team-credentials-client.ts
+++ b/apps/application-admin-console/src/api/team-credentials-client.ts
@@ -1,0 +1,56 @@
+import type { ApiClient } from "./client";
+
+/**
+ * [ADR-026/027/032 / Issue #1413] per-team cloud credential onboarding API client。
+ *
+ * tenant API の `/admin/team-cloud-credentials/{provider}/{teamSlug}` を叩く。 tenantId は JWT claim から
+ * backend が解決するので path / body には乗せない。 secret は register 時に送るだけで status では返らない
+ * (= backend が echo しない)。
+ */
+
+export const TEAM_CREDENTIAL_PROVIDERS = ["sakura", "azure", "gcp"] as const;
+export type TeamCredentialProvider = (typeof TEAM_CREDENTIAL_PROVIDERS)[number];
+
+export interface TeamCredentialStatus {
+  readonly provider: TeamCredentialProvider;
+  readonly teamSlug: string;
+  readonly registered: boolean;
+}
+
+export interface RegisterTeamCredentialResponse {
+  readonly registered: boolean;
+  readonly provider: TeamCredentialProvider;
+  readonly teamSlug: string;
+}
+
+function credentialPath(provider: TeamCredentialProvider, teamSlug: string): string {
+  return `admin/team-cloud-credentials/${encodeURIComponent(provider)}/${encodeURIComponent(teamSlug)}`;
+}
+
+/** provider の credential を登録 / 上書き (rotation 兼用)。 credential は provider 別の JSON。 */
+export async function registerTeamCredential(
+  api: ApiClient,
+  provider: TeamCredentialProvider,
+  teamSlug: string,
+  credential: Readonly<Record<string, unknown>>,
+): Promise<RegisterTeamCredentialResponse> {
+  return api.put<RegisterTeamCredentialResponse>(credentialPath(provider, teamSlug), credential);
+}
+
+/** provider の credential を失効 (revoke / teardown)。 */
+export async function revokeTeamCredential(
+  api: ApiClient,
+  provider: TeamCredentialProvider,
+  teamSlug: string,
+): Promise<void> {
+  return api.del(credentialPath(provider, teamSlug));
+}
+
+/** provider の credential が登録済かを取得 (= secret は返らない、 registered boolean のみ)。 */
+export async function getTeamCredentialStatus(
+  api: ApiClient,
+  provider: TeamCredentialProvider,
+  teamSlug: string,
+): Promise<TeamCredentialStatus> {
+  return api.get<TeamCredentialStatus>(credentialPath(provider, teamSlug));
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -634,5 +634,23 @@
     "secret_modal_manual_header": "Manual deploy details",
     "secret_modal_template_label": "CFn template",
     "secret_modal_manual_hint": "You can also pass the 3 values as Parameters to CloudFormation create-stack."
+  },
+  "team_cloud_credentials": {
+    "title": "Team cloud credentials (non-AWS runtimes)",
+    "description": "Before deploying non-AWS problems (Sakura / Azure / GCP), register each team's cloud credential. Secrets are stored encrypted as SSM SecureString and are never returned by listing. Re-register the same team to rotate.",
+    "provider_label": "Provider",
+    "team_label": "Team slug",
+    "team_description": "The slug derived from the team name at deploy time (lowercase, digits, hyphens).",
+    "team_invalid": "Use only lowercase letters, digits, and hyphens",
+    "credential_label": "Credential (JSON)",
+    "credential_description": "Provider-specific JSON. Sakura: {accessToken, accessTokenSecret} / Azure: {azureTenantId, clientId, clientSecret, subscriptionId, resourceGroup} / GCP: {wifAudience, serviceAccountEmail, projectId, location}.",
+    "register_button": "Register / Update",
+    "status_button": "Check status",
+    "revoke_button": "Revoke",
+    "invalid_json": "The credential JSON is invalid. Please enter valid JSON.",
+    "registered": "Registered (deploys will authenticate with this credential).",
+    "revoked": "Revoked.",
+    "status_registered": "Registered.",
+    "status_unregistered": "Not registered."
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -634,5 +634,23 @@
     "secret_modal_manual_header": "手動 deploy の詳細",
     "secret_modal_template_label": "CFn template",
     "secret_modal_manual_hint": "上記 3 値を Parameter として CloudFormation create-stack でも deploy できます。"
+  },
+  "team_cloud_credentials": {
+    "title": "Team クラウド認証情報 (非 AWS runtime)",
+    "description": "非 AWS の問題 (Sakura / Azure / GCP) を deploy する前に、 team ごとのクラウド認証情報を登録します。 secret は SSM SecureString に暗号化保存され、 一覧では返りません。 鍵を更新したい場合は同じ team に再登録してください (= rotation)。",
+    "provider_label": "プロバイダ",
+    "team_label": "Team slug",
+    "team_description": "deploy 時の team 名から生成される slug (小文字・数字・ハイフン)。",
+    "team_invalid": "小文字・数字・ハイフンのみで入力してください",
+    "credential_label": "認証情報 (JSON)",
+    "credential_description": "プロバイダ別の JSON。 Sakura: {accessToken, accessTokenSecret} / Azure: {azureTenantId, clientId, clientSecret, subscriptionId, resourceGroup} / GCP: {wifAudience, serviceAccountEmail, projectId, location}。",
+    "register_button": "登録 / 更新",
+    "status_button": "登録状況を確認",
+    "revoke_button": "失効",
+    "invalid_json": "認証情報 JSON が不正です。 正しい JSON を入力してください。",
+    "registered": "登録しました (deploy 時にこの鍵で認証されます)。",
+    "revoked": "失効しました。",
+    "status_registered": "登録済みです。",
+    "status_unregistered": "未登録です。"
   }
 }

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -17,6 +17,7 @@ import { AddAccountModal } from "./competitor-accounts/AddAccountModal";
 import { CompetitorAccountDeleteModal } from "./competitor-accounts/CompetitorAccountDeleteModal";
 import { CompetitorAccountsTable } from "./competitor-accounts/CompetitorAccountsTable";
 import { SecretRevealModal } from "./competitor-accounts/SecretRevealModal";
+import { TeamCloudCredentialsPanel } from "./competitor-accounts/TeamCloudCredentialsPanel";
 import { useCompetitorAccounts } from "./competitor-accounts/useCompetitorAccounts";
 
 export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
@@ -70,6 +71,9 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         onVerify={(awsAccountId) => void verify(awsAccountId)}
         onRequestDelete={setDeleteTarget}
       />
+
+      {/* [ADR-026/027/032 / #1413] 非 AWS 問題 (sakura/azure/gcp) の per-team 認証情報 onboarding。 */}
+      <TeamCloudCredentialsPanel config={config} />
 
       <AddAccountModal
         config={config}

--- a/apps/application-admin-console/src/pages/competitor-accounts/TeamCloudCredentialsPanel.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/TeamCloudCredentialsPanel.tsx
@@ -1,0 +1,173 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Textarea from "@cloudscape-design/components/textarea";
+import { useState } from "react";
+import { useApiClient } from "../../api/client";
+import {
+  getTeamCredentialStatus,
+  registerTeamCredential,
+  revokeTeamCredential,
+  type TeamCredentialProvider,
+} from "../../api/team-credentials-client";
+import { FriendlyErrorAlert } from "../../components/FriendlyErrorAlert";
+import type { AppConfig } from "../../config";
+import { useT } from "../../i18n";
+import { type FriendlyError, toFriendlyError } from "../../lib/friendly-error";
+
+/**
+ * [ADR-026/027/032 / Issue #1413] per-team cloud credential onboarding パネル。
+ *
+ * TenantAdmin が非 AWS 問題 (sakura/azure/gcp) を deploy する前に、 team の認証情報 (provider 別 JSON) を
+ * `PUT /admin/team-cloud-credentials/:provider/:teamSlug` で SSM SecureString store に登録 / 失効する。
+ * credential JSON の形は provider 別で backend が Zod 検証するため、 ここでは textarea で受ける
+ * (= per-provider field を画面側で持たず 2 重メンテを避ける)。 secret は送るだけで status では返らない。
+ */
+
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+const PROVIDER_OPTIONS: ReadonlyArray<{ value: TeamCredentialProvider; label: string }> = [
+  { value: "sakura", label: "Sakura (AppRun)" },
+  { value: "azure", label: "Azure (Deployment Stacks)" },
+  { value: "gcp", label: "GCP (Infrastructure Manager)" },
+];
+
+export function TeamCloudCredentialsPanel({ config }: { config: AppConfig }) {
+  const apiClient = useApiClient(config);
+  const t = useT();
+  const [provider, setProvider] = useState<TeamCredentialProvider>("sakura");
+  const [teamSlug, setTeamSlug] = useState("");
+  const [credentialJson, setCredentialJson] = useState("");
+  const [inFlight, setInFlight] = useState(false);
+  const [error, setError] = useState<FriendlyError | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const slugInvalid = teamSlug.length > 0 && !SLUG_RE.test(teamSlug);
+  const baseDisabled = !apiClient || inFlight || teamSlug.length === 0 || slugInvalid;
+  // provider は常に PROVIDER_OPTIONS の value のいずれか (= find は必ず一致する)。
+  const selectedOption = PROVIDER_OPTIONS.find((o) => o.value === provider) as {
+    value: TeamCredentialProvider;
+    label: string;
+  };
+
+  const run = async (fn: () => Promise<void>): Promise<void> => {
+    setInFlight(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await fn();
+    } catch (err) {
+      setError(toFriendlyError(err));
+    } finally {
+      setInFlight(false);
+    }
+  };
+
+  const handleRegister = async (): Promise<void> => {
+    // button は disabled={baseDisabled} (= !apiClient 含む) なので enabled 時のみ呼ばれる (= 防御的不到達)。
+    /* v8 ignore next */
+    if (!apiClient) return;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(credentialJson) as Record<string, unknown>;
+    } catch {
+      setError({ title: t("team_cloud_credentials.invalid_json") });
+      return;
+    }
+    await run(async () => {
+      await registerTeamCredential(apiClient, provider, teamSlug, parsed);
+      setNotice(t("team_cloud_credentials.registered"));
+    });
+  };
+
+  const handleRevoke = async (): Promise<void> => {
+    /* v8 ignore next */
+    if (!apiClient) return;
+    await run(async () => {
+      await revokeTeamCredential(apiClient, provider, teamSlug);
+      setNotice(t("team_cloud_credentials.revoked"));
+    });
+  };
+
+  const handleCheckStatus = async (): Promise<void> => {
+    /* v8 ignore next */
+    if (!apiClient) return;
+    await run(async () => {
+      const status = await getTeamCredentialStatus(apiClient, provider, teamSlug);
+      setNotice(
+        status.registered
+          ? t("team_cloud_credentials.status_registered")
+          : t("team_cloud_credentials.status_unregistered"),
+      );
+    });
+  };
+
+  return (
+    <Container header={<Header variant="h2">{t("team_cloud_credentials.title")}</Header>}>
+      <SpaceBetween size="m">
+        <Box color="text-body-secondary">{t("team_cloud_credentials.description")}</Box>
+        {error && <FriendlyErrorAlert error={error} />}
+        {notice && (
+          <Alert type="success" dismissible onDismiss={() => setNotice(null)}>
+            {notice}
+          </Alert>
+        )}
+        <FormField label={t("team_cloud_credentials.provider_label")}>
+          <Select
+            selectedOption={selectedOption}
+            options={PROVIDER_OPTIONS}
+            disabled={inFlight}
+            onChange={(e) => setProvider(e.detail.selectedOption.value as TeamCredentialProvider)}
+          />
+        </FormField>
+        <FormField
+          label={t("team_cloud_credentials.team_label")}
+          description={t("team_cloud_credentials.team_description")}
+          errorText={slugInvalid ? t("team_cloud_credentials.team_invalid") : undefined}
+        >
+          <Input
+            value={teamSlug}
+            onChange={(e) => setTeamSlug(e.detail.value)}
+            invalid={slugInvalid}
+            placeholder="team-a"
+            disabled={inFlight}
+          />
+        </FormField>
+        <FormField
+          label={t("team_cloud_credentials.credential_label")}
+          description={t("team_cloud_credentials.credential_description")}
+        >
+          <Textarea
+            value={credentialJson}
+            onChange={(e) => setCredentialJson(e.detail.value)}
+            placeholder='{"accessToken":"...","accessTokenSecret":"..."}'
+            disabled={inFlight}
+            rows={5}
+          />
+        </FormField>
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button
+            variant="primary"
+            loading={inFlight}
+            disabled={baseDisabled || credentialJson.length === 0}
+            onClick={() => void handleRegister()}
+          >
+            {t("team_cloud_credentials.register_button")}
+          </Button>
+          <Button disabled={baseDisabled} onClick={() => void handleCheckStatus()}>
+            {t("team_cloud_credentials.status_button")}
+          </Button>
+          <Button disabled={baseDisabled} onClick={() => void handleRevoke()}>
+            {t("team_cloud_credentials.revoke_button")}
+          </Button>
+        </SpaceBetween>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/apps/application-admin-console/test/api/client.test.ts
+++ b/apps/application-admin-console/test/api/client.test.ts
@@ -90,7 +90,22 @@ describe("createApiClient", () => {
     });
   });
 
-  describe("PATCH / DELETE verbs", () => {
+  describe("PUT / PATCH / DELETE verbs", () => {
+    it("should send PUT with a JSON body and return the parsed response", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ registered: true }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = await createApiClient(config.apiBaseUrl, "T").put<{ registered: boolean }>(
+        "admin/team-cloud-credentials/sakura/team-a",
+        { accessToken: "x" },
+      );
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+      expect(init.method).toBe("PUT");
+      expect(init.body).toBe('{"accessToken":"x"}');
+      expect(res).toEqual({ registered: true });
+    });
+
     it("should send PATCH with a JSON body", async () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
       vi.stubGlobal("fetch", fetchMock);

--- a/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
+++ b/apps/application-admin-console/test/api/competitor-accounts-client.test.ts
@@ -20,6 +20,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
       calls.push({ path, method: "GET" });
       return Promise.resolve(response);
     }),
+    put: vi.fn().mockResolvedValue(response),
     post: vi.fn().mockImplementation((path: string, body: unknown) => {
       calls.push({ path, method: "POST", body });
       return Promise.resolve(response);

--- a/apps/application-admin-console/test/api/deploy-client.test.ts
+++ b/apps/application-admin-console/test/api/deploy-client.test.ts
@@ -30,6 +30,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
       calls.push({ path, method: "POST", body });
       return Promise.resolve(response);
     }),
+    put: vi.fn().mockResolvedValue(response),
     patch: vi.fn().mockImplementation((path: string, body: unknown) => {
       calls.push({ path, method: "PATCH", body });
       return Promise.resolve(response);

--- a/apps/application-admin-console/test/api/events-client.test.ts
+++ b/apps/application-admin-console/test/api/events-client.test.ts
@@ -32,6 +32,7 @@ function fakeClient(response: unknown): { client: ApiClient; calls: CapturedCall
       calls.push({ path, method: "POST", body });
       return Promise.resolve(response);
     }),
+    put: vi.fn().mockResolvedValue(response),
     patch: vi.fn().mockImplementation((path: string, body: unknown) => {
       calls.push({ path, method: "PATCH", body });
       return Promise.resolve(response);

--- a/apps/application-admin-console/test/api/team-credentials-client.test.ts
+++ b/apps/application-admin-console/test/api/team-credentials-client.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../src/api/client";
+import {
+  getTeamCredentialStatus,
+  registerTeamCredential,
+  revokeTeamCredential,
+} from "../../src/api/team-credentials-client";
+
+/**
+ * [ADR-032 / #1413] team cloud credential API client の path / body / verb を pin。
+ */
+
+function fakeClient(getResponse: unknown = {}) {
+  const put = vi
+    .fn()
+    .mockResolvedValue({ registered: true, provider: "sakura", teamSlug: "team-a" });
+  const del = vi.fn().mockResolvedValue(undefined);
+  const get = vi.fn().mockResolvedValue(getResponse);
+  const client = { put, del, get } as unknown as ApiClient;
+  return { client, put, del, get };
+}
+
+describe("team-credentials-client (ADR-032 #1413)", () => {
+  it("should PUT the credential to the per-team provider path (register/rotate)", async () => {
+    const { client, put } = fakeClient();
+    const res = await registerTeamCredential(client, "sakura", "team-a", { accessToken: "x" });
+    expect(res.registered).toBe(true);
+    expect(put).toHaveBeenCalledWith("admin/team-cloud-credentials/sakura/team-a", {
+      accessToken: "x",
+    });
+  });
+
+  it("should encode provider + teamSlug into the path", async () => {
+    const { client, put } = fakeClient();
+    await registerTeamCredential(client, "azure", "team a/b", { clientId: "c" });
+    expect(put).toHaveBeenCalledWith("admin/team-cloud-credentials/azure/team%20a%2Fb", {
+      clientId: "c",
+    });
+  });
+
+  it("should DELETE for revoke", async () => {
+    const { client, del } = fakeClient();
+    await revokeTeamCredential(client, "gcp", "team-a");
+    expect(del).toHaveBeenCalledWith("admin/team-cloud-credentials/gcp/team-a");
+  });
+
+  it("should GET the status (registered boolean, no secret)", async () => {
+    const { client, get } = fakeClient({
+      provider: "sakura",
+      teamSlug: "team-a",
+      registered: true,
+    });
+    const status = await getTeamCredentialStatus(client, "sakura", "team-a");
+    expect(status.registered).toBe(true);
+    expect(get).toHaveBeenCalledWith("admin/team-cloud-credentials/sakura/team-a");
+  });
+});

--- a/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
@@ -17,6 +17,9 @@ vi.mock("../../src/i18n", () => {
 vi.mock("../../src/pages/competitor-accounts/useCompetitorAccounts", () => ({
   useCompetitorAccounts: mockHook,
 }));
+vi.mock("../../src/pages/competitor-accounts/TeamCloudCredentialsPanel", () => ({
+  TeamCloudCredentialsPanel: () => <div data-testid="team-cloud-credentials" />,
+}));
 vi.mock("../../src/pages/competitor-accounts/CompetitorAccountsTable", () => ({
   // biome-ignore lint/suspicious/noExplicitAny: stub props。
   CompetitorAccountsTable: ({ onVerify, onRequestDelete }: any) => (

--- a/apps/application-admin-console/test/pages/competitor-accounts/TeamCloudCredentialsPanel.test.tsx
+++ b/apps/application-admin-console/test/pages/competitor-accounts/TeamCloudCredentialsPanel.test.tsx
@@ -1,0 +1,158 @@
+import createWrapper from "@cloudscape-design/components/test-utils/dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../../src/config";
+
+/**
+ * [ADR-032 / #1413] TeamCloudCredentialsPanel の 100% pin。 provider Select / teamSlug / credential JSON /
+ * register (valid→success / invalid JSON→error / API error) / revoke / status (registered/unregistered) /
+ * slug invalid disable / apiClient null disable / notice dismiss を網羅する。
+ */
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    useApiClient: vi.fn(),
+    registerTeamCredential: vi.fn(),
+    revokeTeamCredential: vi.fn(),
+    getTeamCredentialStatus: vi.fn(),
+  },
+}));
+
+vi.mock("../../../src/api/client", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  useApiClient: mocks.useApiClient,
+}));
+vi.mock("../../../src/i18n", () => ({ useT: () => (key: string) => key }));
+vi.mock("../../../src/api/team-credentials-client", () => ({
+  registerTeamCredential: mocks.registerTeamCredential,
+  revokeTeamCredential: mocks.revokeTeamCredential,
+  getTeamCredentialStatus: mocks.getTeamCredentialStatus,
+}));
+
+const { TeamCloudCredentialsPanel } = await import(
+  "../../../src/pages/competitor-accounts/TeamCloudCredentialsPanel"
+);
+
+const config = { apiBaseUrl: "https://api.test", tenantId: "t1" } as AppConfig;
+const FAKE_CLIENT = { put: vi.fn(), del: vi.fn(), get: vi.fn() };
+
+function renderPanel() {
+  const { container } = render(<TeamCloudCredentialsPanel config={config} />);
+  return createWrapper(container);
+}
+
+function setTeamSlug(w: ReturnType<typeof createWrapper>, value: string) {
+  w.findInput()?.setInputValue(value);
+}
+function setCredential(w: ReturnType<typeof createWrapper>, value: string) {
+  w.findTextarea()?.setTextareaValue(value);
+}
+const btn = (key: string) => screen.getByRole("button", { name: key });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useApiClient.mockReturnValue(FAKE_CLIENT);
+  mocks.registerTeamCredential.mockResolvedValue({ registered: true });
+  mocks.revokeTeamCredential.mockResolvedValue(undefined);
+  mocks.getTeamCredentialStatus.mockResolvedValue({ registered: true });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("TeamCloudCredentialsPanel (#1413)", () => {
+  it("should register a valid credential and show a success notice", async () => {
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    setCredential(w, '{"accessToken":"x","accessTokenSecret":"y"}');
+    btn("team_cloud_credentials.register_button").click();
+    await waitFor(() =>
+      expect(mocks.registerTeamCredential).toHaveBeenCalledWith(FAKE_CLIENT, "sakura", "team-a", {
+        accessToken: "x",
+        accessTokenSecret: "y",
+      }),
+    );
+    expect(await screen.findByText("team_cloud_credentials.registered")).toBeInTheDocument();
+  });
+
+  it("should reject invalid JSON without calling the API", async () => {
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    setCredential(w, "{not json");
+    btn("team_cloud_credentials.register_button").click();
+    expect(await screen.findByText("team_cloud_credentials.invalid_json")).toBeInTheDocument();
+    expect(mocks.registerTeamCredential).not.toHaveBeenCalled();
+  });
+
+  it("should surface an API error as a FriendlyErrorAlert", async () => {
+    mocks.registerTeamCredential.mockRejectedValueOnce(new Error("boom"));
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    setCredential(w, "{}");
+    btn("team_cloud_credentials.register_button").click();
+    // toFriendlyError → FriendlyErrorAlert (Cloudscape Alert type=error)。 test-util で検出する。
+    await waitFor(() => expect(w.findAlert()).not.toBeNull());
+    expect(mocks.registerTeamCredential).toHaveBeenCalled();
+  });
+
+  it("should revoke and show a notice", async () => {
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    btn("team_cloud_credentials.revoke_button").click();
+    await waitFor(() =>
+      expect(mocks.revokeTeamCredential).toHaveBeenCalledWith(FAKE_CLIENT, "sakura", "team-a"),
+    );
+    expect(await screen.findByText("team_cloud_credentials.revoked")).toBeInTheDocument();
+  });
+
+  it("should report registered / unregistered status", async () => {
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    btn("team_cloud_credentials.status_button").click();
+    expect(await screen.findByText("team_cloud_credentials.status_registered")).toBeInTheDocument();
+
+    mocks.getTeamCredentialStatus.mockResolvedValueOnce({ registered: false });
+    btn("team_cloud_credentials.status_button").click();
+    expect(
+      await screen.findByText("team_cloud_credentials.status_unregistered"),
+    ).toBeInTheDocument();
+  });
+
+  it("should switch provider via the Select and use it on register", async () => {
+    const w = renderPanel();
+    const select = w.findSelect();
+    select?.openDropdown();
+    select?.selectOptionByValue("gcp");
+    setTeamSlug(w, "team-a");
+    setCredential(w, "{}");
+    btn("team_cloud_credentials.register_button").click();
+    await waitFor(() =>
+      expect(mocks.registerTeamCredential).toHaveBeenCalledWith(FAKE_CLIENT, "gcp", "team-a", {}),
+    );
+  });
+
+  it("should mark an invalid team slug and disable register", () => {
+    const w = renderPanel();
+    setTeamSlug(w, "BAD slug!");
+    setCredential(w, "{}");
+    expect(screen.getByText("team_cloud_credentials.team_invalid")).toBeInTheDocument();
+    expect(btn("team_cloud_credentials.register_button")).toBeDisabled();
+  });
+
+  it("should disable actions when there is no api client (no auth)", () => {
+    mocks.useApiClient.mockReturnValue(null);
+    renderPanel();
+    expect(btn("team_cloud_credentials.status_button")).toBeDisabled();
+  });
+
+  it("should dismiss the success notice", async () => {
+    const w = renderPanel();
+    setTeamSlug(w, "team-a");
+    btn("team_cloud_credentials.revoke_button").click();
+    const notice = await screen.findByText("team_cloud_credentials.revoked");
+    expect(notice).toBeInTheDocument();
+    // Cloudscape Alert dismiss button
+    createWrapper(document.body).findAlert()?.findDismissButton()?.click();
+    await waitFor(() =>
+      expect(screen.queryByText("team_cloud_credentials.revoked")).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Tenant Admin **onboarding + revocation flow** for per-team non-AWS cloud credentials (sakura / azure / gcp) — the app-side slice of #1413. The backend routes (`PUT/DELETE/GET /admin/team-cloud-credentials/:provider/:teamSlug`, SSM SecureString stores) landed in #1657; the federation design is fixed by ADR-032. This wires the UI on top.

- **`team-credentials-client.ts`** — `registerTeamCredential` (PUT, register/rotate), `revokeTeamCredential` (DELETE), `getTeamCredentialStatus` (GET). `encodeURIComponent` on the `:provider` / `:teamSlug` path segments.
- **`TeamCloudCredentialsPanel.tsx`** — Cloudscape `Container` with a provider `Select`, a team-slug `Input` (validated against `/^[a-z0-9-]+$/`), a credential JSON `Textarea`, and register / status / revoke actions. The credential JSON is parsed client-side but its **per-provider shape is Zod-validated server-side**, so the panel stays provider-shape-agnostic (no double-maintained field set). Secrets are **write-only** — status returns a boolean, never the secret back.
- **`ApiClient.put<T>()`** — mirrors `post()` for the PUT register/rotate verb (the one verb the client lacked).
- Wired into the `CompetitorAccounts` page; `ja` / `en` i18n keys added.

The cloud-side federation **trust bootstrap** (WIF pool / federated credential in a real Azure tenant / GCP project) remains owner-driven `[INFRA]` per ADR-032, so this is `Relates #1413` (delivers the onboarding/revocation UX), not `Closes`.

Relates #1413. Relates #1408.

## Test plan

- `team-credentials-client.test.ts` (4) — pins PUT/DELETE/GET path + body + `encodeURIComponent`.
- `TeamCloudCredentialsPanel.test.tsx` (9) — register (valid→success / invalid-JSON→error-without-API / API-error→FriendlyErrorAlert), revoke, status (registered/unregistered), provider switch via Select, invalid-slug disables register, no-api-client disables actions, notice dismiss.
- `client.test.ts` — added a PUT verb assertion (method + JSON body + parsed response).
- `CompetitorAccounts.test.tsx` — stubbed the new panel so the page test stays isolated.
- `make before-commit` green (lint / typecheck / 916 app-admin tests / build / validate-problems / template security / audit-deps / cdk synth).
- Coverage gate (`scripts/check-coverage-gate.ts`): `apps/application-admin-console: 100%`.

## Regression analysis

- **`ApiClient.put` addition** — purely additive to the interface + impl; existing `post`/`patch`/`del`/`get` unchanged. Three sibling API-client test mocks (`deploy-client` / `events-client` / `competitor-accounts-client`) gained a `put: vi.fn()` so their `ApiClient` literals still satisfy the type — no behavioral change.
- **`CompetitorAccounts` page** — the new `<TeamCloudCredentialsPanel>` renders after the table; it self-contains its own `useApiClient`/state, so the existing add/verify/delete/secret flows are untouched. The page test stubs the panel to keep the existing assertions isolated.
- **i18n** — only adds a new `team_cloud_credentials` block as a sibling of `competitor_accounts`; ja/en parity test passes. No existing key renamed.
- **No infra / CFn / DynamoDB / IAM touched** — frontend-only.

## Physical impact

- **NO-OP** on CloudFormation / deployed artifacts. This is `apps/application-admin-console` SPA source only; the built bundle ships through the existing `runtime-config.json` hosting path with no stack or resource diff. No CREATE/UPDATE/REPLACE/DELETE of any AWS resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)