### PR TITLE
feat(disruptions): immediate + scheduled (N分後) red-team fire [ADR-037]

### DIFF
--- a/apps/application-admin-console/src/api/disruptions-client.ts
+++ b/apps/application-admin-console/src/api/disruptions-client.ts
@@ -14,6 +14,9 @@ import type { ApiClient } from "./client";
 
 export type DisruptionScope = "all" | "team" | "random-n";
 
+/** [ADR-037] When the injection runs: immediately, or scheduled `afterMinutes` from now. */
+export type DisruptionTiming = "immediate" | "scheduled";
+
 /** One declared disruption as surfaced by the catalog (a problem's metadata.json declaration). */
 export interface DisruptionCatalogItem {
   readonly id: string;
@@ -26,6 +29,8 @@ export interface DisruptionCatalogItem {
   readonly parameters?: Readonly<Record<string, unknown>>;
   /** Whether competitors can see this disruption exists (operator view shows all). */
   readonly publicHint?: boolean;
+  /** [ADR-037] Declared default delay (minutes) used to pre-fill the schedule input. */
+  readonly defaultAfterMinutes?: number;
 }
 
 export interface DisruptionCatalogEntry {
@@ -46,6 +51,10 @@ export interface FireDisruptionRequest {
   readonly parameters?: Readonly<Record<string, unknown>>;
   /** Idempotency key (>= 8 chars); re-firing with the same id is a no-op on the platform. */
   readonly requestId: string;
+  /** [ADR-037] `immediate` (default) injects now; `scheduled` defers by `afterMinutes`. */
+  readonly timing?: DisruptionTiming;
+  /** [ADR-037] Required when `timing === "scheduled"`; 1–1440 minutes. */
+  readonly afterMinutes?: number;
 }
 
 export interface FireDisruptionResult {
@@ -64,6 +73,8 @@ export interface DisruptionAuditRow {
   readonly targetTeamIds: readonly string[];
   readonly parameters: Readonly<Record<string, unknown>>;
   readonly requestId: string;
+  /** [ADR-037] For a scheduled fire, the time the injection is/was due (ISO8601). */
+  readonly scheduledFor?: string;
 }
 
 export interface DisruptionAuditResponse {

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -723,6 +723,14 @@
     "teams_placeholder": "Select teams",
     "random_label": "Pick the pool of teams (a random subset is hit)",
     "random_description": "The platform hits a random subset sized to your selection.",
-    "fired_flash": "Fired \"{name}\" at {count} team(s)."
+    "timing_label": "Timing",
+    "timing_description": "Inject immediately, or schedule it to run after a number of minutes.",
+    "timing_immediate": "Run now",
+    "timing_scheduled": "Schedule (in N min)",
+    "after_minutes_label": "Run after (minutes)",
+    "after_minutes_description": "1–1440 minutes. The injection runs once this many minutes have elapsed.",
+    "after_minutes_error": "Enter a whole number between 1 and 1440.",
+    "fired_flash": "Fired \"{name}\" at {count} team(s).",
+    "scheduled_flash": "Scheduled \"{name}\" to fire in {minutes} minute(s)."
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -705,6 +705,7 @@
     "col_description": "Description",
     "col_scope": "Scope",
     "col_affected": "Teams hit",
+    "col_scheduled_for": "Scheduled for",
     "col_fired_at": "Fired at",
     "fire_button": "Fire",
     "loading": "Loading disruptions…",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -723,6 +723,14 @@
     "teams_placeholder": "チームを選択",
     "random_label": "母集団のチームを選ぶ (ここからランダムな一部に当たります)",
     "random_description": "選択した数に応じて、 platform がランダムな一部に当てます。",
-    "fired_flash": "「{name}」 を {count} チームに発火しました。"
+    "timing_label": "実行タイミング",
+    "timing_description": "即座に注入するか、 指定した分数後に予約するかを選びます。",
+    "timing_immediate": "即座に実行",
+    "timing_scheduled": "予約 (N 分後)",
+    "after_minutes_label": "何分後に実行するか",
+    "after_minutes_description": "1〜1440 分。 この分数が経過した時点で注入が走ります。",
+    "after_minutes_error": "1〜1440 の整数を入力してください。",
+    "fired_flash": "「{name}」 を {count} チームに発火しました。",
+    "scheduled_flash": "「{name}」 を {minutes} 分後に発火するよう予約しました。"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -705,6 +705,7 @@
     "col_description": "説明",
     "col_scope": "対象範囲",
     "col_affected": "対象チーム数",
+    "col_scheduled_for": "注入予定時刻",
     "col_fired_at": "発火時刻",
     "fire_button": "発火",
     "loading": "障害を読み込み中…",

--- a/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
@@ -4,8 +4,10 @@ import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
 import Modal from "@cloudscape-design/components/modal";
 import Multiselect from "@cloudscape-design/components/multiselect";
+import SegmentedControl from "@cloudscape-design/components/segmented-control";
 import Select from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
@@ -16,6 +18,8 @@ import {
   type DisruptionAuditRow,
   type DisruptionCatalogEntry,
   type DisruptionScope,
+  type DisruptionTiming,
+  type FireDisruptionRequest,
   fetchDisruptionAudit,
   fetchDisruptionCatalog,
   fireDisruption,
@@ -25,12 +29,179 @@ import type { TeamSummary } from "../../api/events-client";
 
 type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
+type TeamOption = { readonly value: string; readonly label: string };
+
 const SCOPE_OPTIONS: readonly DisruptionScope[] = ["all", "team", "random-n"];
 const AUDIT_LIMIT = 20;
+const DEFAULT_AFTER_MINUTES = 30;
+const MAX_AFTER_MINUTES = 1440;
 
 interface FireTarget {
   readonly problemId: string;
   readonly item: DisruptionCatalogEntry["disruption"];
+}
+
+/** Build the fire request from the modal state (pure — keeps the modal flat). */
+function buildFireRequest(
+  target: FireTarget,
+  scope: DisruptionScope,
+  selectedTeamIds: readonly string[],
+  timing: DisruptionTiming,
+  afterMinutes: number,
+): FireDisruptionRequest {
+  return {
+    problemId: target.problemId,
+    disruptionId: target.item.id,
+    scope,
+    ...(scope === "team" ? { targetTeamIds: selectedTeamIds } : {}),
+    ...(scope === "random-n" ? { randomCount: Math.max(selectedTeamIds.length, 1) } : {}),
+    ...(target.item.parameters ? { parameters: target.item.parameters } : {}),
+    ...(timing === "scheduled" ? { timing: "scheduled" as const, afterMinutes } : {}),
+    requestId: newFireRequestId(),
+  };
+}
+
+/**
+ * Fire modal — owns its own form state (scope / timing / minutes), fires once, and reports the
+ * success flash back to the panel. Extracted so the panel stays a thin list + the form is a
+ * cohesive unit ([ADR-037] adds the immediate/scheduled timing toggle here).
+ */
+function FireModal({
+  apiClient,
+  eventId,
+  target,
+  teamOptions,
+  t,
+  onClose,
+  onFired,
+}: {
+  readonly apiClient: ApiClient;
+  readonly eventId: string;
+  readonly target: FireTarget;
+  readonly teamOptions: readonly TeamOption[];
+  readonly t: Translate;
+  readonly onClose: () => void;
+  readonly onFired: (flash: string) => void;
+}) {
+  const [scope, setScope] = useState<DisruptionScope>("all");
+  const [selectedTeamIds, setSelectedTeamIds] = useState<readonly string[]>([]);
+  const [timing, setTiming] = useState<DisruptionTiming>("immediate");
+  const [afterMinutes, setAfterMinutes] = useState<number>(
+    target.item.defaultAfterMinutes ?? DEFAULT_AFTER_MINUTES,
+  );
+  const [firing, setFiring] = useState(false);
+  const [fireError, setFireError] = useState<string | null>(null);
+
+  const scheduleInvalid =
+    timing === "scheduled" &&
+    (!Number.isInteger(afterMinutes) || afterMinutes < 1 || afterMinutes > MAX_AFTER_MINUTES);
+  const fireDisabled =
+    firing || (scope === "team" && selectedTeamIds.length === 0) || scheduleInvalid;
+
+  const confirmFire = async () => {
+    setFiring(true);
+    setFireError(null);
+    try {
+      const result = await fireDisruption(
+        apiClient,
+        eventId,
+        buildFireRequest(target, scope, selectedTeamIds, timing, afterMinutes),
+      );
+      onFired(
+        timing === "scheduled"
+          ? t("disruptions.scheduled_flash", { name: target.item.name, minutes: afterMinutes })
+          : t("disruptions.fired_flash", {
+              name: target.item.name,
+              count: result.affectedTeamIds.length,
+            }),
+      );
+    } catch (err) {
+      setFireError(toErrorMessage(err));
+    } finally {
+      setFiring(false);
+    }
+  };
+
+  const teamPicker = (label: string, description?: string) => (
+    <FormField label={label} description={description}>
+      <Multiselect
+        selectedOptions={teamOptions.filter((o) => selectedTeamIds.includes(o.value))}
+        options={teamOptions}
+        onChange={(e) => setSelectedTeamIds(e.detail.selectedOptions.map((o) => o.value as string))}
+        placeholder={t("disruptions.teams_placeholder")}
+      />
+    </FormField>
+  );
+
+  return (
+    <Modal
+      visible
+      onDismiss={onClose}
+      header={t("disruptions.fire_modal_header", { name: target.item.name })}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={onClose} disabled={firing}>
+              {t("disruptions.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => void confirmFire()}
+              loading={firing}
+              disabled={fireDisabled}
+            >
+              {t("disruptions.confirm_fire")}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <SpaceBetween size="m">
+        {fireError ? <Alert type="error">{fireError}</Alert> : null}
+        <Box color="text-body-secondary">{target.item.description}</Box>
+        <FormField
+          label={t("disruptions.scope_label")}
+          description={t("disruptions.scope_description")}
+        >
+          <Select
+            selectedOption={{ value: scope, label: t(`disruptions.scope_${scope}`) }}
+            options={SCOPE_OPTIONS.map((s) => ({ value: s, label: t(`disruptions.scope_${s}`) }))}
+            onChange={(e) => setScope(e.detail.selectedOption.value as DisruptionScope)}
+          />
+        </FormField>
+        {scope === "team" ? teamPicker(t("disruptions.teams_label")) : null}
+        {scope === "random-n"
+          ? teamPicker(t("disruptions.random_label"), t("disruptions.random_description"))
+          : null}
+        <FormField
+          label={t("disruptions.timing_label")}
+          description={t("disruptions.timing_description")}
+        >
+          <SegmentedControl
+            selectedId={timing}
+            onChange={(e) => setTiming(e.detail.selectedId as DisruptionTiming)}
+            options={[
+              { id: "immediate", text: t("disruptions.timing_immediate") },
+              { id: "scheduled", text: t("disruptions.timing_scheduled") },
+            ]}
+          />
+        </FormField>
+        {timing === "scheduled" ? (
+          <FormField
+            label={t("disruptions.after_minutes_label")}
+            description={t("disruptions.after_minutes_description")}
+            errorText={scheduleInvalid ? t("disruptions.after_minutes_error") : undefined}
+          >
+            <Input
+              type="number"
+              value={String(afterMinutes)}
+              onChange={(e) => setAfterMinutes(Number(e.detail.value))}
+            />
+          </FormField>
+        ) : null}
+      </SpaceBetween>
+    </Modal>
+  );
 }
 
 /**
@@ -55,14 +226,10 @@ export function DisruptionsPanel({
   const [audit, setAudit] = useState<readonly DisruptionAuditRow[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [fireTarget, setFireTarget] = useState<FireTarget | null>(null);
-  const [scope, setScope] = useState<DisruptionScope>("all");
-  const [selectedTeamIds, setSelectedTeamIds] = useState<readonly string[]>([]);
-  const [firing, setFiring] = useState(false);
-  const [fireError, setFireError] = useState<string | null>(null);
   const [lastFired, setLastFired] = useState<string | null>(null);
 
   const reloadAudit = useCallback(async () => {
-    // Only called from confirmFire, which already guarded apiClient — defensive, unreachable.
+    // Only called after a successful fire (apiClient was present) — defensive, unreachable.
     /* v8 ignore next */
     if (!apiClient) return;
     const res = await fetchDisruptionAudit(apiClient, eventId, { limit: AUDIT_LIMIT });
@@ -83,51 +250,16 @@ export function DisruptionsPanel({
       .catch((err) => setLoadError(toErrorMessage(err)));
   }, [apiClient, eventId]);
 
-  const teamOptions = useMemo(
+  const teamOptions = useMemo<readonly TeamOption[]>(
     () => teams.map((tm) => ({ value: tm.teamId, label: tm.displayName || tm.internalSlug })),
     [teams],
   );
 
-  const openFire = (target: FireTarget) => {
-    setFireTarget(target);
-    setScope("all");
-    setSelectedTeamIds([]);
-    setFireError(null);
+  const onFired = (flash: string) => {
+    setLastFired(flash);
+    setFireTarget(null);
+    void reloadAudit();
   };
-
-  const confirmFire = useCallback(async () => {
-    // The confirm button only renders inside the modal (fireTarget set), and the catalog/Fire
-    // buttons only render when apiClient is present — so this guard is defensive, unreachable.
-    /* v8 ignore next */
-    if (!apiClient || !fireTarget) return;
-    setFiring(true);
-    setFireError(null);
-    try {
-      const result = await fireDisruption(apiClient, eventId, {
-        problemId: fireTarget.problemId,
-        disruptionId: fireTarget.item.id,
-        scope,
-        ...(scope === "team" ? { targetTeamIds: selectedTeamIds } : {}),
-        ...(scope === "random-n" ? { randomCount: Math.max(selectedTeamIds.length, 1) } : {}),
-        ...(fireTarget.item.parameters ? { parameters: fireTarget.item.parameters } : {}),
-        requestId: newFireRequestId(),
-      });
-      setLastFired(
-        t("disruptions.fired_flash", {
-          name: fireTarget.item.name,
-          count: result.affectedTeamIds.length,
-        }),
-      );
-      setFireTarget(null);
-      await reloadAudit();
-    } catch (err) {
-      setFireError(toErrorMessage(err));
-    } finally {
-      setFiring(false);
-    }
-  }, [apiClient, eventId, fireTarget, scope, selectedTeamIds, reloadAudit, t]);
-
-  const fireDisabled = firing || (scope === "team" && selectedTeamIds.length === 0);
 
   return (
     <Container
@@ -170,7 +302,7 @@ export function DisruptionsPanel({
               cell: (e: DisruptionCatalogEntry) => (
                 <Button
                   variant="inline-link"
-                  onClick={() => openFire({ problemId: e.problemId, item: e.disruption })}
+                  onClick={() => setFireTarget({ problemId: e.problemId, item: e.disruption })}
                 >
                   {t("disruptions.fire_button")}
                 </Button>
@@ -213,74 +345,17 @@ export function DisruptionsPanel({
         />
       </SpaceBetween>
 
-      {fireTarget ? (
-        <Modal
-          visible
-          onDismiss={() => setFireTarget(null)}
-          header={t("disruptions.fire_modal_header", { name: fireTarget.item.name })}
-          footer={
-            <Box float="right">
-              <SpaceBetween direction="horizontal" size="xs">
-                <Button onClick={() => setFireTarget(null)} disabled={firing}>
-                  {t("disruptions.cancel")}
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={() => void confirmFire()}
-                  loading={firing}
-                  disabled={fireDisabled}
-                >
-                  {t("disruptions.confirm_fire")}
-                </Button>
-              </SpaceBetween>
-            </Box>
-          }
-        >
-          <SpaceBetween size="m">
-            {fireError ? <Alert type="error">{fireError}</Alert> : null}
-            <Box color="text-body-secondary">{fireTarget.item.description}</Box>
-            <FormField
-              label={t("disruptions.scope_label")}
-              description={t("disruptions.scope_description")}
-            >
-              <Select
-                selectedOption={{ value: scope, label: t(`disruptions.scope_${scope}`) }}
-                options={SCOPE_OPTIONS.map((s) => ({
-                  value: s,
-                  label: t(`disruptions.scope_${s}`),
-                }))}
-                onChange={(e) => setScope(e.detail.selectedOption.value as DisruptionScope)}
-              />
-            </FormField>
-            {scope === "team" ? (
-              <FormField label={t("disruptions.teams_label")}>
-                <Multiselect
-                  selectedOptions={teamOptions.filter((o) => selectedTeamIds.includes(o.value))}
-                  options={teamOptions}
-                  onChange={(e) =>
-                    setSelectedTeamIds(e.detail.selectedOptions.map((o) => o.value as string))
-                  }
-                  placeholder={t("disruptions.teams_placeholder")}
-                />
-              </FormField>
-            ) : null}
-            {scope === "random-n" ? (
-              <FormField
-                label={t("disruptions.random_label")}
-                description={t("disruptions.random_description")}
-              >
-                <Multiselect
-                  selectedOptions={teamOptions.filter((o) => selectedTeamIds.includes(o.value))}
-                  options={teamOptions}
-                  onChange={(e) =>
-                    setSelectedTeamIds(e.detail.selectedOptions.map((o) => o.value as string))
-                  }
-                  placeholder={t("disruptions.teams_placeholder")}
-                />
-              </FormField>
-            ) : null}
-          </SpaceBetween>
-        </Modal>
+      {fireTarget && apiClient ? (
+        <FireModal
+          key={`${fireTarget.problemId}:${fireTarget.item.id}`}
+          apiClient={apiClient}
+          eventId={eventId}
+          target={fireTarget}
+          teamOptions={teamOptions}
+          t={t}
+          onClose={() => setFireTarget(null)}
+          onFired={onFired}
+        />
       ) : null}
     </Container>
   );

--- a/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
@@ -339,6 +339,12 @@ export function DisruptionsPanel({
               header: t("disruptions.col_affected"),
               cell: (r: DisruptionAuditRow) => String(r.targetTeamIds.length),
             },
+            {
+              // [ADR-037] scheduled fire の注入予定時刻 (即時 fire は "-")。
+              id: "scheduledFor",
+              header: t("disruptions.col_scheduled_for"),
+              cell: (r: DisruptionAuditRow) => r.scheduledFor ?? "-",
+            },
           ]}
           items={audit}
           empty={<Box textAlign="center">{t("disruptions.audit_empty")}</Box>}

--- a/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
+++ b/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
@@ -270,7 +270,7 @@ describe("DisruptionsPanel", () => {
     expect(mockCatalog).toHaveBeenCalledWith(fakeApi, "EVT1");
   });
 
-  it("should render audit rows when present", async () => {
+  it("should render audit rows, showing scheduledFor for scheduled fires and '-' for immediate", async () => {
     mockAudit.mockResolvedValue({
       items: [
         {
@@ -284,9 +284,24 @@ describe("DisruptionsPanel", () => {
           parameters: {},
           requestId: "r1",
         },
+        {
+          auditId: "a2",
+          problemId: "p",
+          disruptionId: "availability-flood",
+          firedBy: "op",
+          firedAt: "2026-06-03T00:05:00Z",
+          scope: "all",
+          targetTeamIds: ["t1"],
+          parameters: {},
+          requestId: "r2",
+          scheduledFor: "2026-06-03T00:35:00Z", // [ADR-037] scheduled fire
+        },
       ],
     });
     renderPanel();
     expect(await screen.findByText("2026-06-03T00:00:00Z")).toBeInTheDocument();
+    // [ADR-037] scheduled row shows its injection time; immediate row shows "-"
+    expect(await screen.findByText("2026-06-03T00:35:00Z")).toBeInTheDocument();
+    expect(screen.getByText("disruptions.col_scheduled_for")).toBeInTheDocument();
   });
 });

--- a/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
+++ b/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
@@ -176,6 +176,71 @@ describe("DisruptionsPanel", () => {
     await waitFor(() => expect(createWrapper(document.body).findModal()).toBeNull());
   });
 
+  it("[ADR-037] should fire immediately (no timing/afterMinutes) by default", async () => {
+    renderPanel();
+    fireEvent.click(await screen.findByText("disruptions.fire_button"));
+    fireEvent.click(screen.getByText("disruptions.confirm_fire"));
+    await waitFor(() => {
+      const arg = mockFire.mock.calls[0]?.[2];
+      expect(arg).not.toHaveProperty("timing");
+      expect(arg).not.toHaveProperty("afterMinutes");
+    });
+  });
+
+  it("[ADR-037] should fire with timing=scheduled + afterMinutes when scheduled", async () => {
+    renderPanel();
+    fireEvent.click(await screen.findByText("disruptions.fire_button"));
+    // switch the timing segmented control to "scheduled" (2nd segment)
+    modal()?.findContent().findSegmentedControl()?.findSegments()[1]?.click();
+    // set the minutes input
+    modal()?.findContent().findInput()?.setInputValue("45");
+    fireEvent.click(screen.getByText("disruptions.confirm_fire"));
+    await waitFor(() =>
+      expect(mockFire).toHaveBeenCalledWith(
+        fakeApi,
+        "EVT1",
+        expect.objectContaining({ timing: "scheduled", afterMinutes: 45 }),
+      ),
+    );
+    expect(await screen.findByText(/disruptions.scheduled_flash/)).toBeInTheDocument();
+  });
+
+  it("[ADR-037] should pre-fill the scheduled minutes from the declared defaultAfterMinutes", async () => {
+    mockCatalog.mockResolvedValue({
+      entries: [
+        {
+          problemId: "p",
+          disruption: {
+            id: "d",
+            name: "Latency",
+            description: "x",
+            eventDetailType: "E",
+            defaultAfterMinutes: 60,
+          },
+        },
+      ],
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByText("disruptions.fire_button"));
+    modal()?.findContent().findSegmentedControl()?.findSegments()[1]?.click();
+    fireEvent.click(screen.getByText("disruptions.confirm_fire"));
+    await waitFor(() =>
+      expect(mockFire).toHaveBeenCalledWith(
+        fakeApi,
+        "EVT1",
+        expect.objectContaining({ timing: "scheduled", afterMinutes: 60 }),
+      ),
+    );
+  });
+
+  it("[ADR-037] should disable confirm when the scheduled minutes are out of range", async () => {
+    renderPanel();
+    fireEvent.click(await screen.findByText("disruptions.fire_button"));
+    modal()?.findContent().findSegmentedControl()?.findSegments()[1]?.click();
+    modal()?.findContent().findInput()?.setInputValue("0");
+    expect(screen.getByText("disruptions.confirm_fire").closest("button")).toBeDisabled();
+  });
+
   it("should fire a disruption that declares no parameters", async () => {
     mockCatalog.mockResolvedValue({
       entries: [

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -37,6 +37,11 @@ export interface DisruptionFiredDetail {
   readonly parameters: Readonly<Record<string, unknown>>;
   readonly requestId: string;
   readonly firedAt: string;
+  /**
+   * [ADR-037] scheduled fire の遅延分。 未指定 / 0 は即時注入。 1 以上なら executor が
+   * `afterMinutes` 分後に注入を遅延予約する (= mode:"inject" で自分を呼び戻す)。
+   */
+  readonly afterMinutes?: number;
 }
 
 /** 注入対象 team deployment の解決結果。 */
@@ -71,6 +76,11 @@ export interface ExecutorDeps {
     target: DeploymentTarget,
     afterSeconds: number,
   ) => Promise<void>;
+  /**
+   * [ADR-037] scheduled fire の遅延注入を `afterMinutes` 分後に予約する。 scheduler 機構は
+   * 具体実装側 (= scheduleRevert と同じ aws-scheduler one-shot を転用、 payload は mode:"inject")。
+   */
+  readonly scheduleInject: (detail: DisruptionFiredDetail, afterMinutes: number) => Promise<void>;
 }
 
 export type DisruptionExecuteOutcome =
@@ -78,7 +88,8 @@ export type DisruptionExecuteOutcome =
   | { readonly kind: "no_action" }
   | { readonly kind: "duplicate" }
   | { readonly kind: "unknown_disruption" }
-  | { readonly kind: "no_deployment" };
+  | { readonly kind: "no_deployment" }
+  | { readonly kind: "scheduled" };
 
 function resolveAction(
   catalog: ExecutorDeps["problemsDisruptions"],
@@ -93,21 +104,14 @@ function resolveAction(
 }
 
 /**
- * 1 件の fired disruption を実行する。 副作用は deps 経由のみ。 戻り値で結果を表す
- * (= caller の handler が log / metric に使う)。
+ * deployment を解決し、 inject dispatch を送って revert を予約する (= 即時注入の本体)。
+ * 即時 fire と scheduled fire の T+N 遅延注入で共有する (= claim 有無のみが両者の違い)。
  */
-export async function executeDisruptionAction(
+async function injectAndScheduleRevert(
   detail: DisruptionFiredDetail,
+  action: DisruptionAction,
   deps: ExecutorDeps,
 ): Promise<DisruptionExecuteOutcome> {
-  const action = resolveAction(deps.problemsDisruptions, detail.problemId, detail.disruptionId);
-  if (action === "unknown") return { kind: "unknown_disruption" };
-  // action 未宣言 = Phase A 監査のみ。 注入は起こさない (= 後方互換)。
-  if (!action) return { kind: "no_action" };
-
-  // EventBridge at-least-once の再配送を per-team 冪等で弾く。 claim は注入の前に取る。
-  if ((await deps.claimExecution(detail)) === "duplicate") return { kind: "duplicate" };
-
   const target = await deps.resolveDeployment(detail);
   if (!target) return { kind: "no_deployment" };
 
@@ -119,4 +123,48 @@ export async function executeDisruptionAction(
   await deps.scheduleRevert(detail, revert, target, action.revert.afterSeconds);
 
   return { kind: "ok", jobId: target.jobId };
+}
+
+/**
+ * 1 件の fired disruption を実行する。 副作用は deps 経由のみ。 戻り値で結果を表す
+ * (= caller の handler が log / metric に使う)。
+ *
+ * [ADR-037] `afterMinutes > 0` の scheduled fire は、 claim を取った上で注入を T+N に遅延予約し
+ * `scheduled` を返す (= 注入本体は T+N の {@link executeScheduledInject} で走る)。 claim は fired
+ * event 受信時に取るので、 EventBridge at-least-once の再配送は遅延予約より前に弾かれる。
+ */
+export async function executeDisruptionAction(
+  detail: DisruptionFiredDetail,
+  deps: ExecutorDeps,
+): Promise<DisruptionExecuteOutcome> {
+  const action = resolveAction(deps.problemsDisruptions, detail.problemId, detail.disruptionId);
+  if (action === "unknown") return { kind: "unknown_disruption" };
+  // action 未宣言 = Phase A 監査のみ。 注入は起こさない (= 後方互換)。
+  if (!action) return { kind: "no_action" };
+
+  // EventBridge at-least-once の再配送を per-team 冪等で弾く。 claim は注入 / 遅延予約の前に取る。
+  if ((await deps.claimExecution(detail)) === "duplicate") return { kind: "duplicate" };
+
+  // afterMinutes は route で 1..1440 に validate 済 (= 未指定 / 0 は即時)。 正値なら遅延予約。
+  if (detail.afterMinutes) {
+    await deps.scheduleInject(detail, detail.afterMinutes);
+    return { kind: "scheduled" };
+  }
+
+  return injectAndScheduleRevert(detail, action, deps);
+}
+
+/**
+ * [ADR-037] scheduled fire の T+N 遅延注入。 scheduler が積んだ `mode:"inject"` payload で起動され、
+ * 注入 + revert 予約を行う。 claim は fired event 受信時 ({@link executeDisruptionAction}) に取得済の
+ * ため再取得しない (= 二重 claim で duplicate 判定にならない)。
+ */
+export async function executeScheduledInject(
+  detail: DisruptionFiredDetail,
+  deps: ExecutorDeps,
+): Promise<DisruptionExecuteOutcome> {
+  const action = resolveAction(deps.problemsDisruptions, detail.problemId, detail.disruptionId);
+  if (action === "unknown") return { kind: "unknown_disruption" };
+  if (!action) return { kind: "no_action" };
+  return injectAndScheduleRevert(detail, action, deps);
 }

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -57,8 +57,14 @@ export interface DeploymentTarget {
 export interface ExecutorDeps {
   /** problemsDisruptions catalog (= fire と同じ env 由来)。 */
   readonly problemsDisruptions: Readonly<Record<string, readonly ProblemDisruptionEntry[]>>;
-  /** `EXEC#{requestId}#{teamId}` の conditional claim。 claimed=winner / duplicate=既処理。 */
-  readonly claimExecution: (detail: DisruptionFiredDetail) => Promise<"claimed" | "duplicate">;
+  /**
+   * `EXEC#{requestId}#{teamId}` の conditional claim。 claimed=winner / duplicate=既処理。
+   * [ADR-037] phase="inject" は遅延注入用の別 claim key (= scheduler 再配送の二重注入を弾く)。
+   */
+  readonly claimExecution: (
+    detail: DisruptionFiredDetail,
+    phase?: "event" | "inject",
+  ) => Promise<"claimed" | "duplicate">;
   /** team+problem deployment を解決。 未 deploy / 未完了 / stackOutputs 無しは undefined。 */
   readonly resolveDeployment: (
     detail: DisruptionFiredDetail,
@@ -155,9 +161,10 @@ export async function executeDisruptionAction(
 }
 
 /**
- * [ADR-037] scheduled fire の T+N 遅延注入。 scheduler が積んだ `mode:"inject"` payload で起動され、
- * 注入 + revert 予約を行う。 claim は fired event 受信時 ({@link executeDisruptionAction}) に取得済の
- * ため再取得しない (= 二重 claim で duplicate 判定にならない)。
+ * [ADR-037] scheduled fire の T+N 遅延注入。 scheduler が積んだ `mode:"inject"` payload で起動される。
+ * aws-scheduler も at-least-once なので、 注入直前に **inject-phase の claim** を取り、 scheduler の
+ * 再配送による二重注入を弾く (= 即時 path が同一 invocation の event-phase claim で得るのと同じ冪等保証を、
+ * fired event と別経路で届く遅延注入にも与える)。 fired event 時の event-phase claim とは別 key。
  */
 export async function executeScheduledInject(
   detail: DisruptionFiredDetail,
@@ -166,5 +173,6 @@ export async function executeScheduledInject(
   const action = resolveAction(deps.problemsDisruptions, detail.problemId, detail.disruptionId);
   if (action === "unknown") return { kind: "unknown_disruption" };
   if (!action) return { kind: "no_action" };
+  if ((await deps.claimExecution(detail, "inject")) === "duplicate") return { kind: "duplicate" };
   return injectAndScheduleRevert(detail, action, deps);
 }

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
@@ -26,15 +26,24 @@ export interface ExecutorResources {
 const DEFAULT_EXEC_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 /**
- * `EXEC#{requestId}#{teamId}` を conditional Put で奪う。 EventBridge at-least-once の再配送に対する
- * per-team 冪等性。 ConditionalCheckFailed = 既に処理済 (duplicate)、 それ以外の error は伝播。
+ * `EXEC#{requestId}#{teamId}` を conditional Put で奪う。 at-least-once 配送に対する per-team 冪等性。
+ * ConditionalCheckFailed = 既に処理済 (duplicate)、 それ以外の error は伝播。
+ *
+ * [ADR-037] phase で claim key を分ける:
+ *   - `"event"` (既定): fired event (EventBridge at-least-once) の重複を弾く。
+ *   - `"inject"`: scheduled fire の遅延注入 (aws-scheduler at-least-once) の重複を弾く。 遅延注入は
+ *     fired event とは別の配送経路なので、 別 key で claim しないと scheduler 再配送で二重注入になる。
  */
 export async function claimExecution(
   resources: ExecutorResources,
   detail: DisruptionFiredDetail,
   nowMs: number,
+  phase: "event" | "inject" = "event",
 ): Promise<"claimed" | "duplicate"> {
-  const pk = `EXEC#${detail.requestId}#${detail.teamId}`;
+  const pk =
+    phase === "inject"
+      ? `EXEC#${detail.requestId}#${detail.teamId}#INJECT`
+      : `EXEC#${detail.requestId}#${detail.teamId}`;
   try {
     await resources.ddb.send(
       new PutCommand({

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
@@ -89,7 +89,7 @@ function sdkClientConfig(target: DispatchTarget) {
 
 const deps: ExecutorDeps = {
   problemsDisruptions,
-  claimExecution: (detail) => claimExecution(resources, detail, Date.now()),
+  claimExecution: (detail, phase) => claimExecution(resources, detail, Date.now(), phase),
   resolveDeployment: (detail) => resolveDeployment(resources, detail),
   sendDispatch: wiredSendDispatch,
   scheduleRevert: (detail, dispatch, target, afterSeconds) =>

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/index.ts
@@ -25,7 +25,7 @@ import { logDeployTrace } from "../shared/trace-log.js";
 import type { DeploymentTarget, ExecutorDeps } from "./execute.js";
 import { claimExecution, type ExecutorResources, resolveDeployment } from "./executor-store.js";
 import { type RouteOutcome, routeDisruptionInvocation } from "./route.js";
-import { scheduleRevert } from "./schedule-revert.js";
+import { scheduleInject, scheduleRevert } from "./schedule-revert.js";
 import { type DispatchTarget, sendDispatch } from "./send-dispatch.js";
 
 const SESSION_NAME_PREFIX = "tc-disruption-";
@@ -98,6 +98,8 @@ const deps: ExecutorDeps = {
       schedulerRoleArn,
       revertTargetArn,
     }),
+  scheduleInject: (detail, afterMinutes) =>
+    scheduleInject(detail, afterMinutes, { scheduler, schedulerRoleArn, revertTargetArn }),
 };
 
 /** Lambda handler。 inject / revert を route が判別し dispatch する。 outcome は observability の trace に出す。 */

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/route.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/route.ts
@@ -1,11 +1,13 @@
 /**
  * [ADR-031 / Issue #1419] executor Lambda の invocation router (= handler entry の純粋ロジック)。
  *
- * 同じ executor Lambda が 2 経路で起動される:
+ * 同じ executor Lambda が 3 経路で起動される:
  *   1. EventBridge `*DisruptionFired` rule → `{ ..., detail: DisruptionFiredDetail }` envelope (= 注入)
  *   2. aws-scheduler の one-shot → `{ mode: "revert", dispatch, target }` payload (= 復旧、 scheduleRevert が積む)
+ *   3. aws-scheduler の one-shot → `{ mode: "inject", detail }` payload (= [ADR-037] scheduled fire の T+N 遅延注入、 scheduleInject が積む)
  *
- * router は両者を判別し、 注入は `executeDisruptionAction`、 復旧は `sendDispatch` dep をそのまま再利用する
+ * router は 3 者を判別する。 注入 (1) は `executeDisruptionAction` (claim 込)、 遅延注入 (3) は
+ * `executeScheduledInject` (claim 済なので再取得しない)、 復旧 (2) は `sendDispatch` dep を再利用する
  * (= revert の credentials は wired sendDispatch dep が target から都度 AssumeRole する前提なので、 inject と
  * 同じ dep で送れる)。 不正 envelope は `invalid_event` (= loud に落とさず handler が log/metric にできる形)。
  *
@@ -20,12 +22,18 @@ import {
   type DisruptionFiredDetail,
   type ExecutorDeps,
   executeDisruptionAction,
+  executeScheduledInject,
 } from "./execute.js";
 
 interface RevertInvocation {
   readonly mode: "revert";
   readonly dispatch: DisruptionDispatch;
   readonly target: DeploymentTarget;
+}
+
+interface InjectInvocation {
+  readonly mode: "inject";
+  readonly detail: Record<string, unknown>;
 }
 
 export type RouteOutcome =
@@ -55,6 +63,11 @@ export function parseDisruptionFiredDetail(event: unknown): DisruptionFiredDetai
   if (!disruptionId || !eventId || !problemId || !tenantId || !teamId || !requestId || !firedAt) {
     return undefined;
   }
+  // [ADR-037] scheduled fire の遅延分。 正の有限数だけ採用 (= それ以外は即時注入扱い)。
+  const afterMinutes =
+    typeof d.afterMinutes === "number" && Number.isFinite(d.afterMinutes) && d.afterMinutes > 0
+      ? d.afterMinutes
+      : undefined;
   return {
     disruptionId,
     eventId,
@@ -64,6 +77,7 @@ export function parseDisruptionFiredDetail(event: unknown): DisruptionFiredDetai
     requestId,
     firedAt,
     parameters: isObject(d.parameters) ? d.parameters : {},
+    ...(afterMinutes !== undefined ? { afterMinutes } : {}),
   };
 }
 
@@ -71,6 +85,10 @@ function isRevertInvocation(event: unknown): event is RevertInvocation {
   return (
     isObject(event) && event.mode === "revert" && isObject(event.dispatch) && isObject(event.target)
   );
+}
+
+function isInjectInvocation(event: unknown): event is InjectInvocation {
+  return isObject(event) && event.mode === "inject" && isObject(event.detail);
 }
 
 /** executor Lambda の 1 invocation を inject / revert に振り分けて実行する。 */
@@ -83,6 +101,13 @@ export async function routeDisruptionInvocation(
     // (= dep が target から都度 AssumeRole する。 注入時 creds は永続しない)。
     await deps.sendDispatch(event.dispatch, event.target);
     return { kind: "reverted" };
+  }
+  if (isInjectInvocation(event)) {
+    // [ADR-037] scheduled fire の T+N 遅延注入: scheduleInject が積んだ {mode:"inject", detail} を
+    // 注入本体 (claim 済) として実行する。 detail の narrow は fired event と同じ parser を再利用。
+    const detail = parseDisruptionFiredDetail(event);
+    if (!detail) return { kind: "invalid_event" };
+    return executeScheduledInject(detail, deps);
   }
   const detail = parseDisruptionFiredDetail(event);
   if (!detail) return { kind: "invalid_event" };

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/schedule-revert.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/schedule-revert.ts
@@ -28,23 +28,64 @@ export interface ScheduleRevertDeps {
   readonly scheduler: Pick<SchedulerClient, "send">;
   /** schedule が target を起動するために assume する role の ARN (= construct が作成、 env 注入)。 */
   readonly schedulerRoleArn: string;
-  /** revert を実行する target (= executor Lambda 自身) の ARN。 */
+  /** schedule が呼び戻す target (= executor Lambda 自身) の ARN。 revert / inject 共通。 */
   readonly revertTargetArn: string;
 }
 
 const MAX_SCHEDULE_NAME = 64;
 
+function sanitizeScheduleName(raw: string): string {
+  return raw.replace(/[^0-9A-Za-z\-_.]/g, "-").slice(0, MAX_SCHEDULE_NAME);
+}
+
 /** `EXEC#{requestId}#{teamId}` と対の冪等な schedule 名。 aws-scheduler の name 制約に sanitize。 */
 export function revertScheduleName(detail: DisruptionFiredDetail): string {
-  return `tc-revert-${detail.requestId}-${detail.teamId}`
-    .replace(/[^0-9A-Za-z\-_.]/g, "-")
-    .slice(0, MAX_SCHEDULE_NAME);
+  return sanitizeScheduleName(`tc-revert-${detail.requestId}-${detail.teamId}`);
+}
+
+/** [ADR-037] scheduled fire の遅延注入 schedule 名。 revert と対の冪等キー (requestId/teamId)。 */
+export function injectScheduleName(detail: DisruptionFiredDetail): string {
+  return sanitizeScheduleName(`tc-inject-${detail.requestId}-${detail.teamId}`);
+}
+
+/** base 時刻 + afterSeconds の UTC を ISO と aws-scheduler の `at(...)` 式 (秒精度) で返す。 */
+function oneShotAt(baseIso: string, afterSeconds: number): { iso: string; expression: string } {
+  const at = new Date(new Date(baseIso).getTime() + afterSeconds * 1000);
+  const iso = at.toISOString();
+  return { iso, expression: `at(${iso.slice(0, 19)})` };
 }
 
 /** firedAt + afterSeconds の UTC 時刻を aws-scheduler の `at(...)` 式 (秒精度) に。 */
 export function revertAtExpression(firedAtIso: string, afterSeconds: number): string {
-  const at = new Date(new Date(firedAtIso).getTime() + afterSeconds * 1000);
-  return `at(${at.toISOString().slice(0, 19)})`;
+  return oneShotAt(firedAtIso, afterSeconds).expression;
+}
+
+/**
+ * executor 自身を呼び戻す one-shot schedule を 1 件登録する (= revert / inject 共通)。
+ * FlexibleTimeWindow=OFF / ActionAfterCompletion=DELETE (= 発火後に自動削除、 schedule が溜まらない)。
+ * SDK error は握り潰さず伝播 (= 予約失敗を loud にする。 INV-2 を黙って破らない)。
+ */
+function sendOneShot(
+  deps: ScheduleRevertDeps,
+  name: string,
+  expression: string,
+  input: Readonly<Record<string, unknown>>,
+): Promise<unknown> {
+  return deps.scheduler.send(
+    new CreateScheduleCommand({
+      Name: name,
+      ScheduleExpression: expression,
+      ScheduleExpressionTimezone: "UTC",
+      FlexibleTimeWindow: { Mode: FlexibleTimeWindowMode.OFF },
+      State: ScheduleState.ENABLED,
+      ActionAfterCompletion: ActionAfterCompletion.DELETE,
+      Target: {
+        Arn: deps.revertTargetArn,
+        RoleArn: deps.schedulerRoleArn,
+        Input: JSON.stringify(input),
+      },
+    }),
+  );
 }
 
 export async function scheduleRevert(
@@ -54,19 +95,34 @@ export async function scheduleRevert(
   afterSeconds: number,
   deps: ScheduleRevertDeps,
 ): Promise<void> {
-  await deps.scheduler.send(
-    new CreateScheduleCommand({
-      Name: revertScheduleName(detail),
-      ScheduleExpression: revertAtExpression(detail.firedAt, afterSeconds),
-      ScheduleExpressionTimezone: "UTC",
-      FlexibleTimeWindow: { Mode: FlexibleTimeWindowMode.OFF },
-      State: ScheduleState.ENABLED,
-      ActionAfterCompletion: ActionAfterCompletion.DELETE,
-      Target: {
-        Arn: deps.revertTargetArn,
-        RoleArn: deps.schedulerRoleArn,
-        Input: JSON.stringify({ mode: "revert", detail, dispatch: revert, target }),
-      },
-    }),
+  await sendOneShot(
+    deps,
+    revertScheduleName(detail),
+    revertAtExpression(detail.firedAt, afterSeconds),
+    {
+      mode: "revert",
+      detail,
+      dispatch: revert,
+      target,
+    },
   );
+}
+
+/**
+ * [ADR-037] scheduled fire: 注入を `afterMinutes` 分後に予約する。 schedule は executor を
+ * `{mode:"inject", detail}` payload で呼び戻す。 payload の `detail.firedAt` は注入予定時刻に
+ * 進め、 `afterMinutes` は落とす (= T+N の revert が注入時刻基準になる / 再遅延しない)。
+ */
+export async function scheduleInject(
+  detail: DisruptionFiredDetail,
+  afterMinutes: number,
+  deps: ScheduleRevertDeps,
+): Promise<void> {
+  const { iso, expression } = oneShotAt(detail.firedAt, afterMinutes * 60);
+  const { afterMinutes: _drop, ...rest } = detail;
+  const injectDetail: DisruptionFiredDetail = { ...rest, firedAt: iso };
+  await sendOneShot(deps, injectScheduleName(detail), expression, {
+    mode: "inject",
+    detail: injectDetail,
+  });
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-fire.ts
@@ -204,6 +204,11 @@ export async function fireDisruption(
   const auditId = ulid();
   const firedAt = new Date(input.nowMs).toISOString();
   const expiresAt = Math.floor(input.nowMs / 1000) + AUDIT_TTL_SECONDS;
+  // [ADR-037] scheduled fire: 実際の注入予定時刻を audit に残す (= 「N 分後に予約」 を可視化)。
+  // afterMinutes は route で 1..1440 に validate 済 (= 未指定 / 0 は即時 fire)。
+  const scheduledFor = input.afterMinutes
+    ? new Date(input.nowMs + input.afterMinutes * 60_000).toISOString()
+    : undefined;
   const draft: DisruptionAuditRow = {
     auditId,
     tenantId: input.tenantId,
@@ -217,6 +222,7 @@ export async function fireDisruption(
     parameters: mergedParameters,
     requestId: input.requestId,
     expiresAt,
+    ...(scheduledFor ? { scheduledFor } : {}),
   };
 
   // 4. Idempotency claim (= publish 前に排他を取る、 race-safe な順序)
@@ -310,6 +316,8 @@ async function publishEntries(
       parameters: mergedParameters,
       requestId: input.requestId,
       firedAt,
+      // [ADR-037] scheduled fire: executor がこの分数だけ注入を遅延予約する。 即時は省略。
+      ...(input.afterMinutes ? { afterMinutes: input.afterMinutes } : {}),
     }),
   }));
   const BATCH = 10;

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/disruption-types.ts
@@ -26,6 +26,11 @@ export interface DisruptionFireInput {
   readonly firedBy: string;
   /** 現在時刻 (ms)。 test で差し替え可能にする。 */
   readonly nowMs: number;
+  /**
+   * [ADR-037] scheduled fire の遅延分。 未指定 / 0 は即時注入 (= 従来)。 1 以上で
+   * executor が `afterMinutes` 分後に注入を予約する (= published Detail に乗せて executor へ渡す)。
+   */
+  readonly afterMinutes?: number;
 }
 
 export interface DisruptionFireResult {
@@ -56,6 +61,11 @@ export interface DisruptionAuditRow {
   readonly parameters: Readonly<Record<string, unknown>>;
   readonly requestId: string;
   readonly expiresAt: number;
+  /**
+   * [ADR-037] scheduled fire で注入が実行される予定時刻 (ISO8601, UTC)。 immediate fire では
+   * 未設定 (= firedAt と同時)。 audit 表示で 「N 分後に予約」 を可視化するために持つ。
+   */
+  readonly scheduledFor?: string;
 }
 
 export interface DisruptionCatalogEntry extends ProblemDisruptionEntry {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/disruptions.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/disruptions.ts
@@ -114,6 +114,8 @@ export function registerDisruptionRoutes(app: Hono, shared: EventSharedResources
             scope: req.scope,
             targetTeamIds: req.targetTeamIds ?? [],
             ...(req.randomCount !== undefined ? { randomCount: req.randomCount } : {}),
+            // schema は afterMinutes を timing=scheduled の時のみ許す (= 存在 = scheduled)。
+            ...(req.afterMinutes !== undefined ? { afterMinutes: req.afterMinutes } : {}),
             requestId: req.requestId,
             firedBy: resolveCognitoSub(c),
             nowMs: Date.now(),

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -374,8 +374,23 @@ export const DisruptionFireRequestSchema = z
     targetTeamIds: z.array(z.string().min(1).max(128)).max(200).optional(),
     randomCount: z.number().int().finite().min(1).max(200).optional(),
     requestId: z.string().min(8).max(128),
+    /**
+     * [ADR-037] 発火の timing。 `immediate` (既定) は従来どおり即注入、 `scheduled` は
+     * operator が `afterMinutes` 分後に注入を予約する (= executor が自分の aws-scheduler で遅延)。
+     */
+    timing: z.enum(["immediate", "scheduled"]).default("immediate"),
+    /** scheduled のみ必須。 1〜1440 分 (= 最長 24h)。 finite + integer で NaN / 小数を reject。 */
+    afterMinutes: z.number().int().finite().min(1).max(1440).optional(),
   })
   .strict()
+  .refine((v) => v.timing !== "scheduled" || v.afterMinutes !== undefined, {
+    message: "afterMinutes is required when timing is 'scheduled'",
+    path: ["afterMinutes"],
+  })
+  .refine((v) => v.timing === "scheduled" || v.afterMinutes === undefined, {
+    message: "afterMinutes is only valid when timing is 'scheduled'",
+    path: ["afterMinutes"],
+  })
   .refine((v) => v.scope !== "team" || (v.targetTeamIds && v.targetTeamIds.length > 0), {
     message: "targetTeamIds is required when scope is 'team'",
     path: ["targetTeamIds"],

--- a/infrastructure/test/problem-deploy/disruption-execute.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-execute.test.ts
@@ -171,13 +171,21 @@ describe("executeDisruptionAction (ADR-031 #1419)", () => {
 describe("executeScheduledInject (ADR-037 deferred inject)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("should inject + schedule revert WITHOUT re-claiming (claim taken at fire time)", async () => {
+  it("should claim the inject phase, then inject + schedule revert", async () => {
     const deps = makeDeps();
     const outcome = await executeScheduledInject(detail, deps);
     expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
-    expect(deps.claimExecution).not.toHaveBeenCalled(); // already claimed at fired-event time
+    // inject-phase claim (distinct from the fire-time event claim) fences scheduler redelivery
+    expect(deps.claimExecution).toHaveBeenCalledWith(detail, "inject");
     expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
     expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop (duplicate) when the inject phase was already claimed (scheduler redelivery)", async () => {
+    const deps = makeDeps({ claimExecution: vi.fn().mockResolvedValue("duplicate") });
+    expect(await executeScheduledInject(detail, deps)).toEqual({ kind: "duplicate" });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
   });
 
   it("should be a no-op (no_action) when the disruption declares no action", async () => {

--- a/infrastructure/test/problem-deploy/disruption-execute.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-execute.test.ts
@@ -4,6 +4,7 @@ import {
   type DisruptionFiredDetail,
   type ExecutorDeps,
   executeDisruptionAction,
+  executeScheduledInject,
 } from "../../lib/problem-deploy/handlers/disruption-executor-handler/execute";
 import type { ProblemDisruptionEntry } from "../../lib/utils/discover-problems-catalog";
 
@@ -55,6 +56,7 @@ function makeDeps(over: Partial<ExecutorDeps> = {}): ExecutorDeps {
     resolveDeployment: vi.fn().mockResolvedValue(target),
     sendDispatch: vi.fn().mockResolvedValue(undefined),
     scheduleRevert: vi.fn().mockResolvedValue(undefined),
+    scheduleInject: vi.fn().mockResolvedValue(undefined),
     ...over,
   };
 }
@@ -131,5 +133,71 @@ describe("executeDisruptionAction (ADR-031 #1419)", () => {
     });
     await expect(executeDisruptionAction(detail, deps)).rejects.toThrow("SendCommand denied");
     expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  // [ADR-037] scheduled fire
+  it("should defer the inject (schedule it) when afterMinutes > 0, after claiming", async () => {
+    const deps = makeDeps();
+    const scheduled: DisruptionFiredDetail = { ...detail, afterMinutes: 30 };
+    const outcome = await executeDisruptionAction(scheduled, deps);
+    expect(outcome).toEqual({ kind: "scheduled" });
+    // claim is taken first (dedupes EventBridge redelivery before scheduling)
+    expect(deps.claimExecution).toHaveBeenCalledTimes(1);
+    expect(deps.scheduleInject).toHaveBeenCalledTimes(1);
+    expect(deps.scheduleInject).toHaveBeenCalledWith(scheduled, 30);
+    // the inject itself does NOT run now
+    expect(deps.resolveDeployment).not.toHaveBeenCalled();
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+    expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  it("should not defer when afterMinutes is 0 (immediate inject, regression)", async () => {
+    const deps = makeDeps();
+    const outcome = await executeDisruptionAction({ ...detail, afterMinutes: 0 }, deps);
+    expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
+    expect(deps.scheduleInject).not.toHaveBeenCalled();
+    expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not schedule the inject when the fired event is a duplicate", async () => {
+    const deps = makeDeps({ claimExecution: vi.fn().mockResolvedValue("duplicate") });
+    expect(await executeDisruptionAction({ ...detail, afterMinutes: 30 }, deps)).toEqual({
+      kind: "duplicate",
+    });
+    expect(deps.scheduleInject).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeScheduledInject (ADR-037 deferred inject)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should inject + schedule revert WITHOUT re-claiming (claim taken at fire time)", async () => {
+    const deps = makeDeps();
+    const outcome = await executeScheduledInject(detail, deps);
+    expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
+    expect(deps.claimExecution).not.toHaveBeenCalled(); // already claimed at fired-event time
+    expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
+    expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
+  });
+
+  it("should be a no-op (no_action) when the disruption declares no action", async () => {
+    const noAction: ProblemDisruptionEntry = { ...withAction, action: undefined };
+    const deps = makeDeps({
+      problemsDisruptions: { "microservice-migration-battle": [noAction] },
+    });
+    expect(await executeScheduledInject(detail, deps)).toEqual({ kind: "no_action" });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+  });
+
+  it("should return unknown_disruption when not in the catalog", async () => {
+    expect(await executeScheduledInject(detail, makeDeps({ problemsDisruptions: {} }))).toEqual({
+      kind: "unknown_disruption",
+    });
+  });
+
+  it("should be a no-op (no_deployment) when the team has no resolvable deployment", async () => {
+    const deps = makeDeps({ resolveDeployment: vi.fn().mockResolvedValue(undefined) });
+    expect(await executeScheduledInject(detail, deps)).toEqual({ kind: "no_deployment" });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
   });
 });

--- a/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
@@ -44,6 +44,18 @@ describe("claimExecution (ADR-031 #1419)", () => {
     expect(put.input.Item.expiresAt).toBe(Math.floor(1_000_000 / 1000) + 7 * 24 * 60 * 60);
   });
 
+  it("[ADR-037] should Put a distinct EXEC#...#INJECT row for phase='inject'", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    expect(await claimExecution(makeResources(send), detail, 1_000_000, "inject")).toBe("claimed");
+    expect(send.mock.calls[0][0].input.Item.PK).toBe("EXEC#req-1#team-1#INJECT");
+  });
+
+  it("[ADR-037] phase='event' uses the same key as the default", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await claimExecution(makeResources(send), detail, 1_000_000, "event");
+    expect(send.mock.calls[0][0].input.Item.PK).toBe("EXEC#req-1#team-1");
+  });
+
   it("should return duplicate on ConditionalCheckFailed", async () => {
     const send = vi
       .fn()

--- a/infrastructure/test/problem-deploy/disruption-fire.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-fire.test.ts
@@ -103,6 +103,29 @@ describe("fireDisruption (#888)", () => {
     // PR #889 review: publish detail も mergedParameters を載せる
     const detail = JSON.parse(evCmd.input.Entries?.[0]?.Detail ?? "{}");
     expect(detail.parameters).toMatchObject({ throttleRps: 5, durationSec: 60 });
+    // [ADR-037] immediate fire: published detail に afterMinutes を載せない (regression)
+    expect(detail).not.toHaveProperty("afterMinutes");
+  });
+
+  it("[ADR-037] scheduled fire: published detail に afterMinutes、 audit に scheduledFor を載せる", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Items: [{ teamId: "T1" }] }); // team list
+    ddbSend.mockResolvedValueOnce({}); // idempotency claim
+    eventsSend.mockResolvedValueOnce({ FailedEntryCount: 0, Entries: [{}] }); // PutEvents
+    ddbSend.mockResolvedValueOnce({}); // audit Put
+
+    const out = await fireDisruption(shared, baseInput({ afterMinutes: 30 }));
+    expect(out.kind).toBe("ok");
+    // published detail carries afterMinutes so the executor defers the inject
+    const evCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    const detail = JSON.parse(evCmd.input.Entries?.[0]?.Detail ?? "{}");
+    expect(detail.afterMinutes).toBe(30);
+    // audit row records the scheduled-for time (firedAt + 30m)
+    const auditPut = ddbSend.mock.calls.find((c) =>
+      String((c[0] as { input?: { Item?: { SK?: string } } }).input?.Item?.SK).startsWith("AUDIT#"),
+    );
+    const auditItem = (auditPut?.[0] as { input: { Item: { scheduledFor?: string } } }).input.Item;
+    expect(auditItem.scheduledFor).toBe(new Date(NOW_MS + 30 * 60_000).toISOString());
   });
 
   it("scope=team で targetTeamIds dedupe + subset", async () => {

--- a/infrastructure/test/problem-deploy/disruption-route.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-route.test.ts
@@ -133,11 +133,12 @@ describe("routeDisruptionInvocation (ADR-031 #1419)", () => {
     expect(deps.sendDispatch).not.toHaveBeenCalled();
   });
 
-  it("should route a scheduler inject payload to executeScheduledInject (no re-claim)", async () => {
+  it("should route a scheduler inject payload to executeScheduledInject (inject-phase claim)", async () => {
     const deps = makeDeps();
     const outcome = await routeDisruptionInvocation({ mode: "inject", detail: firedDetail }, deps);
     expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
-    expect(deps.claimExecution).not.toHaveBeenCalled(); // claim already taken at fire time
+    // distinct inject-phase claim fences aws-scheduler redelivery (not the fire-time event claim)
+    expect(deps.claimExecution).toHaveBeenCalledWith(firedDetail, "inject");
     expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
     expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
   });

--- a/infrastructure/test/problem-deploy/disruption-route.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-route.test.ts
@@ -51,6 +51,7 @@ function makeDeps(over: Partial<ExecutorDeps> = {}): ExecutorDeps {
     resolveDeployment: vi.fn().mockResolvedValue(deploymentTarget),
     sendDispatch: vi.fn().mockResolvedValue(undefined),
     scheduleRevert: vi.fn().mockResolvedValue(undefined),
+    scheduleInject: vi.fn().mockResolvedValue(undefined),
     ...over,
   };
 }
@@ -74,6 +75,19 @@ describe("parseDisruptionFiredDetail", () => {
     expect(parseDisruptionFiredDetail(undefined)).toBeUndefined();
     expect(parseDisruptionFiredDetail({})).toBeUndefined();
     expect(parseDisruptionFiredDetail({ detail: { ...firedDetail, teamId: "" } })).toBeUndefined();
+  });
+
+  // [ADR-037] scheduled fire: afterMinutes は正の有限数のみ採用
+  it("should carry a positive finite afterMinutes and drop invalid ones", () => {
+    expect(parseDisruptionFiredDetail({ detail: { ...firedDetail, afterMinutes: 30 } })).toEqual({
+      ...firedDetail,
+      afterMinutes: 30,
+    });
+    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, "30"]) {
+      expect(
+        parseDisruptionFiredDetail({ detail: { ...firedDetail, afterMinutes: bad } }),
+      ).not.toHaveProperty("afterMinutes");
+    }
   });
 });
 
@@ -106,6 +120,34 @@ describe("routeDisruptionInvocation (ADR-031 #1419)", () => {
     expect(deps.sendDispatch).toHaveBeenCalledWith(revertDispatch, deploymentTarget);
     expect(deps.claimExecution).not.toHaveBeenCalled();
     expect(deps.scheduleRevert).not.toHaveBeenCalled();
+  });
+
+  it("should defer the inject when the fired envelope carries afterMinutes > 0 (ADR-037)", async () => {
+    const deps = makeDeps();
+    const outcome = await routeDisruptionInvocation(
+      { detail: { ...firedDetail, afterMinutes: 30 } },
+      deps,
+    );
+    expect(outcome).toEqual({ kind: "scheduled" });
+    expect(deps.scheduleInject).toHaveBeenCalledTimes(1);
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
+  });
+
+  it("should route a scheduler inject payload to executeScheduledInject (no re-claim)", async () => {
+    const deps = makeDeps();
+    const outcome = await routeDisruptionInvocation({ mode: "inject", detail: firedDetail }, deps);
+    expect(outcome).toEqual({ kind: "ok", jobId: "job-1" });
+    expect(deps.claimExecution).not.toHaveBeenCalled(); // claim already taken at fire time
+    expect(deps.sendDispatch).toHaveBeenCalledTimes(1);
+    expect(deps.scheduleRevert).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return invalid_event for an inject payload with a malformed detail", async () => {
+    const deps = makeDeps();
+    expect(
+      await routeDisruptionInvocation({ mode: "inject", detail: { teamId: "team-1" } }, deps),
+    ).toEqual({ kind: "invalid_event" });
+    expect(deps.sendDispatch).not.toHaveBeenCalled();
   });
 
   it("should return invalid_event for a malformed envelope (neither revert nor a valid detail)", async () => {

--- a/infrastructure/test/problem-deploy/disruption-routes.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-routes.test.ts
@@ -154,6 +154,31 @@ describe("POST /events/:eventId/disruptions/fire", () => {
     expect(call.targetTeamIds).toEqual(["team-1"]);
   });
 
+  it("[ADR-037] should 400 when timing=scheduled but afterMinutes is missing", async () => {
+    const res = await fire({ ...validFireBody, timing: "scheduled" });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.fireDisruption).not.toHaveBeenCalled();
+  });
+
+  it("[ADR-037] should 400 when afterMinutes is set without timing=scheduled", async () => {
+    const res = await fire({ ...validFireBody, afterMinutes: 30 });
+    expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    expect(mocks.fireDisruption).not.toHaveBeenCalled();
+  });
+
+  it("[ADR-037] should pass afterMinutes to the service when timing=scheduled", async () => {
+    mocks.fireDisruption.mockResolvedValueOnce({ kind: "ok", result: { fired: 1 } });
+    const res = await fire({ ...validFireBody, timing: "scheduled", afterMinutes: 30 });
+    expect(res.status).toBe(StatusCodes.CREATED);
+    expect(mocks.fireDisruption.mock.calls[0][1].afterMinutes).toBe(30);
+  });
+
+  it("[ADR-037] should not pass afterMinutes for an immediate fire (default timing)", async () => {
+    mocks.fireDisruption.mockResolvedValueOnce({ kind: "ok", result: { fired: 1 } });
+    await fire(validFireBody);
+    expect(mocks.fireDisruption.mock.calls[0][1].afterMinutes).toBeUndefined();
+  });
+
   it("should include randomCount when scope=random-n", async () => {
     mocks.fireDisruption.mockResolvedValueOnce({ kind: "unknown_problem" });
     await fire({ ...validFireBody, scope: "random-n", randomCount: 2 });

--- a/infrastructure/test/problem-deploy/disruption-schedule-revert.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-schedule-revert.test.ts
@@ -5,9 +5,11 @@ import type {
   DisruptionFiredDetail,
 } from "../../lib/problem-deploy/handlers/disruption-executor-handler/execute";
 import {
+  injectScheduleName,
   revertAtExpression,
   revertScheduleName,
   type ScheduleRevertDeps,
+  scheduleInject,
   scheduleRevert,
 } from "../../lib/problem-deploy/handlers/disruption-executor-handler/schedule-revert";
 
@@ -99,5 +101,39 @@ describe("scheduleRevert (ADR-031 #1419)", () => {
     await expect(scheduleRevert(revert, detail, target, 600, deps)).rejects.toThrow(
       "ConflictException",
     );
+  });
+});
+
+describe("injectScheduleName", () => {
+  it("should be the idempotent tc-inject- twin of revert (requestId/teamId)", () => {
+    expect(injectScheduleName(detail)).toBe("tc-inject-req-1-team-1");
+    expect(injectScheduleName({ ...detail, requestId: "r".repeat(100) }).length).toBe(64);
+  });
+});
+
+describe("scheduleInject (ADR-037 scheduled fire)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should create a one-shot at firedAt + afterMinutes invoking the target with mode:inject", async () => {
+    const { deps, send } = makeDeps();
+    await scheduleInject(detail, 30, deps);
+    const input = send.mock.calls[0][0].input;
+    expect(input.Name).toBe("tc-inject-req-1-team-1");
+    expect(input.ScheduleExpression).toBe("at(2026-06-02T00:30:00)");
+    expect(input.FlexibleTimeWindow).toEqual({ Mode: "OFF" });
+    expect(input.ActionAfterCompletion).toBe("DELETE");
+    expect(input.Target.Arn).toBe(deps.revertTargetArn);
+    const payload = JSON.parse(input.Target.Input);
+    expect(payload.mode).toBe("inject");
+    // detail.firedAt is bumped to the inject time so the later revert is relative to it,
+    // and afterMinutes is dropped so it does not re-defer.
+    expect(payload.detail.firedAt).toBe("2026-06-02T00:30:00.000Z");
+    expect(payload.detail).not.toHaveProperty("afterMinutes");
+    expect(payload.detail.disruptionId).toBe("ec2-latency-injection");
+  });
+
+  it("should propagate scheduler errors (inject scheduling failure is loud)", async () => {
+    const { deps } = makeDeps(vi.fn().mockRejectedValue(new Error("ConflictException")));
+    await expect(scheduleInject(detail, 30, deps)).rejects.toThrow("ConflictException");
   });
 });


### PR DESCRIPTION
## Summary

Implements the **scheduled-fire** slice of ADR-037: an operator can fire a red-team disruption **immediately** or **scheduled N minutes later**. First of the {scheduled, recurring, while-undefended} timing modes.

**Depends on #1686** (ADR-037 design). Merge #1686 first — this branch references `[ADR-037]` throughout and is the implementation of that ADR's `scheduled` mode.

### Mechanism (zero new infra)
- Fire schema gains `timing` (`immediate` | `scheduled`) + `afterMinutes` (1–1440), with cross-field refines.
- The fire handler stamps `afterMinutes` into the published `DisruptionFired` detail and records `scheduledFor` in the audit row.
- The executor, on `afterMinutes>0`, reuses the existing **aws-scheduler one-shot** (the revert mechanism) to re-invoke itself with `{mode:"inject", detail}` at T+N. The executor's scheduler role + `CreateSchedule` already exist for revert → **no IAM/CDK change**.
- Operator UI: an immediate/scheduled `SegmentedControl` + minutes input (pre-filled from the disruption's `defaultAfterMinutes`); the fire audit table gains a "Scheduled for" column.

### Idempotency (parity with the immediate path)
The immediate path is dedupe-safe because `claimExecution` runs in the same invocation that injects (EventBridge redelivery → duplicate). aws-scheduler is also at-least-once, so the deferred inject claims a **distinct inject-phase key** (`EXEC#{requestId}#{teamId}#INJECT`) at injection time → scheduler redelivery is fenced exactly like the immediate path.

## Test plan
- **infra**: `disruption-execute / route / schedule-revert / executor-store / fire / routes / contract` — 85 disruption tests green (defer, scheduled-inject, inject-phase claim + duplicate, parse guard, scheduledFor, distinct PK).
- **app-admin**: `DisruptionsPanel` 18 tests (timing toggle, out-of-range disable, default pre-fill, scheduledFor column shows time vs "-"); **953 tests, coverage 100%**.
- `make harness` green, tsc green, biome clean.

## Review trail
- `/review`: approve (correct, conventions-clean, no security concerns; clean generalization of the scheduler mechanism).
- `/security-review`: no findings — `afterMinutes` double-validated + bounded; scheduler payload server-built; schedule-name sanitized; tenant ownership/ExternalId path unchanged.
- `/simplify`: diff is de-duplicating (extracts `sendOneShot`/`oneShotAt`/`FireModal`/`teamPicker`); altitude review found + fixed the inject-phase idempotency gap (commit 2).

## Regression analysis
- **Immediate fire is byte-identical to before**: `afterMinutes` absent → published detail / audit unchanged → immediate inject. Regression-pinned ("immediate omits afterMinutes").
- Executor: `afterMinutes`-less fired events take the unchanged inject path; the new `mode:"inject"` route branch only matches the new scheduler payload.
- Idempotency: event-phase and inject-phase claims use distinct PKs (no interference); fire-time claim still fences duplicate fired events to one schedule.
- always-ends (ADR-029): each injection (immediate or deferred) still schedules a revert.

## Physical impact
- **UPDATE**: `DisruptionExecutor` + `EventApi` Lambda function code (bundled assets); frontend `application-admin-console` bundle.
- **NO-OP**: CFn resource topology, IAM policies, DynamoDB capacity — unchanged (the inject-phase claim is a 1-WCU conditional Put to the existing Disruptions table; scheduler perms pre-exist for revert).

Relates #1417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Scheduled disruption injection: Configure execution delays (1–1440 minutes) for deferred fault injection
  * Audit logs now display scheduled execution timestamps alongside immediate fires
  * Immediate vs. scheduled timing modes with pre-filled default delays from disruption catalog
  * New column in disruption audit table showing scheduled execution times
  * Validation and error messaging for scheduling delay inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->