### PR TITLE
feat(capacity): DynamoDB capacity model — when does 1/1 throttle? [#1667]

### DIFF
--- a/infrastructure/test/scripts/capacity-model.test.ts
+++ b/infrastructure/test/scripts/capacity-model.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CapacityInputs,
+  DEFAULT_CAPACITY_INPUTS,
+  maxTeamsBeforeThrottle,
+  modelDeploymentsTable,
+} from "../../../scripts/lib/capacity-model";
+
+/**
+ * [Issue #1667] DynamoDB capacity model — pins the scoring-loop arithmetic and the throttle
+ * point so the "how many teams before 1/1 throttles?" answer is regression-guarded.
+ */
+
+const base = (over: Partial<CapacityInputs> = {}): CapacityInputs => ({
+  ...DEFAULT_CAPACITY_INPUTS,
+  teams: 10,
+  ...over,
+});
+
+describe("modelDeploymentsTable (#1667)", () => {
+  it("should compute the exact scoring-loop load for 10 teams × 3 problems", () => {
+    const m = modelDeploymentsTable(base({ teams: 10 }));
+    expect(m.deployments).toBe(30);
+    expect(m.scoringScanReadsPerSec).toBeCloseTo(0.5); // 30 items / 60s tick
+    expect(m.scoringWritesPerSec).toBeCloseTo(1.0); // 30 deployments × 2 writes / 60s
+    expect(m.participantReadsPerSec).toBeCloseTo(2.0); // (20 participants × 1 × 3) / 30s poll
+    expect(m.totalReadsPerSec).toBeCloseTo(2.5);
+    expect(m.readCapacityUnits).toBeCloseTo(1.25); // eventually-consistent (÷2)
+    expect(m.writeCapacityUnits).toBeCloseTo(1.0);
+  });
+
+  it("should flag a read-throttle at 10 teams but not a write-throttle (WCU exactly at ceiling)", () => {
+    const m = modelDeploymentsTable(base({ teams: 10 }));
+    expect(m.readThrottles).toBe(true); // 1.25 RCU > 1
+    expect(m.writeThrottles).toBe(false); // 1.0 WCU is at, not over, the ceiling
+  });
+
+  it("should not throttle at 5 teams", () => {
+    const m = modelDeploymentsTable(base({ teams: 5 }));
+    expect(m.readThrottles).toBe(false);
+    expect(m.writeThrottles).toBe(false);
+  });
+});
+
+describe("maxTeamsBeforeThrottle (#1667)", () => {
+  it("should report ~8 teams (read-limited) under the default poll assumptions", () => {
+    expect(maxTeamsBeforeThrottle(DEFAULT_CAPACITY_INPUTS)).toEqual({
+      maxTeams: 8,
+      limiting: "read",
+    });
+  });
+
+  it("should become write-limited at 10 teams when participant reads are excluded", () => {
+    // deploymentsReadsPerPoll=0 → only the scoring loop reads (tiny); the WCU ceiling binds first.
+    expect(
+      maxTeamsBeforeThrottle({ ...DEFAULT_CAPACITY_INPUTS, deploymentsReadsPerPoll: 0 }),
+    ).toEqual({ maxTeams: 10, limiting: "write" });
+  });
+
+  it("should report 'none' when nothing throttles within the search range", () => {
+    expect(maxTeamsBeforeThrottle(DEFAULT_CAPACITY_INPUTS, 2)).toEqual({
+      maxTeams: 2,
+      limiting: "none",
+    });
+  });
+});

