### PR TITLE
fix(invite-email): <br> line breaks so the invite renders readably in Gmail

### DIFF
--- a/infrastructure/lib/control-plane/invite-message.ts
+++ b/infrastructure/lib/control-plane/invite-message.ts
@@ -5,8 +5,11 @@
  * URL を本文に埋める (= Phase 3 再 deploy 後)。
  *
  * #714: 旧実装は ja + en を `—` で連結した 1 通だったが、 Gmail 等で改行が collapse されて
- * 「1 段落の長文」 になり可読性が低かった。 English-only に統一し、 各セクションを空行で
- * 分離する (= preview で改行が落ちても各 key:value が独立可読)。
+ * 「1 段落の長文」 になり可読性が低かった。 English-only に統一する。
+ *
+ * 改行は **`<br>`** を使う。 Cognito は招待メールを **HTML** として配信するため `\n` は空白に
+ * collapse され全文が 1 行に潰れる (tenant 招待で実機確認、 #903 と同根)。 段落間は `<br><br>`
+ * (= 配列の空要素)、 連続する credential 行は単一 `<br>`。
  */
 
 const FALLBACK_URL_PLACEHOLDER =
@@ -31,5 +34,5 @@ export function buildInviteEmailBody(adminConsoleOrigin: string | undefined): st
     "Temporary password: {####}",
     "",
     "You will be prompted to set a new password on first sign-in.",
-  ].join("\n");
+  ].join("<br>");
 }

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -10,9 +10,11 @@ const COGNITO_TEMP_PASSWORD = "{####}";
 
 /**
  * Issue #903: 招待メール文面を英語のみに統一する (= 旧 4 言語混在は Gmail で改行が collapse
- * して読めなくなる問題があった)。 Control Plane の System Admin 招待 (Issue #714) と同じ
- * 方針。 各 field を `\n\n` (paragraph break) で区切り、 Gmail / Outlook で改行が保たれる
- * よう整形する。
+ * して読めなくなる問題があった)。 Control Plane の System Admin 招待 (Issue #714) と同じ方針。
+ *
+ * 改行は **`<br>`** を使う。 Cognito は `InviteMessageTemplate` を **HTML メール**として配信する
+ * ため、 `\n` / `\n\n` は Gmail / Outlook で空白に collapse され、 全文が 1 行に潰れて読めなく
+ * なる (実機で確認)。 段落間は `<br><br>` (= 配列の空要素)、 連続する credential 行は単一 `<br>`。
  *
  * Cognito `InviteMessageTemplate` は **UserPool あたり 1 言語**しか保持できないので、
  * 多言語化が必要なら `custom:locale` 属性 + CustomMessage Lambda Trigger + SES への移行が
@@ -21,13 +23,10 @@ const COGNITO_TEMP_PASSWORD = "{####}";
 function buildInviteEmailBody(consoleUrl: string): string {
   return [
     "Welcome to TenkaCloud Battle / Challenge.",
-    "",
     "A temporary account has been issued so you can sign in to the Tenant Admin Console.",
     "",
     `Username: ${COGNITO_USERNAME}`,
-    "",
     `Temporary password: ${COGNITO_TEMP_PASSWORD}`,
-    "",
     `Sign-in URL: ${consoleUrl}`,
     "",
     "Set a new password on first sign-in. From the Tenant Admin Console you can create competition Events and hand out Participant Portal URLs.",
@@ -35,7 +34,7 @@ function buildInviteEmailBody(consoleUrl: string): string {
     "If this email looks unfamiliar, please discard it.",
     "",
     "-- TenkaCloud Operations",
-  ].join("\n");
+  ].join("<br>");
 }
 
 interface IdentityProviderProps {

--- a/infrastructure/test/control-plane-stack.test.ts
+++ b/infrastructure/test/control-plane-stack.test.ts
@@ -51,10 +51,11 @@ describe("buildInviteEmailBody (Issue #714 English-only)", () => {
     expect(matches).toHaveLength(1);
   });
 
-  it("should separate sections with blank lines and stay resilient against newline collapsing (#714)", () => {
+  it("should separate sections with HTML <br> breaks (Cognito sends the invite as HTML, so \\n collapses)", () => {
     const body = buildInviteEmailBody("https://example.com");
-    // 空行が body に最低 1 つあり、 welcome / key:value block / next step instruction が分離される
-    expect(body).toMatch(/\n\n/);
+    // Cognito は HTML 配信なので `\n` は 1 行に collapse される。 段落間は <br><br>、 raw \n は無し。
+    expect(body).toContain("<br><br>");
+    expect(body).not.toContain("\n");
     expect(body.startsWith("Welcome to TenkaCloud Admin Console.")).toBe(true);
   });
 });

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -197,9 +197,9 @@ describe("IdentityProvider", () => {
       expect(body).toContain(consoleUrl);
     });
 
-    it("Issue #903: should separate each field (Username / Temporary password / Sign-in URL) with paragraph breaks (double newline)", () => {
-      // Gmail / Outlook は単一改行を space に re-flow するので、 fields は \n\n で区切らないと
-      // 1 行に潰れて読めなくなる (= PR-582 で起きた regression、 Issue #903 でも継続維持)。
+    it("should separate fields with HTML <br> breaks (Cognito sends the invite as HTML, so \\n collapses)", () => {
+      // Cognito は招待メールを HTML 配信するため `\n` は Gmail / Outlook で space に collapse され、
+      // 全文が 1 行に潰れて読めなくなる (実機確認)。 改行は <br>、 段落間は <br><br> でないといけない。
       const consoleUrl = "https://d123abc.cloudfront.net";
       const { template } = synth("tenant-1", consoleUrl);
       const userPool = Object.values(template.findResources("AWS::Cognito::UserPool"))[0];
@@ -209,9 +209,12 @@ describe("IdentityProvider", () => {
             AdminCreateUserConfig?: { InviteMessageTemplate?: { EmailMessage?: string } };
           }
         )?.AdminCreateUserConfig?.InviteMessageTemplate?.EmailMessage ?? "";
-      expect(body).toMatch(/\n\nUsername: \{username\}\n\n/);
-      expect(body).toMatch(/\n\nTemporary password: \{####\}\n\n/);
-      expect(body).toMatch(/\n\nSign-in URL: /);
+      // credentials block: paragraph break before, single <br> between each line
+      expect(body).toContain(
+        "<br><br>Username: {username}<br>Temporary password: {####}<br>Sign-in URL: ",
+      );
+      // no raw newlines survive (would collapse in HTML mail → the run-on-paragraph bug)
+      expect(body).not.toContain("\n");
     });
 
     it("#529: should set the SMS message with Cognito placeholders to stay consistent with InviteMessageTemplate", () => {


### PR DESCRIPTION
## Summary

The Tenant Admin invitation email arrived as **one run-on paragraph** — Username / Temporary password / Sign-in URL all jammed together (see report). Cognito delivers the `InviteMessageTemplate` as an **HTML** email, so the `\n` / `\n\n` separators collapse to spaces in Gmail / Outlook and the whole body renders on one line. The prior "blank-line paragraph break" approach (#714 / #903) assumed `\n\n` survives HTML rendering — it does not.

**Fix:** build both invite bodies with `<br>` (paragraph breaks `<br><br>`), which render as real line breaks in HTML mail. Applied to **both** invites sharing the root cause:
- `tenant-template/identity-provider.ts` — Tenant Admin invite (the reported one)
- `control-plane/invite-message.ts` — System Admin invite (identical bug)

The SMS message stays a separate short plaintext (no `<br>`).

## Test plan
- `identity-provider.test.ts` / `control-plane-stack.test.ts` updated to assert the `<br>` structure + `not.toContain("\n")` (regression guard so a plaintext newline can't sneak back).
- 34 tests green, tsc green, biome clean, `make harness` green.

## Regression analysis
- Email-body string format only; Cognito construct wiring + the SMS message are unchanged.
- Credential block grouped (Username/password/URL on consecutive single-`<br>` lines) with `<br><br>` paragraph breaks → readable in HTML mail clients.

## Physical impact
- UPDATE: Cognito `InviteMessageTemplate.EmailMessage` strings (tenant UserPool + control plane). NO-OP: no new resources / IAM / DynamoDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invitation email rendering to ensure proper line breaks and section formatting display correctly in HTML email clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->