### PR TITLE
fix(admin-console): SSO Test sign-in URL + i18n + feature-flag gate [ADR-035]

### DIFF
--- a/apps/admin-console/src/App.tsx
+++ b/apps/admin-console/src/App.tsx
@@ -30,7 +30,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/tenants"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <TenantListPage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -40,7 +40,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/tenants/new"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <TenantCreatePage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -52,7 +52,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/tenants/:tenantId"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <TenantDetailPage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -62,7 +62,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/jobs"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <JobsPage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -77,7 +77,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/audit-log"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <AuditLogPage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -88,7 +88,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/operations"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <OperationsPage config={config} />
               </ShellLayout>
             </RequireAuth>
@@ -99,7 +99,7 @@ export function App({ config }: { config: AppConfig }) {
           path="/identity-providers"
           element={
             <RequireAuth>
-              <ShellLayout>
+              <ShellLayout samlSsoEnabled={config.features?.samlSso}>
                 <IdentityProvidersPage config={config} />
               </ShellLayout>
             </RequireAuth>

--- a/apps/admin-console/src/components/AppLayout.tsx
+++ b/apps/admin-console/src/components/AppLayout.tsx
@@ -14,7 +14,14 @@ const LOCALE_NAME: Record<LocaleCode, string> = {
   en: "English",
 };
 
-export function ShellLayout({ children }: { children: ReactNode }) {
+export function ShellLayout({
+  children,
+  samlSsoEnabled = false,
+}: {
+  children: ReactNode;
+  /** Feature-flagged: show the Identity providers (SAML SSO) nav item only when enabled. */
+  samlSsoEnabled?: boolean;
+}) {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
@@ -63,7 +70,16 @@ export function ShellLayout({ children }: { children: ReactNode }) {
               { type: "link", href: "/tenants/new", text: t("nav.tenants_new") },
               { type: "link", href: "/jobs", text: t("nav.jobs") },
               { type: "link", href: "/audit-log", text: t("nav.audit_log") },
-              { type: "link", href: "/identity-providers", text: "Identity providers" },
+              // SAML SSO is feature-flagged off until verified (ADR-035) — hide the nav item.
+              ...(samlSsoEnabled
+                ? [
+                    {
+                      type: "link" as const,
+                      href: "/identity-providers",
+                      text: t("nav.identity_providers"),
+                    },
+                  ]
+                : []),
               { type: "link", href: "/operations", text: t("nav.operations") },
             ]}
             onFollow={(e) => {

--- a/apps/admin-console/src/config.ts
+++ b/apps/admin-console/src/config.ts
@@ -1,4 +1,6 @@
 import { isCognitoDomain, isHttpsUrl } from "@tenkacloud/auth-client";
+import { resolveFeatureFlags } from "@tenkacloud/web-kit";
+import { type AppFeatures, FEATURE_REGISTRY } from "./features";
 
 export interface AppConfig {
   readonly cognitoDomain: string;
@@ -39,6 +41,12 @@ export interface AppConfig {
    * SAML 未設定なら空 object `{}` (= 全 email が Cognito local auth に流れる)。
    */
   readonly samlIdpDirectory: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Resolved feature flags (ADR-035). Registry in src/features.ts; an environment opts a flag on
+   * via runtime-config.json `features: { <key>: true }`. Access as `config.features?.<key>`.
+   * loadConfig always populates it; optional only so test fixtures can omit it (absent → all OFF).
+   */
+  readonly features?: AppFeatures;
 }
 
 /**
@@ -56,6 +64,8 @@ interface RuntimeConfig {
   readonly adminInsightApiUrl?: string;
   readonly cloudWatchDashboardName?: string;
   readonly samlIdpDirectory?: Readonly<Record<string, readonly string[]>>;
+  /** Raw `features` override object from runtime-config.json; resolved against the registry in loadConfig. */
+  readonly features?: Readonly<Record<string, unknown>>;
 }
 
 // Issue #871 / #1246: runtime-config.json URL validators (isHttpsUrl / isCognitoDomain) are
@@ -91,6 +101,10 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfig | null> {
       adminInsightApiUrl: data.adminInsightApiUrl,
       cloudWatchDashboardName: data.cloudWatchDashboardName,
       samlIdpDirectory: data.samlIdpDirectory,
+      features:
+        data.features && typeof data.features === "object" && !Array.isArray(data.features)
+          ? data.features
+          : undefined,
     };
   } catch {
     return null;
@@ -131,6 +145,7 @@ export async function loadConfig(
       cloudWatchDashboardName: runtime.cloudWatchDashboardName ?? "",
       // Issue #1335 Phase 1: SAML 未設定 stack も無音で動かすため空 object fallback。
       samlIdpDirectory: runtime.samlIdpDirectory ?? {},
+      features: resolveFeatureFlags(FEATURE_REGISTRY, runtime.features),
     };
   }
 
@@ -139,6 +154,18 @@ export async function loadConfig(
     const value = env[key];
     if (!value) throw new Error(`Missing required env var: ${key}`);
     return value;
+  };
+  /** Dev-only: parse VITE_FEATURES (a JSON object of overrides); invalid / absent → registry defaults. */
+  const parseDevFeatures = (raw: string | undefined): Record<string, unknown> | undefined => {
+    if (!raw) return undefined;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : undefined;
+    } catch {
+      return undefined;
+    }
   };
   return {
     cognitoDomain: required("VITE_COGNITO_DOMAIN"),
@@ -157,5 +184,7 @@ export async function loadConfig(
     cloudWatchDashboardName: "",
     // Issue #1335 Phase 1: dev では SAML 経路を出さない (= 空 directory で local 一択)。
     samlIdpDirectory: {},
+    // Unverified features default OFF; opt in with VITE_FEATURES='{"samlSso":true}'.
+    features: resolveFeatureFlags(FEATURE_REGISTRY, parseDevFeatures(env.VITE_FEATURES)),
   };
 }

--- a/apps/admin-console/src/features.ts
+++ b/apps/admin-console/src/features.ts
@@ -1,0 +1,16 @@
+import type { FeatureRegistry, ResolvedFeatures } from "@tenkacloud/web-kit";
+
+/**
+ * ADR-035: the single source of truth for this console's feature flags. Add one entry per
+ * experimental feature (default OFF); gate UI on `config.features?.<key>`; delete the entry when
+ * the feature graduates. Enable per environment via `runtime-config.json` `features: { <key>: true }`.
+ */
+export const FEATURE_REGISTRY = {
+  samlSso: {
+    description: "System Admin SAML SSO — the Identity providers page + nav.",
+    stability: "experimental",
+    defaultEnabled: false,
+  },
+} as const satisfies FeatureRegistry;
+
+export type AppFeatures = ResolvedFeatures<typeof FEATURE_REGISTRY>;

--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -12,6 +12,7 @@
     "tenants_new": "Create tenant",
     "jobs": "Provisioning Jobs",
     "audit_log": "Audit log",
+    "identity_providers": "Identity providers",
     "operations": "Operations"
   },
   "operations": {
@@ -205,5 +206,38 @@
     "filter_to": "to (ISO8601)",
     "filter_principal": "principal (sub / username)",
     "filter_action": "action"
+  },
+  "identity_providers": {
+    "title": "Identity providers",
+    "description": "SAML identity providers connected to the System Admin sign-in. The sign-in screen shows a picker for all configured providers.",
+    "add_button": "Add SAML IdP",
+    "not_wired_header": "The identity-provider API is unavailable",
+    "not_wired_body": "This feature is not configured for your environment. Please contact an administrator.",
+    "feature_disabled_header": "Identity providers are not available",
+    "feature_disabled_body": "System Admin SAML SSO is not enabled for this environment yet. Contact an administrator to turn it on.",
+    "col_id": "ID",
+    "col_display_name": "Display name",
+    "col_description": "Description",
+    "col_updated": "Updated",
+    "value_dash": "—",
+    "loading": "Loading…",
+    "test_sign_in": "Test sign-in",
+    "delete": "Delete",
+    "delete_confirm": "Delete IdP \"{idpId}\"?",
+    "empty_header": "No SAML IdPs configured yet",
+    "empty_body": "Sign-in falls back to email + password. Click Add SAML IdP to connect Entra ID or another SAML provider.",
+    "info_alert": "The same email signed in through two different providers is treated as two separate identities. Plan your group-to-role mapping accordingly."
+  },
+  "create_idp": {
+    "header": "Register SAML IdP",
+    "cancel": "Cancel",
+    "register": "Register",
+    "idp_id_label": "IdP ID",
+    "idp_id_description": "Provider name. 3–32 characters: letters, digits, _ or -.",
+    "display_name_label": "Display name",
+    "description_label": "Description (optional)",
+    "email_attr_label": "Email attribute (SAML)",
+    "metadata_xml_label": "Metadata XML",
+    "metadata_xml_description": "Paste the full IdP metadata XML."
   }
 }

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -12,6 +12,7 @@
     "tenants_new": "テナント作成",
     "jobs": "プロビジョニング Jobs",
     "audit_log": "監査ログ",
+    "identity_providers": "ID プロバイダ",
     "operations": "運用ダッシュボード"
   },
   "operations": {
@@ -205,5 +206,38 @@
     "filter_to": "to (ISO8601)",
     "filter_principal": "principal (sub / username)",
     "filter_action": "action"
+  },
+  "identity_providers": {
+    "title": "ID プロバイダ",
+    "description": "System Admin のサインインに接続された SAML ID プロバイダの一覧です。 サインイン画面に、 設定済みのプロバイダの選択肢が表示されます。",
+    "add_button": "SAML IdP を追加",
+    "not_wired_header": "ID プロバイダ API を利用できません",
+    "not_wired_body": "この機能はお使いの環境では設定されていません。 管理者にお問い合わせください。",
+    "feature_disabled_header": "ID プロバイダは利用できません",
+    "feature_disabled_body": "System Admin の SAML SSO はこの環境ではまだ有効化されていません。 有効化するには管理者にお問い合わせください。",
+    "col_id": "ID",
+    "col_display_name": "表示名",
+    "col_description": "説明",
+    "col_updated": "更新",
+    "value_dash": "—",
+    "loading": "読み込み中…",
+    "test_sign_in": "サインインをテスト",
+    "delete": "削除",
+    "delete_confirm": "IdP 「{idpId}」 を削除しますか？",
+    "empty_header": "SAML IdP がまだ設定されていません",
+    "empty_body": "サインインはメールアドレスとパスワードになります。 「SAML IdP を追加」 から Entra ID などの SAML プロバイダを接続できます。",
+    "info_alert": "同じメールアドレスでも、 別々のプロバイダでサインインした場合は別々の ID として扱われます。 グループとロールの対応付けはこれを踏まえて設計してください。"
+  },
+  "create_idp": {
+    "header": "SAML IdP を登録",
+    "cancel": "キャンセル",
+    "register": "登録",
+    "idp_id_label": "IdP ID",
+    "idp_id_description": "プロバイダ名。 3〜32 文字 (英字・数字・アンダースコア・ハイフン)。",
+    "display_name_label": "表示名",
+    "description_label": "説明 (任意)",
+    "email_attr_label": "メール属性 (SAML)",
+    "metadata_xml_label": "メタデータ XML",
+    "metadata_xml_description": "IdP のメタデータ XML 全文を貼り付けてください。"
   }
 }

