### PR TITLE
refactor(app-admin): extract useTeamCloudCredentials view-model hook (SOLID)

### DIFF
--- a/apps/application-admin-console/src/pages/competitor-accounts/TeamCloudCredentialsPanel.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/TeamCloudCredentialsPanel.tsx
@@ -8,135 +8,55 @@ import Input from "@cloudscape-design/components/input";
 import Select from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
-import { useState } from "react";
-import { useApiClient } from "../../api/client";
-import {
-  getTeamCredentialStatus,
-  registerTeamCredential,
-  revokeTeamCredential,
-  type TeamCredentialProvider,
-} from "../../api/team-credentials-client";
 import { FriendlyErrorAlert } from "../../components/FriendlyErrorAlert";
 import type { AppConfig } from "../../config";
 import { useT } from "../../i18n";
-import { type FriendlyError, toFriendlyError } from "../../lib/friendly-error";
+import { PROVIDER_OPTIONS, useTeamCloudCredentials } from "./useTeamCloudCredentials";
 
 /**
  * [ADR-026/027/032 / Issue #1413] per-team cloud credential onboarding パネル。
  *
  * TenantAdmin が非 AWS 問題 (sakura/azure/gcp) を deploy する前に、 team の認証情報 (provider 別 JSON) を
  * `PUT /admin/team-cloud-credentials/:provider/:teamSlug` で SSM SecureString store に登録 / 失効する。
- * credential JSON の形は provider 別で backend が Zod 検証するため、 ここでは textarea で受ける
- * (= per-provider field を画面側で持たず 2 重メンテを避ける)。 secret は送るだけで status では返らない。
+ * data/effect 層は `useTeamCloudCredentials` view-model hook に集約してあり、 本 component は
+ * その state を Cloudscape にレンダリングする presentation に徹する (= SRP)。 credential JSON の形は
+ * provider 別で backend が Zod 検証するため、 ここでは textarea で受ける (= 画面側で per-provider field を
+ * 持たず 2 重メンテを避ける)。 secret は送るだけで status では返らない。
  */
 
