### PR TITLE
feat(scoring): uptime-multi attack-blocked bonus — resolves ADR-034 scoring conflict [#1666]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter.ts
@@ -1,0 +1,43 @@
+/**
+ * [ADR-034 / Issue #1666] CFn-output attack counter からの差分加点の共通ロジック。
+ *
+ * 競技者 stack が「攻撃をブロック/検知した回数」を CFn Output に counter として露出し、 採点 tick が
+ * 前回値からの差分に応じて加点する (= 防御の成否を採点に反映する)。 元は attack-detection kind 内にあった
+ * ロジックを、 uptime-multi の attack-blocked ボーナス (ADR-034 pattern B のスコア統合) と共有するため切り出した。
+ *
+ * 競技者は自 account の CFn Output に任意値を仕込めるため、 1 tick の差分加点には上限を設ける
+ * (= leaderboard の即時 inflation 防止)。 baseline は実値に追従し、 巨大ジャンプは 1 tick 分で止まる。
+ */
+
+/** 1 tick あたりに反映する counter 差分の上限 (#1389)。 */
+export const MAX_ATTACK_DELTA_PER_TICK = 100;
+
+export interface CounterScore {
+  /** この tick で加点する点数 (= 差分 × pointsPer、 上限 cap 済)。 baseline tick は 0。 */
+  readonly points: number;
+  /** 次 tick の baseline として記録する現在値。 */
+  readonly newCount: number;
+}
+
+/**
+ * CFn Output から読んだ counter (string) と前回値から差分加点を計算する。 不正値 (空 / 非整数 / 負) は
+ * `undefined` (= baseline 汚染を避けるため採点しない)。 prev 未定義 (初回) は baseline 記録のみで 0 点。
+ */
+export function scoreCounterDelta(
+  rawValue: unknown,
+  prevCount: number | undefined,
+  pointsPer: number,
+): CounterScore | undefined {
+  if (rawValue === undefined) return undefined;
+  const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
+  if (normalized === "") return undefined;
+  const current = Number(normalized);
+  if (!Number.isFinite(current) || !Number.isInteger(current) || current < 0) return undefined;
+  // 初回 tick: deploy 後の既存値を新検知扱いしない (= baseline 記録のみ)。
+  if (prevCount === undefined) return { points: 0, newCount: current };
+  const delta = current - prevCount;
+  // 巻き戻し / 同値 → 加点なし、 baseline を current に追従。
+  if (delta <= 0) return { points: 0, newCount: current };
+  const cappedDelta = Math.min(delta, MAX_ATTACK_DELTA_PER_TICK);
+  return { points: cappedDelta * pointsPer, newCount: current };
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-detection.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-detection.ts
@@ -1,14 +1,7 @@
 import type { AttackDetectionScoringMetadata } from "../../../../utils/scoring-metadata.js";
 import { parseStackOutputs } from "../../shared/cfn-status.js";
 import { type KindHandlerInput, type KindResult, noopKindResult } from "../shared.js";
-
-/**
- * 1 tick あたりに加点へ反映する attack 差分の上限 (#1389)。 attack counter は競技者が admin 権限
- * を持つ自 account の CFn Output から読むため任意の巨大値を仕込める。 差分加点に上限を設けることで
- * leaderboard の即時 inflation を防ぐ。 baseline は実値に追従させるため、 巨大ジャンプは 1 tick 分の
- * 上限加点で止まり、 次 tick 以降は再加算されない。
- */
-const MAX_ATTACK_DELTA_PER_TICK = 100;
+import { scoreCounterDelta } from "./attack-counter.js";
 
 /**
  * `attack-detection` kind (ADR-012 Phase 3.B、 security-battle-royale の攻撃検知部 想定)。
@@ -29,45 +22,18 @@ export function runAttackDetectionKind(
   if (!deployment.PK || !deployment.problemId) return noopKindResult();
 
   const outputs = parseStackOutputs(deployment.stackOutputs);
-  const rawValue = outputs[scoring.statsOutputKey];
-  if (rawValue === undefined) return noopKindResult();
-
-  // 問題側の CFn Output は string なので Number() で coerce する。 ただし `""` → 0、
-  // `"1.5"` → 1.5 のような falsy/fractional case は不正データ扱いで noop (= baseline 汚染防止)。
-  const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
-  if (normalized === "") return noopKindResult();
-  const current = Number(normalized);
-  if (!Number.isFinite(current) || !Number.isInteger(current) || current < 0) {
-    return noopKindResult();
-  }
-
-  const prev = prevState.attackCount;
-  // 初回 tick: baseline 記録のみで加点しない (= deploy 後の counter 既存値を新検知扱いしない)
-  if (prev === undefined) {
-    return {
-      scoreDelta: 0,
-      scoreEvents: [],
-      newState: { attackCount: current },
-    };
-  }
-
-  const delta = current - prev;
-  if (delta <= 0) {
-    // counter 巻き戻し / 同値 → 加点なし、 baseline を current に追従する
-    return {
-      scoreDelta: 0,
-      scoreEvents: [],
-      newState: { attackCount: current },
-    };
-  }
-
-  // 1 tick あたりの差分加点に上限を設ける (= 競技者が CFn Output に巨大値を仕込んでも leaderboard を
-  // 即時 inflation できない)。 baseline は実値 (current) に追従させ、 巨大ジャンプは 1 tick で止める。
-  const cappedDelta = Math.min(delta, MAX_ATTACK_DELTA_PER_TICK);
-  const points = cappedDelta * scoring.pointsPerAttack;
+  // 差分加点 + cap + baseline 追従の共通ロジックは attack-counter.ts に集約 (uptime-multi の
+  // attack-blocked bonus と共有、 ADR-034)。 不正値 / 未露出は noop。
+  const scored = scoreCounterDelta(
+    outputs[scoring.statsOutputKey],
+    prevState.attackCount,
+    scoring.pointsPerAttack,
+  );
+  if (!scored) return noopKindResult();
   return {
-    scoreDelta: points,
-    scoreEvents: [{ source: "uptime", points, occurredAt: nowIso }],
-    newState: { attackCount: current },
+    scoreDelta: scored.points,
+    scoreEvents:
+      scored.points > 0 ? [{ source: "uptime", points: scored.points, occurredAt: nowIso }] : [],
+    newState: { attackCount: scored.newCount },
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
@@ -13,6 +13,7 @@ import {
   noopKindResult,
   probeUrl,
 } from "../shared.js";
+import { scoreCounterDelta } from "./attack-counter.js";
 
 /**
  * `uptime-multi` kind (ADR-012 Phase 3.B、 security-battle-royale 想定)。
@@ -29,7 +30,7 @@ import {
 export async function runUptimeMultiKind(
   input: KindHandlerInput<UptimeMultiScoringMetadata>,
 ): Promise<KindResult> {
-  const { deployment, scoring, slots, overrides, nowIso } = input;
+  const { deployment, scoring, slots, overrides, nowIso, prevState } = input;
   if (!deployment.PK || !deployment.problemId) return noopKindResult();
 
   const outputs = parseStackOutputs(deployment.stackOutputs);
@@ -68,19 +69,41 @@ export async function runUptimeMultiKind(
     newHealth[key] = { ok, checkedAt: nowIso, ...(since ? { since } : {}) };
   }
 
-  const scoreDelta = allOk ? scoring.pointsAllOk : (scoring.failurePenalty ?? 0);
+  const baseDelta = allOk ? scoring.pointsAllOk : (scoring.failurePenalty ?? 0);
   const attackDetected = !allOk && deployment.lastResult === "ok";
 
+  // [ADR-034 / #1666] optional attack-blocked bonus (= 防御テストの加点を可用性採点に重ねる)。
+  // 宣言時のみ: 競技者 stack が露出する attack-blocked counter の増分で加点 + baseline を追従。
+  let bonusPoints = 0;
+  let bonusState: { attackCount: number } | undefined;
+  if (scoring.attackBlockedOutputKey) {
+    const scored = scoreCounterDelta(
+      outputs[scoring.attackBlockedOutputKey],
+      prevState.attackCount,
+      scoring.pointsPerBlock ?? 1,
+    );
+    if (scored) {
+      bonusPoints = scored.points;
+      bonusState = { attackCount: scored.newCount };
+    }
+  }
+
+  const scoreDelta = baseDelta + bonusPoints;
+  const uptimeEvents =
+    baseDelta !== 0
+      ? [{ source: "uptime" as const, points: baseDelta, occurredAt: nowIso }]
+      : attackDetected
+        ? [{ source: "attack-detected" as const, points: 0, occurredAt: nowIso }]
+        : [];
   return {
     scoreDelta,
     scoreEvents:
-      scoreDelta !== 0
-        ? [{ source: "uptime", points: scoreDelta, occurredAt: nowIso }]
-        : attackDetected
-          ? [{ source: "attack-detected", points: 0, occurredAt: nowIso }]
-          : [],
+      bonusPoints > 0
+        ? [...uptimeEvents, { source: "uptime" as const, points: bonusPoints, occurredAt: nowIso }]
+        : uptimeEvents,
     endpointsHealthJson: JSON.stringify(newHealth),
     lastResult: allOk ? "ok" : "fail",
     ...(attackDetected ? { attackDetected: true } : {}),
+    ...(bonusState ? { newState: bonusState } : {}),
   };
 }

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -87,6 +87,13 @@ export interface UptimeMultiScoringMetadata {
   readonly probedSlots: readonly UptimeMultiProbedSlot[];
   readonly pointsAllOk: number;
   readonly failurePenalty?: number;
+  /**
+   * [ADR-034 / #1666] 任意の attack-blocked bonus。 宣言すると、 競技者 stack が「攻撃をブロックした回数」を
+   * 露出する CFn Output (`attackBlockedOutputKey`) の増分に応じて `pointsPerBlock` (既定 1) を加点する
+   * (= 可用性採点に防御テストの加点を重ねる、 attack-detection と同じ counter-delta ロジック)。 省略で無効・後方互換。
+   */
+  readonly attackBlockedOutputKey?: string;
+  readonly pointsPerBlock?: number;
   /** Issue #742 Phase 5: hints 共通 field。 */
   readonly hints?: readonly ProgressiveHint[];
 }
@@ -276,6 +283,8 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     probedSlots?: unknown;
     pointsAllOk?: unknown;
     failurePenalty?: unknown;
+    attackBlockedOutputKey?: unknown;
+    pointsPerBlock?: unknown;
     hints?: unknown;
   };
   if (!Array.isArray(u.probedSlots) || u.probedSlots.length === 0) return undefined;
