### PR TITLE
feat(scoring): attack-probe defense test — scorer fires the attack [#1666]

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-multi.ts
@@ -93,22 +93,48 @@ export async function runUptimeMultiKind(
     }
   }
 
-  const scoreDelta = baseDelta + bonusPoints;
-  const uptimeEvents =
-    baseDelta !== 0
+  // [ADR-034 / #1666] optional attack-probes (= 防御テスト)。 scorer が各 probe へ攻撃 payload を送り、
+  // 応答ステータスが vulnerableStatus に含まれれば (= 防御が破れた) penalty を減点する。 防御できていれば 0。
+  // 未解決 slot / unreachable は減点しない (= 可用性は probedSlots が見る、 攻撃成否と分離)。
+  let attackPenalty = 0;
+  if (scoring.attackProbes && scoring.attackProbes.length > 0) {
+    const vulnerable = await Promise.all(
+      scoring.attackProbes.map(async (ap) => {
+        const base = resolveSlotBaseUrl(ap.slot);
+        if (!base) return false;
+        const probe = await probeUrl(joinUrl(base, ap.path), {
+          ...(ap.method ? { method: ap.method } : {}),
+          ...(ap.body !== undefined ? { body: ap.body } : {}),
+        });
+        return probe.status !== undefined && ap.vulnerableStatus.includes(probe.status);
+      }),
+    );
+    attackPenalty = scoring.attackProbes.reduce(
+      (sum, ap, i) => (vulnerable[i] ? sum + ap.penalty : sum),
+      0,
+    );
+  }
+
+  const scoreDelta = baseDelta + bonusPoints - attackPenalty;
+  const scoreEvents = [
+    ...(baseDelta !== 0
       ? [{ source: "uptime" as const, points: baseDelta, occurredAt: nowIso }]
       : attackDetected
         ? [{ source: "attack-detected" as const, points: 0, occurredAt: nowIso }]
-        : [];
+        : []),
+    ...(bonusPoints > 0
+      ? [{ source: "uptime" as const, points: bonusPoints, occurredAt: nowIso }]
+      : []),
+    ...(attackPenalty > 0
+      ? [{ source: "attack-detected" as const, points: -attackPenalty, occurredAt: nowIso }]
+      : []),
+  ];
   return {
     scoreDelta,
-    scoreEvents:
-      bonusPoints > 0
-        ? [...uptimeEvents, { source: "uptime" as const, points: bonusPoints, occurredAt: nowIso }]
-        : uptimeEvents,
+    scoreEvents,
     endpointsHealthJson: JSON.stringify(newHealth),
     lastResult: allOk ? "ok" : "fail",
-    ...(attackDetected ? { attackDetected: true } : {}),
+    ...(attackDetected || attackPenalty > 0 ? { attackDetected: true } : {}),
     ...(bonusState ? { newState: bonusState } : {}),
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -193,6 +193,10 @@ export async function probeUrl(
     readonly expectStatus?: readonly number[];
     readonly timeoutMs?: number;
     readonly readBody?: boolean;
+    /** [ADR-034 / #1666] attack-probe 用。 既定 GET。 */
+    readonly method?: "GET" | "POST";
+    /** POST body (= 攻撃 payload)。 method=POST + body 指定時に content-type: application/json で送る。 */
+    readonly body?: string;
   } = {},
 ): Promise<ProbeResult> {
   const ctrl = new AbortController();
@@ -205,7 +209,13 @@ export async function probeUrl(
     return { ok: false, status: undefined, responseTimeMs: Date.now() - start };
   }
   try {
-    const res = await fetch(url, { method: "GET", signal: ctrl.signal });
+    const res = await fetch(url, {
+      method: options.method ?? "GET",
+      signal: ctrl.signal,
+      ...(options.method === "POST" && options.body !== undefined
+        ? { headers: { "content-type": "application/json" }, body: options.body }
+        : {}),
+    });
     const responseTimeMs = Date.now() - start;
     // redirect 追従で blocklist host (IMDS 等) に着地した応答は body を読まず not-ok 扱いにする
     // (= write-time check を redirect で bypass されても内部応答を reflect しない)。

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -98,6 +98,20 @@ export interface UptimeMultiScoringMetadata {
     readonly path: string;
     readonly pointsPerBlock: number;
   };
+  /**
+   * [ADR-034 / #1666] 任意の attack-probes (= 防御テスト)。 採点 tick が各 probe の `slot`+`path` へ
+   * 攻撃 payload を送り (例: SQLi injection を POST)、 応答ステータスが `vulnerableStatus` に含まれれば
+   * (= 防御が破れた) `penalty` を減点する。 防御できているチームは減点 0。 app 計装不要・採点側で判定 (=
+   * scorer が攻撃して結果で採点)。 省略で無効・後方互換。 unreachable は減点しない (= 可用性は probedSlots が見る)。
+   */
+  readonly attackProbes?: readonly {
+    readonly slot: string;
+    readonly path: string;
+    readonly method?: "GET" | "POST";
+    readonly body?: string;
+    readonly vulnerableStatus: readonly number[];
+    readonly penalty: number;
+  }[];
   /** Issue #742 Phase 5: hints 共通 field。 */
   readonly hints?: readonly ProgressiveHint[];
 }
@@ -288,6 +302,7 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
     pointsAllOk?: unknown;
     failurePenalty?: unknown;
     attackBlocked?: unknown;
+    attackProbes?: unknown;
     hints?: unknown;
   };
   if (!Array.isArray(u.probedSlots) || u.probedSlots.length === 0) return undefined;
