### PR TITLE
feat(scoring): live-probe attack-blocked bonus — SQLi defense scoring (ADR-034) [#1666]

### DIFF
--- a/docs/architecture/adr-034-real-attack-realization.html
+++ b/docs/architecture/adr-034-real-attack-realization.html
@@ -128,10 +128,20 @@ disruption に <code>action</code> を追加。 template の <code>InstanceId</c
 完了の定義は「防御したチームは攻撃を凌いで有利になり、 怠ったチームは不利になる」が実機で観測できること。 これは <strong>実クラウドアカウントを要する</strong> (stackstack の純採点圧力と違い、 防御の物理的成否を測るため)。 本 ADR は account 入手前に実装を最大限進めるための設計を確定する。
 </p>
 
-<h2>Open questions (パターン B の未解決点)</h2>
+<h2>Resolved: scoring kind の衝突 (B-3)</h2>
+<p>
+当初の懸念: security-battle-royale は <code>uptime-multi</code> で可用性を採点しており、 ADR-012 は 1 問題 1 scoring kind なので <code>attack-detection</code> へ切替えると可用性採点が消える。
+</p>
+<p>
+<strong>決定 (option a、 ただし live probe で実装)</strong>: <code>uptime-multi</code> に任意の <code>attackBlocked: { slot, path, pointsPerBlock }</code> を追加 (#1666)。 採点 tick は宣言時、 その slot の base URL + path を <strong>live probe</strong> し (= 走行中アプリの counter endpoint を読む)、 応答 body をブロック回数として parse、 前回からの増分に <code>pointsPerBlock</code> を掛けて加点する (差分 cap + baseline 追従は <code>attack-counter.ts</code> の共通ロジックで attack-detection と共有)。 可用性採点はそのまま、 防御の加点を 1 kind 内に重ねる。
+</p>
+<p class="warn">
+⚠ <b>重要な落とし穴</b>: counter は <strong>必ず live probe で読む</strong>。 初期実装で <code>deployment.stackOutputs</code> (= deploy 時 1 回 capture の static な CFn output) から読もうとしたが、 runtime の counter 増分を追えず実 event で永遠に発火しない hollow だった (既存の <code>attack-detection</code> kind も同じ static-read の罠で、 どの問題も使っていない)。 採点時に endpoint を probe して初めて live な防御成否を測れる。
+</p>
+<h2>Open questions (残)</h2>
 <ul>
-  <li><b>scoring kind の衝突 (B-3)</b>: security-battle-royale は現在 <code>uptime-multi</code> で可用性を採点している。 ADR-012 は <strong>1 問題 1 scoring kind</strong> なので、 <code>attack-detection</code> へ「切替」ると可用性採点が消える。 よって SQLi 防御の採点は (a) <code>uptime-multi</code> に attack-counter ボーナス項を足す拡張、 (b) 可用性と攻撃検知を 1 つに束ねた新 kind、 (c) availability-flood (パターン A) と SQLi (パターン B) を別問題に分割、 のいずれかを要する。 <strong>本 ADR では未決</strong> — pattern A (availability-flood) は既存 <code>uptime-multi</code> のままで動くため先に出荷し、 SQLi の採点統合は別 ADR / 実装 PR で詰める。</li>
-  <li>reference アプリの attack-counter 自己申告 (B-1) の置き場 (template UserData か repo か) は security-battle-royale のアプリ構成に依存。</li>
+  <li>reference アプリの attack-counter 自己申告 (B-1): security-battle-royale の <code>api/api.py</code> が SQLi をブロックした回数を counter endpoint (例 <code>/attack-stats</code>) に露出する実装。 endpoint ロジック (SQLi を弾いたら +1) は unit-test 可能だが、 「実 SQLi で正しく弾くか」は実アプリへ撃つ live 検証を要する (account)。</li>
+  <li>既存 <code>attack-detection</code> kind 自体の static-read を live probe に寄せる移行 (= 同じ罠の是正)。</li>
 </ul>
 </body>
 </html>

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter.ts
@@ -1,0 +1,43 @@
+/**
+ * [ADR-034 / Issue #1666] CFn-output attack counter からの差分加点の共通ロジック。
+ *
+ * 競技者 stack が「攻撃をブロック/検知した回数」を CFn Output に counter として露出し、 採点 tick が
+ * 前回値からの差分に応じて加点する (= 防御の成否を採点に反映する)。 元は attack-detection kind 内にあった
+ * ロジックを、 uptime-multi の attack-blocked ボーナス (ADR-034 pattern B のスコア統合) と共有するため切り出した。
+ *
+ * 競技者は自 account の CFn Output に任意値を仕込めるため、 1 tick の差分加点には上限を設ける
+ * (= leaderboard の即時 inflation 防止)。 baseline は実値に追従し、 巨大ジャンプは 1 tick 分で止まる。
+ */
+
+/** 1 tick あたりに反映する counter 差分の上限 (#1389)。 */
+export const MAX_ATTACK_DELTA_PER_TICK = 100;
+
+export interface CounterScore {
+  /** この tick で加点する点数 (= 差分 × pointsPer、 上限 cap 済)。 baseline tick は 0。 */
+  readonly points: number;
+  /** 次 tick の baseline として記録する現在値。 */
+  readonly newCount: number;
+}
+
+/**
+ * CFn Output から読んだ counter (string) と前回値から差分加点を計算する。 不正値 (空 / 非整数 / 負) は
+ * `undefined` (= baseline 汚染を避けるため採点しない)。 prev 未定義 (初回) は baseline 記録のみで 0 点。
+ */
+export function scoreCounterDelta(
+  rawValue: unknown,
+  prevCount: number | undefined,
+  pointsPer: number,
+): CounterScore | undefined {
+  if (rawValue === undefined) return undefined;
+  const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
+  if (normalized === "") return undefined;
+  const current = Number(normalized);
+  if (!Number.isFinite(current) || !Number.isInteger(current) || current < 0) return undefined;
+  // 初回 tick: deploy 後の既存値を新検知扱いしない (= baseline 記録のみ)。
+  if (prevCount === undefined) return { points: 0, newCount: current };
+  const delta = current - prevCount;
+  // 巻き戻し / 同値 → 加点なし、 baseline を current に追従。
+  if (delta <= 0) return { points: 0, newCount: current };
+  const cappedDelta = Math.min(delta, MAX_ATTACK_DELTA_PER_TICK);
+  return { points: cappedDelta * pointsPer, newCount: current };
+}

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-detection.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-detection.ts
@@ -1,14 +1,7 @@
 import type { AttackDetectionScoringMetadata } from "../../../../utils/scoring-metadata.js";
 import { parseStackOutputs } from "../../shared/cfn-status.js";
 import { type KindHandlerInput, type KindResult, noopKindResult } from "../shared.js";
-
-/**
- * 1 tick あたりに加点へ反映する attack 差分の上限 (#1389)。 attack counter は競技者が admin 権限
- * を持つ自 account の CFn Output から読むため任意の巨大値を仕込める。 差分加点に上限を設けることで
- * leaderboard の即時 inflation を防ぐ。 baseline は実値に追従させるため、 巨大ジャンプは 1 tick 分の
- * 上限加点で止まり、 次 tick 以降は再加算されない。
- */
-const MAX_ATTACK_DELTA_PER_TICK = 100;
+import { scoreCounterDelta } from "./attack-counter.js";
 
 /**
  * `attack-detection` kind (ADR-012 Phase 3.B、 security-battle-royale の攻撃検知部 想定)。
@@ -29,45 +22,18 @@ export function runAttackDetectionKind(
   if (!deployment.PK || !deployment.problemId) return noopKindResult();
 
   const outputs = parseStackOutputs(deployment.stackOutputs);
-  const rawValue = outputs[scoring.statsOutputKey];
-  if (rawValue === undefined) return noopKindResult();
-
-  // 問題側の CFn Output は string なので Number() で coerce する。 ただし `""` → 0、
-  // `"1.5"` → 1.5 のような falsy/fractional case は不正データ扱いで noop (= baseline 汚染防止)。
-  const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
-  if (normalized === "") return noopKindResult();
-  const current = Number(normalized);
-  if (!Number.isFinite(current) || !Number.isInteger(current) || current < 0) {
-    return noopKindResult();
-  }
-
-  const prev = prevState.attackCount;
-  // 初回 tick: baseline 記録のみで加点しない (= deploy 後の counter 既存値を新検知扱いしない)
-  if (prev === undefined) {
-    return {
-      scoreDelta: 0,
-      scoreEvents: [],
-      newState: { attackCount: current },
-    };
-  }
-
-  const delta = current - prev;
-  if (delta <= 0) {
-    // counter 巻き戻し / 同値 → 加点なし、 baseline を current に追従する
-    return {
-      scoreDelta: 0,
-      scoreEvents: [],
-      newState: { attackCount: current },
-    };
-  }
-
-  // 1 tick あたりの差分加点に上限を設ける (= 競技者が CFn Output に巨大値を仕込んでも leaderboard を
-  // 即時 inflation できない)。 baseline は実値 (current) に追従させ、 巨大ジャンプは 1 tick で止める。
-  const cappedDelta = Math.min(delta, MAX_ATTACK_DELTA_PER_TICK);
-  const points = cappedDelta * scoring.pointsPerAttack;
+  // 差分加点 + cap + baseline 追従の共通ロジックは attack-counter.ts に集約 (uptime-multi の
+  // attack-blocked bonus と共有、 ADR-034)。 不正値 / 未露出は noop。
+  const scored = scoreCounterDelta(
+    outputs[scoring.statsOutputKey],
+    prevState.attackCount,
+    scoring.pointsPerAttack,
+  );
+  if (!scored) return noopKindResult();
   return {
-    scoreDelta: points,
-    scoreEvents: [{ source: "uptime", points, occurredAt: nowIso }],
-    newState: { attackCount: current },
+    scoreDelta: scored.points,
+    scoreEvents:
+      scored.points > 0 ? [{ source: "uptime", points: scored.points, occurredAt: nowIso }] : [],
+    newState: { attackCount: scored.newCount },
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
@@ -38,18 +38,20 @@ export async function runUptimeMultiKind(
   for (const o of overrides) overrideMap.set(o.slot, o.overrideUrl);
   const slotMap = new Map(slots.map((s) => [s.slot, s] as const));
 
+  // slot の effective base URL (= override ?? CFn output 由来 default) を解決する。 probedSlots と
+  // attack-blocked probe で共有。
+  const resolveSlotBaseUrl = (slotName: string): string | undefined => {
+    const overrideUrl = overrideMap.get(slotName);
+    if (overrideUrl) return overrideUrl;
+    const slot = slotMap.get(slotName);
+    if (!slot) return undefined;
+    const outputValue = outputs[slot.default.key];
+    return outputValue ? resolveDefaultUrl(outputValue, slot.default.appendPath) : undefined;
+  };
+
   const probes = await Promise.all(
     scoring.probedSlots.map(async (ps) => {
-      const overrideUrl = overrideMap.get(ps.slot);
-      let baseUrl: string | undefined;
-      if (overrideUrl) baseUrl = overrideUrl;
-      else {
-        const slot = slotMap.get(ps.slot);
-        if (slot) {
-          const outputValue = outputs[slot.default.key];
-          if (outputValue) baseUrl = resolveDefaultUrl(outputValue, slot.default.appendPath);
-        }
-      }
+      const baseUrl = resolveSlotBaseUrl(ps.slot);
       if (!baseUrl) return { key: ps.slot, ok: false, resolved: false };
       const probe = await probeUrl(joinUrl(baseUrl, ps.path), { expectStatus: ps.expectStatus });
       return { key: ps.slot, ok: probe.ok, resolved: true };
@@ -72,19 +74,22 @@ export async function runUptimeMultiKind(
   const baseDelta = allOk ? scoring.pointsAllOk : (scoring.failurePenalty ?? 0);
   const attackDetected = !allOk && deployment.lastResult === "ok";
 
-  // [ADR-034 / #1666] optional attack-blocked bonus (= 防御テストの加点を可用性採点に重ねる)。
-  // 宣言時のみ: 競技者 stack が露出する attack-blocked counter の増分で加点 + baseline を追従。
+  // [ADR-034 / #1666] optional attack-blocked bonus (= 防御テストの加点を可用性採点に重ねる)。 宣言時のみ:
+  // アプリの counter endpoint を **live probe** し (静的 CFn output でなく走行中の値)、 応答 body を
+  // ブロック回数として読み、 前回からの増分で加点 + baseline を追従。 probe 失敗 / 不正 body は加点 0。
   let bonusPoints = 0;
   let bonusState: { attackCount: number } | undefined;
-  if (scoring.attackBlockedOutputKey) {
-    const scored = scoreCounterDelta(
-      outputs[scoring.attackBlockedOutputKey],
-      prevState.attackCount,
-      scoring.pointsPerBlock ?? 1,
-    );
-    if (scored) {
-      bonusPoints = scored.points;
-      bonusState = { attackCount: scored.newCount };
+  if (scoring.attackBlocked) {
+    const base = resolveSlotBaseUrl(scoring.attackBlocked.slot);
+    if (base) {
+      const probe = await probeUrl(joinUrl(base, scoring.attackBlocked.path), { readBody: true });
+      const scored = probe.ok
+        ? scoreCounterDelta(probe.body, prevState.attackCount, scoring.attackBlocked.pointsPerBlock)
+        : undefined;
+      if (scored) {
+        bonusPoints = scored.points;
+        bonusState = { attackCount: scored.newCount };
+      }
     }
   }
 

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
@@ -13,6 +13,7 @@ import {
   noopKindResult,
   probeUrl,
 } from "../shared.js";
+import { scoreCounterDelta } from "./attack-counter.js";
 
 /**
  * `uptime-multi` kind (ADR-012 Phase 3.B、 security-battle-royale 想定)。
@@ -29,7 +30,7 @@ import {
 export async function runUptimeMultiKind(
   input: KindHandlerInput<UptimeMultiScoringMetadata>,
 ): Promise<KindResult> {
-  const { deployment, scoring, slots, overrides, nowIso } = input;
+  const { deployment, scoring, slots, overrides, nowIso, prevState } = input;
   if (!deployment.PK || !deployment.problemId) return noopKindResult();
 
   const outputs = parseStackOutputs(deployment.stackOutputs);
@@ -68,19 +69,41 @@ export async function runUptimeMultiKind(
     newHealth[key] = { ok, checkedAt: nowIso, ...(since ? { since } : {}) };
   }
 
-  const scoreDelta = allOk ? scoring.pointsAllOk : (scoring.failurePenalty ?? 0);
+  const baseDelta = allOk ? scoring.pointsAllOk : (scoring.failurePenalty ?? 0);
   const attackDetected = !allOk && deployment.lastResult === "ok";
 
+  // [ADR-034 / #1666] optional attack-blocked bonus (= 防御テストの加点を可用性採点に重ねる)。
+  // 宣言時のみ: 競技者 stack が露出する attack-blocked counter の増分で加点 + baseline を追従。
+  let bonusPoints = 0;
+  let bonusState: { attackCount: number } | undefined;
+  if (scoring.attackBlockedOutputKey) {
+    const scored = scoreCounterDelta(
+      outputs[scoring.attackBlockedOutputKey],
+      prevState.attackCount,
+      scoring.pointsPerBlock ?? 1,
+    );
+    if (scored) {
+      bonusPoints = scored.points;
+      bonusState = { attackCount: scored.newCount };
+    }
+  }
+
+  const scoreDelta = baseDelta + bonusPoints;
+  const uptimeEvents =
+    baseDelta !== 0
+      ? [{ source: "uptime" as const, points: baseDelta, occurredAt: nowIso }]
+      : attackDetected
+        ? [{ source: "attack-detected" as const, points: 0, occurredAt: nowIso }]
+        : [];
   return {
     scoreDelta,
     scoreEvents:
-      scoreDelta !== 0
-        ? [{ source: "uptime", points: scoreDelta, occurredAt: nowIso }]
-        : attackDetected
-          ? [{ source: "attack-detected", points: 0, occurredAt: nowIso }]
-          : [],
+      bonusPoints > 0
+        ? [...uptimeEvents, { source: "uptime" as const, points: bonusPoints, occurredAt: nowIso }]
+        : uptimeEvents,
     endpointsHealthJson: JSON.stringify(newHealth),
     lastResult: allOk ? "ok" : "fail",
     ...(attackDetected ? { attackDetected: true } : {}),
+    ...(bonusState ? { newState: bonusState } : {}),
   };
 }

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -88,12 +88,16 @@ export interface UptimeMultiScoringMetadata {
   readonly pointsAllOk: number;
   readonly failurePenalty?: number;
   /**
-   * [ADR-034 / #1666] 任意の attack-blocked bonus。 宣言すると、 競技者 stack が「攻撃をブロックした回数」を
-   * 露出する CFn Output (`attackBlockedOutputKey`) の増分に応じて `pointsPerBlock` (既定 1) を加点する
-   * (= 可用性採点に防御テストの加点を重ねる、 attack-detection と同じ counter-delta ロジック)。 省略で無効・後方互換。
+   * [ADR-034 / #1666] 任意の attack-blocked bonus。 宣言すると採点 tick が `slot` の base URL + `path` を
+   * **live probe** し (= 静的 CFn output でなく、 走っているアプリの counter endpoint を読む)、 応答 body を
+   * ブロック回数 (整数) として parse して、 前回からの増分に `pointsPerBlock` を掛けて加点する (= 防御の成否を
+   * 可用性採点に重ねる。 attack-detection の counter-delta + cap を共有)。 省略で無効・後方互換。
    */
-  readonly attackBlockedOutputKey?: string;
-  readonly pointsPerBlock?: number;
+  readonly attackBlocked?: {
+    readonly slot: string;
+    readonly path: string;
+    readonly pointsPerBlock: number;
+  };
   /** Issue #742 Phase 5: hints 共通 field。 */
   readonly hints?: readonly ProgressiveHint[];
 }
@@ -283,8 +287,7 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     probedSlots?: unknown;
     pointsAllOk?: unknown;
     failurePenalty?: unknown;
-    attackBlockedOutputKey?: unknown;
-    pointsPerBlock?: unknown;
+    attackBlocked?: unknown;
     hints?: unknown;
   };
   if (!Array.isArray(u.probedSlots) || u.probedSlots.length === 0) return undefined;