-const SLUG_RE = /^[a-z0-9-]+$/;
-
-const PROVIDER_OPTIONS: ReadonlyArray<{ value: TeamCredentialProvider; label: string }> = [
-  { value: "sakura", label: "Sakura (AppRun)" },
-  { value: "azure", label: "Azure (Deployment Stacks)" },
-  { value: "gcp", label: "GCP (Infrastructure Manager)" },
-];
-
 export function TeamCloudCredentialsPanel({ config }: { config: AppConfig }) {
-  const apiClient = useApiClient(config);
   const t = useT();
-  const [provider, setProvider] = useState<TeamCredentialProvider>("sakura");
-  const [teamSlug, setTeamSlug] = useState("");
-  const [credentialJson, setCredentialJson] = useState("");
-  const [inFlight, setInFlight] = useState(false);
-  const [error, setError] = useState<FriendlyError | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
-
-  const slugInvalid = teamSlug.length > 0 && !SLUG_RE.test(teamSlug);
-  const baseDisabled = !apiClient || inFlight || teamSlug.length === 0 || slugInvalid;
-  // provider は常に PROVIDER_OPTIONS の value のいずれか (= find は必ず一致する)。
-  const selectedOption = PROVIDER_OPTIONS.find((o) => o.value === provider) as {
-    value: TeamCredentialProvider;
-    label: string;
-  };
-
-  const run = async (fn: () => Promise<void>): Promise<void> => {
-    setInFlight(true);
-    setError(null);
-    setNotice(null);
-    try {
-      await fn();
-    } catch (err) {
-      setError(toFriendlyError(err));
-    } finally {
-      setInFlight(false);
-    }
-  };
-
-  const handleRegister = async (): Promise<void> => {
-    // button は disabled={baseDisabled} (= !apiClient 含む) なので enabled 時のみ呼ばれる (= 防御的不到達)。
-    /* v8 ignore next */
-    if (!apiClient) return;
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(credentialJson) as Record<string, unknown>;
-    } catch {
-      setError({ title: t("team_cloud_credentials.invalid_json") });
-      return;
-    }
-    await run(async () => {
-      await registerTeamCredential(apiClient, provider, teamSlug, parsed);
-      setNotice(t("team_cloud_credentials.registered"));
-    });
-  };
-
-  const handleRevoke = async (): Promise<void> => {
-    /* v8 ignore next */
-    if (!apiClient) return;
-    await run(async () => {
-      await revokeTeamCredential(apiClient, provider, teamSlug);
-      setNotice(t("team_cloud_credentials.revoked"));
-    });
-  };
-
-  const handleCheckStatus = async (): Promise<void> => {
-    /* v8 ignore next */
-    if (!apiClient) return;
-    await run(async () => {
-      const status = await getTeamCredentialStatus(apiClient, provider, teamSlug);
-      setNotice(
-        status.registered
-          ? t("team_cloud_credentials.status_registered")
-          : t("team_cloud_credentials.status_unregistered"),
-      );
-    });
-  };
+  const vm = useTeamCloudCredentials(config);
 
   return (
     <Container header={<Header variant="h2">{t("team_cloud_credentials.title")}</Header>}>
       <SpaceBetween size="m">
         <Box color="text-body-secondary">{t("team_cloud_credentials.description")}</Box>
-        {error && <FriendlyErrorAlert error={error} />}
-        {notice && (
-          <Alert type="success" dismissible onDismiss={() => setNotice(null)}>
-            {notice}
+        {vm.error && <FriendlyErrorAlert error={vm.error} />}
+        {vm.notice && (
+          <Alert type="success" dismissible onDismiss={vm.dismissNotice}>
+            {vm.notice}
           </Alert>
         )}
         <FormField label={t("team_cloud_credentials.provider_label")}>
           <Select
-            selectedOption={selectedOption}
+            selectedOption={vm.providerOption}
             options={PROVIDER_OPTIONS}
-            disabled={inFlight}
-            onChange={(e) => setProvider(e.detail.selectedOption.value as TeamCredentialProvider)}
+            disabled={vm.inFlight}
+            onChange={(e) => vm.setProvider(e.detail.selectedOption.value as string)}
           />
         </FormField>
         <FormField
           label={t("team_cloud_credentials.team_label")}
           description={t("team_cloud_credentials.team_description")}
-          errorText={slugInvalid ? t("team_cloud_credentials.team_invalid") : undefined}
+          errorText={vm.slugInvalid ? t("team_cloud_credentials.team_invalid") : undefined}
         >
           <Input
-            value={teamSlug}
-            onChange={(e) => setTeamSlug(e.detail.value)}
-            invalid={slugInvalid}
+            value={vm.teamSlug}
+            onChange={(e) => vm.setTeamSlug(e.detail.value)}
+            invalid={vm.slugInvalid}
             placeholder="team-a"
-            disabled={inFlight}
+            disabled={vm.inFlight}
           />
         </FormField>
         <FormField
@@ -144,26 +64,26 @@ export function TeamCloudCredentialsPanel({ config }: { config: AppConfig }) {
           description={t("team_cloud_credentials.credential_description")}
         >
           <Textarea
-            value={credentialJson}
-            onChange={(e) => setCredentialJson(e.detail.value)}
+            value={vm.credentialJson}
+            onChange={(e) => vm.setCredentialJson(e.detail.value)}
             placeholder='{"accessToken":"...","accessTokenSecret":"..."}'
-            disabled={inFlight}
+            disabled={vm.inFlight}
             rows={5}
           />
         </FormField>
         <SpaceBetween direction="horizontal" size="xs">
           <Button
             variant="primary"
-            loading={inFlight}
-            disabled={baseDisabled || credentialJson.length === 0}
-            onClick={() => void handleRegister()}
+            loading={vm.inFlight}
+            disabled={!vm.canRegister}
+            onClick={() => void vm.register()}
           >
             {t("team_cloud_credentials.register_button")}
           </Button>
-          <Button disabled={baseDisabled} onClick={() => void handleCheckStatus()}>
+          <Button disabled={!vm.canSubmit} onClick={() => void vm.checkStatus()}>
             {t("team_cloud_credentials.status_button")}
           </Button>
-          <Button disabled={baseDisabled} onClick={() => void handleRevoke()}>
+          <Button disabled={!vm.canSubmit} onClick={() => void vm.revoke()}>
             {t("team_cloud_credentials.revoke_button")}
           </Button>
         </SpaceBetween>

--- a/apps/application-admin-console/src/pages/competitor-accounts/useTeamCloudCredentials.ts
+++ b/apps/application-admin-console/src/pages/competitor-accounts/useTeamCloudCredentials.ts
@@ -1,0 +1,152 @@
+import { useCallback, useState } from "react";
+import { useApiClient } from "../../api/client";
+import {
+  getTeamCredentialStatus,
+  registerTeamCredential,
+  revokeTeamCredential,
+  type TeamCredentialProvider,
+} from "../../api/team-credentials-client";
+import type { AppConfig } from "../../config";
+import { useT } from "../../i18n";
+import { type FriendlyError, toFriendlyError } from "../../lib/friendly-error";
+
+/**
+ * [ADR-026/027/032 / Issue #1413] TeamCloudCredentialsPanel の view-model hook。
+ *
+ * data/effect 層 (apiClient 解決・per-team 認証情報の register/revoke/status・
+ * JSON parse 検証・FriendlyError 変換・notice メッセージ) をここに集約し、 panel を純粋な
+ * presentation に保つ (= `useCompetitorAccounts` と同じ責務分離。 SRP / 高結合解消)。
+ * secret は送るだけで status では boolean しか返らない。
+ */
+
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+export interface ProviderOption {
+  readonly value: TeamCredentialProvider;
+  readonly label: string;
+}
+
+export const PROVIDER_OPTIONS: readonly ProviderOption[] = [
+  { value: "sakura", label: "Sakura (AppRun)" },
+  { value: "azure", label: "Azure (Deployment Stacks)" },
+  { value: "gcp", label: "GCP (Infrastructure Manager)" },
+];
+
+export interface UseTeamCloudCredentialsResult {
+  readonly provider: TeamCredentialProvider;
+  readonly providerOption: ProviderOption;
+  readonly setProvider: (value: string) => void;
+  readonly teamSlug: string;
+  readonly setTeamSlug: (value: string) => void;
+  readonly slugInvalid: boolean;
+  readonly credentialJson: string;
+  readonly setCredentialJson: (value: string) => void;
+  readonly inFlight: boolean;
+  readonly error: FriendlyError | null;
+  readonly notice: string | null;
+  /** apiClient あり & slug が valid & 非 inFlight (= status/revoke を許可)。 */
+  readonly canSubmit: boolean;
+  /** canSubmit かつ credential JSON が非空 (= register を許可)。 */
+  readonly canRegister: boolean;
+  readonly dismissNotice: () => void;
+  readonly register: () => Promise<void>;
+  readonly revoke: () => Promise<void>;
+  readonly checkStatus: () => Promise<void>;
+}
+
+export function useTeamCloudCredentials(config: AppConfig): UseTeamCloudCredentialsResult {
+  const apiClient = useApiClient(config);
+  const t = useT();
+  const [provider, setProviderState] = useState<TeamCredentialProvider>("sakura");
+  const [teamSlug, setTeamSlug] = useState("");
+  const [credentialJson, setCredentialJson] = useState("");
+  const [inFlight, setInFlight] = useState(false);
+  const [error, setError] = useState<FriendlyError | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const slugInvalid = teamSlug.length > 0 && !SLUG_RE.test(teamSlug);
+  const canSubmit = !!apiClient && !inFlight && teamSlug.length > 0 && !slugInvalid;
+  const canRegister = canSubmit && credentialJson.length > 0;
+  // provider は常に PROVIDER_OPTIONS の value のいずれか (= find は必ず一致する)。
+  const providerOption = PROVIDER_OPTIONS.find((o) => o.value === provider) as ProviderOption;
+
+  // Select の選択値は常に PROVIDER_OPTIONS 由来なので narrowing cast で受ける。
+  const setProvider = useCallback(
+    (value: string) => setProviderState(value as TeamCredentialProvider),
+    [],
+  );
+
+  const run = useCallback(async (fn: () => Promise<void>): Promise<void> => {
+    setInFlight(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await fn();
+    } catch (err) {
+      setError(toFriendlyError(err));
+    } finally {
+      setInFlight(false);
+    }
+  }, []);
+
+  const register = useCallback(async (): Promise<void> => {
+    // button は disabled={!canRegister} (= !apiClient 含む) なので enabled 時のみ呼ばれる (= 防御的不到達)。
+    /* v8 ignore next */
+    if (!apiClient) return;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(credentialJson) as Record<string, unknown>;
+    } catch {
+      setError({ title: t("team_cloud_credentials.invalid_json") });
+      return;
+    }
+    await run(async () => {
+      await registerTeamCredential(apiClient, provider, teamSlug, parsed);
+      setNotice(t("team_cloud_credentials.registered"));
+    });
+  }, [apiClient, credentialJson, provider, teamSlug, run, t]);
+
+  const revoke = useCallback(async (): Promise<void> => {
+    /* v8 ignore next */
+    if (!apiClient) return;
+    await run(async () => {
+      await revokeTeamCredential(apiClient, provider, teamSlug);
+      setNotice(t("team_cloud_credentials.revoked"));
+    });
+  }, [apiClient, provider, teamSlug, run, t]);
+
+  const checkStatus = useCallback(async (): Promise<void> => {
+    /* v8 ignore next */
+    if (!apiClient) return;
+    await run(async () => {
+      const status = await getTeamCredentialStatus(apiClient, provider, teamSlug);
+      setNotice(
+        status.registered
+          ? t("team_cloud_credentials.status_registered")
+          : t("team_cloud_credentials.status_unregistered"),
+      );
+    });
+  }, [apiClient, provider, teamSlug, run, t]);
+
+  const dismissNotice = useCallback(() => setNotice(null), []);
+
+  return {
+    provider,
+    providerOption,
+    setProvider,
+    teamSlug,
+    setTeamSlug,
+    slugInvalid,
+    credentialJson,
+    setCredentialJson,
+    inFlight,
+    error,
+    notice,
+    canSubmit,
+    canRegister,
+    dismissNotice,
+    register,
+    revoke,
+    checkStatus,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #1661. The `TeamCloudCredentialsPanel` shipped with its data/effect logic inline, which put it at the import-coupling threshold (16 modules — flagged by `make tech-debt`) and mixed two responsibilities in one component. This extracts a `useTeamCloudCredentials` **view-model hook** so the panel is pure presentation, mirroring the sibling `useCompetitorAccounts` convention.

- **`useTeamCloudCredentials.ts`** (new) — owns `apiClient` resolution, form state (provider / teamSlug / credential JSON), the register / revoke / status effects, JSON-parse validation, `FriendlyError` conversion, and the notice messages. Exposes derived `slugInvalid` / `canSubmit` / `canRegister` flags + `providerOption` so the panel branches on nothing.
- **`TeamCloudCredentialsPanel.tsx`** — now renders hook state into Cloudscape and nothing else. Import count drops 17 → 13 (below threshold; `make tech-debt` no longer flags it).
- `PROVIDER_OPTIONS` moved into the hook module (single source for the provider list).

SRP win: the deploy-time effect/validation logic is now independently testable and reusable, and the component is a thin view.

## Test plan

- No behavior change — the existing `TeamCloudCredentialsPanel.test.tsx` (9) drives the real hook through the rendered DOM (mocked api-client / i18n / team-credentials-client), so it pins the hook's behavior end-to-end and passed unchanged.
- `make harness` — no findings. `make before-commit` green (lint / typecheck / 916 app-admin tests / build / validate-problems / template security / audit-deps / cdk synth).
- Coverage gate: `useTeamCloudCredentials.ts` and `TeamCloudCredentialsPanel.tsx` both 100% (lines / branches / funcs / stmts); `apps/application-admin-console: 100%`.
- `make tech-debt`: the `TeamCloudCredentialsPanel` high-coupling warning is resolved.

Relates #1413.

## Regression analysis

- **Pure refactor, no behavior change.** The hook contains the same logic that was inline in the panel (same SLUG regex, same JSON parse + `invalid_json` error, same `registerTeamCredential` / `revokeTeamCredential` / `getTeamCredentialStatus` calls with identical arguments, same notice keys, same disabled conditions). The rendered DOM is byte-equivalent, which is why the existing component test passes untouched.
- The only surface change is the `Select` `onChange` now narrows `value as string` via the hook's `setProvider` instead of `as TeamCredentialProvider` inline — same runtime result (the value always originates from `PROVIDER_OPTIONS`).
- No other component imports `TeamCloudCredentialsPanel`'s internals; `PROVIDER_OPTIONS` was not previously exported, so the move is non-breaking.
- No infra / CFn / DynamoDB / IAM touched — frontend-only.

## Physical impact

- **NO-OP** on CloudFormation / deployed artifacts. `apps/application-admin-console` SPA source only; ships through the existing `runtime-config.json` hosting path with no stack or resource diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)