### PR TITLE
docs(runbooks): multi-cloud provider onboarding + verification runbook

### DIFF
--- a/docs/runbooks/README.html
+++ b/docs/runbooks/README.html
@@ -105,12 +105,20 @@
 <td>Within 24 hours after the event ends</td>
 <td>60 min</td>
 </tr>
+<tr>
+<td>7</td>
+<td><a href="./multi-cloud-providers.md">Multi-cloud providers</a></td>
+<td>Operator</td>
+<td>Setup — only if a problem targets Sakura / Azure / GCP, before you deploy it</td>
+<td>20 min per team per provider</td>
+</tr>
 </tbody></table>
 <h2>How the runbooks cross-link</h2>
 <ul>
 <li><a href="./pre-event-checklist.md">Pre-event checklist</a> links to <a href="./dry-run.md">Dry run</a> as the T-7 gate (&quot;you cannot skip the dry run&quot;).</li>
 <li><a href="./live-monitoring.md">Live monitoring</a> links to <a href="./incident-response.md">Incident response</a> at the triage decision point.</li>
 <li><a href="./incident-response.md">Incident response</a> and <a href="./teardown.md">Teardown</a> both cross-link back to <a href="./live-monitoring.md">Live monitoring</a> for context on what was already observed.</li>
+<li><a href="./multi-cloud-providers.md">Multi-cloud providers</a> is a setup runbook (not event-day): run it per team before deploying a non-AWS problem, and its per-provider <code>destroy</code> rolls up into <a href="./teardown.md">Teardown</a>.</li>
 <li>All runbooks cite the relevant ADRs as the source of truth for design decisions:<ul>
 <li><a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — operator-to-participant messaging contract.</li>
 <li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge-driven state reconciliation</a> — how state converges without SSE / WebSocket.</li>

--- a/docs/runbooks/README.ja.html
+++ b/docs/runbooks/README.ja.html
@@ -105,12 +105,20 @@
 <td>イベント終了から 24 時間以内</td>
 <td>60 分</td>
 </tr>
+<tr>
+<td>7</td>
+<td><a href="./multi-cloud-providers.ja.md">マルチクラウドプロバイダ</a></td>
+<td>オペレータ</td>
+<td>セットアップ — 問題が Sakura / Azure / GCP を対象とする場合のみ、 deploy 前</td>
+<td>チーム × provider ごとに 20 分</td>
+</tr>
 </tbody></table>
 <h2>Runbook 同士の相互参照</h2>
 <ul>
 <li><a href="./pre-event-checklist.ja.md">事前チェックリスト</a> は <a href="./dry-run.ja.md">Dry run</a> を T-7 のゲートとしてリンクする (=「dry run はスキップ不可」)。</li>
 <li><a href="./live-monitoring.ja.md">Live monitoring</a> は triage 判断ポイントで <a href="./incident-response.ja.md">インシデント対応</a> にリンクする。</li>
 <li><a href="./incident-response.ja.md">インシデント対応</a> と <a href="./teardown.ja.md">Teardown</a> はどちらも <a href="./live-monitoring.ja.md">Live monitoring</a> にバックリンクして、 すでに観測したものを文脈に持ち込む。</li>
+<li><a href="./multi-cloud-providers.ja.md">マルチクラウドプロバイダ</a> はイベント当日でなくセットアップ runbook で、 非 AWS 問題を deploy する前にチームごとに実施する。 provider 別の <code>destroy</code> は <a href="./teardown.ja.md">Teardown</a> に集約される。</li>
 <li>すべての runbook は設計判断の正本として下記の ADR を参照する。<ul>
 <li><a href="../architecture/adr-006-notifications.html">ADR-006: Notifications</a> — オペレータから参加者への通知契約。</li>
 <li><a href="../architecture/adr-014-eventbridge-driven-state-reconciliation.html">ADR-014: EventBridge 駆動 state reconciliation</a> — SSE / WebSocket を使わずに状態を収束させる仕組み。</li>

--- a/docs/runbooks/README.ja.md
+++ b/docs/runbooks/README.ja.md
@@ -16,12 +16,14 @@ Runbook 全体は Lite mode (`make deploy`) をデフォルトとしています
 | 4 | [Live monitoring](./live-monitoring.ja.md) | オンコールオペレータ | イベント実施中ずっと | 継続 |
 | 5 | [インシデント対応](./incident-response.ja.md) | オンコールオペレータ | アラートまたは参加者報告から | 1 件あたり 5 〜 30 分 |
 | 6 | [Teardown](./teardown.ja.md) | オペレータ | イベント終了から 24 時間以内 | 60 分 |
+| 7 | [マルチクラウドプロバイダ](./multi-cloud-providers.ja.md) | オペレータ | セットアップ — 問題が Sakura / Azure / GCP を対象とする場合のみ、 deploy 前 | チーム × provider ごとに 20 分 |
 
 ## Runbook 同士の相互参照
 
 - [事前チェックリスト](./pre-event-checklist.ja.md) は [Dry run](./dry-run.ja.md) を T-7 のゲートとしてリンクする (=「dry run はスキップ不可」)。
 - [Live monitoring](./live-monitoring.ja.md) は triage 判断ポイントで [インシデント対応](./incident-response.ja.md) にリンクする。
 - [インシデント対応](./incident-response.ja.md) と [Teardown](./teardown.ja.md) はどちらも [Live monitoring](./live-monitoring.ja.md) にバックリンクして、 すでに観測したものを文脈に持ち込む。
+- [マルチクラウドプロバイダ](./multi-cloud-providers.ja.md) はイベント当日でなくセットアップ runbook で、 非 AWS 問題を deploy する前にチームごとに実施する。 provider 別の `destroy` は [Teardown](./teardown.ja.md) に集約される。
 - すべての runbook は設計判断の正本として下記の ADR を参照する。
   - [ADR-006: Notifications](../architecture/adr-006-notifications.html) — オペレータから参加者への通知契約。
   - [ADR-014: EventBridge 駆動 state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) — SSE / WebSocket を使わずに状態を収束させる仕組み。

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,12 +16,14 @@ The runbooks assume Lite mode (`make deploy`) as the default, because most paid 
 | 4 | [Live monitoring](./live-monitoring.md) | On-call operator | During the event window | Continuous |
 | 5 | [Incident response](./incident-response.md) | On-call operator | Triggered by alarm or participant report | 5 to 30 min per incident |
 | 6 | [Teardown](./teardown.md) | Operator | Within 24 hours after the event ends | 60 min |
+| 7 | [Multi-cloud providers](./multi-cloud-providers.md) | Operator | Setup — only if a problem targets Sakura / Azure / GCP, before you deploy it | 20 min per team per provider |
 
 ## How the runbooks cross-link
 
 - [Pre-event checklist](./pre-event-checklist.md) links to [Dry run](./dry-run.md) as the T-7 gate ("you cannot skip the dry run").
 - [Live monitoring](./live-monitoring.md) links to [Incident response](./incident-response.md) at the triage decision point.
 - [Incident response](./incident-response.md) and [Teardown](./teardown.md) both cross-link back to [Live monitoring](./live-monitoring.md) for context on what was already observed.
+- [Multi-cloud providers](./multi-cloud-providers.md) is a setup runbook (not event-day): run it per team before deploying a non-AWS problem, and its per-provider `destroy` rolls up into [Teardown](./teardown.md).
 - All runbooks cite the relevant ADRs as the source of truth for design decisions:
   - [ADR-006: Notifications](../architecture/adr-006-notifications.html) — operator-to-participant messaging contract.
   - [ADR-014: EventBridge-driven state reconciliation](../architecture/adr-014-eventbridge-driven-state-reconciliation.html) — how state converges without SSE / WebSocket.

