### PR TITLE
fix(app-admin): record event-lifecycle ops in audit log + drop experimental banner

### DIFF
--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -699,7 +699,6 @@
   "disruptions": {
     "header": "Disruptions (red team)",
     "description": "Fire a declared disruption at teams during the Battle. Each problem declares its own disruptions; the platform injects the fault into the team's deployed stack and auto-reverts it.",
-    "experimental_banner": "Experimental: the disruption mechanism is unit-tested, but the cross-account injection has not yet been verified end-to-end on a live AWS account. Try it on a non-production event first.",
     "col_name": "Disruption",
     "col_problem": "Problem",
     "col_description": "Description",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -699,7 +699,6 @@
   "disruptions": {
     "header": "Disruptions (レッドチーム)",
     "description": "競技中にチームへ宣言済みの障害を発火します。 各問題が自身の障害を宣言し、 platform がチームの deploy 済み stack に障害を注入して自動復旧します。",
-    "experimental_banner": "実験的機能: 障害注入の機構はユニットテスト済みですが、 クロスアカウント注入は実 AWS アカウントでの end-to-end 検証がまだです。 まずは本番以外のイベントでお試しください。",
     "col_name": "障害",
     "col_problem": "問題",
     "col_description": "説明",

--- a/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/DisruptionsPanel.tsx
@@ -270,7 +270,6 @@ export function DisruptionsPanel({
       }
     >
       <SpaceBetween size="l">
-        <Alert type="warning">{t("disruptions.experimental_banner")}</Alert>
         {loadError ? <Alert type="error">{loadError}</Alert> : null}
         {lastFired ? (
           <Alert type="success" dismissible onDismiss={() => setLastFired(null)}>

--- a/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
+++ b/apps/application-admin-console/test/pages/event-detail/DisruptionsPanel.test.tsx
@@ -160,11 +160,8 @@ describe("DisruptionsPanel", () => {
     fireEvent.click(await screen.findByText("disruptions.fire_button"));
     fireEvent.click(screen.getByText("disruptions.confirm_fire"));
     await screen.findByText(/disruptions.fired_flash/);
-    // the success flash is the dismissible alert (the experimental banner is not dismissible).
-    const flash = createWrapper(document.body)
-      .findAllAlerts()
-      .find((a) => a.findDismissButton() !== null);
-    flash?.findDismissButton()?.click();
+    // the success flash is the only alert when there is no load error.
+    createWrapper(document.body).findAlert()?.findDismissButton()?.click();
     await waitFor(() => expect(screen.queryByText(/disruptions.fired_flash/)).toBeNull());
     // open + dismiss the modal via the X (Modal onDismiss)
     fireEvent.click(screen.getByText("disruptions.fire_button"));

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/audit.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/audit.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { resolveTenantId } from "../deploy-handler/auth.js";
+import { type AuditOutcome, extractAuditContext, writeAuditEvent } from "../shared/audit-log.js";
+
+/**
+ * [#950 follow-up] event-handler の mutating route から admin 監査行を 1 行で残す helper。
+ *
+ * 旧状態: tenant 監査ログ (`監査ログ` 画面) に出るのは competitor-accounts-handler が手書きで
+ * `writeAuditEvent` を仕込んだ操作だけで、 event lifecycle (作成 / 終了 / 削除 / deploy / lock /
+ * archive / schedule / notification) は 1 行も記録されていなかった。 本 helper は
+ * competitor-accounts-handler と同じ pattern (= resolveTenantId + extractAuditContext +
+ * best-effort write) を集約し、 各 route が success path で 1 行呼ぶだけにする。
+ *
+ * write は fire-and-forget (`void`)。 response latency を audit DDB に絡めない。 env
+ * `ADMIN_AUDIT_LOG_TABLE_NAME` 未配線なら no-op (= writeAuditEvent 側で吸収)。
+ */
+export function auditEventAction(
+  c: Context,
+  action: string,
+  target: string,
+  outcome: AuditOutcome = "success",
+): void {
+  const ctx = extractAuditContext(c);
+  void writeAuditEvent({
+    tenantId: resolveTenantId(c),
+    actor: ctx.actor,
+    ...(ctx.actorUsername ? { actorUsername: ctx.actorUsername } : {}),
+    action,
+    outcome,
+    target,
+    ...(ctx.ipAddress ? { ipAddress: ctx.ipAddress } : {}),
+    ...(ctx.userAgent ? { userAgent: ctx.userAgent } : {}),
+    occurredAtMs: Date.now(),
+  });
+}

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/bulk-deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/bulk-deploy.ts
@@ -5,6 +5,7 @@ import {
   TENANT_ADMIN_ROLE,
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
+import { auditEventAction } from "../audit.js";
 import { bulkDeployEvent } from "../bulk-deploy.js";
 import { handleRouteError, parseOptionalJsonBody, withEventId } from "../route-helpers.js";
 import type { EventSharedResources } from "../shared.js";
@@ -35,6 +36,7 @@ export function registerBulkDeployRoutes(app: Hono, shared: EventSharedResources
           );
           if (outcome.kind === "not_found")
             return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+          auditEventAction(c, "bulk_deploy", eventId);
           return c.json(outcome.result, StatusCodes.ACCEPTED);
         } catch (err) {
           return handleRouteError(c, "[events] bulkDeployEvent failed", { eventId }, err);

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/disruptions.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/disruptions.ts
@@ -6,6 +6,7 @@ import {
   TENANT_ADMIN_ROLE,
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
+import { auditEventAction } from "../audit.js";
 import { fireDisruption, listDisruptionAudit, listDisruptionCatalog } from "../disruption-fire.js";
 import type { DisruptionFireOutcome } from "../disruption-types.js";
 import {
@@ -120,6 +121,7 @@ export function registerDisruptionRoutes(app: Hono, shared: EventSharedResources
             firedBy: resolveCognitoSub(c),
             nowMs: Date.now(),
           });
+          if (outcome.kind === "ok") auditEventAction(c, "fire_disruption", eventId);
           return disruptionFireOutcomeResponse(c, outcome);
         } catch (err) {
           return handleRouteError(c, "[disruptions] fire failed", { eventId }, err);

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/events.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/events.ts
@@ -6,6 +6,7 @@ import {
   TENANT_ADMIN_ROLE,
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
+import { auditEventAction } from "../audit.js";
 import { bulkTeardownEvent } from "../bulk-delete.js";
 import { createEvent, DuplicateInternalSlugError, DuplicateProblemIdError } from "../create.js";
 import { getEventDetail, listEvents } from "../list.js";
@@ -33,6 +34,7 @@ export function registerEventRoutes(app: Hono, shared: EventSharedResources): vo
             { tenantId: resolveTenantId(c), nowMs: Date.now() },
             body,
           );
+          auditEventAction(c, "create_event", response.eventId);
           return c.json(response, StatusCodes.CREATED);
         } catch (err) {
           if (err instanceof DuplicateInternalSlugError) {
@@ -100,6 +102,7 @@ export function registerEventRoutes(app: Hono, shared: EventSharedResources): vo
           const outcome = await bulkTeardownEvent(shared, resolveTenantId(c), eventId, Date.now());
           if (outcome.kind === "not_found")
             return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+          auditEventAction(c, "delete_event", eventId);
           return c.json(outcome.result, StatusCodes.ACCEPTED);
         } catch (err) {
           return handleRouteError(c, "[events] bulkTeardownEvent failed", { eventId }, err);

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/lifecycle.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/lifecycle.ts
@@ -5,6 +5,7 @@ import {
   TENANT_ADMIN_ROLE,
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
+import { auditEventAction } from "../audit.js";
 import { endEvent } from "../end-event.js";
 import { handleRouteError, parseJsonBody, withEventId } from "../route-helpers.js";
 import { type SetEventScheduleOutcome, setEventSchedule } from "../schedule.js";
@@ -101,6 +102,7 @@ export function registerLifecycleRoutes(app: Hono, shared: EventSharedResources)
             scoreboardFreezeMinutes: parsed.data.scoreboardFreezeMinutes,
             nowMs,
           });
+          if (outcome.kind === "ok") auditEventAction(c, "schedule_event", eventId);
           return scheduleOutcomeResponse(c, outcome);
         } catch (err) {
           return handleRouteError(c, "[events] setEventSchedule failed", { eventId }, err);
@@ -124,6 +126,7 @@ export function registerLifecycleRoutes(app: Hono, shared: EventSharedResources)
               StatusCodes.CONFLICT,
             );
           }
+          auditEventAction(c, "end_event", eventId);
           return c.json(
             { endsAt: outcome.endsAt, updatedDeployments: outcome.updatedDeployments },
             StatusCodes.OK,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/notifications.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/notifications.ts
@@ -7,6 +7,7 @@ import {
   TENANT_OPERATOR_ROLE,
 } from "../../deploy-handler/auth.js";
 import { NotificationCreateRequestSchema } from "../../shared/notification.js";
+import { auditEventAction } from "../audit.js";
 import { createNotification } from "../create-notification.js";
 import { handleRouteError, parseJsonBody, withEventId } from "../route-helpers.js";
 import type { EventSharedResources } from "../shared.js";
@@ -33,6 +34,7 @@ export function registerNotificationRoutes(app: Hono, shared: EventSharedResourc
           );
           if (outcome.kind === "not_found")
             return c.json({ error: "not_found" }, StatusCodes.NOT_FOUND);
+          auditEventAction(c, "create_notification", eventId);
           return c.json(
             { notificationId: outcome.notificationId, occurredAt: outcome.occurredAt },
             StatusCodes.CREATED,

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/routes/scoring.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/routes/scoring.ts
@@ -6,6 +6,7 @@ import {
   TENANT_ADMIN_ROLE,
 } from "../../deploy-handler/auth.js";
 import { archiveEvent } from "../archive.js";
+import { auditEventAction } from "../audit.js";
 import { lockScoring, unlockScoring } from "../lock-scoring.js";
 import { handleRouteError, withEventId } from "../route-helpers.js";
 import type { EventSharedResources } from "../shared.js";
@@ -41,6 +42,7 @@ export function registerScoringRoutes(app: Hono, shared: EventSharedResources): 
               StatusCodes.CONFLICT,
             );
           }
+          auditEventAction(c, "lock_scoring", eventId);
           return c.json(
             {
               scoringLocked: outcome.scoringLocked,
@@ -71,6 +73,7 @@ export function registerScoringRoutes(app: Hono, shared: EventSharedResources): 
               StatusCodes.CONFLICT,
             );
           }
+          auditEventAction(c, "unlock_scoring", eventId);
           return c.json(
             {
               scoringLocked: outcome.scoringLocked,
@@ -100,6 +103,7 @@ export function registerScoringRoutes(app: Hono, shared: EventSharedResources): 
               StatusCodes.CONFLICT,
             );
           }
+          auditEventAction(c, "archive_event", eventId);
           return c.json({ archivedAt: outcome.archivedAt }, StatusCodes.OK);
         } catch (err) {
           return handleRouteError(c, "[events] archiveEvent failed", { eventId }, err);

--- a/infrastructure/test/problem-deploy/event-audit.test.ts
+++ b/infrastructure/test/problem-deploy/event-audit.test.ts
@@ -1,0 +1,76 @@
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * [#950 follow-up] auditEventAction: event-handler の mutating route が admin 監査行を残す helper。
+ * writeAuditEvent / resolveTenantId を mock し、 emit される envelope を pin する。
+ */
+
+const { mockWrite } = vi.hoisted(() => ({ mockWrite: vi.fn() }));
+
+vi.mock("../../lib/problem-deploy/handlers/shared/audit-log", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../lib/problem-deploy/handlers/shared/audit-log")>();
+  return { ...actual, writeAuditEvent: mockWrite };
+});
+
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/auth", () => ({
+  resolveTenantId: () => "tenant-x",
+}));
+
+import { auditEventAction } from "../../lib/problem-deploy/handlers/event-handler/audit";
+
+function ctxWith(
+  claims: Record<string, unknown>,
+  http?: { sourceIp?: string; userAgent?: string },
+) {
+  return {
+    env: { event: { requestContext: { authorizer: { jwt: { claims } }, http } } },
+  } as unknown as Context;
+}
+
+describe("auditEventAction (#950 follow-up)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should emit a success audit envelope with tenant, actor, action, and target", () => {
+    auditEventAction(
+      ctxWith(
+        { sub: "user-1", "cognito:username": "op@example.com" },
+        { sourceIp: "1.2.3.4", userAgent: "UA/1" },
+      ),
+      "create_event",
+      "EVT123",
+    );
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(mockWrite.mock.calls[0][0]).toMatchObject({
+      tenantId: "tenant-x",
+      actor: "user-1",
+      actorUsername: "op@example.com",
+      action: "create_event",
+      outcome: "success",
+      target: "EVT123",
+      ipAddress: "1.2.3.4",
+      userAgent: "UA/1",
+    });
+    expect(typeof mockWrite.mock.calls[0][0].occurredAtMs).toBe("number");
+  });
+
+  it("should omit actorUsername / ipAddress / userAgent when the JWT/context lacks them", () => {
+    auditEventAction(ctxWith({ sub: "user-2" }), "end_event", "EVT9");
+    const env = mockWrite.mock.calls[0][0];
+    expect(env).toMatchObject({ actor: "user-2", action: "end_event", target: "EVT9" });
+    expect(env).not.toHaveProperty("actorUsername");
+    expect(env).not.toHaveProperty("ipAddress");
+    expect(env).not.toHaveProperty("userAgent");
+  });
+
+  it("should honor a non-success outcome", () => {
+    auditEventAction(ctxWith({ sub: "user-3" }), "delete_event", "EVT1", "forbidden");
+    expect(mockWrite.mock.calls[0][0].outcome).toBe("forbidden");
+  });
+
+  it("should default actor to 'unknown' when no JWT claims are present", () => {
+    auditEventAction({ env: {} } as unknown as Context, "bulk_deploy", "EVT2");
+    expect(mockWrite.mock.calls[0][0].actor).toBe("unknown");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two operator-reported defects in the application-admin console.

### 1. 監査ログ was missing event create/end/etc.
The audit log only showed `create_competitor_account`. **Why:** auditing was ad-hoc hand-instrumentation — only `competitor-accounts-handler` emitted audit rows; the entire `event-handler` wrote **zero** audit entries (no generic middleware; the purpose-built `withAudit` wrapper from #1292 was never adopted).

**Fix:** a small DRY helper `auditEventAction(c, action, target)` (mirrors the proven `competitor-accounts` `writeAuditEvent` pattern), called on the **success path** of all 10 event-lifecycle mutations:
`create_event` · `delete_event` · `end_event` · `schedule_event` · `lock_scoring` · `unlock_scoring` · `archive_event` · `bulk_deploy` · `create_notification` · `fire_disruption`.

`ADMIN_AUDIT_LOG_TABLE_NAME` is already wired to the event-handler Lambda (the read path uses it) → **no CDK/IAM change**.

### 2. Removed the experimental disruptions banner
The "実験的機能 … end-to-end 検証がまだ … 本番以外で" banner put internal engineering status into a commercial product UI. The unverified-feature gate is the `redTeam` feature flag, not a user-facing disclaimer — banner removed (component + ja/en + test).

## Test plan
- `event-audit.test.ts` (4): helper emits the right envelope; omits absent fields; honors outcome; defaults actor to `unknown`.
- 236 event/route tests green — audit emit is fire-and-forget + no-op without env, so no existing test is perturbed. app-admin `DisruptionsPanel` + i18n parity green.
- `make harness` green, tsc green, biome clean.

## Regression analysis
- Audit writes are best-effort `void writeAuditEvent`; a write failure / unset env never affects the primary mutation's response (existing fail-safe contract in `shared/audit-log.ts`).
- Only success paths emit (not_found / conflict / validation returns do not).
- Banner removal is display-only; the disruptions feature itself is unchanged.

## Physical impact
- **UPDATE**: EventApi Lambda code (audit emit) + application-admin-console bundle (banner removed).
- **NO-OP**: CFn / IAM / DynamoDB capacity — audit rows are 1-WCU Puts to the existing AdminAuditLog table already wired to this Lambda.

Relates #950 #1417