@@ -285,11 +294,20 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     .filter((slot): slot is UptimeMultiProbedSlot => slot !== undefined);
   if (probedSlots.length === 0) return undefined;
   const hints = parseHints(u.hints);
+  // [ADR-034 / #1666] attack-blocked bonus は両 field が揃ったときだけ有効化 (= 片方欠けは無効)。
+  const attackBonus =
+    typeof u.attackBlockedOutputKey === "string" &&
+    u.attackBlockedOutputKey.length > 0 &&
+    typeof u.pointsPerBlock === "number" &&
+    u.pointsPerBlock > 0
+      ? { attackBlockedOutputKey: u.attackBlockedOutputKey, pointsPerBlock: u.pointsPerBlock }
+      : undefined;
   return {
     kind: "uptime-multi",
     probedSlots,
     pointsAllOk: u.pointsAllOk,
     ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
+    ...(attackBonus ?? {}),
     ...(hints ? { hints } : {}),
   };
 }

--- a/infrastructure/test/problem-deploy/attack-counter.test.ts
+++ b/infrastructure/test/problem-deploy/attack-counter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ATTACK_DELTA_PER_TICK,
+  scoreCounterDelta,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter";
+
+/**
+ * [ADR-034 / #1666] CFn-output attack counter の差分加点ロジック (attack-detection と uptime-multi が共有)。
+ */
+
+describe("scoreCounterDelta (#1666)", () => {
+  it("should record the baseline with 0 points on the first tick (prev undefined)", () => {
+    expect(scoreCounterDelta("5", undefined, 25)).toEqual({ points: 0, newCount: 5 });
+  });
+
+  it("should award (delta × pointsPer) when the counter increases", () => {
+    expect(scoreCounterDelta("5", 2, 25)).toEqual({ points: 75, newCount: 5 }); // 3 × 25
+  });
+
+  it("should award 0 and follow the baseline when the counter is unchanged or rewound", () => {
+    expect(scoreCounterDelta("5", 5, 25)).toEqual({ points: 0, newCount: 5 });
+    expect(scoreCounterDelta("3", 5, 25)).toEqual({ points: 0, newCount: 3 });
+  });
+
+  it("should cap the per-tick delta to prevent leaderboard inflation", () => {
+    expect(scoreCounterDelta("1000", 0, 25)).toEqual({
+      points: MAX_ATTACK_DELTA_PER_TICK * 25,
+      newCount: 1000,
+    });
+  });
+
+  it("should return undefined for absent / empty / non-integer / negative values", () => {
+    expect(scoreCounterDelta(undefined, 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("1.5", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("-3", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("abc", 0, 25)).toBeUndefined();
+  });
+
+  it("should trim surrounding whitespace before coercion", () => {
+    expect(scoreCounterDelta("  7  ", 2, 10)).toEqual({ points: 50, newCount: 7 });
+  });
+});

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
@@ -158,4 +158,56 @@ describe("uptime-multi kind", () => {
     // joinUrl は appendPath (/users) と probe path (/score) を path-style concat する。
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.example.com/users/score");
   });
+
+  // [ADR-034 / #1666] optional attack-blocked bonus: 防御テストの加点を可用性採点に重ねる。
+  function withAttackBonus(
+    blockedCount: string,
+    prevAttackCount: number | undefined,
+  ): KindHandlerInput<UptimeMultiScoringMetadata> {
+    const base = buildInput();
+    return {
+      ...base,
+      scoring: {
+        kind: "uptime-multi",
+        probedSlots: base.scoring.probedSlots,
+        pointsAllOk: 100,
+        attackBlockedOutputKey: "AttackBlockedCount",
+        pointsPerBlock: 25,
+      },
+      deployment: {
+        ...base.deployment,
+        stackOutputs: JSON.stringify({
+          FrontendUrl: "https://frontend.example.com",
+          ApiUrl: "https://api.example.com",
+          AttackBlockedCount: blockedCount,
+        }),
+      },
+      prevState: prevAttackCount === undefined ? {} : { attackCount: prevAttackCount },
+    };
+  }
+
+  it("should add an attack-blocked bonus on counter increment (defense held)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(withAttackBonus("5", 2)); // delta 3 × 25 = 75
+    expect(result.scoreDelta).toBe(175); // pointsAllOk 100 + bonus 75
+    expect(result.newState).toEqual({ attackCount: 5 });
+    expect(result.scoreEvents).toEqual([
+      { source: "uptime", points: 100, occurredAt: NOW_ISO },
+      { source: "uptime", points: 75, occurredAt: NOW_ISO },
+    ]);
+  });
+
+  it("should only record the baseline on the first tick (no bonus yet)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(withAttackBonus("5", undefined));
+    expect(result.scoreDelta).toBe(100); // availability only; bonus 0 on baseline
+    expect(result.newState).toEqual({ attackCount: 5 });
+  });
+
+  it("should not set newState or a bonus when attackBlockedOutputKey is absent (backward compat)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(buildInput());
+    expect(result.scoreDelta).toBe(100);
+    expect(result.newState).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
Resolves the open question ADR-034 raised for SQLi defense-tests: they need `attack-detection` scoring, but security-battle-royale uses `uptime-multi` and ADR-012 allows one scoring kind per problem. **Resolution: extend `uptime-multi` with an opt-in attack-blocked bonus** — availability + defense in one kind, no conflict.

- Factored attack-detection's counter-delta logic (delta × points, per-tick cap, baseline follow) into a shared `attack-counter.ts` (`scoreCounterDelta`). **attack-detection refactored to use it — behavior unchanged (its 11 tests pass).**
- `uptime-multi`: when a problem declares `attackBlockedOutputKey` + `pointsPerBlock`, the tick reads the team stack's "attacks blocked" CFn-output counter and adds `delta × pointsPerBlock` (capped) — a team that actually blocks SQLi is rewarded, on top of availability. **Omitted ⇒ no bonus, no extra state write (backward compatible).**

This is the platform **mechanism** (a tested capability, like #1668 was for disruption effects). It makes the platform able to score SQLi defense.

## Test plan
- `attack-counter.test.ts` (6): baseline / increment / rewind / per-tick cap / invalid (empty/fractional/negative/NaN) / whitespace-trim.
- `generic-scoring-uptime-multi.test.ts` (+3): bonus on counter increment (100 → 175), baseline-only first tick, absent-key unchanged (no `newState`).
- `generic-scoring-attack-detection.test.ts` (11): unchanged (refactor regression guard).
- `make harness` no findings; `make before-commit` green (infra 248 files + all SPAs/packages + cdk synth).

## Scoped follow-ups (ADR-034 steps, NOT claimed done)
- security-battle-royale: reference app self-reports `AttackBlockedCount` + SQLi `action` probes + scoring declares `attackBlockedOutputKey` (submodule).
- Live verification (does the SQLi defense actually hold) — account-gated.

## Regression analysis
- Pure DRY refactor of attack-detection (shared helper) + an **opt-in** uptime-multi extension. No existing problem declares `attackBlockedOutputKey`, so all current scoring is byte-for-byte unchanged (full 248-file infra suite + the 11 attack-detection tests pass).

## Physical impact
- **NO-OP** on CloudFormation. Scoring-Lambda logic only; behavior changes only for a uptime-multi problem that opts into the bonus (none yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)