### PR TITLE
feat(capacity): runtime-adjustable DDB capacity operator tool [#1667]

### DIFF
--- a/infrastructure/test/scripts/scale-event-capacity.test.ts
+++ b/infrastructure/test/scripts/scale-event-capacity.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCapacityPlan,
+  DEFAULT_MAX_UNITS_PER_TABLE,
+  planCapacityChange,
+} from "../../../scripts/lib/scale-event-capacity";
+
+/**
+ * [Issue #1667] runtime-adjustable DDB capacity の planner + guardrail + apply を pin。
+ * 暴走 (非正整数 / per-table 上限超過 / table 未指定) は reject、 Free Tier 超過 / GSI は warning、
+ * apply は 1 件失敗しても残りを試みて applied/failed を返す。
+ */
+
+const plan = (over: Partial<Parameters<typeof planCapacityChange>[0]> = {}) =>
+  planCapacityChange({
+    tables: ["Deployments"],
+    target: { readCapacity: 1, writeCapacity: 1 },
+    maxUnitsPerTable: DEFAULT_MAX_UNITS_PER_TABLE,
+    ...over,
+  });
+
+describe("planCapacityChange (#1667)", () => {
+  it("should plan a baseline (1/1) change for teardown with no warnings", () => {
+    const r = plan({ tables: ["Deployments", "Events"] });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.entries).toEqual([
+        { table: "Deployments", readCapacity: 1, writeCapacity: 1 },
+        { table: "Events", readCapacity: 1, writeCapacity: 1 },
+      ]);
+      expect(r.warnings).toEqual([]);
+    }
+  });
+
+  it("should warn when raising above the baseline and beyond the Free Tier total", () => {
+    const r = plan({
+      tables: ["a", "b", "c"],
+      target: { readCapacity: 10, writeCapacity: 10 }, // 30 RCU/WCU total > 25
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.warnings.some((w) => w.includes("Free Tier") && w.includes("WILL incur cost"))).toBe(
+        true,
+      );
+      expect(r.warnings.some((w) => w.includes("GSI throughput is NOT changed"))).toBe(true);
+    }
+  });
+
+  it("should reject a non-positive or non-integer capacity", () => {
+    expect(plan({ target: { readCapacity: 0, writeCapacity: 1 } }).ok).toBe(false);
+    expect(plan({ target: { readCapacity: 1, writeCapacity: 2.5 } }).ok).toBe(false);
+  });
+
+  it("should reject a capacity above the per-table cap (cost guardrail)", () => {
+    const r = plan({ target: { readCapacity: 50, writeCapacity: 1 }, maxUnitsPerTable: 25 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.some((e) => e.includes("exceeds the per-table cap"))).toBe(true);
+  });
+
+  it("should reject when no tables are given", () => {
+    const r = plan({ tables: [] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors).toContain("no tables specified");
+  });
+});
+
+describe("applyCapacityPlan (#1667)", () => {
+  it("should apply every entry via the injected updateTable", async () => {
+    const updateTable = vi.fn().mockResolvedValue(undefined);
+    const res = await applyCapacityPlan(
+      [
+        { table: "Deployments", readCapacity: 5, writeCapacity: 5 },
+        { table: "Events", readCapacity: 5, writeCapacity: 5 },
+      ],
+      { updateTable },
+    );
+    expect(res.applied).toEqual(["Deployments", "Events"]);
+    expect(res.failed).toEqual([]);
+    expect(updateTable).toHaveBeenCalledWith("Deployments", 5, 5);
+  });
+
+  it("should record a failure but still apply the rest", async () => {
+    const updateTable = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ResourceNotFoundException"))
+      .mockResolvedValue(undefined);
+    const res = await applyCapacityPlan(
+      [
+        { table: "Missing", readCapacity: 5, writeCapacity: 5 },
+        { table: "Events", readCapacity: 5, writeCapacity: 5 },
+      ],
+      { updateTable },
+    );
+    expect(res.applied).toEqual(["Events"]);
+    expect(res.failed).toEqual([{ table: "Missing", error: "ResourceNotFoundException" }]);
+  });
+});