@@ -298,13 +313,49 @@ function parseUptimeMulti(value: unknown): UptimeMultiScoringMetadata | undefine
   if (probedSlots.length === 0) return undefined;
   const hints = parseHints(u.hints);
   const attackBlocked = parseAttackBlocked(u.attackBlocked);
+  const attackProbes = Array.isArray(u.attackProbes)
+    ? u.attackProbes
+        .map(parseAttackProbe)
+        .filter((p): p is NonNullable<UptimeMultiScoringMetadata["attackProbes"]>[number] => !!p)
+    : undefined;
   return {
     kind: "uptime-multi",
     probedSlots,
     pointsAllOk: u.pointsAllOk,
     ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
     ...(attackBlocked ? { attackBlocked } : {}),
+    ...(attackProbes && attackProbes.length > 0 ? { attackProbes } : {}),
     ...(hints ? { hints } : {}),
+  };
+}
+
+/** [ADR-034 / #1666] attack-probe 1 件を fail-safe に parse。 slot/path/vulnerableStatus/penalty 必須。 */
+function parseAttackProbe(
+  value: unknown,
+): NonNullable<UptimeMultiScoringMetadata["attackProbes"]>[number] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const p = value as {
+    slot?: unknown;
+    path?: unknown;
+    method?: unknown;
+    body?: unknown;
+    vulnerableStatus?: unknown;
+    penalty?: unknown;
+  };
+  if (typeof p.slot !== "string" || p.slot.length === 0) return undefined;
+  if (typeof p.path !== "string" || p.path.length === 0) return undefined;
+  if (typeof p.penalty !== "number" || p.penalty <= 0) return undefined;
+  const vulnerableStatus = Array.isArray(p.vulnerableStatus)
+    ? p.vulnerableStatus.filter((s): s is number => typeof s === "number")
+    : [];
+  if (vulnerableStatus.length === 0) return undefined;
+  return {
+    slot: p.slot,
+    path: p.path,
+    ...(p.method === "POST" || p.method === "GET" ? { method: p.method } : {}),
+    ...(typeof p.body === "string" ? { body: p.body } : {}),
+    vulnerableStatus,
+    penalty: p.penalty,
   };
 }
 

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-multi.test.ts
@@ -221,4 +221,67 @@ describe("uptime-multi kind", () => {
     expect(result.scoreDelta).toBe(100);
     expect(result.newState).toBeUndefined();
   });
