### PR TITLE
docs(landing): add llms.txt indexing the developer docs

### DIFF
--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -1,0 +1,47 @@
+# TenkaCloud
+
+> A multi-tenant SaaS cloud-competition platform on AWS. Teams solve real cloud problems delivered as **Battle** (real-time, head-to-head) or **Challenge** (self-paced, evergreen). Built on the AWS SaaS Builder Toolkit (`@cdklabs/sbt-aws`); the Control Plane, Application Plane, and per-competitor problem deployment are all expressed in AWS CDK.
+
+TenkaCloud's moat is its open problem catalog: a problem is a plugin (`metadata.json` + a single-page CloudFormation `template.yaml` + optional portal slots), and the platform is the host that deploys it into a competitor's own AWS account, scores it, and renders the competitor portal. Every backend is an AWS Lambda (Hono); the frontends are Vite + React + Cloudscape SPAs. DynamoDB tables are forced to PROVISIONED 1/1 to stay inside the AWS Free Tier. There are two deploy modes: **Lite** (single-tenant, one organizer, ~10 min) and **SaaS** (full multi-tenant, pooled + silo tiers).
+
+This file follows the [llms.txt](https://llmstxt.org/) convention. Links point to the canonical sources in the GitHub repository.
+
+## Start here
+
+- [README](https://github.com/susumutomita/TenkaCloud/blob/main/README.md): project overview, quick start, and command reference
+- [Architecture overview](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/OVERVIEW.md): what TenkaCloud is, the 4 planes, and why Lite vs SaaS exists
+- [Glossary](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/GLOSSARY.md): AppPlane / ControlPlane / TrustBridge / ParticipantViewerRole and other terms
+- [5-minute quickstart](https://github.com/susumutomita/TenkaCloud/blob/main/docs/demos/quickstart-5min.md): fastest path to a running event
+
+## Architecture & design
+
+- [Module map](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/MODULE_MAP.md): directory-level "where is X" index
+- [Architecture invariants (harness)](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/harness.md): the machine-checked rules every change must satisfy
+- [Architecture Decision Records](https://github.com/susumutomita/TenkaCloud/tree/main/docs/architecture): 37+ ADRs (authored as self-contained HTML)
+- [ADR-012 — Problem = plugin, platform = host](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-012-problem-plugin-architecture.html): the core plugin/host design
+- [ADR-031 — Cross-account disruption dispatch](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-031-cross-account-disruption-dispatch.html): how faults are injected into a competitor account
+- [ADR-037 — Disruption timing & recurrence](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-037-disruption-timing-recurrence.html): immediate / scheduled / recurring / adaptive red-team faults
+
+## Contributing & extending
+
+- [CONTRIBUTING](https://github.com/susumutomita/TenkaCloud/blob/main/CONTRIBUTING.md): setup, development flow, gates, and community roles
+- [Contributor map](https://github.com/susumutomita/TenkaCloud/blob/main/CONTRIBUTOR_MAP.md): pick the recipe matching your goal (new problem / Lambda bug / admin UI)
+- [Roadmap](https://github.com/susumutomita/TenkaCloud/blob/main/ROADMAP.md): product direction and starter tasks
+- [Competitor-side setup](https://github.com/susumutomita/TenkaCloud/blob/main/infrastructure/templates/README.md): the least-privilege IAM role to roll out in a competitor account
+
+## Authoring problems
+
+- [Problem authoring guide](https://github.com/susumutomita/TenkaCloud/blob/main/docs/problems/AUTHORING.html): 30-minute onboarding — 3-asset model, 5 scoring kinds, worked examples
+- [Problem catalog repo (TenkaCloudChallenge)](https://github.com/susumutomita/TenkaCloudChallenge#readme): where competition problems live and are contributed
+- [Problem schema + conventions](https://github.com/susumutomita/TenkaCloud/blob/main/problems/README.md): `metadata.json` schema and `template.yaml` conventions
+
+## For AI coding agents
+
+- [AGENTS.md](https://github.com/susumutomita/TenkaCloud/blob/main/AGENTS.md): operational rules for agents (Claude Code, Codex CLI) — role split, gates, prohibitions
+- [CLAUDE.md](https://github.com/susumutomita/TenkaCloud/blob/main/CLAUDE.md): full product overview, architecture, invariants, and command list
+
+## Optional
+
+- [GitHub repository](https://github.com/susumutomita/TenkaCloud): source of truth for code, issues, and discussions
+- [GitHub Discussions](https://github.com/susumutomita/TenkaCloud/discussions): questions and design discussion
+- [Landing page](https://susumutomita.github.io/TenkaCloud/): product description and live participant-portal demo


### PR DESCRIPTION
## Summary

Adds an [llmstxt.org](https://llmstxt.org/)-compliant `landing/llms.txt` so LLMs / coding agents (and humans, via clickable links) have a structured entry point into TenkaCloud's developer documentation — which previously had no single discoverable index.

GitHub Pages publishes the `landing/` directory (`pages.yml`), so the file is served at the site root `/llms.txt` and redeploys automatically on merge (the workflow triggers on `landing/**`).

Contents: H1 + summary blockquote + sectioned links — **Start here / Architecture & design / Contributing & extending / Authoring problems / For AI coding agents / Optional**. Every link targets a canonical doc in the repo (README, OVERVIEW, MODULE_MAP, GLOSSARY, harness, ADRs incl. 012/031/037, AUTHORING, CONTRIBUTING, AGENTS, CLAUDE) — all verified to exist (no dead links).

## Test plan
- `make harness` green. `landing/llms.txt` is outside every linter glob (markdownlint/textlint target `**/*.md`, biome targets ts/tsx/json), so it is not linted. All referenced files confirmed present.

## Regression analysis
- Single static-file addition; no change to landing or app code. Pages redeploys on merge and serves `/llms.txt`.

## Physical impact
- NO-OP: adds `landing/llms.txt` only. No CFn / IAM / DynamoDB diff (Pages-served static asset).

## Follow-up (needs a decision)
Today `pages.yml` deliberately does **not** publish `docs/` (public landing vs. repo-only dev docs). If human-facing dev docs should also be hosted, options are (a) a small HTML `/docs` index page on the landing site, or (b) publishing the whole `docs/` tree to Pages (needs md→html rendering + reverses the current IA). This PR delivers the agent-facing index; the human-hosting decision is open.