--- a/scripts/capacity-model.ts
+++ b/scripts/capacity-model.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+/**
+ * [Issue #1667] CLI for the DynamoDB capacity model. Prints, for a range of team counts,
+ * the Deployments table's sustained reads/writes per second and consumed capacity units
+ * against the 1 RCU / 1 WCU `DynamoDbLowCapacity` ceiling, plus the team count at which it
+ * first throttles. Run before an event to decide whether to raise capacity (see the
+ * capacity-pressure runbook). Logic-level model — see scripts/lib/capacity-model.ts.
+ *
+ *   bun run scripts/capacity-model.ts            # default assumptions
+ *   bun run scripts/capacity-model.ts 4 3        # problemsPerTeam=4 participantsPerTeam=3
+ */
+
+import {
+  type CapacityInputs,
+  DEFAULT_CAPACITY_INPUTS,
+  maxTeamsBeforeThrottle,
+  modelDeploymentsTable,
+  PROVISIONED_RCU,
+  PROVISIONED_WCU,
+} from "./lib/capacity-model";
+
+function round(n: number): string {
+  return n.toFixed(2);
+}
+
+function formatRow(base: Omit<CapacityInputs, "teams">, teams: number): string {
+  const m = modelDeploymentsTable({ ...base, teams });
+  const flag =
+    m.readThrottles || m.writeThrottles
+      ? `YES (${m.readThrottles ? "R" : ""}${m.writeThrottles ? "W" : ""})`
+      : "no";
+  return (
+    `  ${String(teams).padStart(5)} | ${String(m.deployments).padStart(11)} | ` +
+    `${round(m.totalReadsPerSec).padStart(8)} | ${round(m.readCapacityUnits).padStart(4)} | ` +
+    `${round(m.totalWritesPerSec).padStart(8)} | ${round(m.writeCapacityUnits).padStart(4)} | ${flag}`
+  );
+}
+
+function throttleSummary(base: Omit<CapacityInputs, "teams">): string {
+  const limit = maxTeamsBeforeThrottle(base);
+  if (limit.limiting === "none") return "  → no throttling within the search range.";
+  const axis = limit.limiting === "read" ? "reads (RCU)" : "writes (WCU)";
+  return (
+    `  → 1/1 provisioned holds up to ${limit.maxTeams} team(s); beyond that the Deployments ` +
+    `table throttles on ${axis}. Raise capacity for the event window (see docs/runbooks/capacity-pressure.md).`
+  );
+}
+
+function main(argv: readonly string[]): void {
+  const base: Omit<CapacityInputs, "teams"> = {
+    ...DEFAULT_CAPACITY_INPUTS,
+    problemsPerTeam: argv[0] ? Number(argv[0]) : DEFAULT_CAPACITY_INPUTS.problemsPerTeam,
+    participantsPerTeam: argv[1] ? Number(argv[1]) : DEFAULT_CAPACITY_INPUTS.participantsPerTeam,
+  };
+
+  const lines = [
+    "TenkaCloud Deployments-table capacity model (Issue #1667)",
+    `  problems/team=${base.problemsPerTeam}  participants/team=${base.participantsPerTeam}  ` +
+      `scoring tick=${base.scoringTickSeconds}s  poll=${base.participantPollSeconds}s  ` +
+      `reads/poll/problem=${base.deploymentsReadsPerPoll}`,
+    `  ceiling: ${PROVISIONED_RCU} RCU / ${PROVISIONED_WCU} WCU (DynamoDbLowCapacity)`,
+    "",
+    "  teams | deployments |  reads/s |  RCU | writes/s |  WCU | throttles",
+    "  ------+-------------+----------+------+----------+------+----------",
+    ...[5, 10, 20, 40, 80].map((teams) => formatRow(base, teams)),
+    "",
+    throttleSummary(base),
+  ];
+  console.log(lines.join("\n"));
+}
+
+main(process.argv.slice(2));

