### PR TITLE
docs(adr): ADR-036 — S3 Tables (Iceberg) for audit logs, deferred [#1431]

### DIFF
--- a/docs/architecture/adr-036-s3-tables-audit-log-archive.html
+++ b/docs/architecture/adr-036-s3-tables-audit-log-archive.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-036: S3 Tables (Iceberg) for long-retention audit/operational logs</title>
+<style>
+  :root {
+    --c-text: #1f2328; --c-muted: #59636e; --c-border: #d1d9e0; --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa; --c-accept: #1a7f37; --c-reject: #cf222e; --c-warn: #9a6700;
+    --c-link: #0969da; --c-code-bg: #eff1f3;
+  }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg); max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  pre { background: var(--c-bg-soft); border: 1px solid var(--c-border); border-radius: 6px; padding: 0.8rem 1rem; overflow-x: auto; font-size: 0.85rem; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; }
+  .status { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 0.8rem; font-weight: 600; background: #fff8c5; color: var(--c-warn); }
+  .muted { color: var(--c-muted); }
+  .keep { color: var(--c-accept); font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>ADR-036: S3 Tables (Iceberg) for long-retention audit / operational logs</h1>
+<p><span class="status">Accepted — deferred (conditional adoption)</span></p>
+
+<h2>Context</h2>
+<p>
+A cost-reduction idea was raised: move logs to Amazon S3 Tables (Apache Iceberg) + Athena, as in
+<a href="https://kaminashi-developer.hatenablog.jp/entry/2026/06/01/log-storage-with-iceberg">Kaminashi's write-up</a>,
+which reports an 80%+ ingestion-cost reduction. Before adopting it we measured TenkaCloud's actual
+log/audit cost profile, which differs materially from that case study.
+</p>
+<table>
+  <tr><th>Log</th><th>Where it lives today</th><th>Cost today</th></tr>
+  <tr><td>Audit log (deploy / event / sign-in / disruption operations)</td><td>DynamoDB, <b>PROVISIONED 1 RCU / 1 WCU</b> (the <code>DynamoDbLowCapacity</code> aspect pins every table to 1/1) + TTL (<code>AUDIT_RETENTION_DAYS</code>, 90 default / 365 SOC2)</td><td><b>≈ $0</b> — within the Free Tier 25 GB storage + 25 WCU/RCU. Audit rows are small; even ~1,000 events/day × 365 days ≈ a few hundred MB.</td></tr>
+  <tr><td>Lambda logs</td><td>CloudWatch Logs, <b>1-week retention</b></td><td>Low volume, short retention → cents.</td></tr>
+  <tr><td>High-volume application logs</td><td><b>None</b> — the platform is Lambda-based; there is no always-on ECS app emitting high-volume logs.</td><td>—</td></tr>
+</table>
+<p>
+Kaminashi's saving came from <b>high-volume CloudWatch <em>ingestion</em></b> (their primary cost
+factor). TenkaCloud has no such ingestion: audit data is low-volume in a 1/1 DynamoDB table, and
+Lambda logs are short-retention. So the premise "S3 Tables cuts our log cost" does not hold at the
+current scale.
+</p>
+
+<h2>Decision</h2>
+<p>
+<b>Do not adopt S3 Tables now.</b> At the current scale it would <em>increase</em> cost and
+complexity, not reduce it: Firehose (per-GB + per-record), a Glue Data Catalog, Athena
+(per-query), and Iceberg schema management would add a fixed monthly baseline and operational
+burden on top of an audit store that is effectively free today. Building it now would be a
+"cost optimization" that does not optimize.
+</p>
+<p>
+<b>Define the target architecture and adopt it only when the trigger conditions below are met</b>
+— at which point the Kaminashi pattern applies directly:
+</p>
+<pre>audit / operational events
+   └─ system-audit-writer Lambda  ──►  DynamoDB (hot, recent, cursor-paginated reads)
+                                  └─►  Amazon Data Firehose ──► S3 Tables (Iceberg)  ──► Athena (long-retention, analytical)
+error logs / alarms  ──────────────►  CloudWatch Logs (kept — CloudWatch Alarms integration)</pre>
+<ul>
+  <li><span class="keep">Error logs stay in CloudWatch</span> (CloudWatch Alarms / Logs Insights for alerting), exactly as in the source article.</li>
+  <li>Audit / operational logs dual-write (DynamoDB for hot recent reads + S3 Tables for the long-retention archive), or shift fully to S3 Tables once the DynamoDB hot window is short.</li>
+  <li>The <b>seam</b> is the existing <code>system-audit-writer</code> Lambda (<code>infrastructure/lib/problem-deploy/system-audit-writer-lambda.ts</code>) — add a Firehose put there; the read path (<code>audit-log-read</code> / admin-insight) gains an Athena-backed query for the cold range.</li>
+</ul>
+
+<h3>Trigger conditions (adopt when ANY holds)</h3>
+<table>
+  <tr><th>Signal</th><th>Threshold</th></tr>
+  <tr><td>Audit storage approaches the Free Tier ceiling</td><td>DynamoDB audit table → ~25 GB (≈ tens of millions of rows). Watch via the existing Free Tier DDB storage alarm.</td></tr>
+  <tr><td>Sustained audit write rate throttles 1 WCU</td><td>audit writes approach ~1/sec sustained (≈ 86k/day) → <code>tenkacloud-freetier-ddb-write-*</code> alarm fires on the audit table.</td></tr>
+  <tr><td>Analytical queries over long history are needed</td><td>operators need ad-hoc SQL across &gt; 90–365 days (beyond the current cursor-paginated DynamoDB reads).</td></tr>
+</table>
+
+<h2>Consequences</h2>
+<ul>
+  <li>No change now — the audit store stays DynamoDB 1/1 + TTL (free, simple, already SOC2-retention capable).</li>
+  <li>When triggered, expect Iceberg's trade-offs (from the source article): <b>schema-on-write</b> (vs CloudWatch's schema-on-read) and <b>partitions cannot be altered from Athena</b> (Glue/Spark rewrite needed) — so design the audit Iceberg schema + partitioning (by <code>tenantId</code> / day) carefully up front.</li>
+  <li>This ADR is the standing record so the idea is not re-litigated each time; revisit when an alarm above fires.</li>
+</ul>
+
+<h2>Alternatives considered</h2>
+<table>
+  <tr><th>Option</th><th>Verdict</th></tr>
+  <tr><td>Adopt S3 Tables now</td><td>Rejected — increases cost + complexity at current volume; the saving case (high-volume ingestion) does not exist here.</td></tr>
+  <tr><td>Keep DynamoDB + TTL (status quo)</td><td><b>Chosen for now</b> — free at current scale, already supports 365-day SOC2 retention.</td></tr>
+  <tr><td>Move audit to CloudWatch Logs + Insights</td><td>Rejected — more expensive at long retention; loses the cheap DynamoDB key-value reads.</td></tr>
+  <tr><td>OpenSearch for audit</td><td>Rejected — violates the cost-zero principle (always-on cluster).</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Records the analysis + decision for the "use S3 Tables / Iceberg to cut audit-log cost" idea ([Kaminashi's write-up](https://kaminashi-developer.hatenablog.jp/entry/2026/06/01/log-storage-with-iceberg)).

**Honest finding: it would *increase* cost at TenkaCloud's current scale**, so we don't adopt it now:
- Audit logs sit in a DynamoDB table pinned to 1 RCU / 1 WCU (the `DynamoDbLowCapacity` aspect) with TTL — **≈ $0**, within the Free Tier (storage + capacity).
- There is no high-volume CloudWatch ingestion (Lambda-based, 1-week retention) — which was the cost driver in the source article.
- Firehose + Glue + Athena would add a fixed monthly baseline + Iceberg schema/partition rigidity for ~no saving.

**Decision (deferred):** document the target architecture (audit/operational → Firehose → S3 Tables (Iceberg) → Athena; **error logs stay in CloudWatch** for alarms) and the **trigger conditions** to adopt — DynamoDB audit nears Free Tier 25 GB, sustained 1 WCU throttling, or a need for ad-hoc SQL over long audit history. The `system-audit-writer` Lambda is the named seam for the future dual-write.

This keeps the idea from being re-litigated and from being built prematurely as a "cost optimization" that wouldn't optimize.

## Test plan
- `make harness` clean (`adr-must-be-html` / `adr-self-contained` pass). Docs-only.

## Physical impact
**NO-OP** — documentation only.

Relates #1431.