### PR TITLE
fix(auth): harden Cognito session — explicit token validity + revocation

### DIFF
--- a/infrastructure/lib/control-plane-stack.ts
+++ b/infrastructure/lib/control-plane-stack.ts
@@ -138,6 +138,22 @@ export class ControlPlaneStack extends cdk.Stack {
         : ["http://localhost", ...LOCALHOST_LOGOUT_URLS, ...extraLogoutUrls],
     );
 
+    // Issue #1696 (audit 3 / 12): SystemAdmin セッションの堅牢化。 SBT が内部生成する
+    // UserPoolUserClient に token validity を escape hatch で明示する。 access / id token は
+    // 60 分、 refresh token は default 30 日が「長すぎる」指摘なので 1 日に短縮 (運用で調整可)。
+    // `TokenValidityUnits` を明示しないと AccessTokenValidity=60 は 60 *時間* と解釈されるため
+    // 単位も必ず併せて指定する。 `EnableTokenRevocation` を明示 true にして、 frontend logout が
+    // 呼ぶ `/oauth2/revoke` (#833) が refresh token を実効的に失効できるよう担保する。
+    cfnUserClient.addPropertyOverride("AccessTokenValidity", 60);
+    cfnUserClient.addPropertyOverride("IdTokenValidity", 60);
+    cfnUserClient.addPropertyOverride("RefreshTokenValidity", 1);
+    cfnUserClient.addPropertyOverride("TokenValidityUnits", {
+      AccessToken: "minutes",
+      IdToken: "minutes",
+      RefreshToken: "days",
+    });
+    cfnUserClient.addPropertyOverride("EnableTokenRevocation", true);
+
     // Issue #653: SBT default の SystemAdmin 招待メール本文は `http://localhost` を
     // 埋めてしまうため、 admin-console origin に書き換える。 Phase 1 deploy 時は
     // CDK_PARAM_ADMIN_CONSOLE_ORIGIN 未確定なので fallback 文面、 Phase 3 再 deploy で