--- a/scripts/lib/capacity-model.ts
+++ b/scripts/lib/capacity-model.ts
@@ -1,0 +1,111 @@
+/**
+ * [Issue #1667] DynamoDB capacity model for a TenkaCloud event under the 1 RCU / 1 WCU
+ * `DynamoDbLowCapacity` pin (= Free Tier 25/25). Answers the non-functional question the
+ * platform never measured: **how many teams before the hot Deployments table throttles?**
+ *
+ * This is a logic-level model (no real load test against AWS), which is the verification the
+ * owner accepts. The scoring-loop load is **exact** — derived from `generic-scoring-handler`:
+ * every `rate(1 minute)` tick Scans each COMPLETE deployment (1 read) and, per scored
+ * deployment, writes the score (`UpdateItem`) + a score-event row (`PutItem`) = 2 writes. The
+ * participant read load is **parameterized** (documented assumption) because it flows through
+ * the portal API; tune `deploymentsReadsPerPoll` to match a traced value.
+ *
+ * DDB capacity units: 1 WCU = one write of ≤1 KB per second; 1 RCU = one strongly-consistent
+ * read of ≤4 KB per second (= two eventually-consistent reads). Deployment items here are well
+ * under those sizes, so 1 write ≈ 1 WCU and 1 eventually-consistent read ≈ 0.5 RCU.
+ */
+
+export interface CapacityInputs {
+  readonly teams: number;
+  readonly problemsPerTeam: number;
+  readonly participantsPerTeam: number;
+  /** scoring Lambda の起動間隔 (= EventBridge `rate(1 minute)` = 60s)。 */
+  readonly scoringTickSeconds: number;
+  /** participant portal の poll 間隔 (= 30s、 実 cadence)。 */
+  readonly participantPollSeconds: number;
+  /** poll 1 回で participant が Deployments table から読む problem あたり item 数 (documented 推定、 既定 1)。 */
+  readonly deploymentsReadsPerPoll: number;
+}
+
+/** 実 cadence + 控えめな read 推定。 `teams` だけ caller が与える。 */
+export const DEFAULT_CAPACITY_INPUTS: Omit<CapacityInputs, "teams"> = {
+  problemsPerTeam: 3,
+  participantsPerTeam: 2,
+  scoringTickSeconds: 60,
+  participantPollSeconds: 30,
+  deploymentsReadsPerPoll: 1,
+};
+
+export interface DeploymentsTableLoad {
+  readonly teams: number;
+  readonly deployments: number;
+  readonly scoringScanReadsPerSec: number;
+  readonly scoringWritesPerSec: number;
+  readonly participantReadsPerSec: number;
+  readonly totalReadsPerSec: number;
+  readonly totalWritesPerSec: number;
+  /** eventually-consistent 換算 RCU。 */
+  readonly readCapacityUnits: number;
+  readonly writeCapacityUnits: number;
+  readonly readThrottles: boolean;
+  readonly writeThrottles: boolean;
+}
+
+/** `DynamoDbLowCapacity` aspect が全 table に強制する provisioned 値。 */
+export const PROVISIONED_RCU = 1;
+export const PROVISIONED_WCU = 1;
+/** 採点 tick が 1 deployment あたり Deployments table に出す write 数 (score UpdateItem + score-event PutItem)。 */
+export const SCORING_WRITES_PER_DEPLOYMENT = 2;
+
+/** Deployments table (= 最も hot) の sustained 負荷を K teams で算出する。 */
+export function modelDeploymentsTable(inputs: CapacityInputs): DeploymentsTableLoad {
+  const deployments = inputs.teams * inputs.problemsPerTeam;
+  const participants = inputs.teams * inputs.participantsPerTeam;
+
+  const scoringScanReadsPerSec = deployments / inputs.scoringTickSeconds;
+  const scoringWritesPerSec =
+    (deployments * SCORING_WRITES_PER_DEPLOYMENT) / inputs.scoringTickSeconds;
+  const participantReadsPerSec =
+    (participants * inputs.deploymentsReadsPerPoll * inputs.problemsPerTeam) /
+    inputs.participantPollSeconds;
+
+  const totalReadsPerSec = scoringScanReadsPerSec + participantReadsPerSec;
+  const totalWritesPerSec = scoringWritesPerSec;
+  const readCapacityUnits = totalReadsPerSec / 2; // eventually-consistent
+  const writeCapacityUnits = totalWritesPerSec; // ≤1 KB items
+
+  return {
+    teams: inputs.teams,
+    deployments,
+    scoringScanReadsPerSec,
+    scoringWritesPerSec,
+    participantReadsPerSec,
+    totalReadsPerSec,
+    totalWritesPerSec,
+    readCapacityUnits,
+    writeCapacityUnits,
+    readThrottles: readCapacityUnits > PROVISIONED_RCU,
+    writeThrottles: writeCapacityUnits > PROVISIONED_WCU,
+  };
+}
+
+export interface ThrottlePoint {
+  /** 1/1 を超えない最大 team 数。 */
+  readonly maxTeams: number;
+  /** 最初に超える軸 (= 設備増強の対象)。 `none` は探索上限まで余裕あり。 */
+  readonly limiting: "read" | "write" | "none";
+}
+
+/** Deployments table が 1 RCU / 1 WCU を最初に超える直前の team 数を求める。 */
+export function maxTeamsBeforeThrottle(
+  base: Omit<CapacityInputs, "teams">,
+  searchLimit = 10_000,
+): ThrottlePoint {
+  for (let teams = 1; teams <= searchLimit; teams++) {
+    const load = modelDeploymentsTable({ ...base, teams });
+    if (load.writeThrottles || load.readThrottles) {
+      return { maxTeams: teams - 1, limiting: load.readThrottles ? "read" : "write" };
+    }
+  }
+  return { maxTeams: searchLimit, limiting: "none" };
+}


