### PR TITLE
chore(problems): bump catalog submodule to surface the sample Battle's red team

### DIFF
--- a/apps/participant-portal/src/plugins/props-builder.test.ts
+++ b/apps/participant-portal/src/plugins/props-builder.test.ts
@@ -78,8 +78,16 @@ describe("buildPortalDisruptions", () => {
 
   it("should return empty array for problems without disruptions[]", () => {
     expect(buildPortalDisruptions("hello-world")).toEqual([]);
-    expect(buildPortalDisruptions("hello-world-battle")).toEqual([]);
+    expect(buildPortalDisruptions("iam-least-privilege")).toEqual([]);
+    // security-battle-royale は disruptions[] を持つが全て publicHint!=true なので portal には出ない。
     expect(buildPortalDisruptions("security-battle-royale")).toEqual([]);
+  });
+
+  it("should surface the sample Battle's public red-team disruption (hello-world-battle)", () => {
+    // submodule bump (#38) で sample Battle に publicHint=true の red team が付いた。
+    const out = buildPortalDisruptions("hello-world-battle");
+    expect(out.map((d) => d.id)).toContain("frontend-down");
+    expect(out.every((d) => d.publicHint === true)).toBe(true);
   });
 
   it("should return empty array for a non-existent problemId", () => {


### PR DESCRIPTION
## Summary
「サンプルのバトルにレッドチームの定義がないから何もテストできない」というご指摘の原因は、**problems submodule の pin が古かった**ことでした（`de6a8f5`、サンプル Battle に red team が付く前のコミット）。実は disruption の定義は upstream（TenkaCloudChallenge）に既にあります。pin を `a7ac11e`（main）に bump して取り込みます。

bump で入る変更（`de6a8f5..a7ac11e`、いずれも安全）:
- **#38 hello-world-battle に実用的な red team**: `frontend-down` disruption（`ssm-run-command` で nginx 停止 → frontend probe が 200 を返さず加点停止 → ADR-029 に従い 600 秒後に自動復旧）。これで **Disruptions タブが空でなくなり、運営が機能をテストできる**ようになります。
- #39 microservice-migration-battle: description に red team 説明を追記。
- #40 problem 「check engine」 validator 追加。
- #41 microservice teaser の壊れた ASCII 図を除去。

`apps/participant-portal/src/plugins/props-builder.test.ts` も更新: `hello-world-battle` を「disruptions 無し」の例に使っていたが、red team が付いたので例を challenge に差し替え、新しい public disruption (`frontend-down` / publicHint=true) を pin。

## ⚠️ 反映に deploy が必要
カタログは event-handler Lambda に build 時 bundle されるため、live で見るには **problem-deploy backend の再 deploy** が必要です（既存の "test" イベントは、disruption がイベント作成時 snapshot か live catalog 参照かで挙動が変わります。確実には bump 反映後に新規イベントを作成）。

## Test plan
- `make validate-problems`: bump 後の 7 metadata すべて有効（hello-world-battle の disruption が SCHEMA を通る）。
- `props-builder.test.ts`: 空ケースを challenge に変更、`hello-world-battle` が `frontend-down`(publicHint=true) を返すことを pin。participant-portal 594 テスト green、coverage 100%。
- `make harness` / `make before-commit` green（全 SPA build がカタログ更新込みで通る）。

## Regression analysis
- submodule の gitlink 更新 + テスト 1 ファイルのみ。bump 範囲は metadata 2 件 + clone 内 validator + teaser doc で、テンプレート/スキーマの破壊的変更なし。
- `validate-problems` / 全 SPA build green で、新カタログがアプリの build-time discovery と整合することを確認。

## Physical impact
- submodule pin（gitlink）の更新。CDK / CFn / IAM への変更なし → **NO-OP**（インフラ差分なし）。ただしカタログ内容が変わるため、problem-deploy backend を再 deploy すると event-handler Lambda の bundle が更新される。