### PR TITLE
fix(app-admin): make the empty-state add action work (Competitor Accounts + Events)

### DIFF
--- a/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
+++ b/apps/application-admin-console/src/pages/CompetitorAccounts.tsx
@@ -70,6 +70,7 @@ export function CompetitorAccountsPage({ config }: { config: AppConfig }) {
         verifyInFlight={verifyInFlight}
         onVerify={(awsAccountId) => void verify(awsAccountId)}
         onRequestDelete={setDeleteTarget}
+        onAdd={() => setAddModalVisible(true)}
       />
 
       {/* [ADR-026/027/032 / #1413] non-AWS (sakura/azure/gcp) per-team credential onboarding.

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -9,7 +9,7 @@ import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
-import { toErrorMessage } from "@tenkacloud/web-kit";
+import { EmptyState, toErrorMessage } from "@tenkacloud/web-kit";
 import { StatusCodes } from "http-status-codes";
 import { useCallback, useMemo, useState } from "react";
 import { type NavigateFunction, useNavigate } from "react-router";
@@ -234,11 +234,19 @@ export function EventListPage({ config }: { config: AppConfig }) {
         columnDefinitions={columns}
         loadingText={t("event_list.loading")}
         empty={
-          <Box textAlign="center" color="inherit" padding="xxl">
-            {showArchived || archivedCount === 0
-              ? t("event_list.empty_no_event")
-              : t("event_list.empty_all_archived")}
-          </Box>
+          showArchived || archivedCount === 0 ? (
+            // 真に 0 件: ここから直接 event を作れる primary action を出す。
+            <EmptyState
+              headline={t("event_list.empty_no_event")}
+              primaryAction={{
+                label: t("event_list.create_button"),
+                onClick: () => navigate("/events/new"),
+              }}
+            />
+          ) : (
+            // 全件 archived で filter されている場合は作成導線を出さない (= 件数は存在する)。
+            <EmptyState headline={t("event_list.empty_all_archived")} />
+          )
         }
       />
 

--- a/apps/application-admin-console/src/pages/competitor-accounts/CompetitorAccountsTable.tsx
+++ b/apps/application-admin-console/src/pages/competitor-accounts/CompetitorAccountsTable.tsx
@@ -1,9 +1,9 @@
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
-import Icon from "@cloudscape-design/components/icon";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table, { type TableProps } from "@cloudscape-design/components/table";
+import { EmptyState } from "@tenkacloud/web-kit";
 import { useMemo } from "react";
 import type { CompetitorAccountSummary } from "../../api/competitor-accounts-client";
 import { useT } from "../../i18n";
@@ -13,6 +13,8 @@ interface CompetitorAccountsTableProps {
   verifyInFlight: string | null;
   onVerify: (awsAccountId: string) => void;
   onRequestDelete: (item: CompetitorAccountSummary) => void;
+  /** Empty-state primary action — opens the add-account modal (same as the header button). */
+  onAdd: () => void;
 }
 
 export function CompetitorAccountsTable({
@@ -20,6 +22,7 @@ export function CompetitorAccountsTable({
   verifyInFlight,
   onVerify,
   onRequestDelete,
+  onAdd,
 }: CompetitorAccountsTableProps) {
   const t = useT();
 
@@ -90,16 +93,13 @@ export function CompetitorAccountsTable({
     <Table
       items={items}
       columnDefinitions={columnDefinitions}
-      // Issue #1362: 空表示を icon + 説明 + 次のアクション誘導の 3 段に。
+      // Issue #1362 / empty-state UX: 空表示は説明 + 実際に押せる primary action を出す
+      // (= 装飾 icon ではなく、 ここから直接 account を追加できる)。
       empty={
-        <Box textAlign="center" color="inherit" padding="xxl">
-          <SpaceBetween size="xs">
-            <Box variant="strong" color="text-status-inactive">
-              <Icon name="add-plus" size="big" variant="subtle" />{" "}
-              {t("competitor_accounts.table_empty")}
-            </Box>
-          </SpaceBetween>
-        </Box>
+        <EmptyState
+          headline={t("competitor_accounts.table_empty")}
+          primaryAction={{ label: t("competitor_accounts.add_button"), onClick: onAdd }}
+        />
       }
     />
   );

--- a/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
+++ b/apps/application-admin-console/test/pages/CompetitorAccounts.test.tsx
@@ -22,13 +22,16 @@ vi.mock("../../src/pages/competitor-accounts/TeamCloudCredentialsPanel", () => (
 }));
 vi.mock("../../src/pages/competitor-accounts/CompetitorAccountsTable", () => ({
   // biome-ignore lint/suspicious/noExplicitAny: stub props。
-  CompetitorAccountsTable: ({ onVerify, onRequestDelete }: any) => (
+  CompetitorAccountsTable: ({ onVerify, onRequestDelete, onAdd }: any) => (
     <div data-testid="accounts-table">
       <button type="button" onClick={() => onVerify("acct-1")}>
         stub-verify
       </button>
       <button type="button" onClick={() => onRequestDelete({ awsAccountId: "acct-1" })}>
         stub-request-delete
+      </button>
+      <button type="button" onClick={onAdd}>
+        stub-empty-add
       </button>
     </div>
   ),
@@ -150,6 +153,12 @@ describe("CompetitorAccountsPage", () => {
     // secret modal dismiss → 閉じる。
     fireEvent.click(screen.getByText("stub-secret-dismiss"));
     expect(screen.queryByTestId("secret-modal")).not.toBeInTheDocument();
+  });
+
+  it("should open the add modal from the table's empty-state add action", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("stub-empty-add"));
+    expect(screen.getByTestId("add-modal")).toBeInTheDocument();
   });
 
   it("should close the add modal on dismiss", () => {

--- a/apps/application-admin-console/test/pages/EventList.test.tsx
+++ b/apps/application-admin-console/test/pages/EventList.test.tsx
@@ -116,6 +116,18 @@ describe("EventListPage", () => {
     expect(mockNav).toHaveBeenCalledWith("/events/new");
   });
 
+  it("should show an empty-state create action that navigates when there are no events", async () => {
+    mockList.mockResolvedValue({ items: [] });
+    renderPage();
+    expect(await screen.findByText("event_list.empty_no_event")).toBeInTheDocument();
+    // header + empty-state both expose a create button; clicking the empty-state one navigates too
+    const createButtons = screen.getAllByRole("button", { name: "event_list.create_button" });
+    expect(createButtons.length).toBeGreaterThan(1);
+    mockNav.mockClear();
+    fireEvent.click(createButtons[createButtons.length - 1] as HTMLElement);
+    expect(mockNav).toHaveBeenCalledWith("/events/new");
+  });
+
   it("should disable archive for non-archivable statuses and enable it for DRAFT", async () => {
     mockList.mockResolvedValue({
       items: [

--- a/apps/application-admin-console/test/pages/competitor-accounts/CompetitorAccountsTable.test.tsx
+++ b/apps/application-admin-console/test/pages/competitor-accounts/CompetitorAccountsTable.test.tsx
@@ -32,6 +32,7 @@ describe("CompetitorAccountsTable", () => {
         verifyInFlight={null}
         onVerify={onVerify}
         onRequestDelete={onRequestDelete}
+        onAdd={vi.fn()}
       />,
     );
     expect(screen.getByText("acct-1")).toBeInTheDocument();
@@ -55,21 +56,27 @@ describe("CompetitorAccountsTable", () => {
         verifyInFlight="acct-1"
         onVerify={vi.fn()}
         onRequestDelete={vi.fn()}
+        onAdd={vi.fn()}
       />,
     );
     // acct-2 (not in-flight) の verify button は disabled。
     expect(screen.getByRole("button", { name: "competitor_accounts.verify" })).toBeDisabled();
   });
 
-  it("should render the empty state with no items", () => {
+  it("should render the empty state with a primary action that fires onAdd", () => {
+    const onAdd = vi.fn();
     render(
       <CompetitorAccountsTable
         items={[]}
         verifyInFlight={null}
         onVerify={vi.fn()}
         onRequestDelete={vi.fn()}
+        onAdd={onAdd}
       />,
     );
     expect(screen.getByText("competitor_accounts.table_empty")).toBeInTheDocument();
+    // the empty state has a real, clickable add button (not a decorative "+")
+    fireEvent.click(screen.getByRole("button", { name: "competitor_accounts.add_button" }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Operator report: the "+" in the empty Competitor Accounts / Events tables is a **decorative icon** — clicking it does nothing. When a list is empty is exactly when you want to add from right there. Standard empty-state UX.

Replaced the decorative-icon empty states with the shared design-system `EmptyState` + a real **primary action button**:
- **CompetitorAccountsTable** — empty-state "アカウントを追加" button opens the AddAccountModal (wired to the same `onAdd` as the header button).
- **EventList** — when truly empty, a "Create event" button navigates to `/events/new`. When the list is only empty because all events are archived-and-filtered, no create action is shown (events exist; the user just filtered them out).

## Test plan
- `CompetitorAccountsTable`: empty-state add button fires `onAdd`.
- `CompetitorAccounts` page: the table's empty-state add opens the AddAccountModal.
- `EventList`: empty list → empty-state create button navigates to `/events/new`.
- 955 app-admin tests green, **coverage 100%**, tsc / biome / `make harness` green.

## Regression analysis
- Non-empty rendering unchanged; header add/create buttons unchanged. `EmptyState` is the existing web-kit component — a decorative icon was swapped for a real action.

## Physical impact
- NO-OP: frontend (application-admin-console) only. No CFn / IAM / DynamoDB diff.

Relates #1366