--- a/infrastructure/lib/tenant-template/identity-provider.ts
+++ b/infrastructure/lib/tenant-template/identity-provider.ts
@@ -1,4 +1,4 @@
-import { aws_cognito, Stack } from "aws-cdk-lib";
+import { aws_cognito, Duration, Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import type { IdentityDetails } from "../interfaces/identity-details.js";
 
@@ -234,6 +234,15 @@ export class IdentityProvider extends Construct {
     this.tenantUserPoolClient = new aws_cognito.UserPoolClient(this, "tenantUserPoolClient", {
       userPool: this.tenantUserPool,
       generateSecret: false,
+      // Issue #1696 (audit 3 / 12): セッション堅牢化。 access / id token は 60 分 (= 短命、
+      // logout 後の残存窓を狭める)。 refresh token は default 30 日が「長すぎる」指摘なので 1 日に
+      // 短縮する (運用ポリシーで調整可)。 enableTokenRevocation を明示 true にして、 frontend の
+      // beginLogout が呼ぶ `/oauth2/revoke` (#833) が実効的に refresh token を失効させられるよう
+      // 担保する (= CDK default も true だが、 監査要件として明示する)。
+      accessTokenValidity: Duration.minutes(60),
+      idTokenValidity: Duration.minutes(60),
+      refreshTokenValidity: Duration.days(1),
+      enableTokenRevocation: true,
       authFlows,
       writeAttributes: writeAttributes,
       readAttributes: readAttributes,

--- a/infrastructure/test/identity-provider.test.ts
+++ b/infrastructure/test/identity-provider.test.ts
@@ -45,6 +45,26 @@ describe("IdentityProvider", () => {
       );
     });
 
+    it("Issue #1696: should harden the tenant UserPoolClient session (60min access/id, 1day refresh, revocation on)", () => {
+      const { template } = synth("tenant-1", "https://d123abc.cloudfront.net");
+      // CDK の L2 UserPoolClient は token validity を CFn 上すべて minutes に正規化する
+      // (= refresh 1 day → 1440 min)。 値は機能的に 60min / 60min / 1day で正しい。
+      template.hasResourceProperties(
+        "AWS::Cognito::UserPoolClient",
+        Match.objectLike({
+          AccessTokenValidity: 60,
+          IdTokenValidity: 60,
+          RefreshTokenValidity: 1440,
+          TokenValidityUnits: {
+            AccessToken: "minutes",
+            IdToken: "minutes",
+            RefreshToken: "minutes",
+          },
+          EnableTokenRevocation: true,
+        }),
+      );
+    });
+
     it("UserPoolDomain prefix should use lowercased TenkaCloud-{env}-{tenantId}-{accountId}", () => {
       const { template } = synth("Tenant-ABC", "https://example.cloudfront.net", "Development");
       template.hasResourceProperties("AWS::Cognito::UserPoolDomain", {


### PR DESCRIPTION
## Summary
監査項目 2/3/12（セッション堅牢化）。まず調査結果を共有します。

- **項目 12（ログアウト後操作）**: すでに #833 で対応済み — frontend `beginLogout` が `/oauth2/revoke`（refresh token のサーバ側失効）を呼び、Hosted UI `/logout` に redirect して Cognito セッション cookie を破棄しています。
- **項目 2（固定値トークン）**: participant の `teamLoginKey` は `randomBytes(32).toString("base64url")` = **256-bit のチーム単位ランダム秘密**で、固定値ではありません。変更不要。

残る項目 3（セッションが長い）が UserPoolClient の設定です。本 PR で:
- **テナント UserPoolClient**（`identity-provider.ts`）: `accessTokenValidity` / `idTokenValidity` = 60 分、`refreshTokenValidity` = 1 日（default 30 日から短縮）、`enableTokenRevocation = true`。
- **Control Plane の SystemAdmin client**（SBT 生成）: 既存の `CfnUserPoolClient` escape hatch で同値を設定（`TokenValidityUnits` を明示）。

`enableTokenRevocation = true` は #833 の `/oauth2/revoke` が実効的に refresh token を失効させるために必要です（CDK default も true ですが、監査要件として明示）。

## ⚠️ インフラ（CDK）変更 — メンテナのレビュー/マージをお願いします
役割分担（AGENTS.md）に従い、本 PR は提案として開き、self-merge しません。特に **`refreshTokenValidity = 1 日` は運用ポリシーの判断**です（短くするほど再ログイン頻度が上がる）。値はご判断で調整してください。

## Test plan
- `infrastructure/test/identity-provider.test.ts`: テナント client の synth 出力をアサート。CDK L2 は token validity を CFn 上すべて **minutes** に正規化するため `RefreshTokenValidity: 1440`（= 1 日）になることを pin（synth 出力ベースの機械チェック）。
- Control Plane client は SBT 統合のため `make check-synth`（全スタック synth）で escape-hatch override が成立することを検証。
- `make harness` / `make before-commit` green。

## Regression analysis
- **再ログイン頻度**: refresh token 30 日 → 1 日への短縮で、運営者は最大 1 日ごとに再ログインが必要になる（access/id は従来通り 60 分）。UX とのトレードオフは運用判断。
- **token 失効の実効性**: `enableTokenRevocation` は CDK / SBT default でも true の見込みだが、明示することで #833 の revoke 経路が将来の default 変更に影響されない。
- **SBT escape hatch**: 既存の `CallbackURLs` / `LogoutURLs` override と同じ機構。`make check-synth` で 10 テンプレートが正常 synth されることを確認済み。
- access/id の 60 分は Cognito default と同値（実質的な振る舞い変化なし）。

## Physical impact
- CFn 差分: `AWS::Cognito::UserPoolClient`（Control Plane + tenant-template）の token validity / revocation プロパティ **UPDATE**（リソース置換なし=in-place 更新）。新規/削除リソースなし。

Relates #1699
Closes #1696