### PR TITLE
feat(scoring): disruption scoring effects — condition + operator fired (ADR-033) [#1665]

### DIFF
--- a/docs/architecture/adr-033-scoring-side-disruption-effects.html
+++ b/docs/architecture/adr-033-scoring-side-disruption-effects.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-033: Scoring-side disruption effects</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft { background: #ddf4ff; color: var(--c-link); }
+  .badge.accept { background: #dafbe1; color: var(--c-accept); }
+  .badge.reject { background: #ffe5e5; color: var(--c-reject); }
+  .badge.warn { background: #fff8c5; color: var(--c-warn); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  .ok { color: var(--c-accept); font-weight: 600; }
+  .no { color: var(--c-reject); font-weight: 600; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  .seq { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.82rem; white-space: pre; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-033: Scoring-side disruption effects</h1>
+  <p><em>fire しても採点が動かない disruption に、 実クラウドへの fault 注入を伴わずに「採点上の効果 (減点 / 可用性ダウン)」を与えるための宣言契約と評価経路</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge draft">Proposed</span> 2026-06-03</div>
+    <div><b>Related:</b>
+      <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a> (disruption 宣言 / Phase A→B / condition trigger),
+      <a href="./adr-031-cross-account-disruption-dispatch.html">ADR-031</a> (cross-account の実 fault 注入 <code>action</code>),
+      <a href="./adr-029-attack-resilience-game-always-ends.html">ADR-029</a> (game always ends),
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin, platform = host)
+    </div>
+    <div><b>Issue:</b> #1665 (#1417 の子)</div>
+  </div>
+</header>
+
+<h2>背景 — 何が壊れているか</h2>
+<p>
+2026-06-03 のコード監査で、 宣言済の disruption 9 件のうち <strong>採点や挙動に実際の効果を与えるのは 1 件だけ</strong> (= <code>microservice-migration-battle/ec2-latency-injection</code>、 ADR-031 の <code>action</code> で実 fault を注入) と判明した。 残り 8 件は fire しても <code>*DisruptionFired</code> イベントの publish と監査行の書き込みで終わり、 競技結果は 1 点も動かない。
+</p>
+<p>
+とくに <code>stackstack</code> (scoring kind = <code>phased-polling</code>) の 5 件は説明文で「追加減点」「<code>failurePenalty</code> を累積追加」「auth slot を 5 分間 503 にする (= 5 cycle ぶん加点 0)」と <strong>採点上の効果</strong>を約束しているが、 それを実現するコード経路が無い。 採点 kind (<code>uptime-multi</code> / <code>phased-polling</code> 等) は実エンドポイントを probe するだけで、 fire 済 disruption を一切参照しない。 = 説明文だけのハリボテ。
+</p>
+<p>
+これらは <em>本質的に「ビジネス/シナリオ上の圧力」</em>であり、 競技者アカウントの実インフラを物理的に壊す必要はない (CEO が 5000 人を要求 / Legal が PII を検出 / .env 流出で 5 分間ダウン扱い)。 必要なのは <strong>採点エンジンが、 ある期間その team の点に効果を与える</strong>ことである。 これは ADR-031 の cross-account 実 fault 注入とは別レイヤの実現手段で、 <strong>実クラウドアカウントを必要としない</strong>。
+</p>
+
+<h2>決定</h2>
+<p>
+disruption 宣言に省略可能な <code>effect</code> を追加し、 採点エンジンがその効果を <strong>active window の間だけ</strong> 各 tick で <code>KindResult</code> に畳み込む。 disruption の 2 つの実現手段を明確に分離する:
+</p>
+<table>
+  <thead><tr><th>手段</th><th>実現するもの</th><th>必要環境</th><th>ADR</th></tr></thead>
+  <tbody>
+    <tr><td><code>action</code></td><td>競技者アカウントの実インフラに <strong>物理 fault</strong> (latency / 503 / process kill)。 team の probe がそれを観測して採点が下がる。</td><td>実クラウド + AssumeRole</td><td>ADR-031</td></tr>
+    <tr><td><code>effect</code> (本 ADR)</td><td>採点エンジンが直接与える <strong>採点上の効果</strong> (減点 / 指定 slot を fail 扱い)。 物理 fault は起こさない。</td><td>不要 (platform 内で完結)</td><td>ADR-033</td></tr>
+  </tbody>
+</table>
+<p>
+両者は排他ではない。 1 つの disruption が <code>action</code> と <code>effect</code> の両方を持ってもよい (実 fault + 追加減点)。 どちらも無い disruption は従来どおり「監査のみ」(= 後方互換)。
+</p>
+
+<h3>effect の宣言契約</h3>
+<pre>// metadata.json の disruptions[].effect (省略可)
+{
+  "kind": "penalty",        // 指定点を減点する (= scoreDelta に負値を加える)
+  "points": 50,
+  "durationSeconds": 300
+}
+{
+  "kind": "unavailability", // 指定 slot を window 中 fail 扱いにする (= 加点を 0 にし failurePenalty を課す)
+  "slots": ["auth"],
+  "durationSeconds": 300
+}</pre>
+<ul>
+  <li><code>kind</code> は <code>"penalty" | "unavailability"</code> の allow-list。 未知の kind は validator で reject。</li>
+  <li><code>durationSeconds</code> は正の有限数で上限 <strong>3600 (1h)</strong>。 ADR-029 の「永続障害禁止」と同じ思想で、 効果は必ず期限切れする。</li>
+  <li><code>points</code> (penalty) は正の整数。 <code>slots</code> (unavailability) は問題の <code>endpoints[]</code> slot 名の部分集合 (validator が突合)。</li>
+</ul>
+
+<h3>評価経路 (active window の解決)</h3>
+<p>
+disruption は 2 経路で fire される: <strong>condition-triggered</strong> (ADR-013 Phase 2、 採点 tick が score/経過/phase で発火) と <strong>operator-fired</strong> (ADR-031、 operator が API で発火)。 本 ADR は両経路に効果を与えるが、 実装は段階を分ける:
+</p>
+<table>
+  <thead><tr><th>段階</th><th>fire 経路</th><th>active window の出所</th><th>追加 I/O</th></tr></thead>
+  <tbody>
+    <tr><td><b>Phase 1 (本 ADR の初回実装)</b></td><td>condition-triggered</td><td>採点 tick が発火と同時に <code>scoringState.activeEffects[]</code> に <code>{disruptionId, effect, expiresAtMs}</code> を記録。 以降の tick は <strong>自分の行の scoringState だけ</strong>を読んで適用 + 期限切れを prune。</td><td class="ok">なし (既存の UpdateItem に相乗り)</td></tr>
+    <tr><td>Phase 2 (follow-up)</td><td>operator-fired</td><td>採点 tick が event ごとに disruptions table の AUDIT# 行を 1 回 query し、 当該 team / 効果 window 内の effect を解決。</td><td>event あたり 1 query/tick</td></tr>
+  </tbody>
+</table>
+<p>
+Phase 1 を先に出すのは、 <strong>追加の DDB read を一切増やさず</strong> (cost-zero 原則) に効果機構を end-to-end で成立させ、 ユニットテストで完全に pin できるからである。 operator-fired (stackstack) は宣言に <code>triggers</code> を足せば Phase 1 で動くか、 Phase 2 の query 経路で拾う。
+</p>
+
+<h3>採点 tick への畳み込み</h3>
+<p>
+純関数 <code>applyDisruptionEffects(result, activeEffects, slots, nowMs)</code> が、 kind handler が出した <code>KindResult</code> を受け取り、 active な effect を畳み込んだ新しい <code>KindResult</code> を返す:
+</p>
+<ul>
+  <li><code>penalty</code>: <code>scoreDelta -= points</code>、 かつ <code>source="disruption-penalty"</code> の score event を 1 行追加 (= timeline に減点が見える)。</li>
+  <li><code>unavailability</code>: 対象 slot が <code>uptime-multi</code> / <code>phased-polling</code> の health 集計で fail 扱いになり、 当該 cycle の加点を 0 にして <code>failurePenalty</code> を課す。</li>
+  <li>期限切れ (<code>nowMs &gt;= expiresAtMs</code>) の effect は適用せず、 scoringState から除く。</li>
+  <li>active effect が無ければ <code>result</code> をそのまま返す (= 完全な後方互換)。</li>
+</ul>
+<div class="seq">condition fire (tick T0)            tick T1 (T0+60s)             tick TN (window 経過後)
+  ┌─────────────────┐               ┌────────────────┐           ┌──────────────────┐
+  │ trigger 成立      │               │ activeEffects   │           │ expiresAtMs 経過  │
+  │ effect を         │──scoringState │ を読む          │           │ → prune、 適用なし │
+  │ activeEffects に  │   に永続化     │ → scoreDelta    │           │ → 通常採点に復帰   │
+  │ 記録              │               │   -= points     │           │                  │
+  └─────────────────┘               └────────────────┘           └──────────────────┘</div>
+
+<h2>代替案と却下理由</h2>
+<table>
+  <thead><tr><th>案</th><th>却下理由</th></tr></thead>
+  <tbody>
+    <tr><td>全 disruption を ADR-031 の <code>action</code> (実 fault) で実現する</td><td><span class="no">却下</span>。 「CEO が 5000 人要求」「Legal が PII 検出」は物理 fault が存在しない純粋なシナリオ圧力。 実 fault に無理やり変換すると問題設計が歪む。 採点上の効果が正しい抽象。</td></tr>
+    <tr><td>採点エンジンが毎 tick disruptions table を query して active effect を解決 (Phase 2 を最初からやる)</td><td><span class="no">初回は却下</span>。 deployment ごとに read が増え 1/1 RCU を圧迫 (cost-zero 原則に反する)。 condition-triggered を scoringState 相乗りで先に出し、 operator-fired は別 slice で最小コストの query 設計にする。</td></tr>
+    <tr><td>effect を frontend / scoring の外 (例: 別 Lambda) で適用</td><td><span class="no">却下</span>。 採点の単一責務は generic-scoring に集約済 (ADR-012)。 効果も採点 tick 内で畳むのが SRP。</td></tr>
+    <tr><td>無期限の effect を許す</td><td><span class="no">却下</span>。 ADR-029「どの障害も永続しない / ゲームは必ず終わる」に反する。 <code>durationSeconds</code> 必須 + 上限 1h。</td></tr>
+  </tbody>
+</table>
+
+<h2>影響</h2>
+<ul>
+  <li><strong>SCHEMA</strong> (submodule <code>problems/SCHEMA.json</code>): <code>disruptions[].effect</code> を追加 (省略可、 enum + required + 上限)。</li>
+  <li><strong>catalog 型 + parser</strong> (<code>discover-problems-catalog.ts</code>): <code>DisruptionEffect</code> 型 + <code>parseDisruptionEffect</code> (fail-safe drop、 <code>parseDisruptionAction</code> と同型)。</li>
+  <li><strong>validator</strong> (<code>validate-problems</code>): kind allow-list / durationSeconds 上限 / unavailability の slots ⊆ endpoints を enforce。</li>
+  <li><strong>採点エンジン</strong>: <code>scoringState.activeEffects[]</code> + 純関数 <code>applyDisruptionEffects</code> + condition-fire 時の記録 + tick での適用/prune。</li>
+  <li><strong>参照問題</strong> (submodule): <code>stackstack</code> の減点系 disruption に <code>effect</code> を宣言し、 fire → 減点 → 復帰が実データで動くことを示す。</li>
+  <li>後方互換: <code>effect</code> 未宣言の disruption / 既存問題は挙動不変。</li>
+</ul>
+
+<h2>移行</h2>
+<ol>
+  <li>parent: catalog 型 + parser + 純関数 <code>applyDisruptionEffects</code> + scoringState 拡張 + tick 配線 + unit test (本 ADR の初回 PR、 condition-triggered 経路)。</li>
+  <li>submodule: SCHEMA + <code>stackstack</code> (または新規参照問題) の <code>effect</code> 宣言 + validator。 parent の pin bump。</li>
+  <li>follow-up (#1665 Phase 2): operator-fired 経路の active-effect query (最小コスト設計)。</li>
+</ol>
+<p>
+完了の定義は「fire → 採点が宣言どおり下がり、 window 経過で戻る」が <strong>ユニットテストで証明</strong>されること。 実クラウドや実競技は要らない。 これが満たされて初めて、 当該 disruption を「実装済」と呼ぶ。
+</p>
+</body>
+</html>

--- a/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
+++ b/infrastructure/lib/problem-deploy/generic-scoring-lambda.ts
@@ -51,6 +51,11 @@ export interface GenericScoringLambdaProps {
    */
   readonly problemsDisruptions: Readonly<Record<string, unknown>>;
   /**
+   * [ADR-033 / #1665] disruptions audit table。 operator-fired disruption の active 採点効果を tick で
+   * 解決するため read-only で query する (= scoring-side effect)。
+   */
+  readonly disruptionsTable: ITable;
+  /**
    * [#1422] condition-triggered disruption の publish 先 event bus (= 手動 fire と同じ deploy bus)。
    * scoring Lambda に `events:PutEvents` を least-privilege で付与する。
    */
@@ -111,6 +116,8 @@ export class GenericScoringLambda extends Construct {
         DEPLOY_EVENT_BUS_NAME: props.eventBus.eventBusName,
         // [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler の credential path 構築用。
         DEPLOY_ENVIRONMENT: props.environmentName,
+        // [ADR-033 / #1665] operator-fired disruption の active 採点効果を解決するための audit table。
+        DISRUPTIONS_TABLE_NAME: props.disruptionsTable.tableName,
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {
@@ -147,6 +154,9 @@ export class GenericScoringLambda extends Construct {
     props.eventsTable.grantReadWriteData(this.fn);
     // Endpoint registry: per (tenant, team, problem) の override 行を Query する (= read-only)。
     props.endpointsTable.grantReadData(this.fn);
+    // [ADR-033 / #1665] disruptions audit table: operator-fired disruption の active 採点効果を
+    // event ごとに Query する (= read-only、 scoring-side effect の解決)。
+    props.disruptionsTable.grantReadData(this.fn);
     // #1422: condition-triggered disruption を event bus に publish する (= events:PutEvents、
     // 当該 bus に scope された least-privilege)。
     props.eventBus.grantPutEventsTo(this.fn);

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/condition-disruption-fire.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/condition-disruption-fire.ts
@@ -1,6 +1,7 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type { DeploymentItem } from "../deploy-handler/types.js";
+import { buildActiveDisruptionEffect } from "./disruption-effects.js";
 import { evaluateDisruptionTriggers, type FiredDisruption } from "./disruption-triggers.js";
 import type {
   DeploymentScoringState,
@@ -55,15 +56,27 @@ export async function maybeFireConditionDisruptions(
 
   // score state は applyKindResult が既に result.newState を書いているので、 それ (無ければ prevState)
   // を base に firedDisruptions だけ merge する (= bonusAwarded / attackCount を温存)。
-  const baseState = result.newState ?? prevState;
+  const { activeEffects: priorEffects, ...baseState } = result.newState ?? prevState;
   const mergedFired = [...alreadyFired, ...fired.map((f) => f.disruptionId)];
+  // [ADR-033 / #1665] fire した disruption が effect を宣言していれば減点 window を記録する。
+  // 期限切れの prior 効果は prune し、 新規発火分を足す (= 次 tick 以降 applyDisruptionEffects が適用)。
+  const survivingPrior = (priorEffects ?? []).filter((e) => e.expiresAtMs > nowMs);
+  const newEffects = fired.flatMap((f) => {
+    const declared = disruptions.find((d) => d.id === f.disruptionId)?.effect;
+    return declared ? [buildActiveDisruptionEffect(f.disruptionId, declared, nowMs)] : [];
+  });
+  const activeEffects = [...survivingPrior, ...newEffects];
   await shared.ddb.send(
     new UpdateCommand({
       TableName: shared.deploymentsTableName,
       Key: { PK: item.PK, SK: "META" },
       UpdateExpression: "SET scoringState = :state, updatedAt = :now",
       ExpressionAttributeValues: {
-        ":state": JSON.stringify({ ...baseState, firedDisruptions: mergedFired }),
+        ":state": JSON.stringify({
+          ...baseState,
+          firedDisruptions: mergedFired,
+          ...(activeEffects.length > 0 ? { activeEffects } : {}),
+        }),
         ":now": nowIso,
       },
     }),

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects.ts
@@ -1,4 +1,7 @@
-import type { DisruptionEffect } from "../../../utils/discover-problems-catalog.js";
+import type {
+  DisruptionEffect,
+  ProblemDisruptionEntry,
+} from "../../../utils/discover-problems-catalog.js";
 import type { ActiveDisruptionEffect, KindResult } from "./shared.js";
 
 /**
@@ -41,4 +44,83 @@ export function buildActiveDisruptionEffect(
     points: effect.points,
     expiresAtMs: nowMs + effect.durationSeconds * 1000,
   };
+}
+
+/**
+ * [ADR-033] 同一 disruptionId の重複効果を 1 件に畳む (= condition-triggered と operator-fired が同じ
+ * disruption を両方 active にしても二重減点しない)。 expiresAtMs が最大のものを残す。
+ */
+export function dedupeEffectsByDisruptionId(
+  effects: readonly ActiveDisruptionEffect[],
+): readonly ActiveDisruptionEffect[] {
+  const byId = new Map<string, ActiveDisruptionEffect>();
+  for (const e of effects) {
+    const prev = byId.get(e.disruptionId);
+    if (!prev || e.expiresAtMs > prev.expiresAtMs) byId.set(e.disruptionId, e);
+  }
+  return [...byId.values()];
+}
+
+/** operator が fire した 1 件の disruption audit 行から、 採点効果の解決に要る最小フィールドだけを読む。 */
+export interface DisruptionAuditRowLike {
+  readonly disruptionId?: unknown;
+  readonly problemId?: unknown;
+  readonly targetTeamIds?: unknown;
+  readonly firedAt?: unknown;
+}
+
+/** 1 audit 行が今 active な採点効果かを判定し、 効果 + 対象 team + problemId を返す (= 不正/期限切れは undefined)。 */
+function activeEffectForAuditRow(
+  row: DisruptionAuditRowLike,
+  problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>,
+  nowMs: number,
+):
+  | {
+      readonly problemId: string;
+      readonly teamIds: string[];
+      readonly effect: ActiveDisruptionEffect;
+    }
+  | undefined {
+  if (typeof row.disruptionId !== "string" || typeof row.problemId !== "string") return undefined;
+  if (typeof row.firedAt !== "string" || !Array.isArray(row.targetTeamIds)) return undefined;
+  const declared = problemsDisruptions[row.problemId]?.find(
+    (d) => d.id === row.disruptionId,
+  )?.effect;
+  if (!declared) return undefined;
+  const firedAtMs = Date.parse(row.firedAt);
+  if (Number.isNaN(firedAtMs)) return undefined;
+  const expiresAtMs = firedAtMs + declared.durationSeconds * 1000;
+  if (expiresAtMs <= nowMs) return undefined; // window 経過
+  const teamIds = row.targetTeamIds.filter(
+    (t): t is string => typeof t === "string" && t.length > 0,
+  );
+  return {
+    problemId: row.problemId,
+    teamIds,
+    effect: { disruptionId: row.disruptionId, points: declared.points, expiresAtMs },
+  };
+}
+
+/**
+ * [ADR-033 / #1665] operator-fired disruption の audit 行群から、 まだ window 内の採点効果を team×problem 別に
+ * 解決する。 効果 (points / durationSeconds) は catalog 宣言から引き、 audit 行は「いつ・どの team に」を持つ。
+ * 純関数 — caller (handler) が disruptions table を query して行を渡す。 戻り値の key は `${teamId}#${problemId}`。
+ */
+export function resolveOperatorEffects(
+  auditRows: readonly DisruptionAuditRowLike[],
+  problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>,
+  nowMs: number,
+): Map<string, ActiveDisruptionEffect[]> {
+  const byTeamProblem = new Map<string, ActiveDisruptionEffect[]>();
+  for (const row of auditRows) {
+    const resolved = activeEffectForAuditRow(row, problemsDisruptions, nowMs);
+    if (!resolved) continue;
+    for (const teamId of resolved.teamIds) {
+      const key = `${teamId}#${resolved.problemId}`;
+      const list = byTeamProblem.get(key) ?? [];
+      list.push(resolved.effect);
+      byTeamProblem.set(key, list);
+    }
+  }
+  return byTeamProblem;
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects.ts
@@ -1,0 +1,44 @@
+import type { DisruptionEffect } from "../../../utils/discover-problems-catalog.js";
+import type { ActiveDisruptionEffect, KindResult } from "./shared.js";
+
+/**
+ * [ADR-033 / Issue #1665] disruption の **採点上の効果** を採点 tick に畳み込む純関数。
+ *
+ * kind handler が出した {@link KindResult} と、 deployment の scoringState に記録された active な効果群を
+ * 受け取り、 期限切れ (`expiresAtMs <= nowMs`) を除いた効果を適用した新しい結果と、 生き残った効果リストを返す。
+ * 現状 `penalty` のみ: active な各効果の `points` を当該 tick の `scoreDelta` から引く (= window 内の各 tick で
+ * 累積減点。 ADR-033 の「5 cycle ぶん減点」セマンティクス)。 実 cloud への fault 注入は伴わない (= ADR-031 の
+ * `action` とは別レイヤ)。 副作用なし・全分岐 unit-test 可能。
+ */
+export function applyDisruptionEffects(
+  result: KindResult,
+  active: readonly ActiveDisruptionEffect[],
+  nowMs: number,
+): { readonly result: KindResult; readonly surviving: readonly ActiveDisruptionEffect[] } {
+  const surviving = active.filter((e) => e.expiresAtMs > nowMs);
+  if (surviving.length === 0) {
+    // active 効果が無い / すべて期限切れ。 score は据え置き、 surviving は空 (= caller が prune 永続化)。
+    return { result, surviving };
+  }
+  const penalty = surviving.reduce((sum, e) => sum + e.points, 0);
+  return {
+    result: { ...result, scoreDelta: result.scoreDelta - penalty },
+    surviving,
+  };
+}
+
+/**
+ * [ADR-033] fire した disruption の {@link DisruptionEffect} 宣言から active 効果レコードを作る。
+ * `expiresAtMs = nowMs + durationSeconds * 1000` で window を確定する (= 永続しない、 ADR-029)。
+ */
+export function buildActiveDisruptionEffect(
+  disruptionId: string,
+  effect: DisruptionEffect,
+  nowMs: number,
+): ActiveDisruptionEffect {
+  return {
+    disruptionId,
+    points: effect.points,
+    expiresAtMs: nowMs + effect.durationSeconds * 1000,
+  };
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -10,6 +10,7 @@ import { buildEndpointPK } from "../../problem-endpoints-table.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { writeScoreEvent } from "../shared/score-event.js";
 import { maybeFireConditionDisruptions } from "./condition-disruption-fire.js";
+import { applyDisruptionEffects } from "./disruption-effects.js";
 import { reconcileEventStatuses } from "./event-reconciler.js";
 import { runAttackDetectionKind } from "./kinds/attack-detection.js";
 import { runPhasedPollingKind } from "./kinds/phased-polling.js";
@@ -19,6 +20,7 @@ import { reconcileRuntimeStatuses } from "./runtime-status-reconciler.js";
 import { isScoringActive } from "./scoring-active.js";
 import {
   buildSharedResources,
+  type DeploymentScoringState,
   type GenericScoringSharedResources,
   type KindHandlerInput,
   type KindResult,
@@ -174,6 +176,10 @@ async function processDeployment(
     return;
   }
 
+  // [ADR-033 / #1665] active な disruption 採点効果 (= condition-fire 済の減点 window) を畳み込む。
+  // active 効果が無い問題は完全に挙動不変 (= 余分な scoringState write を出さない)。
+  result = foldActiveDisruptionEffects(result, prevState, nowMs);
+
   await applyKindResult(shared, item, result, nowIso);
 
   // #1422 (ADR-013 Phase 2): 採点後の score / phase / 経過分で condition-triggered disruption を
@@ -189,6 +195,26 @@ async function processDeployment(
     nowMs,
     nowIso,
   );
+}
+
+/**
+ * [ADR-033 / #1665] active な disruption 採点効果を KindResult に畳み込む (= condition-fire 済の
+ * 減点 window を当該 tick に適用 + 期限切れを prune)。 active 効果が無い deployment は result を素通し
+ * (= scoringState write を増やさず完全な後方互換)。 pure。
+ */
+function foldActiveDisruptionEffects(
+  result: KindResult,
+  prevState: DeploymentScoringState,
+  nowMs: number,
+): KindResult {
+  const prior = prevState.activeEffects ?? [];
+  if (prior.length === 0) return result;
+  const { result: effected, surviving } = applyDisruptionEffects(result, prior, nowMs);
+  const { activeEffects: _drop, ...baseState } = effected.newState ?? prevState;
+  return {
+    ...effected,
+    newState: surviving.length > 0 ? { ...baseState, activeEffects: surviving } : baseState,
+  };
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/index.ts
@@ -10,7 +10,12 @@ import { buildEndpointPK } from "../../problem-endpoints-table.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
 import { writeScoreEvent } from "../shared/score-event.js";
 import { maybeFireConditionDisruptions } from "./condition-disruption-fire.js";
-import { applyDisruptionEffects } from "./disruption-effects.js";
+import {
+  applyDisruptionEffects,
+  type DisruptionAuditRowLike,
+  dedupeEffectsByDisruptionId,
+  resolveOperatorEffects,
+} from "./disruption-effects.js";
 import { reconcileEventStatuses } from "./event-reconciler.js";
 import { runAttackDetectionKind } from "./kinds/attack-detection.js";
 import { runPhasedPollingKind } from "./kinds/phased-polling.js";
@@ -19,6 +24,7 @@ import { runUptimeMultiKind } from "./kinds/uptime-multi.js";
 import { reconcileRuntimeStatuses } from "./runtime-status-reconciler.js";
 import { isScoringActive } from "./scoring-active.js";
 import {
+  type ActiveDisruptionEffect,
   buildSharedResources,
   type DeploymentScoringState,
   type GenericScoringSharedResources,
@@ -82,6 +88,11 @@ export async function handler(): Promise<void> {
   // discoverProblemsPhases から JSON 化)。env が無い場合は空 (= phases 無し)。
   const phasesByProblemId = parsePhasesEnv(process.env.BATTLE_PROBLEMS_PHASES);
 
+  // [ADR-033 / #1665] operator-fired disruption の active 採点効果を event ごとに 1 度だけ query して
+  // (`${eventId}#${teamId}#${problemId}` 別に) 解決する。 disruptions table 未配線なら空 (= 無効・後方互換)。
+  const operatorEffects = new Map<string, ActiveDisruptionEffect[]>();
+  const queriedEvents = new Set<string>();
+
   let exclusiveStartKey: Record<string, unknown> | undefined;
   do {
     const out = await shared.ddb.send(
@@ -98,22 +109,73 @@ export async function handler(): Promise<void> {
 
     // #558: deployment が属する event の `scoringLocked` を per-invocation で BatchGet 取得。
     const lockedMap = await fetchScoringLockedMap(shared, items);
+    await loadOperatorEffects(shared, items, queriedEvents, operatorEffects, nowMs);
 
     await Promise.all(
       items.map(async (item) => {
-        await processDeployment(shared, item, lockedMap, phasesByProblemId, nowMs, nowIso).catch(
-          (err) => {
-            console.warn(`[generic-scoring] processDeployment failed jobId=${item.jobId}`, {
-              message: err instanceof Error ? err.message : String(err),
-            });
-          },
-        );
+        const key = `${item.eventId ?? ""}#${item.teamId ?? ""}#${item.problemId ?? ""}`;
+        await processDeployment(
+          shared,
+          item,
+          lockedMap,
+          phasesByProblemId,
+          operatorEffects.get(key) ?? [],
+          nowMs,
+          nowIso,
+        ).catch((err) => {
+          console.warn(`[generic-scoring] processDeployment failed jobId=${item.jobId}`, {
+            message: err instanceof Error ? err.message : String(err),
+          });
+        });
       }),
     );
     exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (exclusiveStartKey);
 
   await Promise.all([reconcilePromise, runtimeReconcilePromise]);
+}
+
+/** [ADR-033 / ADR-029] 採点効果の最大 window (= 1h)。 これより古い audit 行は active になりえない。 */
+const OPERATOR_EFFECT_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * [ADR-033 / #1665] この page の deployment が属する各 event について (未 query のものだけ) disruptions
+ * audit table を query し、 operator-fired disruption の active 採点効果を解決して `out` に蓄積する。
+ * key は `${eventId}#${teamId}#${problemId}`。 disruptions table 未配線なら no-op。
+ */
+async function loadOperatorEffects(
+  shared: GenericScoringSharedResources,
+  items: readonly Partial<DeploymentItem>[],
+  queriedEvents: Set<string>,
+  out: Map<string, ActiveDisruptionEffect[]>,
+  nowMs: number,
+): Promise<void> {
+  if (!shared.disruptionsTableName) return;
+  const since = `AUDIT#${new Date(nowMs - OPERATOR_EFFECT_WINDOW_MS).toISOString()}`;
+  const eventIds = new Set<string>();
+  for (const it of items) {
+    if (typeof it.eventId === "string" && it.eventId.length > 0 && !queriedEvents.has(it.eventId)) {
+      eventIds.add(it.eventId);
+    }
+  }
+  for (const eventId of eventIds) {
+    queriedEvents.add(eventId);
+    const res = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.disruptionsTableName,
+        KeyConditionExpression: "PK = :pk AND SK >= :since",
+        ExpressionAttributeValues: { ":pk": `EVENT#${eventId}`, ":since": since },
+      }),
+    );
+    const rows = (res.Items ?? []) as DisruptionAuditRowLike[];
+    for (const [teamProblem, effects] of resolveOperatorEffects(
+      rows,
+      shared.problemsDisruptions,
+      nowMs,
+    )) {
+      out.set(`${eventId}#${teamProblem}`, effects);
+    }
+  }
 }
 
 /**
@@ -125,6 +187,7 @@ async function processDeployment(
   item: Partial<DeploymentItem>,
   lockedMap: Map<string, boolean>,
   phasesByProblemId: Record<string, readonly PhaseEntry[]>,
+  operatorEffects: readonly ActiveDisruptionEffect[],
   nowMs: number,
   nowIso: string,
 ): Promise<void> {
@@ -176,9 +239,9 @@ async function processDeployment(
     return;
   }
 
-  // [ADR-033 / #1665] active な disruption 採点効果 (= condition-fire 済の減点 window) を畳み込む。
+  // [ADR-033 / #1665] active な disruption 採点効果 (condition-fired + operator-fired) を畳み込む。
   // active 効果が無い問題は完全に挙動不変 (= 余分な scoringState write を出さない)。
-  result = foldActiveDisruptionEffects(result, prevState, nowMs);
+  result = foldActiveDisruptionEffects(result, prevState, operatorEffects, nowMs);
 
   await applyKindResult(shared, item, result, nowIso);
 
@@ -198,23 +261,36 @@ async function processDeployment(
 }
 
 /**
- * [ADR-033 / #1665] active な disruption 採点効果を KindResult に畳み込む (= condition-fire 済の
- * 減点 window を当該 tick に適用 + 期限切れを prune)。 active 効果が無い deployment は result を素通し
- * (= scoringState write を増やさず完全な後方互換)。 pure。
+ * [ADR-033 / #1665] active な disruption 採点効果を KindResult に畳み込む。 2 ソースを統合する:
+ *   - condition-triggered: deployment の `scoringState.activeEffects` (= maybeFireConditionDisruptions が記録)
+ *   - operator-fired: disruptions audit table から毎 tick 解決した効果 (= 永続せず derive)
+ * 同一 disruptionId は dedupe して二重減点を防ぐ。 condition 効果だけを永続 (operator は次 tick で再 derive)、
+ * 期限切れは prune。 どちらの効果も無い deployment は素通し (= 完全な後方互換)。 pure。
  */
 function foldActiveDisruptionEffects(
   result: KindResult,
   prevState: DeploymentScoringState,
+  operatorEffects: readonly ActiveDisruptionEffect[],
   nowMs: number,
 ): KindResult {
-  const prior = prevState.activeEffects ?? [];
-  if (prior.length === 0) return result;
-  const { result: effected, surviving } = applyDisruptionEffects(result, prior, nowMs);
-  const { activeEffects: _drop, ...baseState } = effected.newState ?? prevState;
-  return {
-    ...effected,
-    newState: surviving.length > 0 ? { ...baseState, activeEffects: surviving } : baseState,
-  };
+  const conditionSurviving = (prevState.activeEffects ?? []).filter((e) => e.expiresAtMs > nowMs);
+  const conditionExpiredSome = (prevState.activeEffects?.length ?? 0) !== conditionSurviving.length;
+  const combined = dedupeEffectsByDisruptionId([...conditionSurviving, ...operatorEffects]);
+  if (combined.length === 0 && !conditionExpiredSome) return result;
+
+  const { result: penalized } = applyDisruptionEffects(result, combined, nowMs);
+  // condition 効果だけを永続する (operator は audit から毎 tick 再 derive する)。 期限切れは prune。
+  let newState = penalized.newState;
+  if (conditionSurviving.length > 0 || conditionExpiredSome) {
+    const { activeEffects: _drop, ...base } = penalized.newState ?? prevState;
+    newState =
+      conditionSurviving.length > 0
+        ? { ...base, activeEffects: conditionSurviving }
+        : Object.keys(base).length > 0
+          ? base
+          : undefined;
+  }
+  return { ...penalized, newState };
 }
 
 /**

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -69,6 +69,16 @@ export function buildSharedResources(): GenericScoringSharedResources {
  * DDB の deployment.SK="META" 行に JSON 文字列で保存し、次 tick で read-through で復元する。
  * 失敗時 (= 壊れた JSON) は空 state にフォールバック (= 安全側、最初の tick は 0 加算)。
  */
+/**
+ * [ADR-033 / #1665] active な採点効果の 1 件。 disruption が fire したとき (condition-triggered) に
+ * `expiresAtMs` 付きで記録し、 採点 tick が window 内の各 tick で `points` を減点する。 期限切れは prune。
+ */
+export interface ActiveDisruptionEffect {
+  readonly disruptionId: string;
+  readonly points: number;
+  readonly expiresAtMs: number;
+}
+
 export interface DeploymentScoringState {
   readonly bonusAwarded?: Readonly<Record<string, boolean>>;
   readonly attackCount?: number;
@@ -77,6 +87,32 @@ export interface DeploymentScoringState {
    * 以降抑制する idempotency record (= ADR-013 OQ#5)。 publish 成功後にだけ追記する。
    */
   readonly firedDisruptions?: readonly string[];
+  /**
+   * [ADR-033 / #1665] active な採点効果 (= fire 済 disruption の減点 window)。 各 tick で適用し、
+   * `expiresAtMs <= now` のものは prune する。
+   */
+  readonly activeEffects?: readonly ActiveDisruptionEffect[];
+}
+
+/** [ADR-033] JSON から ActiveDisruptionEffect 配列を fail-safe に復元する。 不正要素は drop。 */
+function parseActiveEffects(raw: unknown): readonly ActiveDisruptionEffect[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const effects: ActiveDisruptionEffect[] = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object" || Array.isArray(e)) continue;
+    const { disruptionId, points, expiresAtMs } = e as Record<string, unknown>;
+    if (
+      typeof disruptionId === "string" &&
+      disruptionId.length > 0 &&
+      typeof points === "number" &&
+      Number.isFinite(points) &&
+      typeof expiresAtMs === "number" &&
+      Number.isFinite(expiresAtMs)
+    ) {
+      effects.push({ disruptionId, points, expiresAtMs });
+    }
+  }
+  return effects.length > 0 ? effects : undefined;
 }
 
 export function parseScoringState(raw: string | undefined): DeploymentScoringState {
@@ -102,10 +138,12 @@ export function parseScoringState(raw: string | undefined): DeploymentScoringSta
   const firedDisruptions = Array.isArray(firedRaw)
     ? firedRaw.filter((s): s is string => typeof s === "string")
     : undefined;
+  const activeEffects = parseActiveEffects((parsed as { activeEffects?: unknown }).activeEffects);
   return {
     ...(bonusAwarded ? { bonusAwarded } : {}),
     ...(attackCount !== undefined ? { attackCount } : {}),
     ...(firedDisruptions && firedDisruptions.length > 0 ? { firedDisruptions } : {}),
+    ...(activeEffects ? { activeEffects } : {}),
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -29,6 +29,8 @@ export interface GenericScoringSharedResources {
   readonly problemsEndpoints: Record<string, readonly ProblemEndpointSlot[]>;
   /** [#1422] condition-triggered disruption の catalog (= `BATTLE_PROBLEMS_DISRUPTIONS` env)。 */
   readonly problemsDisruptions: Record<string, readonly ProblemDisruptionEntry[]>;
+  /** [ADR-033 / #1665] operator-fired disruption の audit table (= 採点効果の active window 解決、 "" で無効)。 */
+  readonly disruptionsTableName: string;
   /** [#1422] condition-triggered fire の publish 先 event bus (= 空なら発火 skip)。 */
   readonly eventBusName: string;
   readonly events: EventBridgeClient;
@@ -50,6 +52,9 @@ export function buildSharedResources(): GenericScoringSharedResources {
     problemsScoring: parseScoringEnv(process.env.BATTLE_PROBLEMS_SCORING),
     problemsEndpoints: parseEndpointsEnv(process.env.PROBLEM_ENDPOINTS),
     problemsDisruptions: parseDisruptionsCatalogEnv(process.env.BATTLE_PROBLEMS_DISRUPTIONS),
+    // [ADR-033 / #1665] operator-fired disruption の audit 行を読む table (= 採点効果の active window 解決)。
+    // 未配線 (= "") なら operator-fired effect は無効 (condition-triggered のみ、 後方互換)。
+    disruptionsTableName: process.env.DISRUPTIONS_TABLE_NAME ?? "",
     eventBusName: process.env.DEPLOY_EVENT_BUS_NAME ?? "",
     events: new EventBridgeClient({}),
     // 非 AWS reconciler 専用 (= AWS only の運用では未使用)。 unset でも throw させず空文字に倒す

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -451,6 +451,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       problemsPhases: props.problemsPhases ?? {},
       // #1422 (ADR-013 Phase 2): condition-triggered disruption の eval + in-account 発火。
       problemsDisruptions: props.problemsDisruptions ?? {},
+      // [ADR-033 / #1665] operator-fired disruption の active 採点効果を tick で解決する (read-only)。
+      disruptionsTable: disruptions.table,
       eventBus,
       // [ADR-026/027/032 / #1410-1412] 非 AWS runtime status reconciler の credential path 構築用。
       environmentName: props.environmentName,

--- a/infrastructure/lib/utils/discover-problems-catalog.ts
+++ b/infrastructure/lib/utils/discover-problems-catalog.ts
@@ -222,6 +222,22 @@ export interface DisruptionAction {
   readonly revert: DisruptionActionRevert;
 }
 
+/**
+ * [ADR-033 / Issue #1665] disruption の **採点上の効果**。 実クラウドへの fault 注入 (= {@link DisruptionAction})
+ * とは別レイヤで、 採点エンジンが active window の間だけ team の点に直接効果を与える (= シナリオ圧力)。
+ *
+ * `kind: "penalty"` のみ実装済 (= active な各 tick で `points` を減点)。 `durationSeconds` は ADR-029
+ * 「いかなる障害も永続しない」に従い正の有限秒・上限 1h。 `unavailability` 等は follow-up。
+ */
+export type DisruptionEffect = {
+  readonly kind: "penalty";
+  readonly points: number;
+  readonly durationSeconds: number;
+};
+
+/** [ADR-033] 採点上の効果の上限秒 (= ADR-029 と揃え 1h、 永続障害を禁止)。 */
+export const DISRUPTION_EFFECT_MAX_DURATION_SECONDS = 3600;
+
 export interface ProblemDisruptionEntry {
   readonly id: string;
   readonly name: string;
@@ -235,6 +251,30 @@ export interface ProblemDisruptionEntry {
   readonly triggers?: readonly DisruptionTrigger[];
   /** [ADR-031 / #1419] cross-account 実行アクション (省略 = Phase A 監査のみ = 後方互換)。 */
   readonly action?: DisruptionAction;
+  /** [ADR-033 / #1665] 採点上の効果 (省略 = 効果なし = 後方互換)。 */
+  readonly effect?: DisruptionEffect;
+}
+
+/**
+ * SCHEMA `disruptions[].effect` を fail-safe に取り出す。 `kind="penalty"` / `points` が正の有限数 /
+ * `durationSeconds` が正の有限数かつ上限以内のときだけ返し、 それ以外は undefined (= 効果なしに倒す)。
+ * 宣言時の strict 検証は validate-problems が担う ({@link parseDisruptionAction} と同型)。
+ */
+export function parseDisruptionEffect(value: unknown): DisruptionEffect | undefined {
+  if (!isPlainObject(value)) return undefined;
+  if (value.kind !== "penalty") return undefined;
+  const points = value.points;
+  const durationSeconds = value.durationSeconds;
+  if (typeof points !== "number" || !Number.isFinite(points) || points <= 0) return undefined;
+  if (
+    typeof durationSeconds !== "number" ||
+    !Number.isFinite(durationSeconds) ||
+    durationSeconds <= 0 ||
+    durationSeconds > DISRUPTION_EFFECT_MAX_DURATION_SECONDS
+  ) {
+    return undefined;
+  }
+  return { kind: "penalty", points, durationSeconds };
 }
 
 /**
@@ -359,6 +399,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
     publicHint?: unknown;
     triggers?: unknown;
     action?: unknown;
+    effect?: unknown;
   };
   if (
     typeof v.id !== "string" ||
@@ -369,6 +410,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
   }
   const triggers = parseDisruptionTriggers(v.triggers);
   const action = parseDisruptionAction(v.action);
+  const effect = parseDisruptionEffect(v.effect);
   return {
     id: v.id,
     name: v.name,
@@ -389,6 +431,7 @@ function parseDisruptionEntry(value: unknown): ProblemDisruptionEntry | undefine
     ...(typeof v.publicHint === "boolean" ? { publicHint: v.publicHint } : {}),
     ...(triggers ? { triggers } : {}),
     ...(action ? { action } : {}),
+    ...(effect ? { effect } : {}),
   };
 }
 

--- a/infrastructure/test/discover-problems-catalog.test.ts
+++ b/infrastructure/test/discover-problems-catalog.test.ts
@@ -225,6 +225,29 @@ describe("discoverProblemsDisruptions triggers[] (#1422)", () => {
     });
     expect(discoverProblemsDisruptions(workspace)["plain-battle"]?.[0]?.triggers).toBeUndefined();
   });
+
+  it("should surface a valid scoring effect and drop a malformed one (ADR-033 #1665)", () => {
+    writeProblem("battles", "effect-battle", {
+      id: "effect-battle",
+      disruptions: [
+        {
+          id: "ceo-pressure",
+          name: "CEO pressure",
+          eventDetailType: "X",
+          effect: { kind: "penalty", points: 40, durationSeconds: 300 },
+        },
+        {
+          id: "bad-effect",
+          name: "bad",
+          eventDetailType: "X",
+          effect: { kind: "unavailability", points: 1, durationSeconds: 1 }, // unknown kind → dropped
+        },
+      ],
+    });
+    const entries = discoverProblemsDisruptions(workspace)["effect-battle"];
+    expect(entries?.[0]?.effect).toEqual({ kind: "penalty", points: 40, durationSeconds: 300 });
+    expect(entries?.[1]?.effect).toBeUndefined(); // fail-safe drop, entry still kept
+  });
 });
 
 describe("discoverProblemsCoordination (ADR-028/030 Phase 3 #1420)", () => {

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -132,6 +132,8 @@ describe("ProblemDeployBackendStack (MVP-1) — GenericScoring Lambda", () => {
     expect(vars.DEPLOYMENTS_TABLE_NAME).toBeDefined();
     expect(vars.EVENTS_TABLE_NAME).toBeDefined();
     expect(vars.PROBLEM_ENDPOINTS_TABLE_NAME).toBeDefined();
+    // [ADR-033 / #1665] operator-fired disruption の active 採点効果を解決する audit table。
+    expect(vars.DISRUPTIONS_TABLE_NAME).toBeDefined();
     expect(vars.BATTLE_PROBLEMS_SCORING).toBeUndefined();
     expect(vars.PROBLEM_ENDPOINTS).toBeUndefined();
     expect(vars.BATTLE_PROBLEMS_PHASES).toBeUndefined();

--- a/infrastructure/test/problem-deploy/disruption-effects.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-effects.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDisruptionEffects,
+  buildActiveDisruptionEffect,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects";
+import type {
+  ActiveDisruptionEffect,
+  KindResult,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/shared";
+
+/**
+ * [ADR-033 / Issue #1665] scoring-side disruption effect の純ロジックを pin。
+ * active な penalty を tick の scoreDelta から引き、 期限切れは prune (= 適用しない)。
+ */
+
+const NOW = 1_700_000_000_000;
+const baseResult = (scoreDelta: number): KindResult => ({ scoreDelta, scoreEvents: [] });
+const effect = (over: Partial<ActiveDisruptionEffect> = {}): ActiveDisruptionEffect => ({
+  disruptionId: "d1",
+  points: 50,
+  expiresAtMs: NOW + 60_000,
+  ...over,
+});
+
+describe("buildActiveDisruptionEffect (#1665)", () => {
+  it("should set expiresAtMs to now + durationSeconds*1000 and carry points", () => {
+    const active = buildActiveDisruptionEffect(
+      "ceo-5000-users",
+      { kind: "penalty", points: 30, durationSeconds: 300 },
+      NOW,
+    );
+    expect(active).toEqual({
+      disruptionId: "ceo-5000-users",
+      points: 30,
+      expiresAtMs: NOW + 300_000,
+    });
+  });
+});
+
+describe("applyDisruptionEffects (#1665)", () => {
+  it("should leave the score unchanged when there are no active effects", () => {
+    const out = applyDisruptionEffects(baseResult(10), [], NOW);
+    expect(out.result.scoreDelta).toBe(10);
+    expect(out.surviving).toEqual([]);
+  });
+
+  it("should subtract a single active penalty from the tick scoreDelta", () => {
+    const out = applyDisruptionEffects(baseResult(10), [effect({ points: 50 })], NOW);
+    expect(out.result.scoreDelta).toBe(-40); // 10 - 50
+    expect(out.surviving).toHaveLength(1);
+  });
+
+  it("should sum multiple active penalties", () => {
+    const out = applyDisruptionEffects(
+      baseResult(100),
+      [effect({ disruptionId: "a", points: 20 }), effect({ disruptionId: "b", points: 30 })],
+      NOW,
+    );
+    expect(out.result.scoreDelta).toBe(50); // 100 - 20 - 30
+    expect(out.surviving).toHaveLength(2);
+  });
+
+  it("should prune expired effects and not apply them", () => {
+    const expired = effect({ disruptionId: "old", expiresAtMs: NOW - 1 });
+    const out = applyDisruptionEffects(baseResult(10), [expired], NOW);
+    expect(out.result.scoreDelta).toBe(10); // expired → not applied
+    expect(out.surviving).toEqual([]);
+  });
+
+  it("should apply only the non-expired effects when mixed", () => {
+    const out = applyDisruptionEffects(
+      baseResult(0),
+      [
+        effect({ disruptionId: "live", points: 25, expiresAtMs: NOW + 1 }),
+        effect({ disruptionId: "dead", points: 99, expiresAtMs: NOW }), // expiresAtMs === now → expired
+      ],
+      NOW,
+    );
+    expect(out.result.scoreDelta).toBe(-25); // only the live 25 applies
+    expect(out.surviving.map((e) => e.disruptionId)).toEqual(["live"]);
+  });
+
+  it("should preserve the rest of the KindResult (scoreEvents / newState)", () => {
+    const result: KindResult = {
+      scoreDelta: 5,
+      scoreEvents: [{ source: "uptime", points: 5, occurredAt: "2026-06-03T00:00:00Z" }],
+      newState: { attackCount: 3 },
+    };
+    const out = applyDisruptionEffects(result, [effect({ points: 5 })], NOW);
+    expect(out.result.scoreDelta).toBe(0);
+    expect(out.result.scoreEvents).toBe(result.scoreEvents);
+    expect(out.result.newState).toEqual({ attackCount: 3 });
+  });
+});

--- a/infrastructure/test/problem-deploy/disruption-effects.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-effects.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   applyDisruptionEffects,
   buildActiveDisruptionEffect,
+  dedupeEffectsByDisruptionId,
+  resolveOperatorEffects,
 } from "../../lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects";
 import type {
   ActiveDisruptionEffect,
   KindResult,
 } from "../../lib/problem-deploy/handlers/generic-scoring-handler/shared";
+import type { ProblemDisruptionEntry } from "../../lib/utils/discover-problems-catalog";
 
 /**
  * [ADR-033 / Issue #1665] scoring-side disruption effect の純ロジックを pin。
@@ -90,5 +93,82 @@ describe("applyDisruptionEffects (#1665)", () => {
     expect(out.result.scoreDelta).toBe(0);
     expect(out.result.scoreEvents).toBe(result.scoreEvents);
     expect(out.result.newState).toEqual({ attackCount: 3 });
+  });
+});
+
+describe("dedupeEffectsByDisruptionId (#1665)", () => {
+  it("should keep one entry per disruptionId with the maximum expiry", () => {
+    const out = dedupeEffectsByDisruptionId([
+      { disruptionId: "a", points: 10, expiresAtMs: 100 },
+      { disruptionId: "a", points: 10, expiresAtMs: 200 },
+      { disruptionId: "b", points: 5, expiresAtMs: 50 },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.find((e) => e.disruptionId === "a")?.expiresAtMs).toBe(200);
+  });
+});
+
+describe("resolveOperatorEffects (#1665)", () => {
+  const catalog = {
+    p1: [
+      {
+        id: "d1",
+        name: "n",
+        eventDetailType: "X",
+        effect: { kind: "penalty", points: 40, durationSeconds: 300 },
+      },
+      { id: "d2", name: "n", eventDetailType: "X" }, // no effect
+    ],
+  } as Record<string, readonly ProblemDisruptionEntry[]>;
+
+  it("should resolve an in-window operator fire to a team×problem effect", () => {
+    const firedAt = new Date(NOW - 60_000).toISOString();
+    const m = resolveOperatorEffects(
+      [{ disruptionId: "d1", problemId: "p1", targetTeamIds: ["t1", "t2"], firedAt }],
+      catalog,
+      NOW,
+    );
+    expect(m.get("t1#p1")).toEqual([
+      { disruptionId: "d1", points: 40, expiresAtMs: Date.parse(firedAt) + 300_000 },
+    ]);
+    expect(m.get("t2#p1")).toHaveLength(1);
+  });
+
+  it("should skip a fire whose effect window has elapsed", () => {
+    const firedAt = new Date(NOW - 400_000).toISOString(); // 400s ago > 300s duration
+    const m = resolveOperatorEffects(
+      [{ disruptionId: "d1", problemId: "p1", targetTeamIds: ["t1"], firedAt }],
+      catalog,
+      NOW,
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it("should skip a disruption that declares no effect", () => {
+    const firedAt = new Date(NOW).toISOString();
+    const m = resolveOperatorEffects(
+      [{ disruptionId: "d2", problemId: "p1", targetTeamIds: ["t1"], firedAt }],
+      catalog,
+      NOW,
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it("should ignore malformed audit rows (missing fields / bad firedAt / blank team)", () => {
+    const m = resolveOperatorEffects(
+      [
+        { disruptionId: "d1" }, // no problemId/targetTeamIds/firedAt
+        { disruptionId: "d1", problemId: "p1", targetTeamIds: ["t1"], firedAt: "not-a-date" },
+        {
+          disruptionId: "d1",
+          problemId: "p1",
+          targetTeamIds: ["", 5],
+          firedAt: new Date(NOW).toISOString(),
+        },
+      ],
+      catalog,
+      NOW,
+    );
+    expect(m.size).toBe(0);
   });
 });

--- a/infrastructure/test/problem-deploy/disruption-triggers.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-triggers.test.ts
@@ -12,6 +12,7 @@ import {
   type DisruptionTrigger,
   type ProblemDisruptionEntry,
   parseDisruptionAction,
+  parseDisruptionEffect,
   parseDisruptionsCatalogEnv,
   parseDisruptionTriggers,
 } from "../../lib/utils/discover-problems-catalog";
@@ -148,6 +149,66 @@ describe("parseDisruptionAction (ADR-031 #1419)", () => {
       kind: "ssm-run-command",
       targetRef: "X",
       revert: { afterSeconds: 5 },
+    });
+  });
+});
+
+describe("parseDisruptionEffect (ADR-033 #1665)", () => {
+  it("should parse a valid penalty effect", () => {
+    expect(parseDisruptionEffect({ kind: "penalty", points: 40, durationSeconds: 300 })).toEqual({
+      kind: "penalty",
+      points: 40,
+      durationSeconds: 300,
+    });
+  });
+
+  it("should fail-safe to undefined for an unknown kind", () => {
+    expect(
+      parseDisruptionEffect({ kind: "unavailability", points: 1, durationSeconds: 1 }),
+    ).toBeUndefined();
+  });
+
+  it("should reject non-positive / non-finite points", () => {
+    expect(
+      parseDisruptionEffect({ kind: "penalty", points: 0, durationSeconds: 60 }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionEffect({ kind: "penalty", points: -5, durationSeconds: 60 }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionEffect({ kind: "penalty", points: "40", durationSeconds: 60 }),
+    ).toBeUndefined();
+  });
+
+  it("should reject duration <= 0 or above the 1h cap", () => {
+    expect(
+      parseDisruptionEffect({ kind: "penalty", points: 1, durationSeconds: 0 }),
+    ).toBeUndefined();
+    expect(
+      parseDisruptionEffect({ kind: "penalty", points: 1, durationSeconds: 3601 }),
+    ).toBeUndefined();
+    expect(parseDisruptionEffect({ kind: "penalty", points: 1, durationSeconds: 3600 })).toEqual({
+      kind: "penalty",
+      points: 1,
+      durationSeconds: 3600,
+    });
+  });
+
+  it("should fail-safe to undefined for non-object / array / null input", () => {
+    expect(parseDisruptionEffect(undefined)).toBeUndefined();
+    expect(parseDisruptionEffect(null)).toBeUndefined();
+    expect(parseDisruptionEffect("penalty")).toBeUndefined();
+    expect(parseDisruptionEffect([{ kind: "penalty" }])).toBeUndefined();
+  });
+
+  it("should preserve a declared effect through the catalog env round-trip", () => {
+    const env = JSON.stringify({
+      p1: [baseDisruption({ effect: { kind: "penalty", points: 10, durationSeconds: 120 } })],
+    });
+    expect(parseDisruptionsCatalogEnv(env).p1?.[0]?.effect).toEqual({
+      kind: "penalty",
+      points: 10,
+      durationSeconds: 120,
     });
   });
 });

--- a/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
@@ -180,3 +180,93 @@ describe("condition-triggered disruption fire", () => {
     expect(updateCommands().length).toBe(1);
   });
 });
+
+/**
+ * [ADR-033 / #1665] scoring-side disruption effect の end-to-end。 fire 時に effect window を
+ * activeEffects に記録し、 次 tick で penalty を score から引くことを実 handler で pin する。
+ */
+const NOW_MS = new Date(NOW_ISO).getTime();
+
+function configureWithPenaltyEffect(): void {
+  process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
+    "hello-world-battle": {
+      kind: "uptime",
+      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+      pointsPerSuccess: 100,
+    },
+  });
+  process.env.PROBLEM_ENDPOINTS = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_PHASES = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_DISRUPTIONS = JSON.stringify({
+    "hello-world-battle": [
+      {
+        id: "latency",
+        name: "EC2 latency",
+        eventDetailType: "DegradedDisruptionFired",
+        parameters: { delayMs: 200 },
+        triggers: [{ kind: "team-score-above", threshold: 50 }],
+        effect: { kind: "penalty", points: 40, durationSeconds: 300 },
+      },
+    ],
+  });
+}
+
+describe("scoring-side disruption effect (#1665)", () => {
+  it("should record an activeEffect window when a disruption with an effect fires", async () => {
+    configureWithPenaltyEffect();
+    mockDdb();
+    await runHandler();
+
+    const updates = updateCommands();
+    expect(updates.length).toBe(2); // score + fired-persist
+    const state = JSON.parse(
+      (updates[1].input.ExpressionAttributeValues as Record<string, string>)[":state"],
+    );
+    expect(state.firedDisruptions).toEqual(["latency"]);
+    expect(state.activeEffects).toEqual([
+      { disruptionId: "latency", points: 40, expiresAtMs: NOW_MS + 300_000 },
+    ]);
+  });
+
+  it("should subtract an active penalty from the score on the next tick", async () => {
+    configureWithPenaltyEffect();
+    // 既に fire 済 (= 再 fire しない) で、 active な penalty window が残っている deployment。
+    mockDdb({
+      scoringState: JSON.stringify({
+        firedDisruptions: ["latency"],
+        activeEffects: [{ disruptionId: "latency", points: 40, expiresAtMs: NOW_MS + 60_000 }],
+      }),
+    });
+    await runHandler();
+
+    // 再 fire は無い (idempotency) → UpdateCommand は score 適用の 1 件のみ。
+    const updates = updateCommands();
+    expect(updates.length).toBe(1);
+    const values = updates[0].input.ExpressionAttributeValues as Record<string, unknown>;
+    // uptime +100 から penalty 40 を引いて +60。
+    expect(values[":pts"]).toBe(60);
+    // 生き残った effect は scoringState に永続化される。
+    const state = JSON.parse(values[":state"] as string);
+    expect(state.activeEffects).toEqual([
+      { disruptionId: "latency", points: 40, expiresAtMs: NOW_MS + 60_000 },
+    ]);
+  });
+
+  it("should resume full scoring and drop the effect once the window expires", async () => {
+    configureWithPenaltyEffect();
+    mockDdb({
+      scoringState: JSON.stringify({
+        firedDisruptions: ["latency"],
+        activeEffects: [{ disruptionId: "latency", points: 40, expiresAtMs: NOW_MS - 1 }], // expired
+      }),
+    });
+    await runHandler();
+
+    const updates = updateCommands();
+    expect(updates.length).toBe(1);
+    const values = updates[0].input.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[":pts"]).toBe(100); // no penalty — full uptime score
+    const state = JSON.parse(values[":state"] as string);
+    expect(state.activeEffects).toBeUndefined(); // pruned
+  });
+});

--- a/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-disruption-fire.test.ts
@@ -120,6 +120,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   process.env.BATTLE_PROBLEMS_DISRUPTIONS = undefined;
   process.env.DEPLOY_EVENT_BUS_NAME = undefined;
+  process.env.DISRUPTIONS_TABLE_NAME = undefined;
 });
 
 describe("condition-triggered disruption fire", () => {
@@ -268,5 +269,87 @@ describe("scoring-side disruption effect (#1665)", () => {
     expect(values[":pts"]).toBe(100); // no penalty — full uptime score
     const state = JSON.parse(values[":state"] as string);
     expect(state.activeEffects).toBeUndefined(); // pruned
+  });
+});
+
+/**
+ * [ADR-033 / #1665] operator-fired disruption effect: 主催者が手動 fire した disruption (= disruptions
+ * audit table の AUDIT 行) を採点 tick が読み、 window 内なら減点する。 condition trigger 無しで動く本命経路。
+ */
+function configureOperatorEffect(): void {
+  process.env.BATTLE_PROBLEMS_SCORING = JSON.stringify({
+    "hello-world-battle": {
+      kind: "uptime",
+      endpoints: [{ outputKey: "FrontendUrl", path: "/", expectStatus: [200] }],
+      pointsPerSuccess: 100,
+    },
+  });
+  process.env.PROBLEM_ENDPOINTS = JSON.stringify({});
+  process.env.BATTLE_PROBLEMS_PHASES = JSON.stringify({});
+  // triggers 無し = operator-fired only。 effect 宣言で採点上の減点を持つ。
+  process.env.BATTLE_PROBLEMS_DISRUPTIONS = JSON.stringify({
+    "hello-world-battle": [
+      {
+        id: "ceo-pressure",
+        name: "CEO pressure",
+        eventDetailType: "X",
+        effect: { kind: "penalty", points: 40, durationSeconds: 300 },
+      },
+    ],
+  });
+  process.env.DISRUPTIONS_TABLE_NAME = "TestDisruptions";
+}
+
+function mockDdbWithAudit(auditRows: Array<Record<string, unknown>>): void {
+  // biome-ignore lint/suspicious/noExplicitAny: fake dispatches by command name + table.
+  ddbSend.mockImplementation(async (cmd: any) => {
+    const name = cmd.constructor.name;
+    if (name === "ScanCommand") {
+      const tn = cmd.input.TableName;
+      if (tn === "TestEvents") return { Items: [] };
+      if (tn === "TestDeployments") return { Items: [sampleDeployment()] };
+    }
+    if (name === "BatchGetCommand") return { Responses: { TestEvents: [] } };
+    if (name === "QueryCommand" && cmd.input.TableName === "TestDisruptions") {
+      return { Items: auditRows };
+    }
+    return {};
+  });
+}
+
+describe("operator-fired disruption effect (#1665)", () => {
+  it("should subtract an operator-fired penalty resolved from the audit table", async () => {
+    configureOperatorEffect();
+    mockDdbWithAudit([
+      {
+        disruptionId: "ceo-pressure",
+        problemId: "hello-world-battle",
+        targetTeamIds: ["team-1"],
+        firedAt: new Date(NOW_MS - 60_000).toISOString(), // 60s ago, within the 300s window
+      },
+    ]);
+    await runHandler();
+
+    // No condition trigger declared → no fire publish → only the score UpdateCommand.
+    expect(ebSend).not.toHaveBeenCalled();
+    const updates = updateCommands();
+    expect(updates.length).toBe(1);
+    const values = updates[0].input.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[":pts"]).toBe(60); // uptime +100 − operator penalty 40
+  });
+
+  it("should not penalize when the operator fire is outside the effect window", async () => {
+    configureOperatorEffect();
+    mockDdbWithAudit([
+      {
+        disruptionId: "ceo-pressure",
+        problemId: "hello-world-battle",
+        targetTeamIds: ["team-1"],
+        firedAt: new Date(NOW_MS - 400_000).toISOString(), // 400s ago > 300s window
+      },
+    ]);
+    await runHandler();
+    const values = updateCommands()[0].input.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[":pts"]).toBe(100); // window elapsed → full score
   });
 });

--- a/infrastructure/test/problem-deploy/generic-scoring-shared.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-shared.test.ts
@@ -187,6 +187,28 @@ describe("parseScoringState (ADR-012 Phase 3.B、 dispatcher state persistence)"
     expect(parseScoringState(JSON.stringify([1, 2]))).toEqual({});
     expect(parseScoringState(JSON.stringify(123))).toEqual({});
   });
+
+  it("should decode activeEffects and drop malformed entries (ADR-033 #1665)", () => {
+    const state = parseScoringState(
+      JSON.stringify({
+        activeEffects: [
+          { disruptionId: "d1", points: 40, expiresAtMs: 1_700_000_060_000 },
+          { disruptionId: "", points: 1, expiresAtMs: 1 }, // empty id → dropped
+          { disruptionId: "d2", points: "x", expiresAtMs: 1 }, // non-number points → dropped
+          { disruptionId: "d3", points: 5 }, // missing expiresAtMs → dropped
+          "nope", // non-object → dropped
+        ],
+      }),
+    );
+    expect(state.activeEffects).toEqual([
+      { disruptionId: "d1", points: 40, expiresAtMs: 1_700_000_060_000 },
+    ]);
+  });
+
+  it("should omit activeEffects when none survive parsing", () => {
+    expect(parseScoringState(JSON.stringify({ activeEffects: [] })).activeEffects).toBeUndefined();
+    expect(parseScoringState(JSON.stringify({ activeEffects: "x" })).activeEffects).toBeUndefined();
+  });
 });
 
 describe("probeUrl (SSRF revalidation + bounded body read)", () => {

--- a/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
+++ b/infrastructure/test/scripts/validate-problems-cross-ref.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   checkDisruptionActionOutputRefs,
   checkDisruptionActions,
+  checkDisruptionEffects,
 } from "../../../scripts/lib/disruption-action-check";
 import { checkCoordinationPluginFile } from "../../../scripts/validate-problems";
 
@@ -219,6 +220,61 @@ describe("checkDisruptionActions (ADR-031 #1419)", () => {
       disruptions: [{ id: "x", name: "x", eventDetailType: "X", action: "nope" }],
     });
     expect(errs.some((e) => e.includes("action must be an object"))).toBe(true);
+  });
+});
+
+describe("checkDisruptionEffects (ADR-033 #1665)", () => {
+  const withEffect = (effect: unknown) => ({
+    disruptions: [{ id: "ceo-pressure", name: "CEO", eventDetailType: "X", effect }],
+  });
+
+  it("should pass a well-formed penalty effect", () => {
+    expect(
+      checkDisruptionEffects(withEffect({ kind: "penalty", points: 40, durationSeconds: 300 })),
+    ).toEqual([]);
+  });
+
+  it("should be a no-op when no effect is declared (backward compat)", () => {
+    expect(
+      checkDisruptionEffects({ disruptions: [{ id: "x", name: "x", eventDetailType: "X" }] }),
+    ).toEqual([]);
+    expect(checkDisruptionEffects({})).toEqual([]);
+  });
+
+  it("should reject a kind outside the allow-list", () => {
+    const errs = checkDisruptionEffects(
+      withEffect({ kind: "unavailability", points: 1, durationSeconds: 1 }),
+    );
+    expect(errs.some((e) => e.includes("effect.kind must be one of penalty"))).toBe(true);
+  });
+
+  it("should reject non-positive points", () => {
+    expect(
+      checkDisruptionEffects(withEffect({ kind: "penalty", points: 0, durationSeconds: 60 })).some(
+        (e) => e.includes("effect.points must be a positive"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should reject a non-positive or over-cap durationSeconds (ADR-029)", () => {
+    expect(
+      checkDisruptionEffects(withEffect({ kind: "penalty", points: 1, durationSeconds: 0 })).some(
+        (e) => e.includes("durationSeconds must be a positive"),
+      ),
+    ).toBe(true);
+    expect(
+      checkDisruptionEffects(
+        withEffect({ kind: "penalty", points: 1, durationSeconds: 3601 }),
+      ).some((e) => e.includes("exceeds the") && e.includes("3600")),
+    ).toBe(true);
+  });
+
+  it("should reject a non-object effect", () => {
+    expect(
+      checkDisruptionEffects(withEffect("nope")).some((e) =>
+        e.includes("effect must be an object"),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/scripts/lib/disruption-action-check.ts
+++ b/scripts/lib/disruption-action-check.ts
@@ -121,6 +121,50 @@ export function checkDisruptionActions(meta: Metadata): ValidationError[] {
   return errors;
 }
 
+/** [ADR-033] 採点上の効果の上限秒 (= ADR-029 と揃え 1h、 永続障害を禁止)。 */
+const MAX_EFFECT_DURATION_SECONDS = 60 * 60;
+const DISRUPTION_EFFECT_KINDS = new Set(["penalty"]);
+
+function checkSingleDisruptionEffect(id: string, effect: unknown): ValidationError[] {
+  if (!effect || typeof effect !== "object" || Array.isArray(effect)) {
+    return [`disruptions[id=${id}].effect must be an object`];
+  }
+  const e = effect as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  if (typeof e.kind !== "string" || !DISRUPTION_EFFECT_KINDS.has(e.kind)) {
+    errors.push(`disruptions[id=${id}].effect.kind must be one of penalty`);
+  }
+  if (typeof e.points !== "number" || !Number.isFinite(e.points) || e.points <= 0) {
+    errors.push(`disruptions[id=${id}].effect.points must be a positive number`);
+  }
+  const dur = e.durationSeconds;
+  if (typeof dur !== "number" || !Number.isFinite(dur) || dur <= 0) {
+    errors.push(
+      `disruptions[id=${id}].effect.durationSeconds must be a positive number of seconds`,
+    );
+  } else if (dur > MAX_EFFECT_DURATION_SECONDS) {
+    errors.push(
+      `disruptions[id=${id}].effect.durationSeconds=${dur} exceeds the ${MAX_EFFECT_DURATION_SECONDS}s cap (ADR-029: no disruption may be permanent)`,
+    );
+  }
+  return errors;
+}
+
+/**
+ * [ADR-033 / #1665] disruptions[].effect (= 採点上の効果) の契約を enforce する。 kind=penalty /
+ * points 正 / durationSeconds 正かつ 1h 以内。 effect 未宣言は無影響 (= 後方互換)。
+ */
+export function checkDisruptionEffects(meta: Metadata): ValidationError[] {
+  const disruptions = Array.isArray(meta.disruptions) ? meta.disruptions : [];
+  const errors: ValidationError[] = [];
+  for (const raw of disruptions as Array<Record<string, unknown>>) {
+    if (!raw || typeof raw !== "object" || raw.effect === undefined) continue;
+    const id = typeof raw.id === "string" ? raw.id : "?";
+    errors.push(...checkSingleDisruptionEffect(id, raw.effect));
+  }
+  return errors;
+}
+
 /**
  * [ADR-031] action.targetRef / functionRef は team の stackOutputs (= CFn Output) key を指す。
  * executable runtime のときだけ template.yaml の Outputs に実在するかを cross-ref する

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -26,6 +26,7 @@ import addFormats from "ajv-formats";
 import {
   checkDisruptionActionOutputRefs,
   checkDisruptionActions,
+  checkDisruptionEffects,
 } from "./lib/disruption-action-check";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
@@ -110,6 +111,7 @@ export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationErro
     ...checkDashboardSlotFiles(meta, dir),
     ...checkCoordinationPluginFile(meta, dir),
     ...checkDisruptionActions(meta),
+    ...checkDisruptionEffects(meta),
     ...checkRegionConsistency(meta),
   ];
 


### PR DESCRIPTION
## Summary

First real fix for the red-team facade (#1665, child of #1417). Of 9 declared disruptions, only 1 (`ec2-latency-injection`, ADR-031 `action`) did anything; the rest published an event + audit row and changed nothing. This adds a **scoring-side effect** so a disruption that declares an `effect` actually penalizes the team's score for a bounded window — **no cloud account, no real fault, fully verifiable**.

Two realization layers, kept separate (ADR-033):
| layer | what | needs |
|---|---|---|
| `action` (ADR-031) | real infra fault in the competitor account | real cloud + AssumeRole |
| `effect` (ADR-033) | scoring engine applies a score penalty directly | nothing (platform-internal) |

### Both fire paths are wired + verified
- **condition-fired** (ADR-013 #1422): when the tick auto-fires a disruption that declares an `effect`, it records the penalty window in `scoringState.activeEffects`; subsequent ticks subtract it and prune on expiry.
- **operator-fired** (the organizer's mid-event manual fire — stackstack's 5 are all this): the tick resolves active effects from the disruptions **audit table** per event (once per tick, cached), with a read-only grant + `DISRUPTIONS_TABLE_NAME` env on the scoring Lambda. Deduped by disruptionId so a disruption fired both ways isn't double-counted.

### Contents
- **ADR-033** — design (HTML, self-contained).
- **catalog**: `DisruptionEffect` (`kind: "penalty"`, `points`, `durationSeconds` ≤ 1h per ADR-029) + `parseDisruptionEffect` (fail-safe) + `effect?` on `ProblemDisruptionEntry`.
- **validator** (`validate-problems`): `checkDisruptionEffects` enforces the contract at authoring time.
- **scoring engine**: `ActiveDisruptionEffect` state + pure `applyDisruptionEffects` / `resolveOperatorEffects` / `dedupeEffectsByDisruptionId` + `foldActiveDisruptionEffects` folded into the tick.
- **CDK**: scoring Lambda reads the disruptions audit table (env + least-priv read grant), wired in the stack.

### Scoped follow-ups (in #1665, NOT claimed done)
- `unavailability` effect (force named slots to score as failed) — needs to hook the kind's health computation.
- submodule SCHEMA + a reference problem (e.g. stackstack) declaring an `effect` so it ships real (depends on this PR merging first).

## Test plan — verified end-to-end at the logic level
- Pure: penalty math / prune / dedupe / operator-effect resolution (window, no-effect, malformed) / `parseDisruptionEffect` / `parseScoringState` round-trip / `checkDisruptionEffects` / `discoverProblemsDisruptions` surfacing.
- **Through the real scoring handler**: condition-fire records window → next tick **100 → 60** → expires → **back to 100** + pruned; **operator fire** in the audit table → tick **100 → 60** within the window, **100** outside it.
- CDK template: `DISRUPTIONS_TABLE_NAME` env present on the scoring Lambda.
- `make harness` exits 0; `make before-commit` green (every workspace's tests — infra 2584 / SPAs / packages — + lint/textlint/build/validate-problems/template-security/**cdk synth**).

## Regression analysis
- **Backward compatible**: a disruption without an `effect`, a problem with no active effects, or an unwired disruptions table (`DISRUPTIONS_TABLE_NAME=""`) all take fast paths — no extra scoringState write, byte-for-byte unchanged. Full 2584-test infra suite passes.
- Effects can only ever lower the score by declared, expiring penalties; operator effects are re-derived from the audit table each tick (not persisted), condition effects persist in scoringState and prune on expiry.
- `discover-problems-catalog.ts` crossed the harness 500-line `file-too-large` **warning** (non-failing); tracked as a separate SRP split to keep this PR reviewable.

## Physical impact
- **CDK: UPDATE** to the GenericScoring Lambda — adds `DISRUPTIONS_TABLE_NAME` env + a read-only (`dynamodb:Query`/`GetItem`) grant on the existing Disruptions table to its role. No new resource, no table/throughput change (cdk synth clean). Behavior changes only for problems that declare an `effect` (none ship yet).

> Infra lane (scoring Lambda + CDK/IAM) per AGENTS.md — opened for your review, **not self-merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)