### PR TITLE
feat(infra): opt-in custom-domain TLS 1.2 for the 3 SPA CloudFront distributions

### DIFF
--- a/infrastructure/lib/admin-console-hosting.ts
+++ b/infrastructure/lib/admin-console-hosting.ts
@@ -11,6 +11,10 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import type { Construct } from "constructs";
+import {
+  buildCustomDomainDistributionProps,
+  type CustomDomainConfig,
+} from "./security/cloudfront-custom-domain.js";
 import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers.js";
 
 /**
@@ -29,7 +33,13 @@ import { buildSecurityHeadersPolicy } from "./security/cloudfront-headers.js";
  * 旧 admin-console-hosting にあった `competitor-bootstrap.yaml` の S3 host は Issue #1053 で
  * ProblemDeployBackendStack 配下に移管済。
  */
-export interface AdminConsoleHostingStackProps extends cdk.StackProps {}
+export interface AdminConsoleHostingStackProps extends cdk.StackProps {
+  /**
+   * Issue #1695: opt-in のカスタムドメイン + ACM 証明書。 設定時のみ TLS 1.2 を強制する
+   * (= `minimumProtocolVersion = TLS_V1_2_2021`)。 未設定なら default 証明書配信のまま (NO-OP)。
+   */
+  readonly customDomain?: CustomDomainConfig;
+}
 
 export class AdminConsoleHostingStack extends cdk.Stack {
   public readonly distributionDomainName: string;
@@ -69,6 +79,8 @@ export class AdminConsoleHostingStack extends cdk.Stack {
     });
 
     this.distribution = new Distribution(this, "Distribution", {
+      // Issue #1695: customDomain 設定時のみ domainNames + ACM 証明書 + TLS 1.2 強制。 未設定は NO-OP。
+      ...buildCustomDomainDistributionProps(this, "ViewerCertificate", props.customDomain),
       defaultBehavior: {
         origin: S3BucketOrigin.withOriginAccessIdentity(this.siteBucket, {
           originAccessIdentity: oai,

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -115,6 +115,8 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     problems,
     challengePayloadBucketName,
     challengePayload,
+    // Issue #1695: config.json の customDomains を AppConfig にそのまま透過 (opt-in TLS 1.2)。
+    customDomains: config?.customDomains,
     deployConcurrentBuildLimit,
     controlPlaneSamlIdps,
     controlPlaneSamlAdminAllowlist,

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -1,6 +1,7 @@
 import type { BillingMode } from "aws-cdk-lib/aws-dynamodb";
 import type { ApiKeySSMParameterNames } from "../interfaces/api-key-ssm-parameter-names.js";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
+import type { CustomDomainsConfig } from "../security/cloudfront-custom-domain.js";
 
 export type { ApiKeySSMParameterNames };
 
@@ -89,6 +90,13 @@ export interface AppConfig {
         readonly noncurrentExpirationDays: number | undefined;
       }
     | undefined;
+
+  /**
+   * Issue #1695: 各 SPA hosting の opt-in カスタムドメイン + ACM 証明書設定 (config.json の
+   * `customDomains` をそのまま透過)。 設定された hosting のみ CloudFront viewer 最小 TLS を
+   * 1.2 に強制する。 未指定は NO-OP。
+   */
+  readonly customDomains: CustomDomainsConfig | undefined;
 
   /** Bulk Deploy の CodeBuild 並列度 (未設定なら AWS account-level quota に任せる)。 */
   readonly deployConcurrentBuildLimit: number | undefined;

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -70,6 +70,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
     stackId("tenkacloud-admin-console-hosting", config.environment),
     {
       ...config.stackEnv,
+      // Issue #1695: config.json に customDomains.adminConsole があれば TLS 1.2 を強制 (opt-in)。
+      customDomain: config.customDomains?.adminConsole,
     },
   );
   cdk.Aspects.of(adminConsoleHostingStack).add(new DestroyPolicySetter());

--- a/infrastructure/lib/config/config-interface.ts
+++ b/infrastructure/lib/config/config-interface.ts
@@ -1,3 +1,5 @@
+import type { CustomDomainsConfig } from "../security/cloudfront-custom-domain.js";
+
 /**
  * Root configuration for TenkaCloud infrastructure.
  * Loaded from environments/{ENV}/config.json with ${VAR} / ${VAR:-default} placeholder replacement.
@@ -41,6 +43,13 @@ export interface Config {
    * 経路だけ動く互換 mode)。
    */
   readonly challengePayloadConfig?: ChallengePayloadConfig;
+
+  /**
+   * Issue #1695: 各 SPA hosting にカスタムドメイン + ACM 証明書 (us-east-1) を割り当てて
+   * CloudFront の viewer 最小 TLS を 1.2 に強制する opt-in 設定。 未指定の hosting は default
+   * `*.cloudfront.net` 証明書配信のまま (= NO-OP、 既存挙動不変)。
+   */
+  readonly customDomains?: CustomDomainsConfig;
 }
 
 export interface ChallengePayloadConfig {

--- a/infrastructure/lib/config/config-schema.json
+++ b/infrastructure/lib/config/config-schema.json
@@ -10,6 +10,21 @@
     "bootstrapConfig"
   ],
   "$defs": {
+    "customDomainConfig": {
+      "type": "object",
+      "required": ["domainName", "certificateArn"],
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "viewer ドメイン名 (例: console.tenkacloud.cloud)。"
+        },
+        "certificateArn": {
+          "type": "string",
+          "description": "ACM 証明書 ARN。 CloudFront 仕様で us-east-1 の証明書であること。"
+        }
+      },
+      "additionalProperties": false
+    },
     "samlIdpConfig": {
       "type": "object",
       "required": ["metadataUrl"],
@@ -184,6 +199,16 @@
           ],
           "description": "Noncurrent 化してから expire までの日数 (default 30)。"
         }
+      },
+      "additionalProperties": false
+    },
+    "customDomains": {
+      "type": "object",
+      "description": "Issue #1695: 各 SPA hosting のカスタムドメイン + ACM 証明書 (us-east-1) 設定。 設定した hosting のみ CloudFront viewer 最小 TLS を 1.2 に強制する。 未指定は default 証明書配信 (NO-OP)。",
+      "properties": {
+        "adminConsole": { "$ref": "#/$defs/customDomainConfig" },
+        "applicationAdminConsole": { "$ref": "#/$defs/customDomainConfig" },
+        "participantPortal": { "$ref": "#/$defs/customDomainConfig" }
       },
       "additionalProperties": false
     }