--- a/docs/runbooks/multi-cloud-providers.html
+++ b/docs/runbooks/multi-cloud-providers.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Multi-cloud problem providers (Sakura / Azure / GCP)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>Multi-cloud problem providers (Sakura / Azure / GCP)</h1>
+<blockquote>
+<p>Japanese: <a href="./multi-cloud-providers.ja.md">multi-cloud-providers.ja.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Audience</td>
+<td>Operator (Tenant Admin) enabling a non-AWS problem for one or more teams</td>
+</tr>
+<tr>
+<td>When to use</td>
+<td>Once per team that will run a Sakura / Azure / GCP problem, before you deploy that problem</td>
+</tr>
+<tr>
+<td>Estimated time</td>
+<td>20 minutes per team per provider (most of it is the one-time cloud-side trust bootstrap)</td>
+</tr>
+<tr>
+<td>Output</td>
+<td>The team&#39;s per-provider credential is registered, the problem&#39;s <code>runtime</code> resolves to a live adapter, and a non-AWS deploy reaches <code>ready</code> and tears down cleanly</td>
+</tr>
+</tbody></table>
+<p>TenkaCloud&#39;s control plane always runs on AWS. Individual <strong>problems</strong> can target another cloud by declaring a <code>runtime</code> other than <code>aws/cloudformation</code>. The deploy worker resolves a <code>ProblemRuntimeAdapter</code> for that provider, exchanges a short-lived credential, and drives the provider&#39;s native deploy API. This runbook is the operator path from &quot;a team exists&quot; to &quot;a non-AWS problem deploys for that team.&quot;</p>
+<p>The design decisions behind each provider live in the ADRs — read them once for context:</p>
+<table>
+<thead>
+<tr>
+<th>Provider / engine</th>
+<th>Adapter</th>
+<th>Credential model</th>
+<th>ADR</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>sakura/apprun</code></td>
+<td>Sakura AppRun</td>
+<td>Stored API key (access token + secret) in SSM SecureString</td>
+<td><a href="../architecture/adr-026-sakura-cloud-problem-provider.html">ADR-026</a></td>
+</tr>
+<tr>
+<td><code>azure/bicep</code></td>
+<td>Azure Deployment Stacks</td>
+<td>Stored app-registration client secret in SSM SecureString → <code>client_credentials</code> ARM token</td>
+<td><a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a></td>
+</tr>
+<tr>
+<td><code>gcp/infra-manager</code></td>
+<td>GCP Infrastructure Manager</td>
+<td><strong>Keyless</strong> Workload Identity Federation: signed <code>sts:GetCallerIdentity</code> → GCP STS → service-account impersonation</td>
+<td><a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a></td>
+</tr>
+</tbody></table>
+<h2>Step 1: cloud-side trust bootstrap (one-time, in the team&#39;s cloud account)</h2>
+<p>This is the one piece that lives outside TenkaCloud — it is set up in the <strong>team&#39;s own</strong> Sakura / Azure / GCP account. Do it once per team. Apply least privilege: each credential should only be able to deploy and delete the problem&#39;s resources.</p>
+<h3>Sakura</h3>
+<ul>
+<li><input disabled="" type="checkbox"> In the team&#39;s Sakura account, issue an <strong>API key</strong> (access token + access token secret) scoped to AppRun.</li>
+<li><input disabled="" type="checkbox"> Note the two values. They are long-lived, so plan a rotation cadence (see <a href="#rotation-and-revocation">Rotation and revocation</a>).</li>
+</ul>
+<h3>Azure</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Create a <strong>per-team app registration</strong> in the team&#39;s Entra ID directory and generate a <strong>client secret</strong>.</li>
+<li><input disabled="" type="checkbox"> Grant that service principal a minimal role (e.g. a custom role with only the resource actions the problem template touches) on the <strong>target subscription / resource group</strong> — not Owner.</li>
+<li><input disabled="" type="checkbox"> Record: <code>azureTenantId</code> (directory GUID), <code>clientId</code>, <code>clientSecret</code>, <code>subscriptionId</code>, <code>resourceGroup</code>, and optional <code>location</code>.</li>
+</ul>
+<blockquote>
+<p>Azure has no AWS-native federation path (Entra federated credentials accept only an OIDC issuer). ADR-032 deliberately defers the platform-as-OIDC-issuer subsystem; v1 uses a stored client secret, so treat it with the same care as the Sakura key.</p>
+</blockquote>
+<h3>GCP (keyless)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> Create a <strong>Workload Identity Pool</strong> and an <strong>AWS provider</strong> in the team&#39;s GCP project that trusts the platform&#39;s AWS deploy-worker identity.</li>
+<li><input disabled="" type="checkbox"> Create (or pick) a <strong>service account</strong> with a minimal role on the target project, and grant the WIF principal <code>roles/iam.serviceAccountTokenCreator</code> on it (impersonation binding).</li>
+<li><input disabled="" type="checkbox"> Record: <code>wifAudience</code> (e.g. <code>//iam.googleapis.com/projects/&lt;n&gt;/locations/global/workloadIdentityPools/tenkacloud/providers/aws</code>), <code>serviceAccountEmail</code>, <code>projectId</code>, and <code>location</code>.</li>
+</ul>
+<blockquote>
+<p>GCP is the only keyless provider: no secret is ever stored. The deploy worker signs a <code>GetCallerIdentity</code> request, exchanges it at GCP STS, and impersonates the service account for a 1-hour token.</p>
+</blockquote>
+<h2>Step 2: register the per-team credential</h2>
+<p>Registration is done from the <strong>Application Admin console → Competitor Accounts → &quot;Team cloud credentials&quot;</strong> panel. The panel <code>PUT</code>s the credential to <code>admin/team-cloud-credentials/:provider/:teamSlug</code>; the backend validates the provider-specific shape and writes it to an SSM SecureString. The secret is write-only — the status check returns a boolean, never the secret.</p>
+<table>
+<thead>
+<tr>
+<th>Provider</th>
+<th>Credential JSON to paste</th>
+<th>SSM SecureString path</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>sakura</code></td>
+<td><code>{ &quot;accessToken&quot;: &quot;...&quot;, &quot;accessTokenSecret&quot;: &quot;...&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/sakura-api-key</code></td>
+</tr>
+<tr>
+<td><code>azure</code></td>
+<td><code>{ &quot;azureTenantId&quot;: &quot;...&quot;, &quot;clientId&quot;: &quot;...&quot;, &quot;clientSecret&quot;: &quot;...&quot;, &quot;subscriptionId&quot;: &quot;...&quot;, &quot;resourceGroup&quot;: &quot;...&quot;, &quot;location&quot;: &quot;japaneast&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/azure-credential</code></td>
+</tr>
+<tr>
+<td><code>gcp</code></td>
+<td><code>{ &quot;wifAudience&quot;: &quot;...&quot;, &quot;serviceAccountEmail&quot;: &quot;...&quot;, &quot;projectId&quot;: &quot;...&quot;, &quot;location&quot;: &quot;asia-northeast1&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/gcp-credential</code></td>
+</tr>
+</tbody></table>
+<ul>
+<li><input disabled="" type="checkbox"> Select the provider, enter the team slug (<code>^[a-z0-9-]+$</code>), paste the JSON, and click <strong>Register</strong>.</li>
+<li><input disabled="" type="checkbox"> Click <strong>Status</strong> — it should report registered.</li>
+<li><input disabled="" type="checkbox"> <code>&lt;env&gt;</code> is the deploy environment (<code>development</code> / <code>staging</code> / <code>production</code>). The deploy worker&#39;s IAM already grants <code>ssm:GetParameter</code> + <code>kms:Decrypt</code> scoped to these paths (<code>deploy-api-lambda.ts</code>), so no IAM change is needed per team.</li>
+</ul>
+<h2>Step 3: declare the problem runtime</h2>
+<p>The problem&#39;s <code>metadata.json</code> declares the target with a <code>runtime</code> block; without it, a problem is treated as legacy <code>aws/cloudformation</code>.</p>
+<pre><code class="language-jsonc">{ &quot;runtime&quot;: { &quot;provider&quot;: &quot;gcp&quot;, &quot;engine&quot;: &quot;infra-manager&quot;, &quot;entry&quot;: &quot;main.tf&quot; } }
+</code></pre>
+<ul>
+<li><input disabled="" type="checkbox"> <code>provider</code> / <code>engine</code> must be one of the three rows in the table above.</li>
+<li><input disabled="" type="checkbox"> <code>make validate-problems</code> checks the runtime block against <code>problems/SCHEMA.json</code>.</li>
+<li><input disabled="" type="checkbox"> If the provider&#39;s credential is <strong>not</strong> registered for the team, <code>selectAdapter</code> raises <code>RuntimeNotSupportedError</code> (reserved) <strong>before any cloud mutation</strong> — a loud failure, never a silent fallback to AWS.</li>
+</ul>
+<h2>Step 4: deploy, reconcile, and tear down</h2>
+<p>The flow is identical to an AWS problem — the adapter abstraction hides the provider:</p>
+<ol>
+<li><strong>Deploy</strong> — the operator deploys the problem for the team. The deploy worker builds the adapter dependencies (<code>buildAdapterDependencies</code>), exchanges the credential, and calls <code>adapter.deploy</code>. Status starts at <code>deploying</code>.</li>
+<li><strong>Reconcile</strong> — the generic-scoring tick calls <code>adapter.getStatus</code> / <code>adapter.collectOutputs</code> (the runtime-status reconciler), advancing the deployment row to <code>ready</code> and persisting the endpoint outputs the participant portal shows.</li>
+<li><strong>Tear down</strong> — teardown calls <code>adapter.destroy</code>; status moves through <code>destroying</code> to <code>destroyed</code>. Follow the normal <a href="./teardown.md">teardown runbook</a> for the event as a whole.</li>
+</ol>
+<h2>Per-provider verification checklist</h2>
+<p>Run this once you have a real account for a provider. It is the acceptance evidence for the multi-cloud tracker (<a href="https://github.com/susumutomita/TenkaCloud/issues/1408">#1408</a>) and the per-provider issues (Sakura #1412 / Azure #1410 / GCP #1411 / federation onboarding #1413). The mechanism and its unit + contract tests already ship; this checklist is the live confirmation.</p>
+<ul>
+<li><input disabled="" type="checkbox"> Trust bootstrap done in the team&#39;s cloud account (Step 1), least privilege applied.</li>
+<li><input disabled="" type="checkbox"> Credential registered and <strong>Status</strong> reports registered (Step 2).</li>
+<li><input disabled="" type="checkbox"> A problem declaring that <code>runtime</code> passes <code>make validate-problems</code>.</li>
+<li><input disabled="" type="checkbox"> Deploy reaches <code>ready</code>; the portal shows the endpoint output.</li>
+<li><input disabled="" type="checkbox"> An unregistered team fails loud with <code>RuntimeNotSupportedError</code>, with no resource created.</li>
+<li><input disabled="" type="checkbox"> Teardown reaches <code>destroyed</code>; no orphan resource remains in the team&#39;s cloud account (cross-check the provider console).</li>
+<li><input disabled="" type="checkbox"> (GCP) Confirm no secret was ever written to SSM — only the non-secret WIF config.</li>
+</ul>
+<h2>Rotation and revocation</h2>
+<ul>
+<li><strong>Rotate</strong> — re-register through the same panel (<code>PUT</code> overwrites the SSM SecureString in place). Sakura keys and Azure client secrets are long-lived; rotate on the team&#39;s normal cadence and after any suspected exposure.</li>
+<li><strong>Revoke</strong> — use the panel&#39;s <strong>Revoke</strong> (<code>DELETE</code>). The next deploy for that team then fails loud (<code>no &lt;provider&gt; credential registered ...</code>) until re-registered. Also revoke the underlying secret in the provider&#39;s console.</li>
+<li>GCP has no stored secret to rotate; revoke by removing the impersonation binding or disabling the WIF provider in the team&#39;s GCP project.</li>
+</ul>
+<h2>Troubleshooting</h2>
+<table>
+<thead>
+<tr>
+<th>Symptom</th>
+<th>Likely cause</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Deploy rejected with <code>RuntimeNotSupportedError</code> (reserved)</td>
+<td>Credential not registered for the team</td>
+<td>Register it (Step 2), then redeploy</td>
+</tr>
+<tr>
+<td><code>no &lt;provider&gt; credential registered for tenant ... team ...</code></td>
+<td>SecureString missing or wrong team slug</td>
+<td>Re-check the slug and re-register</td>
+</tr>
+<tr>
+<td>Azure token error on deploy</td>
+<td>App-registration secret expired, or the role is too narrow</td>
+<td>Rotate the secret / widen the role to the template&#39;s actions</td>
+</tr>
+<tr>
+<td>GCP STS exchange fails</td>
+<td>WIF provider does not trust the worker identity, or impersonation binding missing</td>
+<td>Re-check the pool&#39;s AWS provider condition and the <code>serviceAccountTokenCreator</code> binding</td>
+</tr>
+<tr>
+<td>Sakura 401</td>
+<td>API key revoked or wrong scope</td>
+<td>Re-issue the AppRun-scoped key and re-register</td>
+</tr>
+</tbody></table>
+<h2>Related</h2>
+<ul>
+<li><a href="./teardown.md">Teardown</a> — the event-level teardown that the per-provider <code>destroy</code> rolls up into.</li>
+<li><a href="./incident-response.md">Incident response</a> — if a non-AWS deploy stalls during the event.</li>
+<li><a href="../architecture/adr-026-sakura-cloud-problem-provider.html">ADR-026</a> / <a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a> — the provider and federation design.</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/multi-cloud-providers.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/multi-cloud-providers.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/multi-cloud-providers.ja.html
+++ b/docs/runbooks/multi-cloud-providers.ja.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>マルチクラウド問題プロバイダ (Sakura / Azure / GCP)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-info: #0969da;
+    --c-warn: #9a6700;
+    --c-danger: #cf222e;
+    --c-ok: #1a7f37;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 960px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  h4 { font-size: 0.95rem; margin-top: 1.2rem; color: var(--c-muted); }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 4px;
+        padding: .8rem 1rem; overflow-x: auto; font-size: 0.88rem; line-height: 1.45; }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  a { color: var(--c-info); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  ul, ol { margin: 0.4rem 0; padding-left: 1.6rem; }
+  li { margin: 0.15rem 0; }
+  blockquote { border-left: 4px solid var(--c-border); margin: .6rem 0; padding: .2rem 1rem;
+               color: var(--c-muted); background: var(--c-bg-soft); }
+  hr { border: 0; border-top: 1px solid var(--c-border); margin: 2rem 0; }
+  .doc-source {
+    margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--c-border);
+    font-size: 0.82rem; color: var(--c-muted);
+  }
+  .doc-source code { font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<h1>マルチクラウド問題プロバイダ (Sakura / Azure / GCP)</h1>
+<blockquote>
+<p>English: <a href="./multi-cloud-providers.md">multi-cloud-providers.md</a></p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>項目</th>
+<th>内容</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>対象者</td>
+<td>非 AWS 問題をチームに対して有効化するオペレータ (Tenant Admin)</td>
+</tr>
+<tr>
+<td>使うタイミング</td>
+<td>Sakura / Azure / GCP 問題を動かすチームごとに 1 回、その問題を deploy する前</td>
+</tr>
+<tr>
+<td>所要時間</td>
+<td>チーム × プロバイダごとに 20 分 (大半は一度きりのクラウド側 trust bootstrap)</td>
+</tr>
+<tr>
+<td>成果物</td>
+<td>チームの provider 別認証情報が登録され、問題の <code>runtime</code> が live な adapter に解決し、非 AWS deploy が <code>ready</code> に到達してきれいに撤去できる</td>
+</tr>
+</tbody></table>
+<p>TenkaCloud の control plane は常に AWS 上で動く。個々の <strong>問題</strong> は <code>aws/cloudformation</code> 以外の <code>runtime</code> を宣言することで別クラウドを対象にできる。deploy worker はその provider 用の <code>ProblemRuntimeAdapter</code> を解決し、短命の認証情報を交換して、provider ネイティブの deploy API を駆動する。この runbook は「チームが存在する」状態から「そのチームに非 AWS 問題を deploy できる」状態までのオペレータ手順を示す。</p>
+<p>各 provider の設計判断は ADR にある。背景は一度目を通しておくとよい。</p>
+<table>
+<thead>
+<tr>
+<th>Provider / engine</th>
+<th>Adapter</th>
+<th>認証モデル</th>
+<th>ADR</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>sakura/apprun</code></td>
+<td>Sakura AppRun</td>
+<td>API キー (access token + secret) を SSM SecureString に保管</td>
+<td><a href="../architecture/adr-026-sakura-cloud-problem-provider.html">ADR-026</a></td>
+</tr>
+<tr>
+<td><code>azure/bicep</code></td>
+<td>Azure Deployment Stacks</td>
+<td>app registration の client secret を SSM SecureString に保管 → <code>client_credentials</code> で ARM token</td>
+<td><a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a></td>
+</tr>
+<tr>
+<td><code>gcp/infra-manager</code></td>
+<td>GCP Infrastructure Manager</td>
+<td><strong>鍵レス</strong> Workload Identity Federation: 署名済 <code>sts:GetCallerIdentity</code> → GCP STS → service account impersonation</td>
+<td><a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a></td>
+</tr>
+</tbody></table>
+<h2>Step 1: クラウド側 trust bootstrap (一度きり、チームのクラウドアカウント側)</h2>
+<p>ここだけが TenkaCloud の外にある作業で、<strong>チーム自身の</strong> Sakura / Azure / GCP アカウント側で設定する。チームごとに 1 回行う。最小権限を徹底し、各認証情報は問題のリソースを deploy / delete できるだけにする。</p>
+<h3>Sakura</h3>
+<ul>
+<li><input disabled="" type="checkbox"> チームの Sakura アカウントで、AppRun にスコープした <strong>API キー</strong> (access token + access token secret) を発行する。</li>
+<li><input disabled="" type="checkbox"> 2 つの値を控える。long-lived なので rotation の頻度を決めておく (<a href="#rotation-%E3%81%A8-revocation">Rotation と revocation</a> 参照)。</li>
+</ul>
+<h3>Azure</h3>
+<ul>
+<li><input disabled="" type="checkbox"> チームの Entra ID directory に <strong>チーム専用の app registration</strong> を作り、<strong>client secret</strong> を発行する。</li>
+<li><input disabled="" type="checkbox"> その service principal に、<strong>対象 subscription / resource group</strong> へ最小ロール (問題テンプレートが触る action だけのカスタムロール等) を付与する。Owner は付けない。</li>
+<li><input disabled="" type="checkbox"> 控える値: <code>azureTenantId</code> (directory GUID)、<code>clientId</code>、<code>clientSecret</code>、<code>subscriptionId</code>、<code>resourceGroup</code>、任意の <code>location</code>。</li>
+</ul>
+<blockquote>
+<p>Azure には AWS-native な federation 経路がない (Entra の federated credential は OIDC issuer しか受け付けない)。ADR-032 は platform-as-OIDC-issuer サブシステムを意図的に後回しにしており、v1 は stored client secret を使う。Sakura キーと同等に扱うこと。</p>
+</blockquote>
+<h3>GCP (鍵レス)</h3>
+<ul>
+<li><input disabled="" type="checkbox"> チームの GCP プロジェクトに <strong>Workload Identity Pool</strong> と、platform の AWS deploy-worker identity を信頼する <strong>AWS provider</strong> を作る。</li>
+<li><input disabled="" type="checkbox"> 対象プロジェクトへ最小ロールを持つ <strong>service account</strong> を用意し、WIF principal に <code>roles/iam.serviceAccountTokenCreator</code> を付与する (impersonation binding)。</li>
+<li><input disabled="" type="checkbox"> 控える値: <code>wifAudience</code> (例 <code>//iam.googleapis.com/projects/&lt;n&gt;/locations/global/workloadIdentityPools/tenkacloud/providers/aws</code>)、<code>serviceAccountEmail</code>、<code>projectId</code>、<code>location</code>。</li>
+</ul>
+<blockquote>
+<p>GCP は唯一の鍵レス provider で、secret を一切保管しない。deploy worker は <code>GetCallerIdentity</code> リクエストに署名し、GCP STS で交換し、1 時間有効な token で service account を impersonate する。</p>
+</blockquote>
+<h2>Step 2: チーム別の認証情報を登録する</h2>
+<p>登録は <strong>Application Admin console → Competitor Accounts → &quot;Team cloud credentials&quot;</strong> パネルから行う。パネルは認証情報を <code>admin/team-cloud-credentials/:provider/:teamSlug</code> に <code>PUT</code> し、backend が provider 別の形を検証して SSM SecureString に書く。secret は write-only で、status 確認は boolean だけを返し secret は返さない。</p>
+<table>
+<thead>
+<tr>
+<th>Provider</th>
+<th>貼り付ける認証情報 JSON</th>
+<th>SSM SecureString path</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>sakura</code></td>
+<td><code>{ &quot;accessToken&quot;: &quot;...&quot;, &quot;accessTokenSecret&quot;: &quot;...&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/sakura-api-key</code></td>
+</tr>
+<tr>
+<td><code>azure</code></td>
+<td><code>{ &quot;azureTenantId&quot;: &quot;...&quot;, &quot;clientId&quot;: &quot;...&quot;, &quot;clientSecret&quot;: &quot;...&quot;, &quot;subscriptionId&quot;: &quot;...&quot;, &quot;resourceGroup&quot;: &quot;...&quot;, &quot;location&quot;: &quot;japaneast&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/azure-credential</code></td>
+</tr>
+<tr>
+<td><code>gcp</code></td>
+<td><code>{ &quot;wifAudience&quot;: &quot;...&quot;, &quot;serviceAccountEmail&quot;: &quot;...&quot;, &quot;projectId&quot;: &quot;...&quot;, &quot;location&quot;: &quot;asia-northeast1&quot; }</code></td>
+<td><code>/&lt;env&gt;/tenants/&lt;tenantId&gt;/teams/&lt;teamSlug&gt;/gcp-credential</code></td>
+</tr>
+</tbody></table>
+<ul>
+<li><input disabled="" type="checkbox"> provider を選び、team slug (<code>^[a-z0-9-]+$</code>) を入力し、JSON を貼り付けて <strong>Register</strong> を押す。</li>
+<li><input disabled="" type="checkbox"> <strong>Status</strong> を押すと registered と表示されるはず。</li>
+<li><input disabled="" type="checkbox"> <code>&lt;env&gt;</code> は deploy 環境 (<code>development</code> / <code>staging</code> / <code>production</code>)。deploy worker の IAM はこれらの path にスコープした <code>ssm:GetParameter</code> + <code>kms:Decrypt</code> を既に付与済 (<code>deploy-api-lambda.ts</code>) なので、チームごとの IAM 変更は不要。</li>
+</ul>
+<h2>Step 3: 問題の runtime を宣言する</h2>
+<p>問題の <code>metadata.json</code> は <code>runtime</code> ブロックで対象を宣言する。無ければ legacy の <code>aws/cloudformation</code> として扱われる。</p>
+<pre><code class="language-jsonc">{ &quot;runtime&quot;: { &quot;provider&quot;: &quot;gcp&quot;, &quot;engine&quot;: &quot;infra-manager&quot;, &quot;entry&quot;: &quot;main.tf&quot; } }
+</code></pre>
+<ul>
+<li><input disabled="" type="checkbox"> <code>provider</code> / <code>engine</code> は上表の 3 行のいずれか。</li>
+<li><input disabled="" type="checkbox"> <code>make validate-problems</code> が runtime ブロックを <code>problems/SCHEMA.json</code> に対して検証する。</li>
+<li><input disabled="" type="checkbox"> provider の認証情報がチームに登録されていない場合、<code>selectAdapter</code> は <strong>クラウド変更の前に</strong> <code>RuntimeNotSupportedError</code> (reserved) を投げる。AWS への暗黙フォールバックはせず loud に落ちる。</li>
+</ul>
+<h2>Step 4: deploy・reconcile・撤去</h2>
+<p>流れは AWS 問題と同一で、adapter 抽象が provider 差を隠す。</p>
+<ol>
+<li><strong>Deploy</strong> — オペレータが問題をチームに deploy する。deploy worker は adapter 依存を組み (<code>buildAdapterDependencies</code>)、認証情報を交換し、<code>adapter.deploy</code> を呼ぶ。status は <code>deploying</code> から始まる。</li>
+<li><strong>Reconcile</strong> — generic-scoring の tick が <code>adapter.getStatus</code> / <code>adapter.collectOutputs</code> (runtime-status reconciler) を呼び、deployment 行を <code>ready</code> に進め、participant portal が見せる endpoint outputs を永続化する。</li>
+<li><strong>撤去</strong> — teardown は <code>adapter.destroy</code> を呼び、status は <code>destroying</code> を経て <code>destroyed</code> になる。イベント全体は通常の <a href="./teardown.md">teardown runbook</a> に従う。</li>
+</ol>
+<h2>Provider 別の検証チェックリスト</h2>
+<p>provider の実アカウントを入手したら一度実施する。これがマルチクラウド tracker (<a href="https://github.com/susumutomita/TenkaCloud/issues/1408">#1408</a>) と provider 別 issue (Sakura #1412 / Azure #1410 / GCP #1411 / federation onboarding #1413) の受け入れ証跡になる。機構と unit + contract test は既に出荷済で、このチェックリストは live での確認にあたる。</p>
+<ul>
+<li><input disabled="" type="checkbox"> チームのクラウドアカウント側で trust bootstrap (Step 1) 済、最小権限を適用。</li>
+<li><input disabled="" type="checkbox"> 認証情報を登録し <strong>Status</strong> が registered (Step 2)。</li>
+<li><input disabled="" type="checkbox"> その <code>runtime</code> を宣言した問題が <code>make validate-problems</code> を通る。</li>
+<li><input disabled="" type="checkbox"> deploy が <code>ready</code> に到達し、portal に endpoint output が出る。</li>
+<li><input disabled="" type="checkbox"> 未登録チームは <code>RuntimeNotSupportedError</code> で loud に落ち、リソースは作られない。</li>
+<li><input disabled="" type="checkbox"> teardown が <code>destroyed</code> に到達し、チームのクラウドアカウントに orphan が残らない (provider console で突き合わせ)。</li>
+<li><input disabled="" type="checkbox"> (GCP) SSM に secret が一切書かれていないことを確認 (非秘密の WIF config のみ)。</li>
+</ul>
+<h2>Rotation と revocation</h2>
+<ul>
+<li><strong>Rotate</strong> — 同じパネルから再登録する (<code>PUT</code> が SSM SecureString を上書きする)。Sakura キーと Azure client secret は long-lived なので、チームの通常頻度と漏洩疑いの後に rotate する。</li>
+<li><strong>Revoke</strong> — パネルの <strong>Revoke</strong> (<code>DELETE</code>) を使う。以降そのチームの deploy は再登録まで loud に落ちる (<code>no &lt;provider&gt; credential registered ...</code>)。provider console 側の secret も失効させる。</li>
+<li>GCP は rotate すべき stored secret が無い。impersonation binding を外すか、チームの GCP プロジェクトで WIF provider を無効化して revoke する。</li>
+</ul>
+<h2>トラブルシュート</h2>
+<table>
+<thead>
+<tr>
+<th>症状</th>
+<th>原因の可能性</th>
+<th>対応</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>deploy が <code>RuntimeNotSupportedError</code> (reserved) で拒否される</td>
+<td>チームに認証情報が未登録</td>
+<td>登録 (Step 2) してから再 deploy</td>
+</tr>
+<tr>
+<td><code>no &lt;provider&gt; credential registered for tenant ... team ...</code></td>
+<td>SecureString が無い、または team slug 誤り</td>
+<td>slug を見直して再登録</td>
+</tr>
+<tr>
+<td>deploy 時に Azure token エラー</td>
+<td>app registration の secret 失効、またはロールが狭すぎる</td>
+<td>secret を rotate / ロールをテンプレートの action に合わせて広げる</td>
+</tr>
+<tr>
+<td>GCP STS 交換が失敗</td>
+<td>WIF provider が worker identity を信頼していない、または impersonation binding が無い</td>
+<td>pool の AWS provider 条件と <code>serviceAccountTokenCreator</code> binding を見直す</td>
+</tr>
+<tr>
+<td>Sakura 401</td>
+<td>API キー失効または scope 誤り</td>
+<td>AppRun スコープのキーを再発行して再登録</td>
+</tr>
+</tbody></table>
+<h2>関連</h2>
+<ul>
+<li><a href="./teardown.md">Teardown</a> — provider 別 <code>destroy</code> が集約されるイベントレベルの撤去。</li>
+<li><a href="./incident-response.md">Incident response</a> — イベント中に非 AWS deploy が停滞した場合。</li>
+<li><a href="../architecture/adr-026-sakura-cloud-problem-provider.html">ADR-026</a> / <a href="../architecture/adr-027-azure-gcp-federated-providers.html">ADR-027</a> / <a href="../architecture/adr-032-cross-cloud-federation-subject-token.html">ADR-032</a> — provider と federation の設計。</li>
+</ul>
+
+<div class="doc-source">Source: <code>docs/runbooks/multi-cloud-providers.ja.md</code> — このファイルは
+<code>scripts/build-docs.ts</code> が markdown から自動生成したものです。直接編集せず
+<code>docs/runbooks/multi-cloud-providers.ja.md</code> 側を直して <code>make build-docs</code> を実行してください。</div>
+</body>
+</html>

--- a/docs/runbooks/multi-cloud-providers.ja.md
+++ b/docs/runbooks/multi-cloud-providers.ja.md
@@ -1,0 +1,113 @@
+# マルチクラウド問題プロバイダ (Sakura / Azure / GCP)
+
+> English: [multi-cloud-providers.md](./multi-cloud-providers.md)
+
+| 項目 | 内容 |
+|---|---|
+| 対象者 | 非 AWS 問題をチームに対して有効化するオペレータ (Tenant Admin) |
+| 使うタイミング | Sakura / Azure / GCP 問題を動かすチームごとに 1 回、その問題を deploy する前 |
+| 所要時間 | チーム × プロバイダごとに 20 分 (大半は一度きりのクラウド側 trust bootstrap) |
+| 成果物 | チームの provider 別認証情報が登録され、問題の `runtime` が live な adapter に解決し、非 AWS deploy が `ready` に到達してきれいに撤去できる |
+
+TenkaCloud の control plane は常に AWS 上で動く。個々の **問題** は `aws/cloudformation` 以外の `runtime` を宣言することで別クラウドを対象にできる。deploy worker はその provider 用の `ProblemRuntimeAdapter` を解決し、短命の認証情報を交換して、provider ネイティブの deploy API を駆動する。この runbook は「チームが存在する」状態から「そのチームに非 AWS 問題を deploy できる」状態までのオペレータ手順を示す。
+
+各 provider の設計判断は ADR にある。背景は一度目を通しておくとよい。
+
+| Provider / engine | Adapter | 認証モデル | ADR |
+|---|---|---|---|
+| `sakura/apprun` | Sakura AppRun | API キー (access token + secret) を SSM SecureString に保管 | [ADR-026](../architecture/adr-026-sakura-cloud-problem-provider.html) |
+| `azure/bicep` | Azure Deployment Stacks | app registration の client secret を SSM SecureString に保管 → `client_credentials` で ARM token | [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) |
+| `gcp/infra-manager` | GCP Infrastructure Manager | **鍵レス** Workload Identity Federation: 署名済 `sts:GetCallerIdentity` → GCP STS → service account impersonation | [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) |
+
+## Step 1: クラウド側 trust bootstrap (一度きり、チームのクラウドアカウント側)
+
+ここだけが TenkaCloud の外にある作業で、**チーム自身の** Sakura / Azure / GCP アカウント側で設定する。チームごとに 1 回行う。最小権限を徹底し、各認証情報は問題のリソースを deploy / delete できるだけにする。
+
+### Sakura
+
+- [ ] チームの Sakura アカウントで、AppRun にスコープした **API キー** (access token + access token secret) を発行する。
+- [ ] 2 つの値を控える。long-lived なので rotation の頻度を決めておく ([Rotation と revocation](#rotation-と-revocation) 参照)。
+
+### Azure
+
+- [ ] チームの Entra ID directory に **チーム専用の app registration** を作り、**client secret** を発行する。
+- [ ] その service principal に、**対象 subscription / resource group** へ最小ロール (問題テンプレートが触る action だけのカスタムロール等) を付与する。Owner は付けない。
+- [ ] 控える値: `azureTenantId` (directory GUID)、`clientId`、`clientSecret`、`subscriptionId`、`resourceGroup`、任意の `location`。
+
+> Azure には AWS-native な federation 経路がない (Entra の federated credential は OIDC issuer しか受け付けない)。ADR-032 は platform-as-OIDC-issuer サブシステムを意図的に後回しにしており、v1 は stored client secret を使う。Sakura キーと同等に扱うこと。
+
+### GCP (鍵レス)
+
+- [ ] チームの GCP プロジェクトに **Workload Identity Pool** と、platform の AWS deploy-worker identity を信頼する **AWS provider** を作る。
+- [ ] 対象プロジェクトへ最小ロールを持つ **service account** を用意し、WIF principal に `roles/iam.serviceAccountTokenCreator` を付与する (impersonation binding)。
+- [ ] 控える値: `wifAudience` (例 `//iam.googleapis.com/projects/<n>/locations/global/workloadIdentityPools/tenkacloud/providers/aws`)、`serviceAccountEmail`、`projectId`、`location`。
+
+> GCP は唯一の鍵レス provider で、secret を一切保管しない。deploy worker は `GetCallerIdentity` リクエストに署名し、GCP STS で交換し、1 時間有効な token で service account を impersonate する。
+
+## Step 2: チーム別の認証情報を登録する
+
+登録は **Application Admin console → Competitor Accounts → "Team cloud credentials"** パネルから行う。パネルは認証情報を `admin/team-cloud-credentials/:provider/:teamSlug` に `PUT` し、backend が provider 別の形を検証して SSM SecureString に書く。secret は write-only で、status 確認は boolean だけを返し secret は返さない。
+
+| Provider | 貼り付ける認証情報 JSON | SSM SecureString path |
+|---|---|---|
+| `sakura` | `{ "accessToken": "...", "accessTokenSecret": "..." }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/sakura-api-key` |
+| `azure` | `{ "azureTenantId": "...", "clientId": "...", "clientSecret": "...", "subscriptionId": "...", "resourceGroup": "...", "location": "japaneast" }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/azure-credential` |
+| `gcp` | `{ "wifAudience": "...", "serviceAccountEmail": "...", "projectId": "...", "location": "asia-northeast1" }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/gcp-credential` |
+
+- [ ] provider を選び、team slug (`^[a-z0-9-]+$`) を入力し、JSON を貼り付けて **Register** を押す。
+- [ ] **Status** を押すと registered と表示されるはず。
+- [ ] `<env>` は deploy 環境 (`development` / `staging` / `production`)。deploy worker の IAM はこれらの path にスコープした `ssm:GetParameter` + `kms:Decrypt` を既に付与済 (`deploy-api-lambda.ts`) なので、チームごとの IAM 変更は不要。
+
+## Step 3: 問題の runtime を宣言する
+
+問題の `metadata.json` は `runtime` ブロックで対象を宣言する。無ければ legacy の `aws/cloudformation` として扱われる。
+
+```jsonc
+{ "runtime": { "provider": "gcp", "engine": "infra-manager", "entry": "main.tf" } }
+```
+
+- [ ] `provider` / `engine` は上表の 3 行のいずれか。
+- [ ] `make validate-problems` が runtime ブロックを `problems/SCHEMA.json` に対して検証する。
+- [ ] provider の認証情報がチームに登録されていない場合、`selectAdapter` は **クラウド変更の前に** `RuntimeNotSupportedError` (reserved) を投げる。AWS への暗黙フォールバックはせず loud に落ちる。
+
+## Step 4: deploy・reconcile・撤去
+
+流れは AWS 問題と同一で、adapter 抽象が provider 差を隠す。
+
+1. **Deploy** — オペレータが問題をチームに deploy する。deploy worker は adapter 依存を組み (`buildAdapterDependencies`)、認証情報を交換し、`adapter.deploy` を呼ぶ。status は `deploying` から始まる。
+2. **Reconcile** — generic-scoring の tick が `adapter.getStatus` / `adapter.collectOutputs` (runtime-status reconciler) を呼び、deployment 行を `ready` に進め、participant portal が見せる endpoint outputs を永続化する。
+3. **撤去** — teardown は `adapter.destroy` を呼び、status は `destroying` を経て `destroyed` になる。イベント全体は通常の [teardown runbook](./teardown.md) に従う。
+
+## Provider 別の検証チェックリスト
+
+provider の実アカウントを入手したら一度実施する。これがマルチクラウド tracker ([#1408](https://github.com/susumutomita/TenkaCloud/issues/1408)) と provider 別 issue (Sakura #1412 / Azure #1410 / GCP #1411 / federation onboarding #1413) の受け入れ証跡になる。機構と unit + contract test は既に出荷済で、このチェックリストは live での確認にあたる。
+
+- [ ] チームのクラウドアカウント側で trust bootstrap (Step 1) 済、最小権限を適用。
+- [ ] 認証情報を登録し **Status** が registered (Step 2)。
+- [ ] その `runtime` を宣言した問題が `make validate-problems` を通る。
+- [ ] deploy が `ready` に到達し、portal に endpoint output が出る。
+- [ ] 未登録チームは `RuntimeNotSupportedError` で loud に落ち、リソースは作られない。
+- [ ] teardown が `destroyed` に到達し、チームのクラウドアカウントに orphan が残らない (provider console で突き合わせ)。
+- [ ] (GCP) SSM に secret が一切書かれていないことを確認 (非秘密の WIF config のみ)。
+
+## Rotation と revocation
+
+- **Rotate** — 同じパネルから再登録する (`PUT` が SSM SecureString を上書きする)。Sakura キーと Azure client secret は long-lived なので、チームの通常頻度と漏洩疑いの後に rotate する。
+- **Revoke** — パネルの **Revoke** (`DELETE`) を使う。以降そのチームの deploy は再登録まで loud に落ちる (`no <provider> credential registered ...`)。provider console 側の secret も失効させる。
+- GCP は rotate すべき stored secret が無い。impersonation binding を外すか、チームの GCP プロジェクトで WIF provider を無効化して revoke する。
+
+## トラブルシュート
+
+| 症状 | 原因の可能性 | 対応 |
+|---|---|---|
+| deploy が `RuntimeNotSupportedError` (reserved) で拒否される | チームに認証情報が未登録 | 登録 (Step 2) してから再 deploy |
+| `no <provider> credential registered for tenant ... team ...` | SecureString が無い、または team slug 誤り | slug を見直して再登録 |
+| deploy 時に Azure token エラー | app registration の secret 失効、またはロールが狭すぎる | secret を rotate / ロールをテンプレートの action に合わせて広げる |
+| GCP STS 交換が失敗 | WIF provider が worker identity を信頼していない、または impersonation binding が無い | pool の AWS provider 条件と `serviceAccountTokenCreator` binding を見直す |
+| Sakura 401 | API キー失効または scope 誤り | AppRun スコープのキーを再発行して再登録 |
+
+## 関連
+
+- [Teardown](./teardown.md) — provider 別 `destroy` が集約されるイベントレベルの撤去。
+- [Incident response](./incident-response.md) — イベント中に非 AWS deploy が停滞した場合。
+- [ADR-026](../architecture/adr-026-sakura-cloud-problem-provider.html) / [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) — provider と federation の設計。

--- a/docs/runbooks/multi-cloud-providers.md
+++ b/docs/runbooks/multi-cloud-providers.md
@@ -1,0 +1,113 @@
+# Multi-cloud problem providers (Sakura / Azure / GCP)
+
+> Japanese: [multi-cloud-providers.ja.md](./multi-cloud-providers.ja.md)
+
+| Attribute | Value |
+|---|---|
+| Audience | Operator (Tenant Admin) enabling a non-AWS problem for one or more teams |
+| When to use | Once per team that will run a Sakura / Azure / GCP problem, before you deploy that problem |
+| Estimated time | 20 minutes per team per provider (most of it is the one-time cloud-side trust bootstrap) |
+| Output | The team's per-provider credential is registered, the problem's `runtime` resolves to a live adapter, and a non-AWS deploy reaches `ready` and tears down cleanly |
+
+TenkaCloud's control plane always runs on AWS. Individual **problems** can target another cloud by declaring a `runtime` other than `aws/cloudformation`. The deploy worker resolves a `ProblemRuntimeAdapter` for that provider, exchanges a short-lived credential, and drives the provider's native deploy API. This runbook is the operator path from "a team exists" to "a non-AWS problem deploys for that team."
+
+The design decisions behind each provider live in the ADRs — read them once for context:
+
+| Provider / engine | Adapter | Credential model | ADR |
+|---|---|---|---|
+| `sakura/apprun` | Sakura AppRun | Stored API key (access token + secret) in SSM SecureString | [ADR-026](../architecture/adr-026-sakura-cloud-problem-provider.html) |
+| `azure/bicep` | Azure Deployment Stacks | Stored app-registration client secret in SSM SecureString → `client_credentials` ARM token | [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) |
+| `gcp/infra-manager` | GCP Infrastructure Manager | **Keyless** Workload Identity Federation: signed `sts:GetCallerIdentity` → GCP STS → service-account impersonation | [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) |
+
+## Step 1: cloud-side trust bootstrap (one-time, in the team's cloud account)
+
+This is the one piece that lives outside TenkaCloud — it is set up in the **team's own** Sakura / Azure / GCP account. Do it once per team. Apply least privilege: each credential should only be able to deploy and delete the problem's resources.
+
+### Sakura
+
+- [ ] In the team's Sakura account, issue an **API key** (access token + access token secret) scoped to AppRun.
+- [ ] Note the two values. They are long-lived, so plan a rotation cadence (see [Rotation and revocation](#rotation-and-revocation)).
+
+### Azure
+
+- [ ] Create a **per-team app registration** in the team's Entra ID directory and generate a **client secret**.
+- [ ] Grant that service principal a minimal role (e.g. a custom role with only the resource actions the problem template touches) on the **target subscription / resource group** — not Owner.
+- [ ] Record: `azureTenantId` (directory GUID), `clientId`, `clientSecret`, `subscriptionId`, `resourceGroup`, and optional `location`.
+
+> Azure has no AWS-native federation path (Entra federated credentials accept only an OIDC issuer). ADR-032 deliberately defers the platform-as-OIDC-issuer subsystem; v1 uses a stored client secret, so treat it with the same care as the Sakura key.
+
+### GCP (keyless)
+
+- [ ] Create a **Workload Identity Pool** and an **AWS provider** in the team's GCP project that trusts the platform's AWS deploy-worker identity.
+- [ ] Create (or pick) a **service account** with a minimal role on the target project, and grant the WIF principal `roles/iam.serviceAccountTokenCreator` on it (impersonation binding).
+- [ ] Record: `wifAudience` (e.g. `//iam.googleapis.com/projects/<n>/locations/global/workloadIdentityPools/tenkacloud/providers/aws`), `serviceAccountEmail`, `projectId`, and `location`.
+
+> GCP is the only keyless provider: no secret is ever stored. The deploy worker signs a `GetCallerIdentity` request, exchanges it at GCP STS, and impersonates the service account for a 1-hour token.
+
+## Step 2: register the per-team credential
+
+Registration is done from the **Application Admin console → Competitor Accounts → "Team cloud credentials"** panel. The panel `PUT`s the credential to `admin/team-cloud-credentials/:provider/:teamSlug`; the backend validates the provider-specific shape and writes it to an SSM SecureString. The secret is write-only — the status check returns a boolean, never the secret.
+
+| Provider | Credential JSON to paste | SSM SecureString path |
+|---|---|---|
+| `sakura` | `{ "accessToken": "...", "accessTokenSecret": "..." }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/sakura-api-key` |
+| `azure` | `{ "azureTenantId": "...", "clientId": "...", "clientSecret": "...", "subscriptionId": "...", "resourceGroup": "...", "location": "japaneast" }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/azure-credential` |
+| `gcp` | `{ "wifAudience": "...", "serviceAccountEmail": "...", "projectId": "...", "location": "asia-northeast1" }` | `/<env>/tenants/<tenantId>/teams/<teamSlug>/gcp-credential` |
+
+- [ ] Select the provider, enter the team slug (`^[a-z0-9-]+$`), paste the JSON, and click **Register**.
+- [ ] Click **Status** — it should report registered.
+- [ ] `<env>` is the deploy environment (`development` / `staging` / `production`). The deploy worker's IAM already grants `ssm:GetParameter` + `kms:Decrypt` scoped to these paths (`deploy-api-lambda.ts`), so no IAM change is needed per team.
+
+## Step 3: declare the problem runtime
+
+The problem's `metadata.json` declares the target with a `runtime` block; without it, a problem is treated as legacy `aws/cloudformation`.
+
+```jsonc
+{ "runtime": { "provider": "gcp", "engine": "infra-manager", "entry": "main.tf" } }
+```
+
+- [ ] `provider` / `engine` must be one of the three rows in the table above.
+- [ ] `make validate-problems` checks the runtime block against `problems/SCHEMA.json`.
+- [ ] If the provider's credential is **not** registered for the team, `selectAdapter` raises `RuntimeNotSupportedError` (reserved) **before any cloud mutation** — a loud failure, never a silent fallback to AWS.
+
+## Step 4: deploy, reconcile, and tear down
+
+The flow is identical to an AWS problem — the adapter abstraction hides the provider:
+
+1. **Deploy** — the operator deploys the problem for the team. The deploy worker builds the adapter dependencies (`buildAdapterDependencies`), exchanges the credential, and calls `adapter.deploy`. Status starts at `deploying`.
+2. **Reconcile** — the generic-scoring tick calls `adapter.getStatus` / `adapter.collectOutputs` (the runtime-status reconciler), advancing the deployment row to `ready` and persisting the endpoint outputs the participant portal shows.
+3. **Tear down** — teardown calls `adapter.destroy`; status moves through `destroying` to `destroyed`. Follow the normal [teardown runbook](./teardown.md) for the event as a whole.
+
+## Per-provider verification checklist
+
+Run this once you have a real account for a provider. It is the acceptance evidence for the multi-cloud tracker ([#1408](https://github.com/susumutomita/TenkaCloud/issues/1408)) and the per-provider issues (Sakura #1412 / Azure #1410 / GCP #1411 / federation onboarding #1413). The mechanism and its unit + contract tests already ship; this checklist is the live confirmation.
+
+- [ ] Trust bootstrap done in the team's cloud account (Step 1), least privilege applied.
+- [ ] Credential registered and **Status** reports registered (Step 2).
+- [ ] A problem declaring that `runtime` passes `make validate-problems`.
+- [ ] Deploy reaches `ready`; the portal shows the endpoint output.
+- [ ] An unregistered team fails loud with `RuntimeNotSupportedError`, with no resource created.
+- [ ] Teardown reaches `destroyed`; no orphan resource remains in the team's cloud account (cross-check the provider console).
+- [ ] (GCP) Confirm no secret was ever written to SSM — only the non-secret WIF config.
+
+## Rotation and revocation
+
+- **Rotate** — re-register through the same panel (`PUT` overwrites the SSM SecureString in place). Sakura keys and Azure client secrets are long-lived; rotate on the team's normal cadence and after any suspected exposure.
+- **Revoke** — use the panel's **Revoke** (`DELETE`). The next deploy for that team then fails loud (`no <provider> credential registered ...`) until re-registered. Also revoke the underlying secret in the provider's console.
+- GCP has no stored secret to rotate; revoke by removing the impersonation binding or disabling the WIF provider in the team's GCP project.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Deploy rejected with `RuntimeNotSupportedError` (reserved) | Credential not registered for the team | Register it (Step 2), then redeploy |
+| `no <provider> credential registered for tenant ... team ...` | SecureString missing or wrong team slug | Re-check the slug and re-register |
+| Azure token error on deploy | App-registration secret expired, or the role is too narrow | Rotate the secret / widen the role to the template's actions |
+| GCP STS exchange fails | WIF provider does not trust the worker identity, or impersonation binding missing | Re-check the pool's AWS provider condition and the `serviceAccountTokenCreator` binding |
+| Sakura 401 | API key revoked or wrong scope | Re-issue the AppRun-scoped key and re-register |
+
+## Related
+
+- [Teardown](./teardown.md) — the event-level teardown that the per-provider `destroy` rolls up into.
+- [Incident response](./incident-response.md) — if a non-AWS deploy stalls during the event.
+- [ADR-026](../architecture/adr-026-sakura-cloud-problem-provider.html) / [ADR-027](../architecture/adr-027-azure-gcp-federated-providers.html) / [ADR-032](../architecture/adr-032-cross-cloud-federation-subject-token.html) — the provider and federation design.


### PR DESCRIPTION
## Summary

Adds the operator runbook the multi-cloud work was missing. The adapters, credential stores, onboarding UX (#1661), and IAM are all built (ADR-026/027/032), but there was no doc telling an operator how to actually enable a Sakura / Azure / GCP problem for a team. The existing 7 runbooks cover event-day operations, not this per-team setup.

`docs/runbooks/multi-cloud-providers.md` (+ `.ja.md`) covers, per provider:

- **Cloud-side trust bootstrap** (one-time, in the team's account): Sakura API key, Azure per-team app registration + client secret + minimal ARM role, GCP keyless WIF (pool + AWS provider + SA impersonation binding).
- **Registering the per-team credential** via the Application Admin → Competitor Accounts → "Team cloud credentials" panel, with the **exact credential JSON shapes and SSM SecureString paths** for each provider, and a note that `deploy-api-lambda.ts` already scopes the worker's `ssm:GetParameter` + `kms:Decrypt` to those paths.
- **Declaring `metadata.runtime`** and the loud `RuntimeNotSupportedError` (no silent AWS fallback) when a credential is missing.
- **Deploy → reconcile → teardown** flow through the adapter abstraction.
- **Rotation / revocation** and a **troubleshooting table**.
- A **per-provider verification checklist** — the acceptance evidence for #1408 / #1410 / #1411 / #1412 / #1413 to run once a real cloud account is procured (the mechanism + its unit/contract tests already ship; this is the live confirmation step that lets the owner close those issues).

English + Japanese, generated HTML, indexed in the runbooks README (both locales).

## Test plan

- `make harness` — no findings.
- `make before-commit` green: markdownlint (0 errors), textlint (clean — fixed 常体/敬体 mixing), `build-docs --check` (HTML in sync), plus the full typecheck/test/build/validate-problems/template-security/cdk-synth chain (docs-only change, nothing else affected).

Relates #1408. Relates #1410. Relates #1411. Relates #1412. Relates #1413.

## Regression analysis

- **Docs-only.** New `docs/runbooks/multi-cloud-providers.{md,ja.md,html,ja.html}` + 2 index rows and a cross-link bullet in `README.{md,ja.md}` (and regenerated `README.{html,ja.html}`). No code, no behavior, no other generated HTML changed.
- The runbook documents existing, merged behavior; it cannot drift undetected because the credential JSON shapes / SSM paths it cites are the same builders enforced in code (`*-credential-store.ts`, `deploy-api-lambda.ts`).

## Physical impact

- **NO-OP.** Documentation only; no CloudFormation / IAM / DynamoDB / artifact diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)