### PR TITLE
feat(app-admin): self-service tenant data export (data subject rights)

### DIFF
--- a/apps/application-admin-console/src/App.tsx
+++ b/apps/application-admin-console/src/App.tsx
@@ -48,7 +48,7 @@ export function App({ config }: { config: AppConfig }) {
       <Routes>
         <Route path="/login" element={<LoginRoute config={config} />} />
         <Route path="/callback" element={<CallbackPage config={config} />} />
-        <Route path="/" element={guarded(<HomePage />, config)} />
+        <Route path="/" element={guarded(<HomePage config={config} />, config)} />
         <Route path="/problems" element={guarded(<ProblemsPage />, config)} />
         <Route
           path="/problems/:problemId"

--- a/apps/application-admin-console/src/data/tenant-data-export.ts
+++ b/apps/application-admin-console/src/data/tenant-data-export.ts
@@ -1,0 +1,99 @@
+import type { ApiClient } from "../api/client";
+import { listCompetitorAccounts } from "../api/competitor-accounts-client";
+import { listAllDeployments } from "../api/deploy-client";
+import { listEvents } from "../api/events-client";
+
+/**
+ * Issue #1697 (audit 9, データ主体の権利): 自テナント配下の主要データを 1 操作で JSON に
+ * 集約し、 ブラウザからダウンロードさせる。 新規 backend / IAM を増やさず、 既存の
+ * **テナント scope 済** API (events / deployments / competitor accounts) を再利用して
+ * client 側で束ねる (= cross-tenant に触れない既存 isolation をそのまま継承)。
+ *
+ * 監査ログは別途 Audit Log ページに専用の CSV export があるため本 JSON には含めず、
+ * `auditLog` フィールドにその旨を記す (= データ category として漏らさない明示)。
+ */
+export const TENANT_EXPORT_SCHEMA_VERSION = 1;
+
+export interface TenantDataExport {
+  schemaVersion: number;
+  tenantId: string | null;
+  tenantName: string | null;
+  exportedAt: string;
+  events: readonly unknown[];
+  deployments: readonly unknown[];
+  competitorAccounts: readonly unknown[];
+  /** 監査ログは Audit Log ページの CSV export を参照 (本 JSON には含めない)。 */
+  auditLog: "see CSV export on the Audit Log page";
+}
+
+export interface TenantExportMeta {
+  tenantId: string | null;
+  tenantName: string | null;
+  exportedAt: string;
+}
+
+const PAGE_LIMIT = 200;
+
+/**
+ * cursor ページングを最後まで辿り、 全件を 1 配列に集める。 silent truncation を避ける
+ * ため、 nextCursor が無くなるまでループする (= 「全データ」を謳う export の正直さ)。
+ */
+async function collectAllPages<T>(
+  fetchPage: (cursor?: string) => Promise<{ items: readonly T[]; nextCursor?: string }>,
+): Promise<T[]> {
+  const all: T[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await fetchPage(cursor);
+    all.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return all;
+}
+
+/**
+ * 自テナントの events / deployments / competitor accounts を全件取得し、 メタ情報を付けて
+ * 1 つの export object にまとめる。
+ */
+export async function collectTenantDataExport(
+  api: ApiClient,
+  meta: TenantExportMeta,
+): Promise<TenantDataExport> {
+  const [events, deployments, competitorAccountsResponse] = await Promise.all([
+    collectAllPages((cursor) => listEvents(api, { limit: PAGE_LIMIT, cursor })),
+    collectAllPages((cursor) => listAllDeployments(api, { limit: PAGE_LIMIT, cursor })),
+    listCompetitorAccounts(api),
+  ]);
+  return {
+    schemaVersion: TENANT_EXPORT_SCHEMA_VERSION,
+    tenantId: meta.tenantId,
+    tenantName: meta.tenantName,
+    exportedAt: meta.exportedAt,
+    events,
+    deployments,
+    competitorAccounts: competitorAccountsResponse.items,
+    auditLog: "see CSV export on the Audit Log page",
+  };
+}
+
+/**
+ * JSON を Blob 化してダウンロードさせる。 AuditLog.tsx の CSV download と同じ機構
+ * (createObjectURL → anchor click → revoke)。 `doc` は test から差し替え可能。
+ */
+export function downloadJson(filename: string, data: unknown, doc: Document = document): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = doc.createElement("a");
+  a.href = url;
+  a.download = filename;
+  doc.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** export ファイル名。 tenantId と ISO 日時 (`:`/`.` を `-` に正規化) で一意化する。 */
+export function buildTenantExportFilename(tenantId: string | null, exportedAt: string): string {
+  const stamp = exportedAt.replace(/[:.]/g, "-");
+  return `tenant-data-${tenantId ?? "unknown"}-${stamp}.json`;
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -66,6 +66,10 @@
     "tenant_info_name": "Tenant name",
     "tenant_info_id": "Tenant ID",
     "tenant_info_tier": "Plan",
+    "export_data": "Export data",
+    "export_description": "Download your tenant's events, deployments, and competitor accounts as a single JSON file (the audit log has its own CSV export on the Audit Log page).",
+    "export_error_header": "Export failed",
+    "export_error_generic": "Failed to export your data.",
     "value_unset": "(not set)",
     "value_unknown": "(unknown)"
   },

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -66,6 +66,10 @@
     "tenant_info_name": "テナント名",
     "tenant_info_id": "テナント ID",
     "tenant_info_tier": "プラン",
+    "export_data": "データをエクスポート",
+    "export_description": "自テナントのイベント・デプロイ・競技アカウントを 1 つの JSON にまとめてダウンロードします (監査ログは Audit Log ページの CSV を参照)。",
+    "export_error_header": "エクスポートに失敗しました",
+    "export_error_generic": "データのエクスポートに失敗しました。",
     "value_unset": "(未設定)",
     "value_unknown": "(unknown)"
   },

--- a/apps/application-admin-console/src/pages/Home.tsx
+++ b/apps/application-admin-console/src/pages/Home.tsx
@@ -6,11 +6,18 @@ import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router";
+import { useApiClient } from "../api/client";
 import { useAuth } from "../auth/AuthProvider";
 import { decodeIdToken } from "../auth/claims";
+import type { AppConfig } from "../config";
 import { listProblemSummaries } from "../data/problems";
+import {
+  buildTenantExportFilename,
+  collectTenantDataExport,
+  downloadJson,
+} from "../data/tenant-data-export";
 import { useT } from "../i18n";
 import { resolveTenantDisplayName } from "../lib/tenant-display";
 
@@ -58,14 +65,41 @@ function writeOnboardingDismissed(value: boolean): void {
  * テナント名は JWT (custom:tenantName / custom:tenantId) から取り出す。
  * config.tenantName は pooled stack で "Shared Pooled Tenant" placeholder のため使わない。
  */
-export function HomePage() {
+export function HomePage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const auth = useAuth();
   const t = useT();
+  const apiClient = useApiClient(config);
   const claims = auth.tokens ? decodeIdToken(auth.tokens.idToken) : null;
   const tenantName = claims?.["custom:tenantName"];
   const tenantId = claims?.["custom:tenantId"];
   const tenantTier = claims?.["custom:tenantTier"];
+
+  // Issue #1697 (audit 9): 自テナント配下の events / deployments / competitor accounts を
+  // 1 操作で JSON にまとめてダウンロードする (= データ主体の export 権)。 既存のテナント
+  // scope 済 API を再利用するため cross-tenant には触れない。
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const onExportData = useCallback(async () => {
+    // button は apiClient 存在時のみ render するので null 分岐は防御 (= 不到達)。
+    /* v8 ignore next */
+    if (!apiClient) return;
+    setExporting(true);
+    setExportError(null);
+    try {
+      const exportedAt = new Date().toISOString();
+      const data = await collectTenantDataExport(apiClient, {
+        tenantId: tenantId ?? null,
+        tenantName: tenantName ?? null,
+        exportedAt,
+      });
+      downloadJson(buildTenantExportFilename(tenantId ?? null, exportedAt), data);
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : t("home.export_error_generic"));
+    } finally {
+      setExporting(false);
+    }
+  }, [apiClient, tenantId, tenantName, t]);
   // Issue #831: userEmail は TopNav 右上に移動済。 Home page で参照しない。
   // Issue #830: welcome 文に UUID を出さない。 tenantName が無いときは fallback (= "テナント")
   // を使い、 raw tenantId は 「テナント情報」 panel 側でのみ表示する。
@@ -140,20 +174,46 @@ export function HomePage() {
         </Container>
       )}
 
-      <Container header={<Header variant="h2">{t("home.tenant_info_header")}</Header>}>
-        <ColumnLayout columns={2} variant="text-grid">
-          <KeyValue
-            label={t("home.tenant_info_name")}
-            value={tenantName ?? t("home.value_unset")}
-          />
-          <KeyValue label={t("home.tenant_info_id")} value={tenantId ?? t("home.value_unknown")} />
-          <KeyValue
-            label={t("home.tenant_info_tier")}
-            valueNode={
-              tenantTier ? <Badge>{tenantTier}</Badge> : <span>{t("home.value_unknown")}</span>
+      <Container
+        header={
+          <Header
+            variant="h2"
+            description={t("home.export_description")}
+            actions={
+              apiClient ? (
+                <Button iconName="download" loading={exporting} onClick={onExportData}>
+                  {t("home.export_data")}
+                </Button>
+              ) : undefined
             }
-          />
-        </ColumnLayout>
+          >
+            {t("home.tenant_info_header")}
+          </Header>
+        }
+      >
+        <SpaceBetween size="m">
+          {exportError && (
+            <Alert type="error" header={t("home.export_error_header")}>
+              {exportError}
+            </Alert>
+          )}
+          <ColumnLayout columns={2} variant="text-grid">
+            <KeyValue
+              label={t("home.tenant_info_name")}
+              value={tenantName ?? t("home.value_unset")}
+            />
+            <KeyValue
+              label={t("home.tenant_info_id")}
+              value={tenantId ?? t("home.value_unknown")}
+            />
+            <KeyValue
+              label={t("home.tenant_info_tier")}
+              valueNode={
+                tenantTier ? <Badge>{tenantTier}</Badge> : <span>{t("home.value_unknown")}</span>
+              }
+            />
+          </ColumnLayout>
+        </SpaceBetween>
       </Container>
     </SpaceBetween>
   );

--- a/apps/application-admin-console/test/data/tenant-data-export.test.ts
+++ b/apps/application-admin-console/test/data/tenant-data-export.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../src/api/client";
+
+/**
+ * Issue #1697: 自テナントデータ export。 events / deployments の cursor を最後まで辿って
+ * 全件集約し (silent truncation 無し)、 competitor accounts を 1 回取得し、 メタ付き JSON に
+ * まとめる。 downloadJson は Blob → anchor click → revoke の機構を pin。
+ */
+const { mockListEvents, mockListAllDeployments, mockListCompetitorAccounts } = vi.hoisted(() => ({
+  mockListEvents: vi.fn(),
+  mockListAllDeployments: vi.fn(),
+  mockListCompetitorAccounts: vi.fn(),
+}));
+
+vi.mock("../../src/api/events-client", () => ({ listEvents: mockListEvents }));
+vi.mock("../../src/api/deploy-client", () => ({ listAllDeployments: mockListAllDeployments }));
+vi.mock("../../src/api/competitor-accounts-client", () => ({
+  listCompetitorAccounts: mockListCompetitorAccounts,
+}));
+
+const {
+  collectTenantDataExport,
+  downloadJson,
+  buildTenantExportFilename,
+  TENANT_EXPORT_SCHEMA_VERSION,
+} = await import("../../src/data/tenant-data-export");
+
+const api = {} as ApiClient;
+
+afterEach(() => vi.clearAllMocks());
+
+describe("collectTenantDataExport (Issue #1697)", () => {
+  it("should follow cursors across pages and aggregate all events + deployments", async () => {
+    mockListEvents
+      .mockResolvedValueOnce({ items: [{ id: "e1" }], nextCursor: "c1" })
+      .mockResolvedValueOnce({ items: [{ id: "e2" }] }); // no cursor → stop
+    mockListAllDeployments.mockResolvedValueOnce({ items: [{ jobId: "j1" }] });
+    mockListCompetitorAccounts.mockResolvedValue({ items: [{ awsAccountId: "111122223333" }] });
+
+    const data = await collectTenantDataExport(api, {
+      tenantId: "tenant-1",
+      tenantName: "Acme",
+      exportedAt: "2026-06-04T00:00:00.000Z",
+    });
+
+    expect(data.schemaVersion).toBe(TENANT_EXPORT_SCHEMA_VERSION);
+    expect(data.tenantId).toBe("tenant-1");
+    expect(data.tenantName).toBe("Acme");
+    expect(data.exportedAt).toBe("2026-06-04T00:00:00.000Z");
+    expect(data.events).toEqual([{ id: "e1" }, { id: "e2" }]); // 2 pages merged
+    expect(data.deployments).toEqual([{ jobId: "j1" }]);
+    expect(data.competitorAccounts).toEqual([{ awsAccountId: "111122223333" }]);
+    expect(data.auditLog).toMatch(/CSV export/);
+    expect(mockListEvents).toHaveBeenCalledTimes(2);
+    // 2 ページ目は cursor を渡している
+    expect(mockListEvents).toHaveBeenLastCalledWith(api, { limit: 200, cursor: "c1" });
+  });
+
+  it("should handle empty result sets", async () => {
+    mockListEvents.mockResolvedValue({ items: [] });
+    mockListAllDeployments.mockResolvedValue({ items: [] });
+    mockListCompetitorAccounts.mockResolvedValue({ items: [] });
+    const data = await collectTenantDataExport(api, {
+      tenantId: null,
+      tenantName: null,
+      exportedAt: "2026-06-04T00:00:00.000Z",
+    });
+    expect(data.events).toEqual([]);
+    expect(data.deployments).toEqual([]);
+    expect(data.competitorAccounts).toEqual([]);
+    expect(data.tenantId).toBeNull();
+  });
+});
+
+describe("buildTenantExportFilename", () => {
+  it("should build a filename from tenantId and a colon/dot-normalized timestamp", () => {
+    expect(buildTenantExportFilename("tenant-1", "2026-06-04T01:02:03.456Z")).toBe(
+      "tenant-data-tenant-1-2026-06-04T01-02-03-456Z.json",
+    );
+  });
+
+  it("should fall back to 'unknown' when tenantId is null", () => {
+    expect(buildTenantExportFilename(null, "2026-06-04T00:00:00.000Z")).toBe(
+      "tenant-data-unknown-2026-06-04T00-00-00-000Z.json",
+    );
+  });
+});
+
+describe("downloadJson", () => {
+  it("should create a blob URL, click an anchor, and revoke the URL", () => {
+    const createObjectURL = vi.fn().mockReturnValue("blob:fake");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+
+    const click = vi.fn();
+    const remove = vi.fn();
+    const anchor = { href: "", download: "", click, remove } as unknown as HTMLAnchorElement;
+    const appendChild = vi.fn();
+    const fakeDoc = {
+      createElement: vi.fn().mockReturnValue(anchor),
+      body: { appendChild },
+    } as unknown as Document;
+
+    downloadJson("out.json", { a: 1 }, fakeDoc);
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(anchor.download).toBe("out.json");
+    expect(anchor.href).toBe("blob:fake");
+    expect(appendChild).toHaveBeenCalledWith(anchor);
+    expect(click).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/application-admin-console/test/pages/Home.test.tsx
+++ b/apps/application-admin-console/test/pages/Home.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../src/config";
 import type { ProblemSummary } from "../../src/data/problems";
 
 /**
@@ -9,12 +10,24 @@ import type { ProblemSummary } from "../../src/data/problems";
  * localStorage 例外時の安全側 fallback を pin。 useNavigate / useAuth / decodeIdToken /
  * listProblemSummaries / useT / resolveTenantDisplayName を mock。
  */
-const { mockNav, mockAuth, mockDecode, mockListProblems, mockResolveName } = vi.hoisted(() => ({
+const {
+  mockNav,
+  mockAuth,
+  mockDecode,
+  mockListProblems,
+  mockResolveName,
+  mockUseApiClient,
+  mockCollectExport,
+  mockDownloadJson,
+} = vi.hoisted(() => ({
   mockNav: vi.fn(),
   mockAuth: vi.fn(),
   mockDecode: vi.fn(),
   mockListProblems: vi.fn(),
   mockResolveName: vi.fn(),
+  mockUseApiClient: vi.fn(),
+  mockCollectExport: vi.fn(),
+  mockDownloadJson: vi.fn(),
 }));
 
 vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
@@ -23,9 +36,16 @@ vi.mock("../../src/auth/claims", () => ({ decodeIdToken: mockDecode }));
 vi.mock("../../src/data/problems", () => ({ listProblemSummaries: mockListProblems }));
 vi.mock("../../src/i18n", () => ({ useT: () => (k: string) => k }));
 vi.mock("../../src/lib/tenant-display", () => ({ resolveTenantDisplayName: mockResolveName }));
+vi.mock("../../src/api/client", () => ({ useApiClient: mockUseApiClient }));
+vi.mock("../../src/data/tenant-data-export", () => ({
+  collectTenantDataExport: mockCollectExport,
+  downloadJson: mockDownloadJson,
+  buildTenantExportFilename: (id: string | null, at: string) => `tenant-data-${id}-${at}.json`,
+}));
 
 const { HomePage } = await import("../../src/pages/Home");
 
+const cfg = {} as AppConfig;
 const ONBOARDING_KEY = "TenkaCloud.applicationAdmin.onboardingDismissed";
 
 /**
@@ -78,6 +98,9 @@ beforeEach(() => {
     "custom:tenantTier": "PLATINUM",
   });
   mockResolveName.mockReturnValue({ displayName: "Acme", fromFallback: false });
+  mockUseApiClient.mockReturnValue({ get: vi.fn() }); // export button visible by default
+  mockCollectExport.mockReset().mockResolvedValue({ events: [], deployments: [] });
+  mockDownloadJson.mockReset();
   mockListProblems.mockReturnValue([
     summary({ id: "a", status: "ready", category: "Battle" }),
     summary({ id: "b", status: "draft", category: "Challenge" }),
@@ -88,7 +111,7 @@ afterEach(() => vi.clearAllMocks());
 
 describe("HomePage", () => {
   it("should render the welcome hero, catalog stats, and tenant info from claims", () => {
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     expect(screen.getByText("home.welcome")).toBeInTheDocument();
     expect(screen.getByText("Acme")).toBeInTheDocument(); // tenant name
     expect(screen.getByText("t-1")).toBeInTheDocument(); // tenant id
@@ -100,7 +123,7 @@ describe("HomePage", () => {
 
   it("should show the tenant-name-missing warning when the name falls back", () => {
     mockResolveName.mockReturnValue({ displayName: null, fromFallback: true });
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     expect(screen.getByText("home.tenant_name_missing_body")).toBeInTheDocument();
   });
 
@@ -108,20 +131,20 @@ describe("HomePage", () => {
     mockAuth.mockReturnValue({ tokens: null });
     mockDecode.mockReturnValue(null);
     mockResolveName.mockReturnValue({ displayName: null, fromFallback: true });
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     expect(mockDecode).not.toHaveBeenCalled();
     expect(screen.getByText("home.value_unset")).toBeInTheDocument(); // tenant name unset
     expect(screen.getAllByText("home.value_unknown").length).toBeGreaterThan(0); // id + tier
   });
 
   it("should navigate to the catalog from the header button", () => {
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     fireEvent.click(screen.getByRole("button", { name: "home.open_catalog" }));
     expect(mockNav).toHaveBeenCalledWith("/problems");
   });
 
   it("should navigate from the onboarding view-all and dismiss it on close", () => {
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     expect(screen.getByText("home.next_action_body")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "home.next_action_view_all" }));
     expect(mockNav).toHaveBeenCalledWith("/problems");
@@ -133,14 +156,14 @@ describe("HomePage", () => {
 
   it("should hide the onboarding section when already dismissed", () => {
     window.localStorage.setItem(ONBOARDING_KEY, "true");
-    render(<HomePage />);
+    render(<HomePage config={cfg} />);
     expect(screen.queryByText("home.next_action_body")).not.toBeInTheDocument();
   });
 
   it("should fall back to showing onboarding when localStorage read throws", () => {
     const restore = installThrowingStorage();
     try {
-      render(<HomePage />);
+      render(<HomePage config={cfg} />);
       // 初期 read で getItem が throw → readOnboardingDismissed の catch → false → onboarding 表示。
       expect(screen.getByText("home.next_action_body")).toBeInTheDocument();
     } finally {
@@ -151,7 +174,7 @@ describe("HomePage", () => {
   it("should still hide onboarding even if persisting the dismissal throws", () => {
     const restore = installThrowingStorage();
     try {
-      render(<HomePage />);
+      render(<HomePage config={cfg} />);
       fireEvent.click(screen.getByRole("button", { name: "home.next_action_close_aria" }));
       // close の setItem が throw → writeOnboardingDismissed の catch (no-op)。 それでも
       // setOnboardingDismissed(true) は走るので section は消える。
@@ -159,5 +182,52 @@ describe("HomePage", () => {
     } finally {
       restore();
     }
+  });
+
+  describe("Issue #1697: data export", () => {
+    it("should collect tenant data and trigger a JSON download on export", async () => {
+      mockCollectExport.mockResolvedValue({ events: [{ id: "e1" }], deployments: [] });
+      render(<HomePage config={cfg} />);
+      fireEvent.click(screen.getByRole("button", { name: /home.export_data/ }));
+      await waitFor(() => expect(mockCollectExport).toHaveBeenCalledOnce());
+      expect(mockCollectExport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tenantId: "t-1", tenantName: "Acme" }),
+      );
+      expect(mockDownloadJson).toHaveBeenCalledOnce();
+    });
+
+    it("should surface an error alert when the export fails", async () => {
+      mockCollectExport.mockRejectedValue(new Error("export boom"));
+      render(<HomePage config={cfg} />);
+      fireEvent.click(screen.getByRole("button", { name: /home.export_data/ }));
+      expect(await screen.findByText("export boom")).toBeInTheDocument();
+      expect(screen.getByText("home.export_error_header")).toBeInTheDocument();
+      expect(mockDownloadJson).not.toHaveBeenCalled();
+    });
+
+    it("should show a generic message when the export rejects with a non-Error", async () => {
+      mockCollectExport.mockRejectedValue("string failure");
+      render(<HomePage config={cfg} />);
+      fireEvent.click(screen.getByRole("button", { name: /home.export_data/ }));
+      expect(await screen.findByText("home.export_error_generic")).toBeInTheDocument();
+    });
+
+    it("should hide the export button when the API client is unavailable", () => {
+      mockUseApiClient.mockReturnValue(null);
+      render(<HomePage config={cfg} />);
+      expect(screen.queryByRole("button", { name: /home.export_data/ })).not.toBeInTheDocument();
+    });
+
+    it("should pass null tenant identifiers when the claims lack them", async () => {
+      mockDecode.mockReturnValue({}); // no custom:tenantId / custom:tenantName
+      render(<HomePage config={cfg} />);
+      fireEvent.click(screen.getByRole("button", { name: /home.export_data/ }));
+      await waitFor(() => expect(mockCollectExport).toHaveBeenCalledOnce());
+      expect(mockCollectExport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tenantId: null, tenantName: null }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
監査項目 9（データ主体の権利）の **export** を実装します。運営者が Home の「データをエクスポート」ボタンで、自テナントの events / deployments / competitor accounts を 1 つの JSON にまとめてダウンロードできます。

- `src/data/tenant-data-export.ts`: 既存のテナント scope 済 API を再利用し、events / deployments は **cursor を最後まで辿って全件集約**（silent truncation なし）、competitor accounts を 1 回取得。メタ（schemaVersion / tenantId / tenantName / exportedAt）付きで束ねる。新規 backend / IAM は増やさず、既存の PK ベース cross-tenant isolation をそのまま継承。
- `src/pages/Home.tsx`: テナント情報カードに「データをエクスポート」ボタン + エラー Alert。`useApiClient` が無いときは非表示。
- 監査ログは Audit Log ページの CSV export が既にあるため JSON には含めず、`auditLog` フィールドでその旨を明記。
- i18n（ja/en）キー追加。

## ⚠️ スコープ: #1697 の export 半分
本 PR は **export** のみです。**自己サービス削除（erase-my-tenant）** は control-plane の deprovision フローに乗せる必要があり、インフラオーナー領域のため別途とします。per-event teardown（`DELETE /events/:eventId`）+ イベント終了後 7 日の自動削除は既存です。`Relates #1697`（Closes にしないのは削除半分が未了のため）。

## Test plan
- `test/data/tenant-data-export.test.ts`: cursor 跨ぎの全件集約 / 空集合 / ファイル名生成（null tenantId fallback 含む）/ `downloadJson` の Blob→anchor→revoke 機構を pin。
- `test/pages/Home.test.tsx`: export 成功（collect + download 呼び出し）/ Error・非 Error 失敗時の Alert / apiClient 無で非表示 / claims 欠落時 tenantId・tenantName が null。
- admin-console: coverage **100%**（statements/branches/functions/lines）維持。
- `make harness` / `make before-commit` green。

## Regression analysis
- **既存 Home テスト**: `HomePage` に `config` prop を追加（App.tsx の routing も更新）。既存 render を `config` 付きに更新、`useApiClient` / `tenant-data-export` を mock。全 Home テスト green。
- **cross-tenant**: export は既存のテナント scope 済エンドポイント（JWT の `custom:tenantId`）だけを叩くため、他テナントには到達しない。
- **ページング**: nextCursor を最後まで辿るため大量データでも全件。competitor accounts は単一リスト（cursor なし）。
- **ダウンロード機構**: AuditLog の CSV export と同じ `createObjectURL`→anchor click→`revokeObjectURL`。

## Physical impact
- フロントエンド（admin-console）のみ。CDK / CFn / IAM 変更なし → **NO-OP**（インフラ差分なし）。

Relates #1697