### PR TITLE
fix(api): add security headers to all execute-api/Hono JSON responses

### DIFF
--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { StatusCodes } from "http-status-codes";
+import { secureApiHeaders } from "../../../problem-deploy/handlers/shared/secure-headers.js";
 import { exportAuditEntriesCsv, listAuditEntries } from "./audit.js";
 import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
 import { defaultBudgetsClient, getCostSummary } from "./cost.js";
@@ -48,6 +49,11 @@ const MAX_TENANT_IDS = 100;
 const LIST_LIMIT_MAX = 200;
 
 const app = new Hono();
+
+// #1694: 全レスポンスに API セキュリティヘッダを付与 (nosniff / no-store / X-Frame-Options /
+// Referrer-Policy)。 audit CSV export は独自の Content-Disposition を持つため middleware は
+// それを尊重 (= 上書きしない)。
+app.use("*", secureApiHeaders());
 
 // #1392: CORS は API Gateway HTTP API の corsPreflight (admin-console-insight-stack.ts) が
 // localhost dev + admin-console CloudFront origin の allowlist で一元管理する。 ここで Hono の

--- a/infrastructure/lib/control-plane/handlers/idp-handler/routes.ts
+++ b/infrastructure/lib/control-plane/handlers/idp-handler/routes.ts
@@ -9,6 +9,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
+import { secureApiHeaders } from "../../../problem-deploy/handlers/shared/secure-headers.js";
 import { resolveCognitoSub } from "./auth.js";
 import {
   type AuditEventInput,
@@ -41,6 +42,9 @@ export interface RouteWiringOptions {
 
 export function buildIdpApp(opts: RouteWiringOptions): Hono {
   const app = new Hono();
+
+  // #1694: API セキュリティヘッダを CORS より前 (outermost) に適用 (= onError 経路にも付与)。
+  app.use("*", secureApiHeaders());
 
   app.use(
     "*",

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/index.ts
@@ -13,6 +13,7 @@ import {
   TENANT_ROLES,
 } from "../deploy-handler/auth.js";
 import { extractAuditContext, writeAuditEvent } from "../shared/audit-log.js";
+import { secureApiHeaders } from "../shared/secure-headers.js";
 import { routeDelete, routeGet, routePut } from "./saml-routes.js";
 import { buildCompetitorAccountsSharedResources } from "./shared.js";
 import {
@@ -56,6 +57,9 @@ const AWS_ACCOUNT_ID_RE = /^\d{12}$/;
 const shared = buildCompetitorAccountsSharedResources();
 
 const app = new Hono();
+
+// #1694: API セキュリティヘッダを CORS より前 (outermost) に適用 (= onError 経路にも付与)。
+app.use("*", secureApiHeaders());
 
 app.use(
   "*",

--- a/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/index.ts
@@ -13,6 +13,7 @@ import { parseJsonBody, withBearerAuth } from "../participant-handler/route-help
 import { CoordinationOpBodySchema } from "../participant-handler/schemas.js";
 import { buildParticipantSharedResources } from "../participant-handler/shared.js";
 import { RATE_LIMITS } from "../shared/rate-limiter.js";
+import { secureApiHeaders } from "../shared/secure-headers.js";
 import { defaultS3PluginImporter } from "./s3-plugin-importer.js";
 
 /**
@@ -65,6 +66,10 @@ function respondCoordination(
 }
 
 const app = new Hono();
+
+// #1694: 全レスポンスに API セキュリティヘッダ (nosniff / no-store / X-Frame-Options /
+// Referrer-Policy / JSON Content-Disposition)。
+app.use("*", secureApiHeaders());
 
 app.get("/portal/healthz", (c) => c.json({ ok: true }));
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import { StatusCodes } from "http-status-codes";
 import { ULID_RE as JOB_ID_RE, PROBLEM_ID_RE } from "../shared/constants.js";
 import { RuntimeNotSupportedError } from "../shared/runtime/index.js";
+import { secureApiHeaders } from "../shared/secure-headers.js";
 import {
   ForbiddenRoleError,
   MissingTenantClaimError,
@@ -57,6 +58,11 @@ function parseLimit(value: string | undefined): { ok: true; limit: number | unde
 }
 
 const app = new Hono();
+
+// #1694: 全レスポンスに API セキュリティヘッダ (nosniff / no-store / X-Frame-Options /
+// Referrer-Policy / JSON Content-Disposition)。 CORS より前 (outermost) に置き、 onError
+// 経由のエラーレスポンスにも付くようにする。
+app.use("*", secureApiHeaders());
 
 // CORS は本 Lambda 側で打つ (= API Gateway の defaultCorsPreflightOptions は OPTIONS のみ
 // 対応で、実 POST/GET レスポンスには Access-Control-Allow-Origin が付かないため)。

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/index.ts
@@ -9,6 +9,7 @@ import {
   requireRole,
   TENANT_ROLES,
 } from "../deploy-handler/auth.js";
+import { secureApiHeaders } from "../shared/secure-headers.js";
 import { registerAuditLogRoutes } from "./routes/audit-log.js";
 import { registerBulkDeployRoutes } from "./routes/bulk-deploy.js";
 import { registerDisruptionRoutes } from "./routes/disruptions.js";
@@ -45,6 +46,9 @@ import { buildEventSharedResources } from "./shared.js";
 const shared = buildEventSharedResources();
 
 const app = new Hono();
+
+// #1694: API セキュリティヘッダを CORS より前 (outermost) に適用 (= onError 経路にも付与)。
+app.use("*", secureApiHeaders());
 
 app.use(
   "*",

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -8,6 +8,7 @@ import {
   upsertProblemEndpointOverride,
 } from "../problem-endpoints-handler/endpoints.js";
 import { RATE_LIMITS } from "../shared/rate-limiter.js";
+import { secureApiHeaders } from "../shared/secure-headers.js";
 import { BATTLE_ATTACKS_SINCE_MIN_DEFAULT, listBattleAttacks } from "./battle-attacks.js";
 import { castEvent, INBOX_SINCE_MS_MAX, readInbox } from "./cast-event.js";
 import {
@@ -72,6 +73,11 @@ const shared = buildParticipantSharedResources();
 // Lambda は sts:AssumeRole / ssm / kms を持つため、 未信頼 plugin を実行する coordination は
 // ここに置かない (ADR-030 S2 = blast radius を IAM で封じる)。
 const app = new Hono();
+
+// #1694: 全レスポンスに API セキュリティヘッダ (nosniff / no-store / X-Frame-Options /
+// Referrer-Policy / JSON Content-Disposition)。 fetch/XHR では Content-Disposition は無視
+// されるため SPA は壊れず、 cli-credentials 等の機密 JSON が no-store になる。
+app.use("*", secureApiHeaders());
 
 app.get("/portal/healthz", (c) => c.json({ ok: true }));
 

--- a/infrastructure/lib/problem-deploy/handlers/shared/secure-headers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/secure-headers.ts
@@ -1,0 +1,46 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Issue #1694: execute-api (Hono on Lambda) の JSON レスポンスにセキュリティヘッダを付与する
+ * 共有 middleware。 SPA 静的配信 (CloudFront ResponseHeadersPolicy, #855) と違い API は別
+ * オリジンでヘッダが付いていなかったため、 CloudFront を経由しない直叩きに対する多層防御として
+ * API レスポンスにも同等のヘッダを付ける (元監査 4 / 8 / 1 / 5 / 7)。
+ *
+ * **なぜ Hono 標準の `hono/secure-headers` を直接使わないか**:
+ *   標準 `secureHeaders()` は default で `Cross-Origin-Resource-Policy: same-origin` /
+ *   `Cross-Origin-Embedder-Policy: require-corp` / `Cross-Origin-Opener-Policy: same-origin`
+ *   を付ける。 本 API は SPA (CloudFront origin) から **クロスオリジン** で fetch される
+ *   (= API は `*.execute-api` origin)。 CORP: same-origin はクロスオリジン読み取りを壊し得る
+ *   ため、 これらを 1 つ 1 つ false にするより、 安全なヘッダだけを明示的に立てる方が
+ *   「CORS を壊さない」 (受け入れ条件) を確実に満たせる。
+ *
+ * 付与するヘッダ:
+ *   - `X-Content-Type-Options: nosniff` — MIME sniffing 由来の JSON-XSS を無効化 (監査 4)。常に強制。
+ *   - `X-Frame-Options: DENY` — API レスポンスは frame 化させない (監査 1)。常に強制。
+ *   - `Referrer-Policy: strict-origin-when-cross-origin` — リファラ漏洩を抑制 (監査 7)。常に強制。
+ *   - `Cache-Control: no-store` — 認証必須 / 機密 JSON をキャッシュさせない (監査 8)。
+ *       route が独自に Cache-Control を立てた場合は尊重 (= 上書きしない) ので、 将来 cacheable な
+ *       public endpoint が出ても opt-out できる。
+ *   - `Content-Disposition: attachment` — JSON を直叩きされたときの inline render を防ぐ多層防御
+ *       (監査 4)。 fetch/XHR では無視されるため SPA は壊れない。 **JSON のみ** に付け、 CSV export 等が
+ *       既に独自 Content-Disposition (`attachment; filename=...`) を立てている場合は尊重する。
+ *
+ * `await next()` 後に `c.res.headers` を直接 set する (= Hono 標準 secureHeaders と同じ機構)。
+ * これにより onError 経由のエラーレスポンスにもヘッダが付く。
+ */
+export function secureApiHeaders(): MiddlewareHandler {
+  return async (c, next) => {
+    await next();
+    const headers = c.res.headers;
+    headers.set("X-Content-Type-Options", "nosniff");
+    headers.set("X-Frame-Options", "DENY");
+    headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+    if (!headers.has("Cache-Control")) {
+      headers.set("Cache-Control", "no-store");
+    }
+    const contentType = headers.get("Content-Type") ?? "";
+    if (contentType.includes("application/json") && !headers.has("Content-Disposition")) {
+      headers.set("Content-Disposition", "attachment");
+    }
+  };
+}

--- a/infrastructure/test/problem-deploy/handlers/shared/secure-headers.test.ts
+++ b/infrastructure/test/problem-deploy/handlers/shared/secure-headers.test.ts
@@ -1,0 +1,108 @@
+import { Hono } from "hono";
+import { StatusCodes } from "http-status-codes";
+import { describe, expect, it } from "vitest";
+import { secureApiHeaders } from "../../../../lib/problem-deploy/handlers/shared/secure-headers.js";
+
+/**
+ * Issue #1694: execute-api (Hono on Lambda) の JSON レスポンスにセキュリティヘッダを付与する
+ * 共有 middleware。 bare-Hono app に乗せて dispatch し、 付与ヘッダ / 既存ヘッダ尊重 /
+ * CORS 非干渉 / onError 経路でも付くことを pin する。
+ */
+function buildApp() {
+  const app = new Hono();
+  app.use("*", secureApiHeaders());
+  app.get("/json", (c) => c.json({ ok: true }, StatusCodes.OK));
+  app.get("/with-cache", (c) => {
+    c.header("Cache-Control", "public, max-age=60");
+    return c.json({ cacheable: true }, StatusCodes.OK);
+  });
+  app.get("/csv", (c) => {
+    c.header("Content-Type", "text/csv; charset=utf-8");
+    c.header("Content-Disposition", 'attachment; filename="audit.csv"');
+    return c.body("a,b\n1,2\n", StatusCodes.OK);
+  });
+  app.get("/text", (c) => c.text("hello", StatusCodes.OK));
+  app.get("/no-content", (c) => c.body(null, StatusCodes.NO_CONTENT));
+  app.get("/boom", () => {
+    throw new Error("kaboom");
+  });
+  return app;
+}
+
+describe("secureApiHeaders (Issue #1694)", () => {
+  it("should set X-Content-Type-Options: nosniff on JSON responses", async () => {
+    const res = await buildApp().request("/json");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("should set X-Frame-Options: DENY", async () => {
+    const res = await buildApp().request("/json");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("should set Referrer-Policy: strict-origin-when-cross-origin", async () => {
+    const res = await buildApp().request("/json");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("should set Cache-Control: no-store when the route did not set one", async () => {
+    const res = await buildApp().request("/json");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("should NOT override a route-level Cache-Control (cacheable opt-out)", async () => {
+    const res = await buildApp().request("/with-cache");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("should add Content-Disposition: attachment for JSON responses", async () => {
+    const res = await buildApp().request("/json");
+    expect(res.headers.get("Content-Disposition")).toBe("attachment");
+  });
+
+  it("should NOT override an existing Content-Disposition (CSV export preserved)", async () => {
+    const res = await buildApp().request("/csv");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="audit.csv"');
+    // CSV でも nosniff / no-store は付く
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("should NOT add Content-Disposition for non-JSON responses", async () => {
+    const res = await buildApp().request("/text");
+    expect(res.headers.get("Content-Disposition")).toBeNull();
+    // 但し nosniff / frame-options は全レスポンスに付く
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("should handle a response without a Content-Type (no Content-Disposition added)", async () => {
+    const res = await buildApp().request("/no-content");
+    expect(res.status).toBe(StatusCodes.NO_CONTENT);
+    expect(res.headers.get("Content-Disposition")).toBeNull();
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("should still attach headers to error responses routed through onError", async () => {
+    const app = buildApp();
+    app.onError((_err, c) =>
+      c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR),
+    );
+    const res = await app.request("/boom");
+    expect(res.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("should not interfere with CORS headers set by a downstream middleware", async () => {
+    const app = new Hono();
+    app.use("*", secureApiHeaders());
+    app.use("*", async (c, next) => {
+      await next();
+      c.res.headers.set("Access-Control-Allow-Origin", "*");
+    });
+    app.get("/json", (c) => c.json({ ok: true }, StatusCodes.OK));
+    const res = await app.request("/json");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});


### PR DESCRIPTION
## Summary
CloudFront の `ResponseHeadersPolicy` (#855) は **SPA 静的配信オリジンのみ** に効いており、API (別オリジンの `*.execute-api`、Hono on Lambda) の JSON レスポンスにはセキュリティヘッダが付いていませんでした。CloudFront を経由しない直叩きに対する多層防御として、共有 middleware `secureApiHeaders()` を追加し、HTTP-facing な全 Hono ハンドラに配線します。

付与するヘッダ:
- `X-Content-Type-Options: nosniff`（常に / 監査4）— MIME sniffing 由来の JSON-XSS を無効化
- `X-Frame-Options: DENY` + `Referrer-Policy: strict-origin-when-cross-origin`（常に / 監査1・7）
- `Cache-Control: no-store`（認証必須 JSON / 監査8）— route が独自に Cache-Control を立てた場合は尊重（将来 cacheable な public endpoint が opt-out 可能）
- `Content-Disposition: attachment`（**JSON のみ** / 監査4）— 直叩き時の inline render 防止。fetch/XHR では無視されるため SPA は無影響。CSV export 等の既存 `Content-Disposition` は尊重

配線先（HTTP-facing Hono ハンドラ 8 本）: `deploy-handler` / `event-handler` / `competitor-accounts-handler` / `participant-handler` / `coordination-dispatcher-handler` / `admin-insight-handler` + Control/Application 両プレーンの IdP ハンドラ（`buildIdpApp` 経由で 1 箇所配線）。

### なぜ `hono/secure-headers` 既定を使わないか
標準 `secureHeaders()` は default で `Cross-Origin-Resource-Policy: same-origin` / COEP / COOP を付けます。本 API は SPA (CloudFront origin) から**クロスオリジン**で fetch されるため、CORP: same-origin はクロスオリジン読み取りを壊し得ます。各オプションを個別に false にするより、CORS-safe なヘッダだけを明示的に立てる方が「既存 CORS を壊さない」受け入れ条件を確実に満たせるため、薄いカスタム middleware を採用しました。

## Test plan
- `infrastructure/test/problem-deploy/handlers/shared/secure-headers.test.ts`: nosniff/X-Frame/Referrer の常時付与、no-store の付与と route 上書きの尊重、JSON への Content-Disposition 付与、CSV の Content-Disposition 非上書き、非 JSON への非付与、Content-Type 無しレスポンス、onError 経路でもヘッダが付く、CORS 非干渉 を pin（11 ケース）。新ファイル coverage 100%（stmts/branch/func/line）。
- 既存 infra テスト 253 ファイル / 2696 件すべて green（middleware 配線による回帰なし）。
- `make harness` / `make before-commit` green。

## Regression analysis
- **CORS**: middleware は `Access-Control-*` を一切触らず、CORP/COEP/COOP も設定しないため、SPA のクロスオリジン fetch は無影響。テストで CORS 非干渉を pin。
- **CSV download**: `admin-insight` audit export と `event-handler` audit-log export は独自の `Content-Disposition: attachment; filename=...` を持つ。middleware は既存値を上書きしないため download 挙動は不変（テストで pin）。
- **既存ハンドラ動作**: middleware は `await next()` 後にレスポンスヘッダを追加するのみで status/body を変えない。全 2696 既存テスト green。
- **healthz**: 未認証だが no-store / nosniff が付くだけで実害なし。
- **キャッシュ**: これまで API レスポンスにキャッシュ指示は無く、ブラウザ/中間でのヒューリスティックキャッシュが起こり得た。`no-store` 付与で機密 JSON が確実に非キャッシュ化される（望ましい変化）。

## Physical impact
- Lambda ハンドラ（アプリ）コードのみ。CDK スタック / CFn テンプレート / IAM への変更なし → **NO-OP**（インフラ差分なし）。`make check-synth` で synth 済み 10 テンプレートの IAM Description が Latin-1 範囲であることを確認、構成差分なし。

Relates #1699
Closes #1694