### PR TITLE
fix(audit-log): absolute+relative time, labeled target, captured IP

### DIFF
--- a/apps/application-admin-console/src/lib/format.ts
+++ b/apps/application-admin-console/src/lib/format.ts
@@ -18,6 +18,24 @@ import type { SupportedLang } from "@tenkacloud/format";
 
 export { formatRelativeTime, type SupportedLang } from "@tenkacloud/format";
 
+/**
+ * ISO timestamp → 絶対時刻ラベル (= 「2026/06/04 08:53」)。 相対時刻 (formatRelativeTime) と
+ * 併記して使う (= 監査ログで 「いつ」 を相対だけでなく絶対でも示す)。 不正値はそのまま返す。
+ * 表示は閲覧者のローカル timezone (= operator が自分の時刻で読める)。
+ */
+export function formatDateTime(iso: string, lang: SupportedLang = "ja"): string {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return iso;
+  return new Intl.DateTimeFormat(lang === "ja" ? "ja-JP" : "en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(ms));
+}
+
 const EVENT_STATUS_LABELS: Record<string, { ja: string; en: string }> = {
   DRAFT: { ja: "下書き", en: "Draft" },
   DEPLOYING: { ja: "デプロイ中", en: "Deploying" },

--- a/apps/application-admin-console/src/pages/AuditLog.tsx
+++ b/apps/application-admin-console/src/pages/AuditLog.tsx
@@ -19,9 +19,29 @@ import {
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useLang } from "../i18n";
-import { formatRelativeTime } from "../lib/format";
+import { formatDateTime, formatRelativeTime } from "../lib/format";
 
 const PAGE_LIMIT = 50;
+
+/**
+ * action から 対象 (target) resource の種別を推定し、 生 ID にラベルを付ける。 監査ログの
+ * 「対象」 が ULID / account id の生値だけだと 「何の ID か」 が分からないため。
+ */
+export function describeTarget(action: string, target: string | undefined): string {
+  if (!target) return "-";
+  if (action.includes("competitor_account")) return `AWS account ${target}`;
+  if (action.includes("credential")) return `Team credential ${target}`;
+  if (
+    action.includes("event") ||
+    action.includes("scoring") ||
+    action.includes("deploy") ||
+    action.includes("notification") ||
+    action.includes("disruption")
+  ) {
+    return `Event ${target}`;
+  }
+  return target;
+}
 
 type AuditFilters = {
   readonly from: string;
@@ -225,13 +245,22 @@ export function AuditLogPage({ config }: { config: AppConfig }) {
           {
             id: "occurredAt",
             header: "発生日時",
-            // Issue #1362: ISO 生値ではなく 「N 分前」 表示 + hover で絶対時刻 tooltip。
-            cell: (i) => <span title={i.occurredAt}>{formatRelativeTime(i.occurredAt, lang)}</span>,
+            // 絶対時刻 + 相対時刻を併記 (= 「いつ」 を一目で。 相対だけだと 「今 / 17 分前」 で
+            // 何時か分からない、 絶対だけだと直近かどうか分かりにくい)。
+            cell: (i) => (
+              <span title={i.occurredAt}>
+                {formatDateTime(i.occurredAt, lang)}
+                <Box variant="small" color="text-status-inactive" display="inline">
+                  {" "}
+                  ({formatRelativeTime(i.occurredAt, lang)})
+                </Box>
+              </span>
+            ),
           },
           { id: "actor", header: "実行者", cell: (i) => i.actorUsername ?? i.actor },
           { id: "action", header: "操作", cell: (i) => i.action },
           { id: "outcome", header: "結果", cell: (i) => outcomeIndicator(i.outcome) },
-          { id: "target", header: "対象", cell: (i) => i.target ?? "-" },
+          { id: "target", header: "対象", cell: (i) => describeTarget(i.action, i.target) },
           { id: "ipAddress", header: "IP", cell: (i) => i.ipAddress ?? "-" },
         ]}
         empty={

--- a/apps/application-admin-console/test/lib/format.test.ts
+++ b/apps/application-admin-console/test/lib/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatEventStatus, formatRelativeTime, formatRole } from "../../src/lib/format";
+import {
+  formatDateTime,
+  formatEventStatus,
+  formatRelativeTime,
+  formatRole,
+} from "../../src/lib/format";
 
 /**
  * Issue #1362: 用途別グルーピング + 表示加工 helpers の pure-function 検証。
@@ -45,6 +50,19 @@ describe("formatRelativeTime", () => {
 
   it("should treat future timestamps as 「今」 (= clock skew defense)", () => {
     expect(formatRelativeTime("2026-05-05T11:00:00.000Z", "ja", NOW)).toBe("今");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("should pass through an invalid ISO unchanged (= defensive fallback)", () => {
+    expect(formatDateTime("not-a-date")).toBe("not-a-date");
+  });
+
+  it("should render an absolute date-time for a valid ISO (ja + en)", () => {
+    const ja = formatDateTime("2026-05-05T10:00:00.000Z", "ja");
+    expect(ja).toContain("2026");
+    expect(ja).not.toBe("2026-05-05T10:00:00.000Z"); // not the raw ISO
+    expect(formatDateTime("2026-05-05T10:00:00.000Z", "en")).toContain("2026");
   });
 });
 

--- a/apps/application-admin-console/test/pages/AuditLog.test.tsx
+++ b/apps/application-admin-console/test/pages/AuditLog.test.tsx
@@ -3,7 +3,13 @@ import { StatusCodes } from "http-status-codes";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantAuditApiError, type TenantAuditItem } from "../../src/api/audit-log-client";
 import type { AppConfig } from "../../src/config";
-import { AuditLogPage, buildListInput, describeError, mergeItems } from "../../src/pages/AuditLog";
+import {
+  AuditLogPage,
+  buildListInput,
+  describeError,
+  describeTarget,
+  mergeItems,
+} from "../../src/pages/AuditLog";
 
 /**
  * Tenant Admin Console の AuditLogPage (#1292)。 pure helper (buildListInput / mergeItems /
@@ -49,6 +55,22 @@ describe("AuditLog helpers", () => {
     );
     expect(describeError(new Error("network down"))).toBe("network down");
     expect(describeError("weird")).toBe("audit log の取得に失敗しました");
+  });
+
+  it("should label the target by resource type inferred from the action", () => {
+    expect(describeTarget("create_event", "EV1")).toBe("Event EV1");
+    expect(describeTarget("fire_disruption", "EV1")).toBe("Event EV1");
+    expect(describeTarget("lock_scoring", "EV1")).toBe("Event EV1");
+    expect(describeTarget("bulk_deploy", "EV1")).toBe("Event EV1");
+    expect(describeTarget("create_notification", "EV1")).toBe("Event EV1");
+    expect(describeTarget("create_competitor_account", "672726205532")).toBe(
+      "AWS account 672726205532",
+    );
+    expect(describeTarget("register_team_cloud_credential", "team-1")).toBe(
+      "Team credential team-1",
+    );
+    expect(describeTarget("some_other_action", "raw-id")).toBe("raw-id");
+    expect(describeTarget("create_event", undefined)).toBe("-");
   });
 });
 

--- a/infrastructure/lib/problem-deploy/handlers/shared/audit-log.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/audit-log.ts
@@ -176,12 +176,17 @@ export function extractAuditContext(c: {
     typeof claims?.["cognito:username"] === "string"
       ? (claims["cognito:username"] as string)
       : undefined;
-  const http = (event?.requestContext as { http?: { sourceIp?: string; userAgent?: string } })
-    ?.http;
+  // HTTP API v2 → requestContext.http.* ; REST API v1 (= tenant API) → requestContext.identity.*。
+  // claims と同様に v1/v2 両方を fallback で読む。 旧実装は v2 path のみで、 REST v1 の tenant API
+  // では IP / userAgent が常に undefined → 監査ログの IP 列が "-" のままだった。
+  const requestContext = event?.requestContext as {
+    http?: { sourceIp?: string; userAgent?: string };
+    identity?: { sourceIp?: string; userAgent?: string };
+  };
   return {
     actor: sub,
     actorUsername: cognitoUsername,
-    ipAddress: http?.sourceIp,
-    userAgent: http?.userAgent,
+    ipAddress: requestContext?.http?.sourceIp ?? requestContext?.identity?.sourceIp,
+    userAgent: requestContext?.http?.userAgent ?? requestContext?.identity?.userAgent,
   };
 }

--- a/infrastructure/test/problem-deploy/audit-log.test.ts
+++ b/infrastructure/test/problem-deploy/audit-log.test.ts
@@ -200,17 +200,23 @@ describe("extractAuditContext (#950)", () => {
     expect(ctx.userAgent).toBe("curl/8.0");
   });
 
-  it("should still extract actor from REST API form (authorizer.claims)", () => {
+  it("should extract actor + ipAddress + userAgent from REST API V1 form (authorizer.claims + identity.*)", () => {
+    // REST API v1 (= tenant API) は IP を requestContext.identity.* に置く。 旧実装は v2 の
+    // http.* しか読まず IP が常に "-" になっていた regression を pin する。
     const ctx = extractAuditContext({
       env: {
         event: {
           requestContext: {
-            authorizer: { claims: { sub: "def-456" } },
+            authorizer: { claims: { sub: "def-456", "cognito:username": "bob@example.com" } },
+            identity: { sourceIp: "198.51.100.7", userAgent: "Mozilla/5.0" },
           },
         },
       },
     });
     expect(ctx.actor).toBe("def-456");
+    expect(ctx.actorUsername).toBe("bob@example.com");
+    expect(ctx.ipAddress).toBe("198.51.100.7");
+    expect(ctx.userAgent).toBe("Mozilla/5.0");
   });
 
   it("claims 不在なら actor='unknown', 他は undefined", () => {


### PR DESCRIPTION
## Summary

Operator report on the 監査ログ: 発生日時 showed only relative time, 対象 was a bare ID, and IP was always "-".

1. **発生日時** — now shows **absolute + relative** ("2026/06/04 08:53 (17 min ago)"). Added `formatDateTime` (local absolute time; raw passthrough on invalid).
2. **対象** — labeled by **resource type inferred from the action**: `Event {id}` / `AWS account {id}` / `Team credential {id}` (a bare ULID/account-id didn't say *what* it was).
3. **IP** — fixed the **always-"-"** root cause. The tenant API is a **REST API (v1)**, which puts the source IP at `requestContext.identity.sourceIp`, but `extractAuditContext` only read the **v2-only** path `requestContext.http.sourceIp` (claims had a v1 fallback; IP didn't). Added the v1 `identity.*` fallback.

## Test plan
- `audit-log.test`: new REST-v1 (`identity.*`) extraction test — **fails before the fix, passes after**; existing v2 (`http.*`) test still green.
- app-admin: `describeTarget` all branches + `formatDateTime` (valid/invalid, ja/en) pinned. 956 tests green, **coverage 100%**, tsc / biome / `make harness` green.

## Regression analysis
- `extractAuditContext` keeps v2 precedence via `??` → HTTP-API paths unaffected. It's a single shared helper, so every audit row (competitor-accounts + event-handler) now records the IP.
- 発生日時 / 対象 are display-only; invalid timestamps fall back to the raw value.

## Physical impact
- UPDATE: EventApi / CompetitorAccountsApi Lambda code + app-admin bundle. NO-OP: CFn / IAM / DynamoDB (audit schema unchanged; `ipAddress` was already optional).

## Follow-up (PR-B, separate)
The filter overhaul you asked for — CloudWatch-style from/to (DateRangePicker: absolute calendar + relative quick-select) and `action` as a combobox from the defined action list — is a larger frontend change; coming next.

Relates #950 #1292