--- a/apps/admin-console/src/lib/cognito.test.ts
+++ b/apps/admin-console/src/lib/cognito.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { cognitoOrigin, spEntityId, userPoolIdFromIssuer } from "./cognito";
+
+/**
+ * Regression: the Test sign-in link built `https://${cognitoDomain}` where cognitoDomain already
+ * had a scheme, yielding `https://https://…` → a dead host. cognitoOrigin must add the scheme at
+ * most once and produce a valid base for `new URL(path, origin)`.
+ */
+describe("cognitoOrigin", () => {
+  const DOMAIN = "tenkacloud-development-local-672726205532.auth.ap-northeast-1.amazoncognito.com";
+
+  it("should add https:// to a scheme-less domain", () => {
+    expect(cognitoOrigin(DOMAIN)).toBe(`https://${DOMAIN}`);
+  });
+
+  it("should NOT double the scheme when the domain already has https://", () => {
+    expect(cognitoOrigin(`https://${DOMAIN}`)).toBe(`https://${DOMAIN}`);
+  });
+
+  it("should preserve an http:// scheme (no forced upgrade, no doubling)", () => {
+    expect(cognitoOrigin("http://localhost:9000")).toBe("http://localhost:9000");
+  });
+
+  it("should strip a trailing slash and surrounding whitespace", () => {
+    expect(cognitoOrigin(`  https://${DOMAIN}/  `)).toBe(`https://${DOMAIN}`);
+  });
+
+  it("should compose a valid absolute URL with new URL(path, origin)", () => {
+    const url = new URL("/oauth2/authorize", cognitoOrigin(`https://${DOMAIN}`));
+    expect(url.toString()).toBe(`https://${DOMAIN}/oauth2/authorize`);
+    expect(url.host).toBe(DOMAIN); // host is the real domain, not "https"
+  });
+});
+
+describe("userPoolIdFromIssuer + spEntityId", () => {
+  it("should extract the User Pool ID from a Cognito iss claim", () => {
+    expect(
+      userPoolIdFromIssuer(
+        "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_AbCd123",
+      ),
+    ).toBe("ap-northeast-1_AbCd123");
+  });
+
+  it("should return undefined for a missing or non-Cognito issuer", () => {
+    expect(userPoolIdFromIssuer(undefined)).toBeUndefined();
+    expect(userPoolIdFromIssuer("https://accounts.google.com")).toBeUndefined();
+  });
+
+  it("should build the real SP Entity ID when the pool id is known", () => {
+    expect(spEntityId("ap-northeast-1_AbCd123")).toBe(
+      "urn:amazon:cognito:sp:ap-northeast-1_AbCd123",
+    );
+  });
+
+  it("should fall back to the placeholder only when the pool id is unknown", () => {
+    expect(spEntityId(undefined)).toBe("urn:amazon:cognito:sp:<userPoolId>");
+  });
+});

