### PR TITLE
docs(adr): ADR-037 disruption timing & recurrence model

### DIFF
--- a/docs/architecture/adr-037-disruption-timing-recurrence.html
+++ b/docs/architecture/adr-037-disruption-timing-recurrence.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ADR-037: Disruption timing & recurrence (scheduled / recurring / adaptive)</title>
+<style>
+  :root {
+    --c-text: #1f2328;
+    --c-muted: #59636e;
+    --c-border: #d1d9e0;
+    --c-bg: #ffffff;
+    --c-bg-soft: #f6f8fa;
+    --c-accept: #1a7f37;
+    --c-reject: #cf222e;
+    --c-warn: #9a6700;
+    --c-link: #0969da;
+    --c-code-bg: #eff1f3;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic UI", sans-serif;
+    color: var(--c-text); background: var(--c-bg);
+    max-width: 980px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6;
+  }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid var(--c-border); padding-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin-top: 2.2rem; border-bottom: 1px solid var(--c-border); padding-bottom: .3rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.6rem; }
+  code { background: var(--c-code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.9em; }
+  a { color: var(--c-link); }
+  table { border-collapse: collapse; margin: 0.6rem 0; width: 100%; font-size: 0.92rem; }
+  th, td { border: 1px solid var(--c-border); padding: 6px 10px; vertical-align: top; }
+  th { background: var(--c-bg-soft); text-align: left; font-weight: 600; }
+  .meta { display: flex; flex-wrap: wrap; gap: 1.2rem; padding: .8rem 1rem; background: var(--c-bg-soft);
+          border-left: 4px solid var(--c-link); border-radius: 3px; font-size: 0.92rem; margin-bottom: 1.5rem; }
+  .meta b { color: var(--c-muted); margin-right: .3rem; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.78rem;
+           font-weight: 600; line-height: 1.4; }
+  .badge.draft { background: #ddf4ff; color: var(--c-link); }
+  .badge.accept { background: #dafbe1; color: var(--c-accept); }
+  .badge.reject { background: #ffe5e5; color: var(--c-reject); }
+  .badge.warn { background: #fff8c5; color: var(--c-warn); }
+  pre { background: var(--c-code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.85rem; line-height: 1.45; }
+  .risk-high { color: var(--c-reject); font-weight: 600; }
+  .risk-med { color: var(--c-warn); font-weight: 600; }
+  .ok { color: var(--c-accept); font-weight: 600; }
+  details { background: var(--c-bg-soft); padding: .6rem 1rem; margin: .6rem 0; border-radius: 4px; border: 1px solid var(--c-border); }
+  details > summary { cursor: pointer; font-weight: 600; }
+  .seq { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.82rem; white-space: pre; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ADR-037: Disruption timing &amp; recurrence (scheduled / recurring / adaptive)</h1>
+  <p><em>障害をワンタイムで終わらせず、 予約・定期・「対策が不十分なら再発」 を、 問題が宣言し platform が疎結合に駆動する timing モデル</em></p>
+  <div class="meta">
+    <div><b>Status:</b> <span class="badge draft">Proposed</span> 2026-06-03</div>
+    <div><b>Related:</b>
+      <a href="./adr-031-cross-account-disruption-dispatch.html">ADR-031</a> (cross-account 注入 / action 契約 / revert),
+      <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a> (condition-triggered 発火 / 一度きり),
+      <a href="./adr-034-real-attack-realization.html">ADR-034</a> (attackProbe = 防御状態の検知),
+      <a href="./adr-029-attack-resilience-liveness.html">ADR-029</a> (game always ends / 永続障害禁止),
+      <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin, platform = host)
+    </div>
+  </div>
+</header>
+
+<h2>Context</h2>
+
+<p>
+  TenkaCloud の障害 (disruption) は、 問題が <code>metadata.json</code> の <code>disruptions[]</code> に
+  <b>データとして宣言</b>し、 platform の汎用 executor が競技者アカウントへ <code>AssumeRole</code> して注入する
+  (ADR-031)。 注入の実体は 3 つの汎用 <code>action.kind</code> — <code>ssm-run-command</code> /
+  <code>lambda-invoke</code>(問題が自前の障害 Lambda を同梱して呼ばせる) / <code>cfn-stack-update</code> —
+  に閉じており、 platform は問題固有コードを一切 import しない (= 疎結合)。
+</p>
+
+<p>現状、 障害が「発火」 する経路は 2 つあり、 <b>いずれも実質ワンタイム</b>である:</p>
+
+<table>
+  <tr><th>発火経路</th><th>現状の挙動</th><th>限界</th></tr>
+  <tr>
+    <td><b>operator fire</b> (<code>POST /events/:id/disruptions/fire</code>, ADR-031 Phase A)</td>
+    <td>operator が押した瞬間に <code>DisruptionFired</code> を publish → 即注入 → revert を予約</td>
+    <td><span class="risk-med">即時 1 回のみ</span>。 「30 分後に」 や 「5 分ごとに」 は表現できない</td>
+  </tr>
+  <tr>
+    <td><b>condition-triggered</b> (scoring tick, ADR-013 / #1422)</td>
+    <td>tick が <code>after-deploy</code> / <code>team-score-above</code> / <code>phase-entered</code> を評価し発火。 <code>firedDisruptions</code> set で <b>一度発火したら抑制</b></td>
+    <td><span class="risk-med">一度きり</span>。 条件が再成立しても二度と撃たない</td>
+  </tr>
+</table>
+
+<p>
+  Battle を競技として成立させるには、 これでは足りない。 現実の運用 (例: Web サイト書き換え、 レイテンシ注入、
+  リソース枯渇) は <b>一度直して終わり</b>ではなく、
+</p>
+
+<ul>
+  <li><b>定期的に再発</b>させたい — 例: 5 分ごとに改ざんし直し、 防御を維持し続けないとスコアが落ちる。</li>
+  <li><b>対策が不十分なら再発</b>させたい — 表面的に復旧しても根本対策 (WAF / 入力検証 / patch) を打っていなければ、
+      次の tick で同じ障害がまた起きる。 これが無いと 「1 回 revert を待てば勝ち」 になり、 防御の巧拙が点差にならない。</li>
+</ul>
+
+<p>
+  「対策が不十分か」 の判定は <b>既に存在する</b> — ADR-034 の <code>attackProbe</code> は毎 tick 攻撃 payload を撃ち、
+  防御が破れているか (例: SQLi が通る / 改ざんが書き戻せる) を観測して減点する。 不足しているのは、
+  <b>その観測を「再注入」 に接続する timing 層</b>と、 operator が予約・定期発火を選べる UI/API だけである。
+</p>
+
+<h2>Decision</h2>
+
+<p>
+  disruption 宣言に <b>timing/recurrence ポリシー</b>を 1 つ足し、 <b>既存の 2 つの発火ドライバ</b>
+  (operator fire API / scoring tick) を拡張する。 注入の実体 (executor + 3 kind + revert) と
+  疎結合契約は <b>一切変えない</b> — 変わるのは「いつ・何回 <code>DisruptionFired</code> を publish するか」 だけ。
+</p>
+
+<h3>1. timing モデル (4 mode)</h3>
+
+<table>
+  <tr><th>mode</th><th>駆動</th><th>意味</th><th>新規/既存</th></tr>
+  <tr>
+    <td><code>one-shot</code> (default)</td><td>operator / tick</td>
+    <td>1 回注入 → revert。 既存の操作・条件発火と完全互換</td>
+    <td><span class="ok">既存</span></td>
+  </tr>
+  <tr>
+    <td><code>scheduled</code></td><td>operator</td>
+    <td>operator が「<b>N 分後に</b>」 を選んで予約。 <code>defaultAfterMinutes</code> / <code>operatorEditable:["afterMinutes"]</code> で既定値と上書き可否を宣言</td>
+    <td><span class="badge draft">新規</span></td>
+  </tr>
+  <tr>
+    <td><code>recurring</code></td><td>operator / tick</td>
+    <td>window 中 <code>intervalMinutes</code> ごとに再注入。 <code>maxFires</code> 必須 (= 上限到達で停止)</td>
+    <td><span class="badge draft">新規</span></td>
+  </tr>
+  <tr>
+    <td><code>while-undefended</code> (適応的)</td><td>tick</td>
+    <td>毎 tick、 宣言した防御 probe を評価し、 <b>まだ脆弱な間だけ</b>再注入。 <code>minIntervalMinutes</code> で throttle、 <code>maxFires</code> で上限</td>
+    <td><span class="badge draft">新規</span></td>
+  </tr>
+</table>
+
+<h3>2. 宣言スキーマ (問題作者が書くもの)</h3>
+
+<p>
+  既存の <code>action</code> / <code>triggers</code> はそのまま。 disruption に <code>recurrence</code> を足し、
+  <code>triggers[].kind</code> に <b>防御状態を見る</b> <code>defense-insufficient</code> を 1 つ追加する
+  (= ADR-034 の attackProbe を <code>probeRef</code> で参照、 検知 primitive を再利用)。
+</p>
+
+<pre>{
+  "id": "homepage-defacement",
+  "name": "トップページ改ざん",
+  "action": { "kind": "lambda-invoke", "targetRef": "DefaceLambdaArn",
+              "paramTemplate": { "path": "/index.html" },
+              "revert": { "afterSeconds": 120, "kind": "lambda-invoke", "targetRef": "RestoreLambdaArn" } },
+
+  "recurrence": {
+    "mode": "while-undefended",   // one-shot | scheduled | recurring | while-undefended
+    "minIntervalMinutes": 3,      // recurring/while-undefended: 再注入の最小間隔 (throttle)
+    "maxFires": 8                 // recurring/while-undefended: 必須。 0 でも event 終了でも必ず止まる
+  },
+
+  "triggers": [
+    { "kind": "defense-insufficient", "probeRef": "tamper-detect" }   // ← 新 kind。 probe が「脆弱」なら再発
+  ]
+}</pre>
+
+<p>後方互換: <code>recurrence</code> 未宣言 = <code>one-shot</code>。 既存の全問題は無改修で従来どおり動く。</p>
+
+<h3>3. 発火フロー (platform 側・汎用)</h3>
+
+<div class="seq">  ── operator 経路 ───────────────────────────────────────────────
+  operator ─fire(timing)─▶ disruption-fire (Phase A)
+       timing=immediate  ─▶ PutEvents(DisruptionFired)            [既存]
+       timing=scheduled  ─▶ aws-scheduler one-shot  at(T+N) ─┐
+       timing=recurring  ─▶ aws-scheduler rate(N) ×maxFires ─┤
+                                                              ▼
+  ── tick 経路 ───────────────────────────────────────────────────  PutEvents(DisruptionFired)
+  scoring tick ─評価─▶ condition-disruption-fire                       │
+       one-shot trigger    : firedDisruptions で抑制 (既存)            │
+       defense-insufficient: probe=脆弱 かつ (now-lastFired)≥minInt    │
+                             かつ fireCount&lt;maxFires なら再発 ──────┤
+                                                              ▼
+  ────────────────────────────────────────────────────────▶ DisruptionExecutorLambda
+                              AssumeRole(ExternalId) ─▶ sendDispatch(kind) ─▶ scheduleRevert</div>
+
+<p>
+  <code>scheduled</code> / <code>recurring</code> は <code>schedule-revert.ts</code> で実証済みの
+  <b>aws-scheduler one-shot/rate</b> パターンをそのまま転用する (= 新機構ゼロ)。 schedule の target は
+  既存の経路に合流させるため、 注入そのものではなく <code>DisruptionFired</code> の再 publish を行う
+  (= fire→executor の経路・冪等性・監査を 1 本に保つ)。
+</p>
+
+<h3>4. 状態管理</h3>
+
+<p>
+  <code>one-shot</code> は既存の <code>DeploymentScoringState.firedDisruptions: string[]</code>
+  (発火済み set) のまま。 <code>recurring</code> / <code>while-undefended</code> は再発を許すため、
+  per-disruption の <code>{ lastFiredAtMs, fireCount }</code> を同 state に足す
+  (DynamoDB は 1/1 PROVISIONED のまま、 既存 item の属性追記なので追加 RCU/WCU 無し)。
+  tick は <code>fireCount &lt; maxFires</code> かつ <code>now - lastFiredAtMs ≥ minIntervalMinutes</code>
+  を満たす時だけ再 publish する。
+</p>
+
+<h2>Always-ends との結線 (ADR-029)</h2>
+
+<p>再発は <b>無限ではない</b>ことを多重に保証する (INV-2: どの障害も必ず復旧し、 競技は必ず終わる):</p>
+
+<table>
+  <tr><th>停止条件</th><th>機構</th></tr>
+  <tr><td>注入ごとの復旧</td><td><code>action.revert</code> は ADR-031 で <b>必須</b>。 再発しても各注入に revert が予約され、 永続化しない</td></tr>
+  <tr><td>回数上限</td><td><code>recurring</code> / <code>while-undefended</code> は <code>maxFires</code> <b>必須</b>。 validate で未宣言を reject</td></tr>
+  <tr><td>時間上限</td><td>scoring lock / event 終了 (ADR-029) で tick 自体が止まる。 operator の <code>recurring</code> schedule は event teardown で削除</td></tr>
+  <tr><td>適応的の自然停止</td><td><code>while-undefended</code> は probe が「防御済み」 を返した瞬間に再発が止まる (= 対策すれば終わる、 これが狙い)</td></tr>
+</table>
+
+<h2>Trust model (ADR-031 から不変)</h2>
+
+<p>
+  timing 層は <b>「いつ publish するか」 しか変えない</b>ため、 ADR-031 の信頼境界はそのまま効く:
+  AssumeRole は team の <code>competitorRoleArn</code> + tenant の ExternalId でのみ成立、
+  <code>operatorEditable</code> allow-list で fold 済の値しか <code>paramTemplate</code> に入らない、
+  <code>EXEC#{requestId}#{teamId}</code> conditional Put で per-team 冪等。 再発は <code>requestId</code> に
+  fire 連番 (<code>#{n}</code>) を付与して別注入として監査する (= 重複配送は依然 no-op、 再発は別レコード)。
+</p>
+
+<h2>Alternatives considered</h2>
+
+<table>
+  <tr><th>案</th><th>判定</th><th>理由</th></tr>
+  <tr>
+    <td>EventBridge Scheduler でなく Step Functions で再発ループ</td>
+    <td><span class="badge reject">Rejected</span></td>
+    <td>state machine の常設 = コスト/運用増。 既に <code>schedule-revert.ts</code> で one-shot scheduler が実証済みで、 tick が周期エンジンを兼ねる</td>
+  </tr>
+  <tr>
+    <td>再発を問題側 Lambda の中で完結 (自分で setInterval 相当)</td>
+    <td><span class="badge reject">Rejected</span></td>
+    <td>停止保証 (always-ends) を platform が握れない。 maxFires / event 終了で止める責務は host 側に必要</td>
+  </tr>
+  <tr>
+    <td><code>while-undefended</code> を専用の新 probe 機構で作る</td>
+    <td><span class="badge reject">Rejected</span></td>
+    <td>ADR-034 attackProbe が既に「毎 tick 防御状態を検知」 を実装済。 <code>probeRef</code> で再利用すれば二重実装を避けられる</td>
+  </tr>
+  <tr>
+    <td><code>recurrence</code> + <code>defense-insufficient</code> trigger を宣言で表現し、 既存 2 ドライバを拡張</td>
+    <td><span class="badge accept">Accepted</span></td>
+    <td>疎結合・後方互換・always-ends を全て満たし、 新規機構ゼロ。 問題作者の学習面は <code>recurrence</code> 1 ブロックのみ</td>
+  </tr>
+</table>
+
+<h2>Consequences</h2>
+
+<h3 class="ok">Positive</h3>
+<ul>
+  <li>「対策が不十分なら再発」 が成立し、 防御の巧拙が初めて点差になる (= Battle が競技として成立)。</li>
+  <li>operator は即時 / 予約 / 定期を 1 つの fire UI で選べる。</li>
+  <li>新規 AWS リソース機構はゼロ (scheduler / tick / executor は既存)。 DynamoDB も属性追記のみで 1/1 維持。</li>
+  <li>後方互換 — 既存問題は <code>recurrence</code> 無しで従来どおり one-shot。</li>
+</ul>
+
+<h3 class="risk-med">Negative / trade-off</h3>
+<ul>
+  <li>operator <code>recurring</code> は schedule を作るため、 event teardown での確実な削除が要る (cleanup に追加)。</li>
+  <li><code>while-undefended</code> の体感粒度は tick 間隔 (≈1 分) に律速される (= 秒単位の再発はしない。 運用上は十分)。</li>
+  <li>監査ログは再発のたびに 1 行増える (= 意図どおり。 「何回・いつ再発したか」 が可視化される)。</li>
+</ul>
+
+<h2>Migration</h2>
+
+<ol>
+  <li><b>SCHEMA</b>: <code>problems/SCHEMA.json</code> の <code>disruptions[]</code> に <code>recurrence</code> を追加、 <code>triggers[].kind</code> に <code>defense-insufficient</code> を追加。 旧説明文 (「Phase 4 future-facing / カタログ用途のみ」) を実装済みの内容へ更新。</li>
+  <li><b>tick</b>: <code>condition-disruption-fire.ts</code> の抑制を「<code>one-shot</code> のみ抑制、 <code>recurring</code>/<code>while-undefended</code> は interval+cap 判定で再発」 に拡張。 <code>defense-insufficient</code> 評価を <code>disruption-triggers.ts</code> に追加。</li>
+  <li><b>operator fire</b>: fire schema に <code>timing</code> (<code>immediate</code>|<code>scheduled</code>|<code>recurring</code>) + <code>afterMinutes</code>/<code>intervalMinutes</code> を追加。 即時以外は aws-scheduler に登録。</li>
+  <li><b>fire UI</b>: DisruptionsPanel に timing トグル (即座 / N 分後 / N 分ごと) を追加。</li>
+  <li><b>author ガイド</b>: <code>docs/problems/</code> に 「障害の足し方」 (3 kind + 自前 Lambda + recurrence + revert + 注入フロー) を追加。</li>
+</ol>
+
+<p>各ステップは独立に観測可能な increment として別 PR で出荷する (INVARIANT_PR_SHIPS_WORKING_INCREMENT)。</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

障害を **ワンタイムで終わらせない** ための timing/recurrence モデルを設計 (ADR-037)。ユーザー要件「障害も定期実行とかでウェブサイトを書き換えたり、対策が不十分だと再度障害が発生するように」を満たす設計の正本。

- **scheduled**: operator が「N 分後に」を予約
- **recurring**: window 中 N 分ごとに再注入 (`maxFires` 必須)
- **while-undefended** (適応的): 防御 probe が脆弱を返す間だけ再注入 = 「対策が不十分なら再発」

設計の肝は **既存を正確に踏まえ、新規機構をゼロにする** こと:
- 注入の実体 (executor 3 kind = ssm-run-command / lambda-invoke / cfn-stack-update + revert, ADR-031) と疎結合契約は不変
- condition-triggered 発火 (ADR-013/#1422) は既に存在するが `firedDisruptions` で一度きり抑制 → 再発を許す拡張
- 防御状態の検知 (attackProbe, ADR-034) を `defense-insufficient` trigger の `probeRef` で再利用
- スケジュールは `schedule-revert.ts` の aws-scheduler パターンを転用

always-ends (ADR-029) は `maxFires` 必須 / 注入ごと revert / event 終了で多重保証。後方互換 — `recurrence` 未宣言 = 従来 one-shot。

実装は本 ADR の Migration 節どおり別 PR に分割 (scheduled → recurring → while-undefended → author ガイド)。

## Test plan
- `make harness` green (adr-must-be-html / adr-self-contained)
- `make before-commit` green (pre-commit hook で実行済み)
- HTML 設計ドキュメントのみ。dead link 無し (adr-031 と同じ adr-029-attack-resilience-liveness.html を参照)

## Regression analysis
- HTML 設計ドキュメントの新規追加のみ。コードから import されず実行経路に影響なし。

## Physical impact
- NO-OP: `docs/architecture/adr-037-*.html` の追加のみ。CFn / artifact 差分なし。

Relates #1417