### PR DESCRIPTION
## Summary

Part of #1667 (competition-scale non-functional). The `DynamoDbLowCapacity` aspect pins every table to **1 RCU / 1 WCU** (Free Tier 25/25), and nobody had measured the team ceiling. This adds a **logic-level capacity model** (no AWS load test — the verification the owner accepts) that computes the hot **Deployments table**'s sustained load for K teams and reports where it crosses the 1-unit ceiling.

- **Scoring-loop load is exact**, derived from `generic-scoring-handler`: each `rate(1 minute)` tick Scans every COMPLETE deployment (1 read) and, per scored deployment, writes the score (`UpdateItem`) + a score-event row (`PutItem`) = 2 writes.
- **Participant read load is parameterized** (`deploymentsReadsPerPoll`, documented default) since it flows through the portal API — tune it to a traced value.

**Finding** (default: 3 problems/team, 2 participants/team, 30s poll, 60s tick): **1/1 provisioned holds ~8 teams; beyond that the Deployments table read-throttles.** Write-only (no participant reads) it's ~10 teams before the WCU ceiling binds.

```
$ bun run scripts/capacity-model.ts
  teams | deployments |  reads/s |  RCU | writes/s |  WCU | throttles
      5 |          15 |     1.25 | 0.63 |     0.50 | 0.50 | no
     10 |          30 |     2.50 | 1.25 |     1.00 | 1.00 | YES (R)
     ...
  → 1/1 provisioned holds up to 8 team(s); beyond that the Deployments table throttles on reads (RCU).
```

This is #1667's harness. The **runtime-adjustable DDB capacity** piece (raise/lower for the event window without a redeploy) is `[INFRA]` and the separate follow-up.

## Test plan
- `capacity-model.test.ts` (6) — pins the exact scoring-loop arithmetic (30 deployments → 1.0 WCU, 1.25 RCU at 10 teams), the read-throttle at 10 teams, the no-throttle at 5, and `maxTeamsBeforeThrottle` for read-limited (8) / write-limited (10) / none cases.
- `make harness` no findings; `make before-commit` green (all workspaces + cdk synth).

## Regression analysis
- **Additive, analysis-only**: a new `scripts/lib/capacity-model.ts` (pure) + `scripts/capacity-model.ts` (CLI) + a test. No production code, no infra, no behavior touched. The model documents its assumptions; the scoring-loop half is exact and will drift only if the scoring tick's per-deployment op count changes (then the test should be updated alongside).

## Physical impact
- **NO-OP.** Script + test only; no CloudFormation / resource diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)