--- a/apps/admin-console/src/lib/cognito.ts
+++ b/apps/admin-console/src/lib/cognito.ts
@@ -1,0 +1,31 @@
+/**
+ * Build the Cognito Hosted UI origin from `config.cognitoDomain`.
+ *
+ * `cognitoDomain` arrives with a scheme in some environments (`https://xxx.auth.<region>.amazoncognito.com`)
+ * and without one in others (`xxx.auth.<region>.amazoncognito.com`). Blindly prefixing `https://`
+ * produced `https://https://xxx…` — `new URL()` then parsed the host as `https`, so the Test sign-in
+ * link and the SAML ACS URL pointed at a dead host. This normalizes to exactly one scheme and no
+ * trailing slash, so both call sites build a valid origin.
+ */
+export function cognitoOrigin(cognitoDomain: string): string {
+  const trimmed = cognitoDomain.trim().replace(/\/+$/, "");
+  if (trimmed.startsWith("https://") || trimmed.startsWith("http://")) return trimmed;
+  return `https://${trimmed}`;
+}
+
+/**
+ * Extract the User Pool ID from a Cognito ID token's `iss` claim
+ * (`https://cognito-idp.<region>.amazonaws.com/<userPoolId>`). The User Pool ID is not in
+ * runtime-config, but the signed-in admin's own ID token carries it, so we can show the real
+ * SP Entity ID instead of a `<userPoolId>` placeholder the operator has to substitute by hand.
+ */
+export function userPoolIdFromIssuer(iss: string | undefined): string | undefined {
+  if (!iss) return undefined;
+  const match = iss.match(/cognito-idp\.[a-z0-9-]+\.amazonaws\.com\/([A-Za-z0-9_-]+)$/);
+  return match?.[1];
+}
+
+/** The Cognito SAML SP Entity ID. Falls back to the placeholder only when the pool id is unknown. */
+export function spEntityId(userPoolId: string | undefined): string {
+  return userPoolId ? `urn:amazon:cognito:sp:${userPoolId}` : "urn:amazon:cognito:sp:<userPoolId>";
+}