+
+  // [ADR-034 / #1666] attack-probes: scorer が攻撃 payload を送り、 防御が破れていれば減点 (= SQLi 防御テスト)。
+  function withAttackProbe(): KindHandlerInput<UptimeMultiScoringMetadata> {
+    const base = buildInput();
+    return {
+      ...base,
+      scoring: {
+        kind: "uptime-multi",
+        probedSlots: base.scoring.probedSlots,
+        pointsAllOk: 100,
+        attackProbes: [
+          {
+            slot: "api",
+            path: "/api/v1/auth",
+            method: "POST",
+            body: JSON.stringify({ username: "' OR '1'='1", password: "x" }),
+            vulnerableStatus: [200], // 認証 bypass で 200 = 脆弱
+            penalty: 60,
+          },
+        ],
+      },
+    };
+  }
+
+  it("should penalize when the SQLi attack-probe bypasses auth (defense failed)", async () => {
+    // slot probes ok (200) AND the attack POST returns 200 (bypassed) → vulnerable → -60.
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeMultiKind(withAttackProbe());
+    expect(result.scoreDelta).toBe(40); // 100 availability − 60 vulnerability
+    expect(result.attackDetected).toBe(true);
+    expect(result.scoreEvents).toContainEqual({
+      source: "attack-detected",
+      points: -60,
+      occurredAt: NOW_ISO,
+    });
+    // the attack probe was a POST carrying the injection payload.
+    const authCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("/api/v1/auth"),
+    );
+    expect((authCall?.[1] as { method?: string })?.method).toBe("POST");
+  });
+
+  it("should NOT penalize when the SQLi attack is rejected (defense held)", async () => {
+    // slot probes ok, but the attack POST returns 403 (rejected) → defended → no penalty.
+    fetchMock.mockImplementation(async (url: string) => ({
+      status: url.includes("/api/v1/auth") ? 403 : 200,
+      url,
+      text: async () => "",
+    }));
+    const result = await runUptimeMultiKind(withAttackProbe());
+    expect(result.scoreDelta).toBe(100); // full availability, no vulnerability penalty
+    expect(result.attackDetected).toBeUndefined();
+  });
+
+  it("should not penalize when the attack-probe endpoint is unreachable", async () => {
+    // can't conclude vulnerability from an unreachable app (availability is probedSlots' job).
+    fetchMock.mockImplementation(async (url: string) => {
+      if ((url as string).includes("/api/v1/auth")) throw new TypeError("network");
+      return { status: 200, url, text: async () => "" };
+    });
+    const result = await runUptimeMultiKind(withAttackProbe());
+    expect(result.scoreDelta).toBe(100);
+  });
 });


### PR DESCRIPTION
## Summary
The clean, account-free realization of the SQLi defense-test (the right mechanism, after the static-output #1673 and counter-read #1674 iterations): **the scorer itself sends the attack and judges the response** — no app instrumentation, no pedagogy conflict, no static output.

- `probeUrl` gains optional `method` + `body` (backward-compatible; default GET, no body).
- `uptime-multi` gains optional `attackProbes[]`: each tick POSTs the attack payload to `slot`+`path`; if the response status ∈ `vulnerableStatus` (e.g. 200 = SQLi bypassed auth) the team is **vulnerable → −penalty** + an `attack-detected` event; rejected (e.g. 403) → defended → 0; **unreachable → 0** (availability stays the job of `probedSlots`). Faithful: it tests the parameterization defense by actually sending `' OR '1'='1`.

## Test plan
- `generic-scoring-uptime-multi.test.ts` (+3): bypass (200) → −60 + attack-detected event + the probe was a POST carrying the injection; rejected (403) → no penalty; unreachable → no penalty.
- `generic-scoring-shared.test.ts`: probeUrl POST/body covered.
- `make harness` no findings; `make before-commit` green (all workspaces + cdk synth).

## Why this is the right mechanism (vs #1673/#1674)
`#1673` read a static CFn output (can't track live — killed). `#1674` reads a live app-exposed counter (valid but needs app instrumentation + has a pedagogy issue: the app shouldn't pattern-match the payload). The attack-probe needs **no app changes** — the app's existing `/api/v1/auth` response (200 bypass vs 403 reject) IS the signal. ADR-034 records this as the resolved direction.

## Scoped follow-up
- security-battle-royale declares `attackProbes` for its 2 SQLi attacks (submodule) → the SQLi attacks become live-scored. (Next PR.)
- Live confirmation that the real app responds 200/403 as modeled — flood/ec2-latency bar (account).

## Regression analysis
- Opt-in extension; no problem declares `attackProbes` yet, so all current scoring is byte-for-byte unchanged. `probeUrl` change is additive (default GET). Full infra suite green.

## Physical impact
- **NO-OP** on CloudFormation. Scoring-Lambda logic only; for a problem that opts in, the scorer issues one extra HTTP request per attack-probe per tick (a deliberate, bounded attack against the team's own app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable attack probe checks that detect vulnerabilities and apply scoring penalties when conditions are met.
  * Extended probing capability to support POST requests alongside existing GET functionality.

* **Tests**
  * Expanded test coverage for attack probe detection and vulnerability scoring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->