--- a/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
+++ b/infrastructure/lib/problem-deploy/participant-portal-hosting.ts
@@ -11,6 +11,10 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
+import {
+  buildCustomDomainDistributionProps,
+  type CustomDomainConfig,
+} from "../security/cloudfront-custom-domain.js";
 import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers.js";
 
 export type ParticipantPortalMode = "dev-mock" | "backend";
@@ -53,7 +57,7 @@ export class ParticipantPortalHosting extends Construct {
   private readonly bucket: Bucket;
   private readonly distribution: Distribution;
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, customDomain?: CustomDomainConfig) {
     super(scope, id);
 
     this.bucket = new Bucket(this, "SiteBucket", {
@@ -84,6 +88,8 @@ export class ParticipantPortalHosting extends Construct {
     });
 
     this.distribution = new Distribution(this, "Distribution", {
+      // Issue #1695: customDomain 設定時のみ TLS 1.2 強制 (= ACM 証明書必須)。 未設定は NO-OP。
+      ...buildCustomDomainDistributionProps(this, "ViewerCertificate", customDomain),
       defaultBehavior: {
         origin: S3BucketOrigin.withOriginAccessIdentity(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,

--- a/infrastructure/lib/security/cloudfront-custom-domain.ts
+++ b/infrastructure/lib/security/cloudfront-custom-domain.ts
@@ -1,0 +1,57 @@
+import { Certificate, type ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import { SecurityPolicyProtocol } from "aws-cdk-lib/aws-cloudfront";
+import type { Construct } from "constructs";
+
+/**
+ * Issue #1695 (元監査 13 / 14): CloudFront の viewer 最小 TLS を 1.2 に上げる opt-in 機構。
+ *
+ * **背景**: default の `*.cloudfront.net` 証明書のままでは CloudFront 側が TLS の floor を
+ * 管理しており、 CDK から `minimumProtocolVersion` を上げられない (= TLS 1.0/1.1 が legacy SNI
+ * 向けに許容される)。 確実に 1.0/1.1 を切るには **カスタムドメイン + ACM 証明書** が前提。
+ *
+ * 本ヘルパは 3 つの SPA hosting (admin-console / application-admin-console / participant-portal)
+ * が共有する。 `config` が与えられたときだけ `domainNames` + `certificate` +
+ * `minimumProtocolVersion = TLS_V1_2_2021` を返し、 未設定 (= ドメイン未用意) なら空 props を
+ * 返して現状の default 証明書配信を維持する (= NO-OP、 既存デプロイの挙動不変)。
+ */
+export interface CustomDomainConfig {
+  /** viewer ドメイン名 (例: `console.tenkacloud.cloud`)。 */
+  readonly domainName: string;
+  /**
+   * ACM 証明書 ARN。 **CloudFront 仕様で us-east-1 の証明書でなければならない**。
+   * cross-stack / 既存証明書の import を前提に ARN で受ける。
+   */
+  readonly certificateArn: string;
+}
+
+/** 3 SPA それぞれのカスタムドメイン設定 (任意)。 未指定の hosting は default 証明書のまま。 */
+export interface CustomDomainsConfig {
+  readonly adminConsole?: CustomDomainConfig;
+  readonly applicationAdminConsole?: CustomDomainConfig;
+  readonly participantPortal?: CustomDomainConfig;
+}
+
+export interface CustomDomainDistributionProps {
+  readonly domainNames?: string[];
+  readonly certificate?: ICertificate;
+  readonly minimumProtocolVersion?: SecurityPolicyProtocol;
+}
+
+/**
+ * `config` があれば custom domain + ACM 証明書 + TLS 1.2 強制の Distribution props を返す。
+ * 未設定 / `domainName` 空文字 (= placeholder 展開で未設定) のときは `{}` (NO-OP) を返す。
+ */
+export function buildCustomDomainDistributionProps(
+  scope: Construct,
+  id: string,
+  config: CustomDomainConfig | undefined,
+): CustomDomainDistributionProps {
+  if (!config || config.domainName.trim() === "" || config.certificateArn.trim() === "") {
+    return {};
+  }
+  return {
+    domainNames: [config.domainName],
+    certificate: Certificate.fromCertificateArn(scope, id, config.certificateArn),
+    minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
+  };
+}

--- a/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
+++ b/infrastructure/lib/tenant-template/application-admin-console-hosting.ts
@@ -11,11 +11,20 @@ import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, CacheControl, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
+import {
+  buildCustomDomainDistributionProps,
+  type CustomDomainConfig,
+} from "../security/cloudfront-custom-domain.js";
 import { buildSecurityHeadersPolicy } from "../security/cloudfront-headers.js";
 
 interface ApplicationAdminConsoleHostingProps {
   /** TenantTemplateStack を識別するためのテナント ID。pooled の場合は "pooled" */
   readonly tenantId: string;
+  /**
+   * Issue #1695: opt-in のカスタムドメイン + ACM 証明書。 設定時のみ TLS 1.2 を強制する。
+   * 未設定なら default 証明書配信のまま (NO-OP)。
+   */
+  readonly customDomain?: CustomDomainConfig;
 }
 
 interface RuntimeConfigProps {
@@ -104,7 +113,7 @@ export class ApplicationAdminConsoleHosting extends Construct {
   private readonly bucket: Bucket;
   private readonly distribution: Distribution;
 
-  constructor(scope: Construct, id: string, _props: ApplicationAdminConsoleHostingProps) {
+  constructor(scope: Construct, id: string, props: ApplicationAdminConsoleHostingProps) {
     super(scope, id);
 
     this.bucket = new Bucket(this, "SiteBucket", {
@@ -135,6 +144,8 @@ export class ApplicationAdminConsoleHosting extends Construct {
     });
 
     this.distribution = new Distribution(this, "Distribution", {
+      // Issue #1695: customDomain 設定時のみ TLS 1.2 強制 (= ACM 証明書必須)。 未設定は NO-OP。
+      ...buildCustomDomainDistributionProps(this, "ViewerCertificate", props.customDomain),
       defaultBehavior: {
         origin: S3BucketOrigin.withOriginAccessIdentity(this.bucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,

--- a/infrastructure/test/admin-console-hosting.test.ts
+++ b/infrastructure/test/admin-console-hosting.test.ts
@@ -33,6 +33,18 @@ function synth(): Template {
   return Template.fromStack(stack);
 }
 
+function synthWithCustomDomain(): Template {
+  const app = new cdk.App();
+  const stack = new AdminConsoleHostingStack(app, "TestStack", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+    customDomain: {
+      domainName: "console.tenkacloud.cloud",
+      certificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+    },
+  });
+  return Template.fromStack(stack);
+}
+
 describe("AdminConsoleHostingStack", () => {
   beforeAll(() => {
     ensurePlaceholderDist();
@@ -63,6 +75,31 @@ describe("AdminConsoleHostingStack", () => {
       const policy = Object.values(policies)[0];
       const cspJson = JSON.stringify(policy);
       expect(cspJson).toMatch(/form-action[^;]*amazoncognito\.com/);
+    });
+  });
+
+  describe("Issue #1695: opt-in custom domain → TLS 1.2", () => {
+    it("should use the default certificate and NOT pin a min TLS version when no custom domain is set", () => {
+      const dists = synth().findResources("AWS::CloudFront::Distribution");
+      const cfg = Object.values(dists)[0]?.Properties?.DistributionConfig;
+      // CDK は default 証明書のとき ViewerCertificate ブロックを emit しない (= CloudFront 既定)。
+      // よって alias も min TLS も付かない (= 現状デプロイの挙動と同一)。
+      expect(cfg?.Aliases).toBeUndefined();
+      expect(cfg?.ViewerCertificate?.MinimumProtocolVersion).toBeUndefined();
+    });
+
+    it("should enforce TLSv1.2_2021 with the ACM cert + alias when a custom domain is set", () => {
+      const template = synthWithCustomDomain();
+      template.hasResourceProperties("AWS::CloudFront::Distribution", {
+        DistributionConfig: {
+          Aliases: ["console.tenkacloud.cloud"],
+          ViewerCertificate: {
+            AcmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc",
+            MinimumProtocolVersion: "TLSv1.2_2021",
+            SslSupportMethod: "sni-only",
+          },
+        },
+      });
     });
   });
 

--- a/infrastructure/test/security/cloudfront-custom-domain.test.ts
+++ b/infrastructure/test/security/cloudfront-custom-domain.test.ts
@@ -1,0 +1,44 @@
+import { App, Stack } from "aws-cdk-lib";
+import { describe, expect, it } from "vitest";
+import { buildCustomDomainDistributionProps } from "../../lib/security/cloudfront-custom-domain.js";
+
+/**
+ * Issue #1695: opt-in カスタムドメイン props ヘルパ。 config 未設定 / 空文字なら NO-OP ({}),
+ * 設定時のみ domainNames + certificate + TLS 1.2 を返すことを pin する。
+ */
+function scope() {
+  return new Stack(new App(), "TestStack");
+}
+
+describe("buildCustomDomainDistributionProps (Issue #1695)", () => {
+  it("should return empty props (NO-OP) when config is undefined", () => {
+    expect(buildCustomDomainDistributionProps(scope(), "Cert", undefined)).toEqual({});
+  });
+
+  it("should return empty props when domainName is blank", () => {
+    const result = buildCustomDomainDistributionProps(scope(), "Cert", {
+      domainName: "   ",
+      certificateArn: "arn:aws:acm:us-east-1:111122223333:certificate/abc",
+    });
+    expect(result).toEqual({});
+  });
+
+  it("should return empty props when certificateArn is blank", () => {
+    const result = buildCustomDomainDistributionProps(scope(), "Cert", {
+      domainName: "console.example.com",
+      certificateArn: "",
+    });
+    expect(result).toEqual({});
+  });
+
+  it("should set domainNames, a certificate, and TLS 1.2 when configured", () => {
+    const result = buildCustomDomainDistributionProps(scope(), "Cert", {
+      domainName: "console.example.com",
+      certificateArn: "arn:aws:acm:us-east-1:111122223333:certificate/abc",
+    });
+    expect(result.domainNames).toEqual(["console.example.com"]);
+    expect(result.certificate).toBeDefined();
+    // SecurityPolicyProtocol.TLS_V1_2_2021
+    expect(result.minimumProtocolVersion).toBe("TLSv1.2_2021");
+  });
+});


### PR DESCRIPTION
## Summary
監査項目 13/14。SPA を配信する 3 つの CloudFront distribution が `minimumProtocolVersion` 未設定で、default の `*.cloudfront.net` 証明書では CDK から TLS フロアを上げられません（AWS 制約: TLS 1.2 強制にはカスタムドメイン + ACM(us-east-1) 証明書が必要）。

メンテナ判断（「opt-in 配線」）に従い、opt-in 機構を追加します:
- **共有ヘルパ** `infrastructure/lib/security/cloudfront-custom-domain.ts`: ドメイン + 証明書 ARN が与えられたときだけ `domainNames` + `certificate` + `minimumProtocolVersion=TLS_V1_2_2021` を返す。未設定/空なら `{}`（NO-OP、default 証明書のまま = 現状挙動不変）。
- **3 つの hosting Distribution**（admin-console / application-admin-console / participant-portal）に optional `customDomain` prop を追加し、ヘルパ結果を spread。
- **admin-console は config を end-to-end 配線**: `customDomains.adminConsole`（config.json）→ schema → `resolveAppConfig` → `AppConfig` → `wire.ts`。participant-portal / application-admin-console は optional param を公開（capability 準備済み）。両者の config を `ProblemDeployBackendStack` / `AppPlaneCore` props 経由で配線するのは小さな follow-up です。

既定（config.json に `customDomains` なし）は厳格な NO-OP: Aliases なし・min TLS なし・既存デプロイ不変。

## ⚠️ インフラ（CDK）変更
役割分担上インフラですが、本セッションのご指示（「CI green なら self-merge」）に従い、CI green を確認のうえ私がマージします。**実際の TLS 1.2 強制を有効化するにはドメイン + ACM 証明書(us-east-1)の用意が必要**です（その運用ステップはあなたの担当）。

## Test plan
- `test/security/cloudfront-custom-domain.test.ts`: undefined/空文字で NO-OP、設定時に domainNames + certificate + `TLSv1.2_2021` を返すことを pin（ヘルパ網羅）。
- `test/admin-console-hosting.test.ts`: customDomain 無で Aliases/min TLS が付かない（現状不変）、有で `ViewerCertificate.MinimumProtocolVersion=TLSv1.2_2021` + `AcmCertificateArn` + `Aliases` + `SslSupportMethod=sni-only`（synth 出力ベースの機械チェック）。
- 既存の participant-portal / application-admin-console hosting テストは optional param 既定 NO-OP で green。
- `make harness` / `make before-commit` / `make check-synth` green（10 テンプレート synth、IAM Description Latin-1 安全）。

## Regression analysis
- **既存デプロイ**: `customDomains` を config に書かない限り 3 distribution はすべて NO-OP（ViewerCertificate ブロック非出力 = 現状と同一 synth 出力）。
- **schema**: root は `additionalProperties:false`。`customDomains` を `$defs/customDomainConfig` + properties に追加したため、設定した config.json も validate を通る。未設定の既存 config は影響なし。
- **証明書リージョン**: ACM は CloudFront 仕様で us-east-1 必須。ヘルパ doc + schema description に明記。誤リージョン証明書は CFn デプロイ時に検出される。
- **participant-portal / application-admin-console**: optional param 追加のみ（現呼び出しは undefined = NO-OP）。挙動不変。

## Physical impact
- 既定（config 未設定）: CFn 差分 **NO-OP**（3 distribution の synth 出力不変）。
- `customDomains.adminConsole` を設定した場合のみ: `AWS::CloudFront::Distribution` の `DistributionConfig.Aliases` / `ViewerCertificate`(ACM cert + TLS1.2) が **UPDATE**（証明書差し替え = in-place、リソース置換なし）。

Relates #1699
Closes #1695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom domain support added for Admin Console, Application Admin Console, and Participant Portal applications with optional TLS 1.2 minimum protocol enforcement via AWS ACM certificate integration.

* **Tests**
  * Added test coverage for custom domain configuration and CloudFront TLS behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->