### PR TITLE
fix(challenge-payload): ASCII-safe IAM description + synth-level IAM gate [#664]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ before-commit: lint test validate-problems check-docs check-http-status check-te
 check-synth:
 	@CDK_SKIP_BUNDLING=1 $(MAKE) synth >/dev/null 2>&1 || { echo "ERROR: cdk synth failed (= make deploy も失敗します)。 CDK_SKIP_BUNDLING=1 make synth で詳細を確認してください。"; exit 1; }
 	@echo "OK  cdk synth (module 解決 / 型 / construct を検証、 Docker バンドルは skip — 実バンドルは make synth)"
+	@bun run scripts/check-synth-iam-ascii.ts
 
 # ===== Lint / Fix =====
 lint:   lint-md lint-text lint-format

--- a/infrastructure/lib/challenge-payload/challenge-payload-stack.ts
+++ b/infrastructure/lib/challenge-payload/challenge-payload-stack.ts
@@ -87,7 +87,7 @@ export class ChallengePayloadStack extends cdk.Stack {
 
     const role = new iam.Role(this, "PublishRole", {
       assumedBy: principal,
-      description: `Publish role for ${props.githubRepository} → ${bucket.bucketName} (ADR-003 Phase 2).`,
+      description: `Publish role for ${props.githubRepository} -> ${bucket.bucketName} (ADR-003 Phase 2).`,
       maxSessionDuration: cdk.Duration.hours(1),
     });
 

--- a/infrastructure/test/challenge-payload-stack.test.ts
+++ b/infrastructure/test/challenge-payload-stack.test.ts
@@ -1,6 +1,7 @@
 import { App } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { describe, expect, it } from "vitest";
+import { scanTemplateForIamDescriptions } from "../../scripts/lib/iam-description-ascii";
 import { ChallengePayloadStack } from "../lib/challenge-payload/challenge-payload-stack.js";
 
 /**
@@ -146,5 +147,13 @@ describe("ChallengePayloadStack", () => {
         branches: [],
       }),
     ).toThrow(/at least one entry/);
+  });
+
+  // Issue #664 regression: PublishRole's description interpolates the bucket name (a token), so it
+  // synthesizes to an Fn::Join. A non-Latin1 char in the literal fragment (a → arrow once did) makes
+  // IAM CREATE_FAILED. Guard the synthesized IAM descriptions with the same scanner check-synth uses.
+  it("should keep every IAM Role/ManagedPolicy description within the IAM Latin-1 range", () => {
+    const findings = scanTemplateForIamDescriptions(synth().toJSON());
+    expect(findings).toEqual([]);
   });
 });

--- a/infrastructure/test/scripts/iam-description-ascii.test.ts
+++ b/infrastructure/test/scripts/iam-description-ascii.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectStrings,
+  firstDisallowedChar,
+  formatCodePoint,
+  scanTemplateForIamDescriptions,
+} from "../../../scripts/lib/iam-description-ascii";
+
+/**
+ * [Issue #664 follow-up] IAM Description Latin-1 gate — pure logic pin.
+ *
+ * The real bug: ChallengePayloadStack's PublishRole description interpolated a token, so it
+ * synthesized to an `Fn::Join` whose literal fragment held a U+2192 arrow — outside IAM's allowed
+ * range — and CloudFormation `CREATE_FAILED`. These tests pin that the scanner catches that exact
+ * shape (intrinsic-wrapped IAM description) plus plain-string CJK, and ignores non-IAM resources.
+ */
+
+const ARROW = "→"; // → — the char that failed the deploy
+
+describe("firstDisallowedChar", () => {
+  it("should allow tab/LF/CR + printable ASCII + Latin-1 supplement", () => {
+    expect(firstDisallowedChar("Publish role for repo -> bucket (ADR-003).")).toBeUndefined();
+    expect(firstDisallowedChar("café résumé naïve ÿ")).toBeUndefined(); // Latin-1 supplement ok
+    expect(firstDisallowedChar("\t\n\r")).toBeUndefined();
+  });
+
+  it("should flag a U+2192 arrow, an em-dash, and CJK", () => {
+    expect(firstDisallowedChar(`a ${ARROW} b`)).toEqual({ char: ARROW, codePoint: 0x2192 });
+    expect(firstDisallowedChar("a — b")?.codePoint).toBe(0x2014); // em-dash
+    expect(firstDisallowedChar("テナント")?.codePoint).toBe(0x30c6); // CJK
+  });
+});
+
+describe("collectStrings (recurse intrinsics)", () => {
+  it("should collect a plain string", () => {
+    expect(collectStrings("hello")).toEqual(["hello"]);
+  });
+
+  it("should collect literal fragments out of an Fn::Join, recursing object values not keys", () => {
+    const join = { "Fn::Join": ["", [`lit ${ARROW} `, { Ref: "Bucket83908E77" }, " tail"]] };
+    expect(collectStrings(join)).toEqual(["", `lit ${ARROW} `, "Bucket83908E77", " tail"]);
+  });
+
+  it("should return [] for non-string scalars", () => {
+    expect(collectStrings(42)).toEqual([]);
+    expect(collectStrings(null)).toEqual([]);
+  });
+});
+
+describe("formatCodePoint", () => {
+  it("should format as U+XXXX", () => {
+    expect(formatCodePoint(0x2192)).toBe("U+2192");
+    expect(formatCodePoint(0x9)).toBe("U+0009");
+  });
+});
+
+describe("scanTemplateForIamDescriptions (#664)", () => {
+  const role = (description: unknown) => ({
+    Resources: {
+      PublishRole: { Type: "AWS::IAM::Role", Properties: { Description: description } },
+    },
+  });
+
+  it("should flag a U+2192 arrow buried in an Fn::Join IAM Role description (the deploy bug)", () => {
+    const template = role({
+      "Fn::Join": [
+        "",
+        [`Publish role for repo ${ARROW} `, { Ref: "Bucket83908E77" }, " (ADR-003)."],
+      ],
+    });
+    const findings = scanTemplateForIamDescriptions(template);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      logicalId: "PublishRole",
+      resourceType: "AWS::IAM::Role",
+      codePoint: 0x2192,
+    });
+  });
+
+  it("should flag a plain-string IAM Role description with CJK", () => {
+    expect(scanTemplateForIamDescriptions(role("テナント向け role"))).toHaveLength(1);
+  });
+
+  it("should flag a ManagedPolicy description too", () => {
+    const template = {
+      Resources: {
+        P: { Type: "AWS::IAM::ManagedPolicy", Properties: { Description: `a ${ARROW} b` } },
+      },
+    };
+    expect(scanTemplateForIamDescriptions(template)).toHaveLength(1);
+  });
+
+  it("should pass a clean ASCII / Latin-1 IAM description", () => {
+    expect(
+      scanTemplateForIamDescriptions(role("Publish role for repo -> bucket (ADR-003).")),
+    ).toEqual([]);
+    expect(scanTemplateForIamDescriptions(role(undefined))).toEqual([]);
+    expect(scanTemplateForIamDescriptions(role(null))).toEqual([]);
+  });
+
+  it("should ignore non-IAM resources even if their Description has CJK (only IAM is constrained)", () => {
+    const template = {
+      Resources: {
+        Q: { Type: "AWS::SQS::Queue", Properties: { Description: `キュー ${ARROW}` } },
+        T: { Type: "AWS::DynamoDB::Table", Properties: { Description: "テーブル名" } },
+      },
+    };
+    expect(scanTemplateForIamDescriptions(template)).toEqual([]);
+  });
+
+  it("should not throw on a template with no Resources / garbage input", () => {
+    expect(scanTemplateForIamDescriptions({})).toEqual([]);
+    expect(scanTemplateForIamDescriptions(null)).toEqual([]);
+    expect(scanTemplateForIamDescriptions("nope")).toEqual([]);
+  });
+});