@@ -294,22 +297,27 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     .filter((slot): slot is UptimeMultiProbedSlot => slot !== undefined);
   if (probedSlots.length === 0) return undefined;
   const hints = parseHints(u.hints);
-  // [ADR-034 / #1666] attack-blocked bonus は両 field が揃ったときだけ有効化 (= 片方欠けは無効)。
-  const attackBonus =
-    typeof u.attackBlockedOutputKey === "string" &&
-    u.attackBlockedOutputKey.length > 0 &&
-    typeof u.pointsPerBlock === "number" &&
-    u.pointsPerBlock > 0
-      ? { attackBlockedOutputKey: u.attackBlockedOutputKey, pointsPerBlock: u.pointsPerBlock }
-      : undefined;
+  const attackBlocked = parseAttackBlocked(u.attackBlocked);
   return {
     kind: "uptime-multi",
     probedSlots,
     pointsAllOk: u.pointsAllOk,
     ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
-    ...(attackBonus ?? {}),
+    ...(attackBlocked ? { attackBlocked } : {}),
     ...(hints ? { hints } : {}),
   };
+}
+
+/** [ADR-034 / #1666] attack-blocked bonus は slot/path/pointsPerBlock が全て揃ったときだけ有効化。 */
+function parseAttackBlocked(
+  value: unknown,
+): UptimeMultiScoringMetadata["attackBlocked"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const a = value as { slot?: unknown; path?: unknown; pointsPerBlock?: unknown };
+  if (typeof a.slot !== "string" || a.slot.length === 0) return undefined;
+  if (typeof a.path !== "string" || a.path.length === 0) return undefined;
+  if (typeof a.pointsPerBlock !== "number" || a.pointsPerBlock <= 0) return undefined;
+  return { slot: a.slot, path: a.path, pointsPerBlock: a.pointsPerBlock };
 }
 
 function parseUptimeMultiSlot(value: unknown): UptimeMultiProbedSlot | undefined {

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -87,6 +87,13 @@ export interface UptimeMultiScoringMetadata {
   readonly probedSlots: readonly UptimeMultiProbedSlot[];
   readonly pointsAllOk: number;
   readonly failurePenalty?: number;
+  /**
+   * [ADR-034 / #1666] 任意の attack-blocked bonus。 宣言すると、 競技者 stack が「攻撃をブロックした回数」を
+   * 露出する CFn Output (`attackBlockedOutputKey`) の増分に応じて `pointsPerBlock` (既定 1) を加点する
+   * (= 可用性採点に防御テストの加点を重ねる、 attack-detection と同じ counter-delta ロジック)。 省略で無効・後方互換。
+   */
+  readonly attackBlockedOutputKey?: string;
+  readonly pointsPerBlock?: number;
   /** Issue #742 Phase 5: hints 共通 field。 */
   readonly hints?: readonly ProgressiveHint[];
 }
@@ -276,6 +283,8 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     probedSlots?: unknown;
     pointsAllOk?: unknown;
     failurePenalty?: unknown;
+    attackBlockedOutputKey?: unknown;
+    pointsPerBlock?: unknown;
     hints?: unknown;
   };
   if (!Array.isArray(u.probedSlots) || u.probedSlots.length === 0) return undefined;