--- a/apps/admin-console/src/pages/CreateIdpModal.tsx
+++ b/apps/admin-console/src/pages/CreateIdpModal.tsx
@@ -8,6 +8,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
 import { useCallback, useState } from "react";
 import { describeIdpError, type IdpClient } from "../api/idp-client";
+import { useT } from "../i18n";
 
 interface CreateIdpModalProps {
   readonly client: IdpClient | null;
@@ -22,6 +23,7 @@ interface CreateIdpModalProps {
  * Textarea 依存をこの module に閉じ込めた (= ページの高結合を解消)。
  */
 export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: CreateIdpModalProps) {
+  const t = useT();
   const [idpId, setIdpId] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
@@ -56,15 +58,15 @@ export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: Cr
     <Modal
       visible
       onDismiss={onClose}
-      header="Register SAML IdP"
+      header={t("create_idp.header")}
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
             <Button onClick={onClose} disabled={busy}>
-              Cancel
+              {t("create_idp.cancel")}
             </Button>
             <Button variant="primary" onClick={onSubmit} loading={busy}>
-              Register
+              {t("create_idp.register")}
             </Button>
           </SpaceBetween>
         </Box>
@@ -72,19 +74,25 @@ export function CreateIdpModal({ client, onClose, onCreated, busy, setBusy }: Cr
     >
       <SpaceBetween size="m">
         {error ? <Alert type="error">{error}</Alert> : null}
-        <FormField label="IdP ID" description="Cognito ProviderName. 3–32 chars, [A-Za-z0-9_-].">
+        <FormField
+          label={t("create_idp.idp_id_label")}
+          description={t("create_idp.idp_id_description")}
+        >
           <Input value={idpId} onChange={(e) => setIdpId(e.detail.value)} />
         </FormField>
-        <FormField label="Display name">
+        <FormField label={t("create_idp.display_name_label")}>
           <Input value={displayName} onChange={(e) => setDisplayName(e.detail.value)} />
         </FormField>
-        <FormField label="Description (optional)">
+        <FormField label={t("create_idp.description_label")}>
           <Input value={description} onChange={(e) => setDescription(e.detail.value)} />
         </FormField>
-        <FormField label="Email attribute (SAML)">
+        <FormField label={t("create_idp.email_attr_label")}>
           <Input value={emailAttr} onChange={(e) => setEmailAttr(e.detail.value)} />
         </FormField>
-        <FormField label="Metadata XML" description="Paste the full IdP metadata XML.">
+        <FormField
+          label={t("create_idp.metadata_xml_label")}
+          description={t("create_idp.metadata_xml_description")}
+        >
           <Textarea
             value={metadataXml}
             onChange={(e) => setMetadataXml(e.detail.value)}

--- a/apps/admin-console/src/pages/IdentityProviders.tsx
+++ b/apps/admin-console/src/pages/IdentityProviders.tsx
@@ -15,7 +15,8 @@ import {
 } from "../api/idp-client";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
-import { useLang } from "../i18n";
+import { useLang, useT } from "../i18n";
+import { cognitoOrigin } from "../lib/cognito";
 import { formatRelativeTime } from "../lib/format";
 import { CreateIdpModal } from "./CreateIdpModal";
 
@@ -23,24 +24,18 @@ import { CreateIdpModal } from "./CreateIdpModal";
  * Issue #1293: System Admin → list / add / edit / delete SAML IdPs attached to
  * the Control Plane Cognito UserPool.
  *
- * Notes for the operator UI:
- *   - **Multi-IdP per UserPool**. The Hosted UI picker shows all IdPs at the
- *     same time. There is no domain-based auto-routing — Issue #1293 calls this
- *     out explicitly because the same email domain may be served by both an
- *     Entra ID and an Okta tenant in parallel.
- *   - **`Cognito sub` does not collide across IdPs**. We surface a help text
- *     under the table to keep admins from confusing same-email sign-ins as the
- *     same identity.
- *
- * The page is metadata-driven only — actual sign-in is exercised by following
- * the "Test sign-in" button which jumps to the Hosted UI authorize endpoint with
+ * Feature-flagged (`samlSso`, ADR-035, default OFF) — hidden until the SAML sign-in path is
+ * verified live, so it isn't mistaken for ready. The Hosted UI picker shows all IdPs at once
+ * (no domain auto-routing); the "Test sign-in" button jumps to the authorize endpoint with
  * `identity_provider=<idpId>`.
  */
 export function IdentityProvidersPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
+  const t = useT();
   const lang = useLang();
   const client: IdpClient | null = useMemo(
-    () => (auth.tokens ? createIdpClient(config, auth.tokens.idToken) : null),
+    () =>
+      auth.tokens && config.features?.samlSso ? createIdpClient(config, auth.tokens.idToken) : null,
     [auth.tokens, config],
   );
 
@@ -66,7 +61,7 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
 
   const hostedUiTestSignInUrl = useCallback(
     (idpId: string) => {
-      const url = new URL(`https://${config.cognitoDomain}/oauth2/authorize`);
+      const url = new URL("/oauth2/authorize", cognitoOrigin(config.cognitoDomain));
       url.searchParams.set("client_id", config.cognitoClientId);
       url.searchParams.set("response_type", "code");
       url.searchParams.set("scope", config.scope);
@@ -77,25 +72,36 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
     [config],
   );
 
+  if (!config.features?.samlSso) {
+    return (
+      <Container
+        header={
+          <Header variant="h1" description={t("identity_providers.feature_disabled_body")}>
+            {t("identity_providers.title")}
+          </Header>
+        }
+      >
+        <Box textAlign="center" padding="xxl">
+          <Box variant="strong">
+            <Icon name="lock-private" size="big" variant="subtle" />{" "}
+            {t("identity_providers.feature_disabled_header")}
+          </Box>
+        </Box>
+      </Container>
+    );
+  }
+
   if (!config.apiBaseUrl) {
     return (
       <Container
         header={
-          <Header
-            variant="h1"
-            description="SAML identity providers attached to the System Admin Cognito UserPool."
-          >
-            Identity providers
+          <Header variant="h1" description={t("identity_providers.description")}>
+            {t("identity_providers.title")}
           </Header>
         }
       >
-        <Alert type="warning" header="IdP CRUD API not wired up in this environment">
-          <SpaceBetween size="xs">
-            <Box>
-              Set <code>apiBaseUrl</code> in runtime-config.json or the dev <code>.env</code> and
-              reload the page.
-            </Box>
-          </SpaceBetween>
+        <Alert type="warning" header={t("identity_providers.not_wired_header")}>
+          {t("identity_providers.not_wired_body")}
         </Alert>
       </Container>
     );
@@ -105,34 +111,37 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
     <SpaceBetween size="m">
       <Header
         variant="h1"
-        description="SAML identity providers attached to the System Admin Cognito UserPool. Same email may sign in via multiple IdPs — each is a separate identity."
+        description={t("identity_providers.description")}
         actions={
           <Button variant="primary" onClick={() => setShowCreate(true)}>
-            Add SAML IdP
+            {t("identity_providers.add_button")}
           </Button>
         }
       >
-        Identity providers
+        {t("identity_providers.title")}
       </Header>
       {loadError ? <Alert type="error">{loadError}</Alert> : null}
       <Container>
         <Table
           columnDefinitions={[
-            { id: "idpId", header: "ID", cell: (i: IdpSummary) => i.idpId },
+            {
+              id: "idpId",
+              header: t("identity_providers.col_id"),
+              cell: (i: IdpSummary) => i.idpId,
+            },
             {
               id: "displayName",
-              header: "Display name",
+              header: t("identity_providers.col_display_name"),
               cell: (i: IdpSummary) => i.displayName,
             },
             {
               id: "description",
-              header: "Description",
-              cell: (i: IdpSummary) => i.description ?? "—",
+              header: t("identity_providers.col_description"),
+              cell: (i: IdpSummary) => i.description ?? t("identity_providers.value_dash"),
             },
             {
               id: "updatedAt",
-              header: "Updated",
-              // Issue #1362: ISO 生値ではなく 「N 日前」 表示 + hover で絶対時刻 tooltip。
+              header: t("identity_providers.col_updated"),
               cell: (i: IdpSummary) => (
                 <span title={i.updatedAt}>{formatRelativeTime(i.updatedAt, lang)}</span>
               ),
@@ -148,16 +157,16 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
                     href={hostedUiTestSignInUrl(i.idpId)}
                     target="_blank"
                   >
-                    Test sign-in
+                    {t("identity_providers.test_sign_in")}
                   </Button>
                   <Button
                     variant="inline-link"
                     onClick={async () => {
-                      // defensive: 行 (= items) は client.list 成功時のみ存在するので Delete button
-                      // が押せる時点で client は必ず非 null (= この guard は不到達)。
+                      // defensive: rows only exist on client.list success, so client is non-null here.
                       /* v8 ignore next */
                       if (!client) return;
-                      if (!confirm(`Delete IdP "${i.idpId}"?`)) return;
+                      if (!confirm(t("identity_providers.delete_confirm", { idpId: i.idpId })))
+                        return;
                       setBusy(true);
                       try {
                         await client.remove(i.idpId);
@@ -169,7 +178,7 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
                       }
                     }}
                   >
-                    Delete
+                    {t("identity_providers.delete")}
                   </Button>
                 </SpaceBetween>
               ),
@@ -177,29 +186,21 @@ export function IdentityProvidersPage({ config }: { config: AppConfig }) {
           ]}
           items={items ?? []}
           loading={items === null}
-          loadingText="Loading…"
+          loadingText={t("identity_providers.loading")}
           empty={
-            // Issue #1362: アイコン + 説明 + 行動誘導の 3 段で 「dev 感のある空表示」 を脱却。
             <Box textAlign="center" padding="l">
               <SpaceBetween size="xs">
                 <Box variant="strong" color="text-status-inactive">
-                  <Icon name="lock-private" size="big" variant="subtle" /> No SAML IdPs configured
-                  yet
+                  <Icon name="lock-private" size="big" variant="subtle" />{" "}
+                  {t("identity_providers.empty_header")}
                 </Box>
-                <Box color="text-body-secondary">
-                  Sign-in falls back to local Cognito email + password. Click{" "}
-                  <strong>Add SAML IdP</strong> to wire Entra ID / Okta / etc.
-                </Box>
+                <Box color="text-body-secondary">{t("identity_providers.empty_body")}</Box>
               </SpaceBetween>
             </Box>
           }
         />
       </Container>
-      <Alert type="info">
-        Cognito treats <code>IdP A's user@example.com</code> and{" "}
-        <code>IdP B's user@example.com</code> as separate identities. Same email across multiple
-        IdPs ⇒ separate Users rows keyed by (idpId, subjectId).
-      </Alert>
+      <Alert type="info">{t("identity_providers.info_alert")}</Alert>
       {showCreate ? (
         <CreateIdpModal
           client={client}

--- a/apps/admin-console/test/CreateIdpModal.test.tsx
+++ b/apps/admin-console/test/CreateIdpModal.test.tsx
@@ -5,6 +5,29 @@ import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { IdpClient } from "../src/api/idp-client";
 import { CreateIdpModal } from "../src/pages/CreateIdpModal";
 
+// i18n: resolve against the real en.json so assertions check the actual shipped copy.
+vi.mock("../src/i18n", async () => {
+  const en = (await import("../src/i18n/locales/en.json")).default as Record<string, unknown>;
+  const resolve = (key: string): string => {
+    const v = key
+      .split(".")
+      .reduce<unknown>(
+        (o, k) => (o && typeof o === "object" ? (o as Record<string, unknown>)[k] : undefined),
+        en,
+      );
+    return typeof v === "string" ? v : key;
+  };
+  return {
+    useLang: () => "en",
+    useT: () => (key: string, params?: Record<string, string | number>) => {
+      let s = resolve(key);
+      if (params)
+        for (const [k, v] of Object.entries(params)) s = s.split(`{${k}}`).join(String(v));
+      return s;
+    },
+  };
+});
+
 /**
  * Issue #1418: 未テストだった admin CreateIdpModal (SAML IdP 登録モーダル) を 100% に。
  * client は prop 注入なので mock client を渡し、 Cloudscape test-utils で input/textarea を駆動。

--- a/apps/admin-console/test/IdentityProviders.test.tsx
+++ b/apps/admin-console/test/IdentityProviders.test.tsx
@@ -20,7 +20,27 @@ vi.mock("../src/api/idp-client", () => ({
   createIdpClient: mockCreateIdpClient,
   describeIdpError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
 }));
-vi.mock("../src/i18n", () => ({ useLang: () => "en" }));
+vi.mock("../src/i18n", async () => {
+  const en = (await import("../src/i18n/locales/en.json")).default as Record<string, unknown>;
+  const resolve = (key: string): string => {
+    const v = key
+      .split(".")
+      .reduce<unknown>(
+        (o, k) => (o && typeof o === "object" ? (o as Record<string, unknown>)[k] : undefined),
+        en,
+      );
+    return typeof v === "string" ? v : key;
+  };
+  return {
+    useLang: () => "en",
+    useT: () => (key: string, params?: Record<string, string | number>) => {
+      let s = resolve(key);
+      if (params)
+        for (const [k, v] of Object.entries(params)) s = s.split(`{${k}}`).join(String(v));
+      return s;
+    },
+  };
+});
 vi.mock("../src/lib/format", () => ({ formatRelativeTime: (iso: string) => `rel:${iso}` }));
 vi.mock("../src/pages/CreateIdpModal", () => ({
   CreateIdpModal: ({
@@ -52,6 +72,7 @@ const config = {
   cognitoClientId: "client-123",
   scope: "openid email",
   redirectUri: "https://app.example.com/callback",
+  features: { samlSso: true },
 } as AppConfig;
 
 const idp = (over: Record<string, unknown> = {}) => ({
@@ -73,9 +94,17 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("IdentityProvidersPage", () => {
+  it("should show the feature-disabled hero (and skip fetch) when samlSso is off", () => {
+    render(
+      <IdentityProvidersPage config={{ ...config, features: { samlSso: false } } as AppConfig} />,
+    );
+    expect(screen.getByText("Identity providers are not available")).toBeInTheDocument();
+    expect(mockCreateIdpClient).not.toHaveBeenCalled();
+  });
+
   it("should show the not-wired alert when apiBaseUrl is missing", () => {
     render(<IdentityProvidersPage config={{ ...config, apiBaseUrl: "" } as AppConfig} />);
-    expect(screen.getByText(/IdP CRUD API not wired up/)).toBeInTheDocument();
+    expect(screen.getByText("The identity-provider API is unavailable")).toBeInTheDocument();
   });
 
   it("should not call list when there is no auth token (client null)", () => {


### PR DESCRIPTION
## Summary
The **System Admin console** (admin-console) had the same three problems on its Identity providers page that #1680/#1681 fixed in the tenant console — you flagged that "SSO はテナント管理画面でもあった". Mirroring the fix:

1. **Dead "Test sign-in" link** — built `https://${config.cognitoDomain}/oauth2/authorize` where `cognitoDomain` already has a scheme → `https://https//…` (host parsed as `https`). Added `lib/cognito.ts` `cognitoOrigin()` (same shared logic, 9 tests).
2. **Hardcoded English** — the page + Add-IdP modal never called `useT()`, so 日本語 did nothing. Wired both into i18n (`identity_providers.*` / `create_idp.*` + the nav label), ja + en.
3. **Unverified SSO exposed** — gated behind the ADR-035 feature flag `samlSso` (experimental, **default OFF**). The page itself (not just the nav) is hidden until verified, so a direct URL can't expose it. Enable per environment via `runtime-config.json` `features.samlSso`.

## Test plan
- `make harness` clean; admin-console + web-kit **100% coverage**; 289 admin-console tests pass.
- Added the feature-disabled-gate test; updated the i18n-mock + changed assertions; cognito test mirrored.
- `cognitoOrigin` regression pinned (`https://https//` can't reappear).

## Regression analysis
App-only. The IdP nav + page are hidden by default → no behavior change for existing deployments. `config.features` optional so test fixtures compile unchanged. No infra/CFn change.

## Physical impact
**NO-OP** on every CFn stack.

Relates #1418.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added identity providers management page with SAML identity provider registration capability.
  * Introduced feature flag system for SAML SSO functionality.

* **UI/UX Updates**
  * Identity providers navigation link now conditionally displays based on feature flag status.
  * Added comprehensive English and Japanese localization for identity providers interface.

* **Improvements**
  * Enhanced configuration system to support runtime and development-based feature flag overrides.

* **Tests**
  * Added test coverage for Cognito helpers and identity providers functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->