--- a/scripts/check-synth-iam-ascii.ts
+++ b/scripts/check-synth-iam-ascii.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * [Issue #664 follow-up] Scan the **synthesized** CloudFormation for IAM Role / ManagedPolicy
+ * descriptions that contain a character outside the IAM Latin-1 range — the class of bug that
+ * `CREATE_FAILED` a real deploy (`ChallengePayloadStack` PublishRole had a U+2192 `->` arrow).
+ *
+ * `scripts/check-template-ascii.ts` covers hand-written YAML; this covers descriptions set in CDK,
+ * which only exist in the synth output (often wrapped in `Fn::Join`). Run AFTER `cdk synth` — the
+ * `check-synth` make target invokes it on the freshly-written `cdk.out`.
+ *
+ *   bun run scripts/check-synth-iam-ascii.ts                 # scans infrastructure/cdk.out
+ *   bun run scripts/check-synth-iam-ascii.ts <synth-outdir>  # explicit dir
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  formatCodePoint,
+  type IamDescriptionFinding,
+  scanTemplateForIamDescriptions,
+} from "./lib/iam-description-ascii";
+
+const DEFAULT_OUTDIR = "infrastructure/cdk.out";
+
+function templateFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    console.error(`ERROR: synth outdir not found: ${dir} (run cdk synth first)`);
+    process.exit(1);
+  }
+  return entries
+    .filter((name) => name.endsWith(".template.json"))
+    .map((name) => join(dir, name))
+    .filter((p) => statSync(p).isFile());
+}
+
+const outdir = process.argv[2] ?? DEFAULT_OUTDIR;
+const files = templateFiles(outdir);
+if (files.length === 0) {
+  console.error(`ERROR: no *.template.json under ${outdir} (run cdk synth first)`);
+  process.exit(1);
+}
+
+const findings: Array<IamDescriptionFinding & { file: string }> = [];
+for (const file of files) {
+  let template: unknown;
+  try {
+    template = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    console.error(`ERROR: ${file} is not valid JSON: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
+  for (const f of scanTemplateForIamDescriptions(template)) findings.push({ ...f, file });
+}
+
+if (findings.length > 0) {
+  console.error(
+    "NG: 合成後の CFn に IAM Description の非 Latin-1 文字があります (#664 / CREATE_FAILED 必至)",
+  );
+  for (const f of findings) {
+    console.error(
+      `  ${f.file}: ${f.logicalId} (${f.resourceType}) Description に ${formatCodePoint(f.codePoint)} (${f.char}) — fragment: ${JSON.stringify(f.fragment)}`,
+    );
+  }
+  console.error(
+    "\nIAM Role / ManagedPolicy の description は ASCII (0x20-0x7E) + Latin-1 (0xA1-0xFF) のみ。\n" +
+      "CDK 側の `description:` から CJK / 矢印 (→) / em-dash 等を ASCII (例: -> ) に置換してください。",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${files.length} synthesized template(s) の IAM Description はすべて Latin-1 範囲 (#664 safe)`,
+);

--- a/scripts/check-template-ascii.ts
+++ b/scripts/check-template-ascii.ts
@@ -13,6 +13,7 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
+import { isAllowedCharCode } from "./lib/iam-description-ascii";
 
 /**
  * Issue #691: 問題側 yaml (= problems/<category>/<id>/template.yaml) も同じ
@@ -20,16 +21,6 @@ import { extname, join } from "node:path";
  * infrastructure/templates/ と並列に walk する。
  */
 const TEMPLATES_DIRS = ["infrastructure/templates", "problems"];
-
-function isAllowedCharCode(cp: number): boolean {
-  return (
-    cp === 0x09 ||
-    cp === 0x0a ||
-    cp === 0x0d ||
-    (cp >= 0x20 && cp <= 0x7e) ||
-    (cp >= 0xa1 && cp <= 0xff)
-  );
-}
 
 function isCfnTemplate(filename: string): boolean {
   // CFn template は `*.yaml` のみ (= ASCII restriction が IAM Description 経由で効く)。

--- a/scripts/lib/iam-description-ascii.ts
+++ b/scripts/lib/iam-description-ascii.ts
@@ -1,0 +1,117 @@
+/**
+ * [Issue #664 follow-up] IAM Description ASCII / Latin-1 gate — pure logic.
+ *
+ * IAM `AWS::IAM::Role` / `AWS::IAM::ManagedPolicy` `Description` is constrained by the IAM service to
+ * a regex allowing only tab/LF/CR + printable ASCII (0x20-0x7E) + Latin-1 supplement (0xA1-0xFF).
+ * Anything outside it (CJK, an em-dash, a U+2192 arrow) makes CloudFormation fail the stack with
+ * `CREATE_FAILED ... failed to satisfy constraint ... regular expression pattern`.
+ *
+ * `scripts/check-template-ascii.ts` already gates the hand-written YAML templates. But a description
+ * set in CDK (e.g. `new iam.Role(this, "X", { description: "... -> ..." })`) never appears in a YAML
+ * file — it lands in the *synthesized* CloudFormation, often wrapped in an `Fn::Join` because it
+ * interpolates a token. That gap let a U+2192 arrow in `ChallengePayloadStack`'s PublishRole reach a
+ * real deploy and fail it. This module scans the **synthesized template** (the actual deploy
+ * artifact), recursing into CFn intrinsics, so the same class of bug is caught before deploy.
+ *
+ * Pure (no fs). The I/O shell is scripts/check-synth-iam-ascii.ts.
+ */
+
+/** Resource types whose `Description` carries the IAM Latin-1 constraint. */
+export const IAM_DESCRIPTION_RESOURCE_TYPES = [
+  "AWS::IAM::Role",
+  "AWS::IAM::ManagedPolicy",
+] as const;
+
+/** The exact character class IAM allows in a Description (shared with check-template-ascii). */
+export function isAllowedCharCode(cp: number): boolean {
+  return (
+    cp === 0x09 ||
+    cp === 0x0a ||
+    cp === 0x0d ||
+    (cp >= 0x20 && cp <= 0x7e) ||
+    (cp >= 0xa1 && cp <= 0xff)
+  );
+}
+
+export interface DisallowedChar {
+  readonly char: string;
+  readonly codePoint: number;
+}
+
+/** First character in `s` outside the IAM Latin-1 range, or undefined when all are allowed. */
+export function firstDisallowedChar(s: string): DisallowedChar | undefined {
+  for (const ch of s) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined && !isAllowedCharCode(cp)) return { char: ch, codePoint: cp };
+  }
+  return undefined;
+}
+
+/**
+ * Collect every leaf string inside a (possibly intrinsic-wrapped) value. An `Fn::Join` description
+ * is `["", ["lit -> ", {"Ref": "X"}]]`; the literal fragments carry the user text and must be
+ * scanned. We recurse object *values* (not keys — `Fn::Join`/`Ref` are CFn syntax, not content).
+ */
+export function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(collectStrings);
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap(collectStrings);
+  }
+  return [];
+}
+
+export interface IamDescriptionFinding {
+  readonly logicalId: string;
+  readonly resourceType: string;
+  readonly fragment: string;
+  readonly char: string;
+  readonly codePoint: number;
+}
+
+/** Format a codepoint as `U+XXXX`. */
+export function formatCodePoint(cp: number): string {
+  return `U+${cp.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+/**
+ * Scan one parsed CloudFormation template for IAM Role / ManagedPolicy descriptions containing a
+ * character outside the IAM Latin-1 range. Returns one finding per offending resource.
+ */
+export function scanTemplateForIamDescriptions(template: unknown): IamDescriptionFinding[] {
+  const resources =
+    template && typeof template === "object"
+      ? (template as Record<string, unknown>).Resources
+      : undefined;
+  if (!resources || typeof resources !== "object") return [];
+
+  const findings: IamDescriptionFinding[] = [];
+  for (const [logicalId, raw] of Object.entries(resources as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") continue;
+    const resource = raw as Record<string, unknown>;
+    const type = resource.Type;
+    if (typeof type !== "string" || !IAM_DESCRIPTION_RESOURCE_TYPES.includes(type as never)) {
+      continue;
+    }
+    const props = resource.Properties;
+    const description =
+      props && typeof props === "object"
+        ? (props as Record<string, unknown>).Description
+        : undefined;
+    if (description === undefined || description === null) continue;
+    for (const fragment of collectStrings(description)) {
+      const bad = firstDisallowedChar(fragment);
+      if (bad) {
+        findings.push({
+          logicalId,
+          resourceType: type,
+          fragment,
+          char: bad.char,
+          codePoint: bad.codePoint,
+        });
+        break; // one finding per resource is enough to fail + locate it
+      }
+    }
+  }
+  return findings;
+}


### PR DESCRIPTION
## Summary

A real `make deploy` failed: `tenkacloud-challenge-payload` `CREATE_FAILED` on the `PublishRole`:

```
Value at 'description' failed to satisfy constraint: Member must satisfy regular expression
pattern: [	
 -~¡-ÿ]*
```

IAM constrains `Role` / `ManagedPolicy` `Description` to tab/LF/CR + printable ASCII + Latin-1 supplement. The description used a **`→` (U+2192)** arrow — outside that range. Replaced it with `->`.

### Why the existing gate missed it
`scripts/check-template-ascii.ts` (built for #664) scans **hand-written YAML** only. This description is set in CDK and interpolates the bucket name (a token), so it synthesizes to an `Fn::Join` whose literal fragment held the `→` — it never appears in any YAML file. The gate had no eyes on CDK-synthesized IAM descriptions.

### Mechanical fix so it can't recur (any stack, any non-Latin1 char)
- **`scripts/lib/iam-description-ascii.ts`** — pure scanner: recurses CFn intrinsics (`Fn::Join`, etc.) and flags any `AWS::IAM::Role` / `AWS::IAM::ManagedPolicy` `Description` character outside the Latin-1 range. Shares `isAllowedCharCode` with `check-template-ascii` (DRY).
- **`scripts/check-synth-iam-ascii.ts`** — scans the **synth output** (the actual deploy artifact), wired into `make check-synth` so every `before-commit` / CI run checks it right after `cdk synth`.
- **Tests** — 12 unit tests including the **exact `Fn::Join`-wrapped U+2192 shape** that broke the deploy, plus a `ChallengePayloadStack` regression assertion using the same scanner.

**Verified both directions**: the scanner **fails** on the pre-fix synth output (`PublishRoleF42F66B6 ... U+2192 (→)`) and **passes** after the fix (`10 synthesized template(s) ... Latin-1 範囲 (#664 safe)`).

Fixes #664.

## Test plan
- `bunx vitest run test/scripts/iam-description-ascii.test.ts test/challenge-payload-stack.test.ts` — 21 pass.
- Ran `scripts/check-synth-iam-ascii.ts` against the stale cdk.out → exit 1 on the `→` (regression proof); against fresh cdk.out → exit 0.
- `make harness` clean. `make before-commit` green — `check-synth` now ends with the IAM-description scan.

## Regression analysis
- `check-template-ascii.ts` change is a behavior-preserving extraction of `isAllowedCharCode` into the shared lib; re-ran it → still green on the YAML templates.
- New scan runs **after** synth (inside `check-synth`), so it reads a fresh `cdk.out`; no ordering hazard.
- Only IAM resource types are scanned — `CfnOutput` / DynamoDB / SQS descriptions keep their Japanese (those fields have no Latin-1 constraint), so no false positives.
- The `PublishRole` description is the only runtime change; everything else is tests + checks.

## Physical impact
- **UPDATE** (no replacement) to `tenkacloud-challenge-payload`: `PublishRole` `Description` text changes from `… → …` to `… -> …`. IAM Role description is mutable in place.
- **NO-OP** on every other stack. The new files are developer/CI tooling + tests.