@@ -285,11 +294,20 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     .filter((slot): slot is UptimeMultiProbedSlot => slot !== undefined);
   if (probedSlots.length === 0) return undefined;
   const hints = parseHints(u.hints);
+  // [ADR-034 / #1666] attack-blocked bonus は両 field が揃ったときだけ有効化 (= 片方欠けは無効)。
+  const attackBonus =
+    typeof u.attackBlockedOutputKey === "string" &&
+    u.attackBlockedOutputKey.length > 0 &&
+    typeof u.pointsPerBlock === "number" &&
+    u.pointsPerBlock > 0
+      ? { attackBlockedOutputKey: u.attackBlockedOutputKey, pointsPerBlock: u.pointsPerBlock }
+      : undefined;
   return {
     kind: "uptime-multi",
     probedSlots,
     pointsAllOk: u.pointsAllOk,
     ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
+    ...(attackBonus ?? {}),
     ...(hints ? { hints } : {}),
   };
 }

--- a/infrastructure/test/problem-deploy/attack-counter.test.ts
+++ b/infrastructure/test/problem-deploy/attack-counter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ATTACK_DELTA_PER_TICK,
+  scoreCounterDelta,
+} from "../../lib/problem-deploy/handlers/generic-scoring-handler/kinds/attack-counter";
+
+/**
+ * [ADR-034 / #1666] CFn-output attack counter の差分加点ロジック (attack-detection と uptime-multi が共有)。
+ */
+
+describe("scoreCounterDelta (#1666)", () => {
+  it("should record the baseline with 0 points on the first tick (prev undefined)", () => {
+    expect(scoreCounterDelta("5", undefined, 25)).toEqual({ points: 0, newCount: 5 });
+  });
+
+  it("should award (delta × pointsPer) when the counter increases", () => {
+    expect(scoreCounterDelta("5", 2, 25)).toEqual({ points: 75, newCount: 5 }); // 3 × 25
+  });
+
+  it("should award 0 and follow the baseline when the counter is unchanged or rewound", () => {
+    expect(scoreCounterDelta("5", 5, 25)).toEqual({ points: 0, newCount: 5 });
+    expect(scoreCounterDelta("3", 5, 25)).toEqual({ points: 0, newCount: 3 });
+  });
+
+  it("should cap the per-tick delta to prevent leaderboard inflation", () => {
+    expect(scoreCounterDelta("1000", 0, 25)).toEqual({
+      points: MAX_ATTACK_DELTA_PER_TICK * 25,
+      newCount: 1000,
+    });
+  });
+
+  it("should return undefined for absent / empty / non-integer / negative values", () => {
+    expect(scoreCounterDelta(undefined, 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("1.5", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("-3", 0, 25)).toBeUndefined();
+    expect(scoreCounterDelta("abc", 0, 25)).toBeUndefined();
+  });
+
+  it("should trim surrounding whitespace before coercion", () => {
+    expect(scoreCounterDelta("  7  ", 2, 10)).toEqual({ points: 50, newCount: 7 });
+  });
+});

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
@@ -159,9 +159,8 @@ describe("uptime-multi kind", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.example.com/users/score");
   });
 
-  // [ADR-034 / #1666] optional attack-blocked bonus: 防御テストの加点を可用性採点に重ねる。
+  // [ADR-034 / #1666] optional attack-blocked bonus: アプリの counter endpoint を live probe して防御加点。
   function withAttackBonus(
-    blockedCount: string,
     prevAttackCount: number | undefined,
   ): KindHandlerInput<UptimeMultiScoringMetadata> {
     const base = buildInput();
@@ -171,24 +170,24 @@ describe("uptime-multi kind", () => {
         kind: "uptime-multi",
         probedSlots: base.scoring.probedSlots,
         pointsAllOk: 100,
-        attackBlockedOutputKey: "AttackBlockedCount",
-        pointsPerBlock: 25,
-      },
-      deployment: {
-        ...base.deployment,
-        stackOutputs: JSON.stringify({
-          FrontendUrl: "https://frontend.example.com",
-          ApiUrl: "https://api.example.com",
-          AttackBlockedCount: blockedCount,
-        }),
+        attackBlocked: { slot: "api", path: "/attack-stats", pointsPerBlock: 25 },
       },
       prevState: prevAttackCount === undefined ? {} : { attackCount: prevAttackCount },
     };
   }
 
+  /** slot probe は 200/空、 counter endpoint (/attack-stats) は body にブロック回数を返す fetch mock。 */
+  function mockProbesWithCounter(blockedCount: string): void {
+    fetchMock.mockImplementation(async (url: string) => ({
+      status: 200,
+      url,
+      text: async () => (url.includes("/attack-stats") ? blockedCount : ""),
+    }));
+  }
+
   it("should add an attack-blocked bonus on counter increment (defense held)", async () => {
-    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
-    const result = await runUptimeMultiKind(withAttackBonus("5", 2)); // delta 3 × 25 = 75
+    mockProbesWithCounter("5");
+    const result = await runUptimeMultiKind(withAttackBonus(2)); // delta 3 × 25 = 75
     expect(result.scoreDelta).toBe(175); // pointsAllOk 100 + bonus 75
     expect(result.newState).toEqual({ attackCount: 5 });
     expect(result.scoreEvents).toEqual([
@@ -198,13 +197,25 @@ describe("uptime-multi kind", () => {
   });
 
   it("should only record the baseline on the first tick (no bonus yet)", async () => {
-    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
-    const result = await runUptimeMultiKind(withAttackBonus("5", undefined));
+    mockProbesWithCounter("5");
+    const result = await runUptimeMultiKind(withAttackBonus(undefined));
     expect(result.scoreDelta).toBe(100); // availability only; bonus 0 on baseline
     expect(result.newState).toEqual({ attackCount: 5 });
   });
 
-  it("should not set newState or a bonus when attackBlockedOutputKey is absent (backward compat)", async () => {
+  it("should award no bonus when the counter endpoint is unreachable", async () => {
+    // slot probes ok, but the counter endpoint 500s → no bonus, no state.
+    fetchMock.mockImplementation(async (url: string) => ({
+      status: url.includes("/attack-stats") ? 500 : 200,
+      url,
+      text: async () => "",
+    }));
+    const result = await runUptimeMultiKind(withAttackBonus(2));
+    expect(result.scoreDelta).toBe(100);
+    expect(result.newState).toBeUndefined();
+  });
+
+  it("should not set newState or a bonus when attackBlocked is absent (backward compat)", async () => {
     fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
     const result = await runUptimeMultiKind(buildInput());
     expect(result.scoreDelta).toBe(100);

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
@@ -158,4 +158,56 @@ describe("uptime-multi kind", () => {
     // joinUrl は appendPath (/users) と probe path (/score) を path-style concat する。
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.example.com/users/score");
   });
+
+  // [ADR-034 / #1666] optional attack-blocked bonus: 防御テストの加点を可用性採点に重ねる。
+  function withAttackBonus(
+    blockedCount: string,
+    prevAttackCount: number | undefined,
+  ): KindHandlerInput<UptimeMultiScoringMetadata> {
+    const base = buildInput();
+    return {
+      ...base,
+      scoring: {
+        kind: "uptime-multi",
+        probedSlots: base.scoring.probedSlots,
+        pointsAllOk: 100,
+        attackBlockedOutputKey: "AttackBlockedCount",
+        pointsPerBlock: 25,
+      },
+      deployment: {
+        ...base.deployment,
+        stackOutputs: JSON.stringify({
+          FrontendUrl: "https://frontend.example.com",
+          ApiUrl: "https://api.example.com",
+          AttackBlockedCount: blockedCount,
+        }),
+      },
+      prevState: prevAttackCount === undefined ? {} : { attackCount: prevAttackCount },
+    };
+  }
+
+  it("should add an attack-blocked bonus on counter increment (defense held)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(withAttackBonus("5", 2)); // delta 3 × 25 = 75
+    expect(result.scoreDelta).toBe(175); // pointsAllOk 100 + bonus 75
+    expect(result.newState).toEqual({ attackCount: 5 });
+    expect(result.scoreEvents).toEqual([
+      { source: "uptime", points: 100, occurredAt: NOW_ISO },
+      { source: "uptime", points: 75, occurredAt: NOW_ISO },
+    ]);
+  });
+
+  it("should only record the baseline on the first tick (no bonus yet)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(withAttackBonus("5", undefined));
+    expect(result.scoreDelta).toBe(100); // availability only; bonus 0 on baseline
+    expect(result.newState).toEqual({ attackCount: 5 });
+  });
+
+  it("should not set newState or a bonus when attackBlockedOutputKey is absent (backward compat)", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(buildInput());
+    expect(result.scoreDelta).toBe(100);
+    expect(result.newState).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
Supersedes the draft #1673. Resolves ADR-034's pattern-B scoring conflict so a uptime-multi problem (security-battle-royale) can score **SQLi defense** alongside availability — **correctly, via a live probe** (not the static-output read that #1673 self-review caught as hollow).

- `uptime-multi` gains optional `attackBlocked: { slot, path, pointsPerBlock }`. Each tick it **live-probes** `{slot base URL}{path}` (`readBody`), parses the body as the "attacks blocked" count, and awards `delta × pointsPerBlock` vs the previous tick (cap + baseline via the shared `attack-counter.ts`). Availability scoring is unchanged; defense reward is layered into the one kind.
- Shared `attack-counter.ts` (`scoreCounterDelta`): the delta/cap/baseline logic, **refactored out of `attack-detection` (its 11 tests pass unchanged)**.
- ADR-034 updated: open question **resolved** (live probe), with the static-read pitfall documented (the existing `attack-detection` kind has the same trap — reads static CFn outputs, used by no problem).

## Why a live probe (the #1673 correction)
`deployment.stackOutputs` is captured once at deploy — CFn outputs are static. A team's app incrementing a counter at runtime would never change it, so a static-read bonus can't fire live (passes tests with a changing fixture, dead in reality). The scorer already does live HTTP probes (`probeUrl`); reading the counter that way is the correct, verifiable mechanism.

## Test plan
- `attack-counter.test.ts` (6): baseline / increment / rewind / cap / invalid / trim.
- `generic-scoring-uptime-multi.test.ts` (+4): bonus on counter increment (100→175), baseline-only first tick, **no bonus when the counter endpoint is unreachable**, absent-key unchanged.
- `generic-scoring-attack-detection.test.ts` (11): unchanged (refactor regression guard).
- `make harness` no findings; `make before-commit` green (all workspaces + cdk synth).

## Scoped follow-ups (ADR-034, NOT claimed done)
- security-battle-royale `api/api.py`: expose a `/attack-stats` block counter (endpoint logic unit-testable; "blocks real SQLi" needs live verification) + SQLi probe `action`s + declare `attackBlocked` (submodule).
- Migrate the existing `attack-detection` kind off static-read to a live probe (same trap).

## Regression analysis
- Opt-in extension + pure DRY refactor; no existing problem declares `attackBlocked`, so all current scoring is byte-for-byte unchanged (full infra suite + the 11 attack-detection tests pass).

## Physical impact
- **NO-OP** on CloudFormation. Scoring-Lambda logic only; behavior changes only for a uptime-multi problem that opts in (none yet). The opt-in adds one extra HTTP probe per tick for that problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)