### PR TITLE
feat(web-kit): centralized feature-flag framework + migrate app-admin [ADR-035]

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -32,7 +32,7 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 function guarded(element: React.ReactNode, config: AppConfig) {
   return (
     <RequireAuth>
-      <ShellLayout samlSsoEnabled={config.featureSamlSso}>{element}</ShellLayout>
+      <ShellLayout samlSsoEnabled={config.features?.samlSso}>{element}</ShellLayout>
     </RequireAuth>
   );
 }

--- a/apps/application-admin-console/src/config.ts
+++ b/apps/application-admin-console/src/config.ts
@@ -1,4 +1,6 @@
 import { isCognitoDomain, isHttpsUrl } from "@tenkacloud/auth-client";
+import { resolveFeatureFlags } from "@tenkacloud/web-kit";
+import { type AppFeatures, FEATURE_REGISTRY } from "./features";
 
 export interface AppConfig {
   readonly cognitoDomain: string;
@@ -44,15 +46,12 @@ export interface AppConfig {
    */
   readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
   /**
-   * Feature flags for capabilities that are not yet verified end-to-end. Default OFF so operators
-   * never mistake an unproven feature for a ready one; flip to `true` per environment in
-   * runtime-config.json once the feature has been validated.
-   *   - featureSamlSso: the per-tenant SAML SSO (Identity providers) page + nav.
-   *   - featureNonAwsRuntime: the non-AWS (Sakura / Azure / GCP) team cloud-credentials panel.
-   * Optional so an omitted flag reads as off (undefined is falsy) — fail-safe by default.
+   * Resolved feature flags (ADR-035). The registry (src/features.ts) holds defaults; an environment
+   * opts a flag on via runtime-config.json `features: { <key>: true }`. Access as
+   * `config.features?.<key>` — unknown keys are a compile error. loadConfig always populates it;
+   * optional only so test fixtures can omit it (absent → every flag reads OFF, fail-safe).
    */
-  readonly featureSamlSso?: boolean;
-  readonly featureNonAwsRuntime?: boolean;
+  readonly features?: AppFeatures;
 }
 
 interface RuntimeConfig {
@@ -65,8 +64,8 @@ interface RuntimeConfig {
   readonly competitorBootstrapTemplateUrl?: string;
   readonly isolation?: "pooled" | "silo";
   readonly samlIdpDirectory?: Readonly<Record<string, readonly string[]>>;
-  readonly featureSamlSso: boolean;
-  readonly featureNonAwsRuntime: boolean;
+  /** Raw `features` override object from runtime-config.json; resolved against the registry in loadConfig. */
+  readonly features?: Readonly<Record<string, unknown>>;
 }
 
 // Issue #871 / #1246: runtime-config.json URL validators (isHttpsUrl / isCognitoDomain) are
@@ -116,9 +115,11 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
         data.samlIdpDirectory && typeof data.samlIdpDirectory === "object"
           ? data.samlIdpDirectory
           : {},
-      // Unverified features stay OFF unless runtime-config explicitly opts in (=== true).
-      featureSamlSso: data.featureSamlSso === true,
-      featureNonAwsRuntime: data.featureNonAwsRuntime === true,
+      // Raw feature overrides; resolved against the registry in loadConfig (ADR-035).
+      features:
+        data.features && typeof data.features === "object" && !Array.isArray(data.features)
+          ? data.features
+          : undefined,
     };
   } catch {
     return null;
@@ -152,8 +153,7 @@ export async function loadConfig(
       isolation: runtime.isolation ?? "pooled",
       samlIdpDirectory: runtime.samlIdpDirectory ?? {},
       /* v8 ignore stop */
-      featureSamlSso: runtime.featureSamlSso,
-      featureNonAwsRuntime: runtime.featureNonAwsRuntime,
+      features: resolveFeatureFlags(FEATURE_REGISTRY, runtime.features),
       redirectUri,
       scope,
     };
@@ -164,6 +164,18 @@ export async function loadConfig(
     if (!value) throw new Error(`Missing required env var: ${key}`);
     return value;
   };
+  /** Dev-only: parse VITE_FEATURES (a JSON object of overrides); invalid / absent → registry defaults. */
+  const parseDevFeatures = (raw: string | undefined): Record<string, unknown> | undefined => {
+    if (!raw) return undefined;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  };
   return {
     cognitoDomain: required("VITE_COGNITO_DOMAIN"),
     cognitoClientId: required("VITE_COGNITO_CLIENT_ID"),
@@ -173,9 +185,8 @@ export async function loadConfig(
     isolation: env.VITE_ISOLATION === "silo" ? "silo" : "pooled",
     // Issue #1340 Phase 2: dev では SAML 経路を出さない (= 空 directory で local 一択)。
     samlIdpDirectory: {},
-    // Unverified features default OFF in dev too; opt in with VITE_FEATURE_* to exercise them.
-    featureSamlSso: env.VITE_FEATURE_SAML_SSO === "true",
-    featureNonAwsRuntime: env.VITE_FEATURE_NON_AWS_RUNTIME === "true",
+    // Dev: opt features in with VITE_FEATURES='{"samlSso":true}'; absent → registry defaults (OFF).
+    features: resolveFeatureFlags(FEATURE_REGISTRY, parseDevFeatures(env.VITE_FEATURES)),
     redirectUri,
     scope,
   };

--- a/apps/application-admin-console/src/features.ts
+++ b/apps/application-admin-console/src/features.ts
@@ -1,0 +1,21 @@
+import type { FeatureRegistry, ResolvedFeatures } from "@tenkacloud/web-kit";
+
+/**
+ * ADR-035: the single source of truth for this console's feature flags. Add one entry per
+ * experimental feature (default OFF); gate UI on `config.features.<key>`; delete the entry when
+ * the feature graduates. Enable per environment via `runtime-config.json` `features: { <key>: true }`.
+ */
+export const FEATURE_REGISTRY = {
+  samlSso: {
+    description: "Per-tenant SAML SSO — the Identity providers page + nav.",
+    stability: "experimental",
+    defaultEnabled: false,
+  },
+  nonAwsRuntime: {
+    description: "Non-AWS (Sakura / Azure / GCP) team cloud-credentials panel.",
+    stability: "experimental",
+    defaultEnabled: false,
+  },
+} as const satisfies FeatureRegistry;
+
+export type AppFeatures = ResolvedFeatures<typeof FEATURE_REGISTRY>;

--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -74,7 +74,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
 
       {/* [ADR-026/027/032 / #1413] non-AWS (sakura/azure/gcp) per-team credential onboarding.
           Feature-flagged off until the non-AWS runtimes are verified end-to-end. */}
-      {config.featureNonAwsRuntime ? <TeamCloudCredentialsPanel config={config} /> : null}
+      {config.features?.nonAwsRuntime ? <TeamCloudCredentialsPanel config={config} /> : null}
 
       <AddAccountModal
         config={config}

--- a/apps/application-admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/application-admin-console/src/pages/IdentityProviders.tsx
@@ -39,7 +39,7 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
   const lang = useLang();
   const client: TenantIdpClient | null = useMemo(
     () =>
-      auth.tokens && config.featureSamlSso
+      auth.tokens && config.features?.samlSso
         ? createTenantIdpClient(config, auth.tokens.idToken)
         : null,
     [auth.tokens, config],
@@ -85,7 +85,7 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
     [config],
   );
 
-  if (!config.featureSamlSso) {
+  if (!config.features?.samlSso) {
     // Feature-flagged off until verified end-to-end. Gate the page itself (not just the nav) so a
     // direct URL does not expose an unproven feature.
     return (

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -52,6 +52,33 @@ describe("loadConfig", () => {
     it("should take apiBaseUrl from runtime-config.apiUrl (different key)", async () => {
       expect((await loadWithFullRuntime()).apiBaseUrl).toBe("https://prod-api.example.com/prod");
     });
+
+    it("should default features OFF when runtime-config omits the features object", async () => {
+      expect((await loadWithFullRuntime()).features).toEqual({
+        samlSso: false,
+        nonAwsRuntime: false,
+      });
+    });
+
+    it("should resolve features from a runtime-config features override object", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
+              userClientId: "prod-client-id",
+              tenantId: "tenant-prod-1",
+              tenantName: "tenant",
+              apiUrl: "https://prod-api.example.com/prod",
+              features: { samlSso: true, nonAwsRuntime: true },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+      expect((await loadConfig(env)).features).toEqual({ samlSso: true, nonAwsRuntime: true });
+    });
   });
 
   describe("when /runtime-config.json returns 404 (dev fallback)", () => {
@@ -69,6 +96,26 @@ describe("loadConfig", () => {
       vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
       const config = await loadConfig(env);
       expect(config.tenantId).toBe("dev-local");
+    });
+
+    it("should default all features OFF when VITE_FEATURES is absent", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      const config = await loadConfig(env);
+      expect(config.features).toEqual({ samlSso: false, nonAwsRuntime: false });
+    });
+
+    it("should opt features in from a VITE_FEATURES JSON object", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      const config = await loadConfig({ ...env, VITE_FEATURES: '{"samlSso":true}' });
+      expect(config.features).toEqual({ samlSso: true, nonAwsRuntime: false });
+    });
+
+    it("should ignore invalid / non-object VITE_FEATURES and use defaults", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+      const bad = await loadConfig({ ...env, VITE_FEATURES: "not-json" });
+      expect(bad.features).toEqual({ samlSso: false, nonAwsRuntime: false });
+      const arr = await loadConfig({ ...env, VITE_FEATURES: "[1,2]" });
+      expect(arr.features).toEqual({ samlSso: false, nonAwsRuntime: false });
     });
   });
 

--- a/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
@@ -123,7 +123,7 @@ describe("CompetitorAccountsPage", () => {
   });
 
   it("should show the non-AWS team cloud credentials panel when featureNonAwsRuntime is on", () => {
-    renderPage(config({ featureNonAwsRuntime: true }));
+    renderPage(config({ features: { samlSso: false, nonAwsRuntime: true } }));
     expect(screen.getByTestId("team-cloud-credentials")).toBeInTheDocument();
   });
 

--- a/apps/application-admin-console/test/pages/IdentityProviders.test.tsx
+++ b/apps/application-admin-console/test/pages/IdentityProviders.test.tsx
@@ -73,7 +73,7 @@ const config = (over: Partial<AppConfig> = {}): AppConfig =>
     tenantName: "Acme",
     apiBaseUrl: "https://api.example.com",
     isolation: "silo",
-    featureSamlSso: true,
+    features: { samlSso: true, nonAwsRuntime: false },
     ...over,
   }) as AppConfig;
 const idp = (over: Partial<TenantIdpSummary> = {}): TenantIdpSummary =>