--- a/scripts/lib/scale-event-capacity.ts
+++ b/scripts/lib/scale-event-capacity.ts
@@ -1,0 +1,120 @@
+/**
+ * [Issue #1667] Runtime-adjustable DynamoDB capacity — pure planner + guardrails.
+ *
+ * The `DynamoDbLowCapacity` aspect pins every table to 1 RCU / 1 WCU at deploy time (cost-zero
+ * baseline). The capacity model (`scripts/capacity-model.ts`) shows that throttles at ~8 teams.
+ * For a larger event the operator needs to raise capacity **without a redeploy** and return it
+ * to 1/1 at teardown — exactly the "運用中に変更できるように" improvement the owner asked for.
+ *
+ * This module is the **pure plan + guardrail** layer (no AWS calls): it validates the target,
+ * caps per-table units, and warns when the total leaves the 25/25 Free Tier (= will incur cost).
+ * The actual `UpdateTable` lives in the CLI (`scripts/scale-event-capacity.ts`) behind an
+ * injected client so this stays unit-testable. The aspect re-pins to 1/1 on the next deploy, so
+ * a runtime raise is a deliberate, temporary, event-window override — not a permanent change.
+ *
+ * Scope: base-table provisioned throughput. GSI throughput (its own units) is a documented
+ * follow-up — surfaced as a warning so the operator is not misled into thinking GSIs scaled.
+ */
+
+export interface CapacityTarget {
+  readonly readCapacity: number;
+  readonly writeCapacity: number;
+}
+
+export interface ScalePlanInput {
+  readonly tables: readonly string[];
+  readonly target: CapacityTarget;
+  /** per-table の上限 unit (= 暴走防止のコストガードレール)。 */
+  readonly maxUnitsPerTable: number;
+}
+
+export interface ScalePlanEntry {
+  readonly table: string;
+  readonly readCapacity: number;
+  readonly writeCapacity: number;
+}
+
+export type ScalePlanResult =
+  | {
+      readonly ok: true;
+      readonly entries: readonly ScalePlanEntry[];
+      readonly warnings: readonly string[];
+    }
+  | { readonly ok: false; readonly errors: readonly string[] };
+
+/** AWS Free Tier (per account, per axis)。 これを超えると課金される。 */
+export const FREE_TIER_TOTAL_UNITS = 25;
+/** per-table の既定上限 (= Free Tier 全枠を 1 table が食い尽くさないための安全弁)。 */
+export const DEFAULT_MAX_UNITS_PER_TABLE = 25;
+/** `DynamoDbLowCapacity` が強制する baseline (= teardown 時に戻す値)。 */
+export const BASELINE_UNITS = 1;
+
+/**
+ * 目標 capacity を検証し、 table 別の UpdateTable 計画を返す。 不正値 (非正整数 / per-table 上限超過 /
+ * table 未指定) は errors で reject。 合計が Free Tier を超える場合は warning (= 課金の明示) を付けて ok。
+ */
+export function planCapacityChange(input: ScalePlanInput): ScalePlanResult {
+  const errors: string[] = [];
+  const { readCapacity, writeCapacity } = input.target;
+
+  for (const [label, value] of [
+    ["readCapacity", readCapacity],
+    ["writeCapacity", writeCapacity],
+  ] as const) {
+    if (!Number.isInteger(value) || value < BASELINE_UNITS) {
+      errors.push(`${label} must be an integer >= ${BASELINE_UNITS} (got ${value})`);
+    } else if (value > input.maxUnitsPerTable) {
+      errors.push(
+        `${label}=${value} exceeds the per-table cap ${input.maxUnitsPerTable} (cost guardrail; raise --max only deliberately)`,
+      );
+    }
+  }
+  if (input.tables.length === 0) errors.push("no tables specified");
+  if (errors.length > 0) return { ok: false, errors };
+
+  const warnings: string[] = [];
+  const totalRead = readCapacity * input.tables.length;
+  const totalWrite = writeCapacity * input.tables.length;
+  if (totalRead > FREE_TIER_TOTAL_UNITS || totalWrite > FREE_TIER_TOTAL_UNITS) {
+    warnings.push(
+      `total provisioned ${totalRead} RCU / ${totalWrite} WCU across ${input.tables.length} table(s) ` +
+        `exceeds the ${FREE_TIER_TOTAL_UNITS}/${FREE_TIER_TOTAL_UNITS} Free Tier — this WILL incur cost. ` +
+        `Return to ${BASELINE_UNITS}/${BASELINE_UNITS} at teardown.`,
+    );
+  }
+  if (readCapacity > BASELINE_UNITS || writeCapacity > BASELINE_UNITS) {
+    warnings.push(
+      "GSI throughput is NOT changed by this tool (GSIs have their own units); scale them separately if a hot read path uses a GSI.",
+    );
+  }
+
+  const entries = input.tables.map((table) => ({ table, readCapacity, writeCapacity }));
+  return { ok: true, entries, warnings };
+}
+
+/** UpdateTable 1 本ぶんの注入 I/O (= CLI が実 DynamoDB client を渡す、 test は fake)。 */
+export interface CapacityApplyDeps {
+  readonly updateTable: (
+    table: string,
+    readCapacity: number,
+    writeCapacity: number,
+  ) => Promise<void>;
+}
+
+/** 計画を順に適用する。 1 件失敗しても残りを試み、 適用できた table と失敗を返す (= 部分適用の可視化)。 */
+export async function applyCapacityPlan(
+  entries: readonly ScalePlanEntry[],
+  deps: CapacityApplyDeps,
+): Promise<{ readonly applied: string[]; readonly failed: { table: string; error: string }[] }> {
+  const applied: string[] = [];
+  const failed: { table: string; error: string }[] = [];
+  for (const e of entries) {
+    try {
+      await deps.updateTable(e.table, e.readCapacity, e.writeCapacity);
+      applied.push(e.table);
+    } catch (err) {
+      failed.push({ table: e.table, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { applied, failed };
+}

--- a/scripts/scale-event-capacity.ts
+++ b/scripts/scale-event-capacity.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * [Issue #1667] Operator CLI to raise/lower DynamoDB provisioned capacity for an event window
+ * WITHOUT a redeploy (the `DynamoDbLowCapacity` aspect re-pins to 1/1 on the next deploy, so this
+ * is a deliberate, temporary override). Use it with the capacity model (scripts/capacity-model.ts)
+ * and the capacity-pressure runbook: the model says when to scale, this does it.
+ *
+ *   bun run scripts/scale-event-capacity.ts <rcu> <wcu> <table...>           # dry-run (prints the plan)
+ *   bun run scripts/scale-event-capacity.ts <rcu> <wcu> <table...> --apply    # execute UpdateTable
+ *   bun run scripts/scale-event-capacity.ts 1 1 <table...> --apply            # return to baseline at teardown
+ *
+ * Pure plan + guardrails live in scripts/lib/scale-event-capacity.ts.
+ */
+
+import { DynamoDBClient, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import {
+  applyCapacityPlan,
+  DEFAULT_MAX_UNITS_PER_TABLE,
+  planCapacityChange,
+} from "./lib/scale-event-capacity";
+
+interface ParsedArgs {
+  readonly readCapacity: number;
+  readonly writeCapacity: number;
+  readonly tables: readonly string[];
+  readonly apply: boolean;
+  readonly maxUnitsPerTable: number;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const positional: string[] = [];
+  let apply = false;
+  let maxUnitsPerTable = DEFAULT_MAX_UNITS_PER_TABLE;
+  for (const a of argv) {
+    if (a === "--apply") apply = true;
+    else if (a.startsWith("--max=")) maxUnitsPerTable = Number(a.slice("--max=".length));
+    else positional.push(a);
+  }
+  return {
+    readCapacity: Number(positional[0]),
+    writeCapacity: Number(positional[1]),
+    tables: positional.slice(2),
+    apply,
+    maxUnitsPerTable,
+  };
+}
+
+async function main(argv: readonly string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const plan = planCapacityChange({
+    tables: args.tables,
+    target: { readCapacity: args.readCapacity, writeCapacity: args.writeCapacity },
+    maxUnitsPerTable: args.maxUnitsPerTable,
+  });
+
+  if (!plan.ok) {
+    console.error("Cannot scale capacity:");
+    for (const e of plan.errors) console.error(`  - ${e}`);
+    console.error(
+      "\nUsage: bun run scripts/scale-event-capacity.ts <rcu> <wcu> <table...> [--apply] [--max=N]",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Plan: set ${args.readCapacity} RCU / ${args.writeCapacity} WCU on ${args.tables.length} table(s):`,
+  );
+  for (const e of plan.entries) console.log(`  - ${e.table}`);
+  for (const w of plan.warnings) console.warn(`  ⚠ ${w}`);
+
+  if (!args.apply) {
+    console.log("\nDry run. Re-run with --apply to execute UpdateTable.");
+    return;
+  }
+
+  const client = new DynamoDBClient({});
+  const result = await applyCapacityPlan(plan.entries, {
+    updateTable: async (table, readCapacity, writeCapacity) => {
+      await client.send(
+        new UpdateTableCommand({
+          TableName: table,
+          ProvisionedThroughput: {
+            ReadCapacityUnits: readCapacity,
+            WriteCapacityUnits: writeCapacity,
+          },
+        }),
+      );
+    },
+  });
+  console.log(`\nApplied: ${result.applied.length}/${plan.entries.length} table(s).`);
+  for (const f of result.failed) console.error(`  ✗ ${f.table}: ${f.error}`);
+  if (result.failed.length > 0) process.exitCode = 1;
+}
+
+await main(process.argv.slice(2));


### PR DESCRIPTION
## Summary

Completes #1667's runtime-adjustable capacity (the owner's "運用中に DynamoDB キャパシティを変更できるように" ask). The `DynamoDbLowCapacity` aspect pins every table to 1/1 at deploy; the capacity model (#1669) shows that throttles at ~8 teams. This operator CLI raises/lowers provisioned throughput **for the event window without a redeploy** — and because the aspect re-pins to 1/1 on the next deploy, a runtime raise is a deliberate, temporary override (teardown returns to baseline automatically).

- **`scripts/lib/scale-event-capacity.ts`** (pure): `planCapacityChange` validates the target (rejects non-positive / non-integer, a per-table cap, and no-tables) and warns when the total leaves the 25/25 Free Tier (= will incur cost) and that GSI throughput is separate. `applyCapacityPlan` applies each entry and is partial-apply-safe (one failure doesn't abort the rest).
- **`scripts/scale-event-capacity.ts`** (CLI): dry-run by default; `--apply` executes `UpdateTable`. `… 1 1 <tables> --apply` returns to baseline at teardown.

Companion to the capacity model (#1669) + capacity-pressure runbook: **the model says when to scale, this does it.**

```
$ bun run scripts/scale-event-capacity.ts 5 5 Deployments Events
Plan: set 5 RCU / 5 WCU on 2 table(s):
  - Deployments
  - Events
  ⚠ GSI throughput is NOT changed by this tool ...
Dry run. Re-run with --apply to execute UpdateTable.
```

## Test plan
- `scale-event-capacity.test.ts` (7): baseline plan (no warnings), Free-Tier + GSI warnings, rejects (non-positive / non-integer / over-cap / no-tables), `applyCapacityPlan` applies all + records a partial failure while continuing.
- CLI dry-run + reject paths smoke-tested. `make harness` no findings; `make before-commit` green (all workspaces + cdk synth).

## Regression analysis
- **Additive operator tooling** — a new `scripts/lib/scale-event-capacity.ts` (pure) + `scripts/scale-event-capacity.ts` (CLI) + test. No production code, no CDK, no behavior changed. The CLI only mutates capacity when run **deliberately** by an operator with `--apply` + AWS creds; the pure planner + apply are fully unit-tested without AWS.
- The 1/1 baseline + the `DynamoDbLowCapacity` aspect are unchanged; this is a runtime override the aspect reverts on the next deploy.

## Physical impact
- **NO-OP at deploy** (script + test only; no CloudFormation/resource diff). At **operator runtime**, `--apply` issues `dynamodb:UpdateTable` to raise/lower provisioned throughput on the named tables — a deliberate, cost-bearing action guarded by the per-table cap + Free-Tier warning.

> The tool mutates DDB capacity (cost-sensitive) — opened for your review, **not self-merged**, even though it's `scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)