@@ -99,7 +99,7 @@ afterEach(() => vi.clearAllMocks());
 
 describe("IdentityProvidersPage", () => {
   it("should show the feature-disabled hero (and skip fetch) when featureSamlSso is off", () => {
-    renderPage(config({ featureSamlSso: false }));
+    renderPage(config({ features: { samlSso: false, nonAwsRuntime: false } }));
     expect(screen.getByText("Identity providers are not available")).toBeInTheDocument();
     expect(mockCreateClient).not.toHaveBeenCalled();
   });

--- a/docs/architecture/adr-035-feature-flag-framework.html
+++ b/docs/architecture/adr-035-feature-flag-framework.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-035: Centralized feature-flag framework</title>
+<style>
+  :root {
+    --c-text: #1f2328; --c-muted: #59636e; --c-border: #d1d9e0; --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa; --c-accept: #1a7f37; --c-reject: #cf222e; --c-warn: #9a6700;
+    --c-link: #0969da; --c-code-bg: #eff1f3;
+  }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg); max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 6px; padding: 0.8rem 1rem; overflow-x: auto; font-size: 0.85rem; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; }
+  .status { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 0.8rem; font-weight: 600; background: #dafbe1; color: var(--c-accept); }
+  .muted { color: var(--c-muted); }
+</style>
+</head>
+<body>
+<h1>ADR-035: Centralized feature-flag framework</h1>
+<p><span class="status">Accepted</span></p>
+
+<h2>Context</h2>
+<p>
+We need to ship experimental / not-yet-verified features (per-tenant SAML SSO, non-AWS problem
+runtimes) without operators mistaking them for production-ready, and we need to add more such
+features over time. The first cut introduced ad-hoc <code>config.featureSamlSso</code> /
+<code>config.featureNonAwsRuntime</code> booleans. Left unchecked, that pattern sprawls: flags get
+read with scattered <code>?? false</code> defaults, there is no single list of what exists, dead
+flags linger, and each SPA reinvents resolution — i.e. it becomes spaghetti.
+</p>
+
+<h2>Decision</h2>
+<p>One typed mechanism, shared across the three SPAs.</p>
+<table>
+  <tr><th>#</th><th>Decision</th><th>Why</th></tr>
+  <tr><td>1</td><td><b>Single registry per app</b> — <code>src/features.ts</code> declares every flag once: <code>key &rarr; { description, stability, defaultEnabled }</code>.</td><td>The whole flag list is one object; discoverable, no hunting.</td></tr>
+  <tr><td>2</td><td><b>Typed keys.</b> <code>ResolvedFeatures&lt;typeof FEATURE_REGISTRY&gt;</code> gives a union of valid keys; referencing an unknown flag is a compile error.</td><td>No string typos; deleting a graduated flag surfaces every dead usage.</td></tr>
+  <tr><td>3</td><td><b>Shared resolver</b> in <code>@tenkacloud/web-kit</code>: <code>resolveFeatureFlags(registry, overrides)</code> (pure).</td><td>Resolution + its tests live once, not per SPA.</td></tr>
+  <tr><td>4</td><td><b>One override channel</b> — <code>runtime-config.json</code> <code>features: { &lt;key&gt;: boolean }</code> (dev: <code>VITE_FEATURES</code> JSON).</td><td>Flip per environment with no rebuild; matches how the rest of runtime-config is injected.</td></tr>
+  <tr><td>5</td><td><b>Resolved once</b> in <code>config.ts</code> &rarr; <code>config.features</code>.</td><td>No scattered <code>?? false</code>; one resolution point.</td></tr>
+  <tr><td>6</td><td><b>One access pattern</b>: <code>config.features?.&lt;key&gt;</code>.</td><td>Consistent, refactor-safe.</td></tr>
+  <tr><td>7</td><td><b>Experimental &rArr; default OFF; graduate &rArr; delete the entry.</b></td><td>Keeps the flag table short and honest; no permanent flags.</td></tr>
+</table>
+
+<h3>Resolution rules (robust to a hand-edited config)</h3>
+<ul>
+  <li>A boolean override wins over the registry default.</li>
+  <li>A non-boolean override (<code>"true"</code>, <code>1</code>, <code>null</code>) is ignored &rarr; default wins.</li>
+  <li>An override key not in the registry is ignored — no crash, no silently-introduced flag.</li>
+  <li>Only registry keys appear in the result, so consumers get exactly the typed surface.</li>
+</ul>
+
+<h3>Authoring a new experimental feature</h3>
+<pre>// src/features.ts
+export const FEATURE_REGISTRY = {
+  myThing: { description: "...", stability: "experimental", defaultEnabled: false },
+} as const satisfies FeatureRegistry;
+
+// component
+if (!config.features?.myThing) return &lt;FeatureDisabled /&gt;;   // gate the page too, not just the nav</pre>
+
+<h2>Consequences</h2>
+<ul>
+  <li>Adding an experimental feature = one registry entry + gate on <code>config.features?.&lt;key&gt;</code>. Nothing else.</li>
+  <li>Flags are discoverable in one file per app; the resolver is shared + unit-tested once (web-kit).</li>
+  <li>Gate the <em>page/route</em>, not just the nav link, so a direct URL cannot expose a disabled feature.</li>
+  <li>To enable in an environment: set <code>features.&lt;key&gt;: true</code> in that environment's <code>runtime-config.json</code>. <span class="muted">Surfacing this as a deploy-time CDK parameter on the console hosting stacks is a follow-up; today the key is read from runtime-config.json.</span></li>
+</ul>
+
+<h2>Alternatives considered</h2>
+<table>
+  <tr><th>Option</th><th>Verdict</th></tr>
+  <tr><td>Scattered <code>config.featureX</code> booleans</td><td>Rejected — the spaghetti this ADR exists to prevent.</td></tr>
+  <tr><td>External flag service (LaunchDarkly etc.)</td><td>Rejected — violates the cost-zero principle; <code>runtime-config.json</code> is already our per-environment injection channel.</td></tr>
+  <tr><td>Build-time env only</td><td>Rejected — cannot flip a flag in a deployed environment without a rebuild.</td></tr>
+</table>
+
+<h2>Scope</h2>
+<p>
+Frontend (the three Cloudscape SPAs). Backend Lambda feature toggles, when needed, read their own
+environment / SSM and are out of scope here. The shared resolver lives in
+<code>packages/web-kit/src/feature-flags.ts</code>; the first registry is
+<code>apps/application-admin-console/src/features.ts</code> (<code>samlSso</code>,
+<code>nonAwsRuntime</code>).
+</p>
+</body>
+</html>

--- a/packages/web-kit/src/feature-flags.ts
+++ b/packages/web-kit/src/feature-flags.ts
@@ -1,0 +1,53 @@
+/**
+ * @tenkacloud/web-kit feature flags (ADR-035): one shared, typed mechanism so experimental
+ * features can ship behind a switch without scattering `config.featureX` booleans (spaghetti).
+ *
+ * The contract, per app:
+ *   1. Declare every flag once in the app's `FEATURE_REGISTRY` (key → {description, stability,
+ *      defaultEnabled}). This is the single source of truth — the whole flag list is one object.
+ *   2. `config.ts` calls `resolveFeatureFlags(FEATURE_REGISTRY, runtimeConfig.features)` once and
+ *      exposes the typed result as `config.features`.
+ *   3. Components gate on `config.features.<key>` (a compile error for unknown keys).
+ *
+ * Experimental features set `stability: "experimental"` + `defaultEnabled: false`, so they stay
+ * OFF until an environment opts in via `runtime-config.json` `features: { <key>: true }`. When a
+ * feature graduates, delete its registry entry — TypeScript then flags every now-dead usage.
+ *
+ * Pure (no React / no I/O), so it is unit-tested once here instead of per SPA.
+ */
+
+export type FeatureStability = "experimental" | "beta" | "stable";
+
+export interface FeatureSpec {
+  /** Human-facing one-liner — what the flag gates. */
+  readonly description: string;
+  /** Maturity. `experimental` features should default OFF. */
+  readonly stability: FeatureStability;
+  /** Value used when `runtime-config.json` does not override this flag. */
+  readonly defaultEnabled: boolean;
+}
+
+export type FeatureRegistry = Readonly<Record<string, FeatureSpec>>;
+
+/** The resolved, typed flag map: every registry key → effective boolean. */
+export type ResolvedFeatures<R extends FeatureRegistry> = Readonly<Record<keyof R, boolean>>;
+
+/**
+ * Resolve effective flags = each registry default, overridden by a boolean in `overrides`.
+ *
+ * Robustness for a config authored by hand / drifted from the code:
+ *   - a non-boolean override (string "true", number, null) is ignored → registry default wins;
+ *   - an override key that is not in the registry is ignored (no crash, no silent new flag).
+ * Only registry keys ever appear in the result, so consumers get exactly the typed surface.
+ */
+export function resolveFeatureFlags<R extends FeatureRegistry>(
+  registry: R,
+  overrides?: Readonly<Record<string, unknown>> | null,
+): ResolvedFeatures<R> {
+  const resolved = {} as Record<keyof R, boolean>;
+  for (const key of Object.keys(registry) as (keyof R)[]) {
+    const override = overrides ? overrides[key as string] : undefined;
+    resolved[key] = typeof override === "boolean" ? override : registry[key].defaultEnabled;
+  }
+  return resolved;
+}

--- a/packages/web-kit/src/index.ts
+++ b/packages/web-kit/src/index.ts
@@ -11,6 +11,13 @@ export { EmptyState, type EmptyStateAction, type EmptyStateProps } from "./Empty
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export { toErrorMessage } from "./error-message";
 export {
+  type FeatureRegistry,
+  type FeatureSpec,
+  type FeatureStability,
+  type ResolvedFeatures,
+  resolveFeatureFlags,
+} from "./feature-flags";
+export {
   createI18n,
   type I18nConfig,
   type I18nContextValue,

--- a/packages/web-kit/test/feature-flags.test.ts
+++ b/packages/web-kit/test/feature-flags.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { type FeatureRegistry, resolveFeatureFlags } from "../src/feature-flags";
+
+/**
+ * ADR-035 feature-flag resolver. Pins: registry default when unset, boolean override wins,
+ * non-boolean / unknown override ignored, and the result surface is exactly the registry keys.
+ */
+const REGISTRY = {
+  samlSso: { description: "SAML SSO", stability: "experimental", defaultEnabled: false },
+  nonAwsRuntime: {
+    description: "Non-AWS runtimes",
+    stability: "experimental",
+    defaultEnabled: false,
+  },
+  scoreboard: { description: "Scoreboard", stability: "stable", defaultEnabled: true },
+} as const satisfies FeatureRegistry;
+
+describe("resolveFeatureFlags", () => {
+  it("should use each registry default when no overrides are given", () => {
+    expect(resolveFeatureFlags(REGISTRY)).toEqual({
+      samlSso: false,
+      nonAwsRuntime: false,
+      scoreboard: true,
+    });
+  });
+
+  it("should let a boolean override win over the default (both directions)", () => {
+    expect(resolveFeatureFlags(REGISTRY, { samlSso: true, scoreboard: false })).toEqual({
+      samlSso: true,
+      nonAwsRuntime: false,
+      scoreboard: false,
+    });
+  });
+
+  it("should ignore a non-boolean override and fall back to the default", () => {
+    // a hand-edited config might put "true" (string) / 1 / null — none flip the flag.
+    expect(
+      resolveFeatureFlags(REGISTRY, {
+        samlSso: "true" as unknown as boolean,
+        nonAwsRuntime: 1 as unknown as boolean,
+        scoreboard: null as unknown as boolean,
+      }),
+    ).toEqual({ samlSso: false, nonAwsRuntime: false, scoreboard: true });
+  });
+
+  it("should ignore unknown override keys and only emit registry keys", () => {
+    const out = resolveFeatureFlags(REGISTRY, { somethingElse: true, samlSso: true });
+    expect(out).toEqual({ samlSso: true, nonAwsRuntime: false, scoreboard: true });
+    expect(Object.keys(out).sort()).toEqual(["nonAwsRuntime", "samlSso", "scoreboard"]);
+  });
+
+  it("should treat null/undefined overrides as no overrides", () => {
+    expect(resolveFeatureFlags(REGISTRY, null)).toEqual(resolveFeatureFlags(REGISTRY));
+    expect(resolveFeatureFlags(REGISTRY, undefined)).toEqual(resolveFeatureFlags(REGISTRY));
+  });
+
+  it("should return an empty object for an empty registry", () => {
+    expect(resolveFeatureFlags({}, { anything: true })).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the ad-hoc `config.featureSamlSso` / `config.featureNonAwsRuntime` booleans (from #1680) with one typed, shared mechanism so experimental features can ship behind a switch without sprawl — per your "スパゲティにならないように設計がいります".

- **`packages/web-kit/src/feature-flags.ts`** — `resolveFeatureFlags(registry, overrides)`, pure + 100%-tested. Boolean override wins; non-boolean / unknown-key overrides ignored; only registry keys emitted.
- **`apps/application-admin-console/src/features.ts`** — the single `FEATURE_REGISTRY` (`samlSso`, `nonAwsRuntime`; experimental, default OFF). `config.ts` resolves it once → `config.features`, from `runtime-config.json` `features:{}` (dev: `VITE_FEATURES` JSON). Consumers read `config.features?.<key>`.
- **`docs/architecture/adr-035`** — the design (single registry, typed keys, shared resolver, one override channel, default-off, delete-on-graduation) + rejected alternatives.

**Where a flag is controlled:** `runtime-config.json` → `features: { samlSso: true }` per environment (default OFF). Adding a new experimental feature = one registry entry + `config.features?.<key>` gate.

## Test plan
- web-kit: `resolveFeatureFlags` 100% (default / boolean-override / non-boolean ignored / unknown-key ignored / null / empty registry).
- application-admin-console: 935 tests pass; config.ts covers runtime `features` override + dev `VITE_FEATURES` (valid / invalid / non-object). Coverage gate 100%.
- `make harness` clean.

## Regression analysis
App-only. `runtime-config.json` gains an optional `features` object (absent → all OFF = unchanged behavior). `config.features` optional so existing test fixtures omit it. No infra/CFn change.

## Physical impact
**NO-OP** on every CFn stack. Frontend + shared-package + docs only.

Relates #1418. Follow-up: mirror the SSO gate into the System Admin console (admin-console) using this framework + fix its `https://https//` Test sign-in URL.