### PR TITLE
fix(problem-deploy): make disruptions work in Lite mode (same-account injection)

### DIFF
--- a/infrastructure/lib/problem-deploy/disruption-executor-lambda.ts
+++ b/infrastructure/lib/problem-deploy/disruption-executor-lambda.ts
@@ -36,8 +36,15 @@ export interface DisruptionExecutorLambdaProps {
  *   - ssm:GetParameter + kms:Decrypt は tenant ExternalId の SecureString のみ (describe-stack と同パターン)
  *   - DDB は deployments の Query (GSI1) + disruptions の PutItem (EXEC# 冪等) のみ
  *   - scheduler:CreateSchedule + iam:PassRole は revert scheduler role のみ
- * SDK の SendCommand / Invoke / UpdateStack 権限は **本 Lambda の role には無い** (= 注入は assumed
- * credentials で行う)。 = blast radius を IAM で封じつつ、 破壊操作は competitor の同意済 role に閉じる。
+ * SaaS (cross-account) では SDK の SendCommand / Invoke / UpdateStack 権限は **本 Lambda の role には
+ * 無い** (= 注入は assumed competitor 同意済 Admin role で行う)。 = blast radius を IAM で封じつつ、
+ * 破壊操作は competitor の同意済 role に閉じる。
+ *
+ * #1710 Lite mode 例外: Lite (= same-account deploy) では AssumeRole 先の競技者アカウントが存在せず、
+ * 注入は本 Lambda 自身の credentials で同一アカウントへ行う。 そのため ssm-run-command kind の注入
+ * (SendCommand) を **同一アカウントの instance + 標準 shell document に限定**して付与する。 SaaS では
+ * assumed Admin role 経由で注入するため本 grant は不使用 (= 同一アカウントの自テナント問題スタックに限定
+ * された余剰権限で、 Lite の単一テナント運用ではブラスト半径は organizer 自身の account に閉じる)。
  *
  * revert は scheduler が本 Lambda 自身を `mode:"revert"` payload で呼び戻す one-shot (= EXEC# 冪等 name)。
  */
@@ -128,6 +135,20 @@ export class DisruptionExecutorLambda extends Construct {
         effect: iam.Effect.ALLOW,
         actions: ["sts:AssumeRole"],
         resources: ["arn:aws:iam::*:role/TenkaCloud-*"],
+      }),
+    );
+    // #1710: Lite mode (= same-account) では AssumeRole 先が無く、 注入は本 Lambda の credentials で
+    // 行う。 ssm-run-command kind の注入/復旧 (SendCommand) を同一アカウントの instance と標準 shell
+    // document に限定して許可する。 SaaS では assumed Admin role で注入するため本 grant は不使用。
+    this.fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["ssm:SendCommand"],
+        resources: [
+          `arn:aws:ec2:*:${stack.account}:instance/*`,
+          "arn:aws:ssm:*::document/AWS-RunShellScript",
+          `arn:aws:ssm:*:${stack.account}:document/SSM-SessionManagerRunShell`,
+        ],
       }),
     );
     // deployments: team deployment 解決は GSI1 Query のみ。

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/execute.ts
@@ -48,8 +48,13 @@ export interface DisruptionFiredDetail {
 export interface DeploymentTarget {
   readonly jobId: string;
   readonly region: string;
-  readonly competitorRoleArn: string;
-  readonly externalIdParameterName: string;
+  /**
+   * cross-account (SaaS) deploy の競技者ロール ARN。 Lite mode (= same-account) では未設定 (#1710)。
+   * 未設定なら executor は AssumeRole せず Lambda 自身の credentials で同一アカウントへ注入する。
+   */
+  readonly competitorRoleArn?: string;
+  /** cross-account deploy の ExternalId SSM パラメータ名。 Lite mode では未設定 (#1710)。 */
+  readonly externalIdParameterName?: string;
   /** CFn Outputs (= deployment row の stackOutputs JSON を parse 済)。 */
   readonly stackOutputs: Readonly<Record<string, string>>;
 }

--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
@@ -72,9 +72,14 @@ export async function claimExecution(
 }
 
 /**
- * fired `(tenantId, eventId, teamId, problemId)` の **COMPLETE** deployment を GSI1 query で解決し、
- * cross-account 注入に必要な情報が揃った行のみ返す。 未 deploy / 未完了 / cross-account 情報や
- * stackOutputs 欠落は undefined (= 注入対象なし、 caller が no-op にする)。
+ * fired `(tenantId, eventId, teamId, problemId)` の **COMPLETE** deployment を GSI1 query で解決する。
+ * 未 deploy / 未完了は undefined (= 注入対象なし、 caller が no-op にする)。
+ *
+ * #1710: competitorRoleArn / externalIdParameterName は **必須にしない**。 SaaS (cross-account) では
+ * 両方揃うが、 Lite mode (= same-account deploy) では両方とも未設定で、 その場合 executor は AssumeRole
+ * せず Lambda 自身の credentials で同一アカウントへ注入する (= `assumeCompetitorRole` が双方 absent で
+ * undefined creds を返す既存 same-account 経路)。 両者を必須にしていたため Lite では常に undefined →
+ * 障害が silently no-op していた。
  */
 export async function resolveDeployment(
   resources: ExecutorResources,
@@ -95,20 +100,22 @@ export async function resolveDeployment(
     }),
   );
   const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  // #1710: cross-account 情報 (competitorRoleArn / externalIdParameterName) は要求しない。
+  // 同一アカウント (Lite) deploy では両者とも欠落するのが正常。
   const ready = items.find(
-    (d) =>
-      d.status === "COMPLETE" &&
-      typeof d.jobId === "string" &&
-      typeof d.region === "string" &&
-      typeof d.competitorRoleArn === "string" &&
-      typeof d.externalIdParameterName === "string",
+    (d) => d.status === "COMPLETE" && typeof d.jobId === "string" && typeof d.region === "string",
   );
   if (!ready) return undefined;
   return {
     jobId: ready.jobId as string,
     region: ready.region as string,
-    competitorRoleArn: ready.competitorRoleArn as string,
-    externalIdParameterName: ready.externalIdParameterName as string,
+    // SaaS は両方 string、 Lite は両方 undefined (= same-account injection)。
+    ...(typeof ready.competitorRoleArn === "string"
+      ? { competitorRoleArn: ready.competitorRoleArn }
+      : {}),
+    ...(typeof ready.externalIdParameterName === "string"
+      ? { externalIdParameterName: ready.externalIdParameterName }
+      : {}),
     stackOutputs: parseStackOutputs(ready.stackOutputs),
   };
 }

--- a/infrastructure/test/problem-deploy/disruption-executor-lambda.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-lambda.test.ts
@@ -7,8 +7,10 @@ import { DisruptionExecutorLambda } from "../../lib/problem-deploy/disruption-ex
 
 /**
  * [ADR-031 / #1419] cross-account disruption executor の CDK 境界を pin する。 核心は
- * 「自前 role は最小 (sts:AssumeRole は TenkaCloud-* のみ、 SendCommand/Invoke/UpdateStack は **持たない**)」
+ * 「自前 role は最小 (sts:AssumeRole は TenkaCloud-* のみ、 Invoke/UpdateStack は **持たない**)」
  * = 破壊力は assumed の CompetitorDeployRole に閉じ、 executor 自身の blast radius は IAM で封じる。
+ * #1710 例外: Lite (= same-account) 注入のため ssm:SendCommand のみ自前 role に付与し、 同一アカウントの
+ * instance + 標準 shell document に scope する。
  */
 
 const SYNTH_TIMEOUT_MS = 120_000;
@@ -92,11 +94,12 @@ describe("DisruptionExecutorLambda (ADR-031 #1419)", () => {
   );
 
   it(
-    "should NOT grant the executor's own role the destructive cross-account actions (they ride the assumed role)",
+    "should grant only ssm:SendCommand on the executor's own role (Lite same-account, #1710) — not Invoke/UpdateStack",
     () => {
       const actions = inlineActions(synth());
-      // 注入/復旧の破壊操作は assumed CompetitorDeployRole 経由。 executor 自身の role には付けない。
-      expect(actions).not.toContain("ssm:SendCommand");
+      // #1710: Lite (= same-account) では assumed role が無いので SendCommand は自前 role で行う。
+      expect(actions).toContain("ssm:SendCommand");
+      // 他 kind (lambda-invoke / cfn-stack-update) の破壊操作は依然 assumed role 経由のみ (自前 role には無い)。
       expect(actions).not.toContain("lambda:InvokeFunction"); // 自前 role には無い (= scheduler role 側のみ)
       expect(actions).not.toContain("cloudformation:UpdateStack");
       // 最小権限は揃っている。
@@ -105,6 +108,27 @@ describe("DisruptionExecutorLambda (ADR-031 #1419)", () => {
       expect(actions).toContain("scheduler:CreateSchedule");
       expect(actions).toContain("iam:PassRole");
       expect(actions).toContain("ssm:GetParameter");
+    },
+    SYNTH_TIMEOUT_MS,
+  );
+
+  it(
+    "#1710: ssm:SendCommand should be scoped to same-account instances + the standard shell document",
+    () => {
+      const tpl = synth();
+      tpl.hasResourceProperties(
+        "AWS::IAM::Policy",
+        Match.objectLike({
+          PolicyDocument: Match.objectLike({
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Action: "ssm:SendCommand",
+                Resource: Match.arrayWith([Match.stringLikeRegexp("document/AWS-RunShellScript")]),
+              }),
+            ]),
+          }),
+        }),
+      );
     },
     SYNTH_TIMEOUT_MS,
   );

--- a/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
@@ -116,11 +116,21 @@ describe("resolveDeployment (ADR-031 #1419)", () => {
     expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
   });
 
-  it("should skip a COMPLETE row missing cross-account fields", async () => {
-    const send = vi
-      .fn()
-      .mockResolvedValue({ Items: [{ ...completeRow, competitorRoleArn: undefined }] });
-    expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
+  it("#1710: should return a same-account target for a Lite COMPLETE row without cross-account fields", async () => {
+    // Lite mode (= same-account deploy) は competitorRoleArn / externalIdParameterName を持たない。
+    // 旧実装はこれを skip して disruption が silently no-op していた。 今は target を返し、
+    // executor は AssumeRole せず自分の credentials で同一アカウントへ注入する。
+    const send = vi.fn().mockResolvedValue({
+      Items: [{ ...completeRow, competitorRoleArn: undefined, externalIdParameterName: undefined }],
+    });
+    const target = await resolveDeployment(makeResources(send), detail);
+    expect(target).toEqual({
+      jobId: "job-1",
+      region: "ap-northeast-1",
+      stackOutputs: { WorkerInstanceIds: "i-aaa,i-bbb" },
+    });
+    expect(target?.competitorRoleArn).toBeUndefined();
+    expect(target?.externalIdParameterName).toBeUndefined();
   });
 
   it("should default stackOutputs to {} when the row has no stackOutputs", async () => {


### PR DESCRIPTION
## Summary
Lite mode で「障害を注入したのにフロントエンドがダウンしない」(fire は記録されるが注入が silently no-op) を修正します。Closes #1710。原因は 2 つの連動した問題でした。

1. **`resolveDeployment` が cross-account フィールドを必須にしていた**: `competitorRoleArn` + `externalIdParameterName` が両方無いと `undefined`（→ `no_deployment` → no-op）。Lite は same-account deploy でどちらも持たないため、Lite の fire は常に no-op。→ 両フィールドを **optional** にし、COMPLETE な same-account row は target を返す。executor は既存の `assumeCompetitorRole` の same-account 経路（双方 absent → undefined creds）で Lambda 自身の credentials を使う。

2. **executor Lambda の role に `ssm:SendCommand` が無かった**: 注入は assumed の競技者 `AdministratorAccess` role 経由という設計（ADR-031）。Lite には assume 先が無いので、`ssm:SendCommand` を Lambda 自身の role に、**同一アカウントの instance + 標準 shell document（AWS-RunShellScript / SSM-SessionManagerRunShell）に scope** して付与。SaaS は従来通り assumed role で注入するため本 grant は不使用。

`lambda-invoke` / `cfn-stack-update` kind の Lite 対応は同様の own-role grant が必要（follow-up）。`ssm-run-command`（サンプル red team）は本 PR で動作。

## 反映
problem-deploy backend の再デプロイで executor Lambda が更新されます。

## Test plan
- `disruption-executor-store.test.ts`: cross-account フィールド無しの Lite COMPLETE row が same-account target を返すことを pin（旧 "skip" テストを置換）。
- `disruption-executor-lambda.test.ts`: 自前 role に `ssm:SendCommand` が付き同一アカウント instance + AWS-RunShellScript に scope、Invoke/UpdateStack は依然無いことを pin。
- 既存 executor / contract テスト green。`make harness` / `make before-commit`（synth 含む）green。

## Regression analysis
- **SaaS (cross-account)**: 両フィールドが揃えば従来通り target を返し、注入は assumed Admin role 経由のまま（own role の SendCommand 不使用）。挙動不変。
- **IAM scope**: `ssm:SendCommand` は same-account（`${stack.account}`）の instance + 標準 shell document に限定。Lite は単一テナント=organizer 自身の account のためブラスト半径は閉じる。

## Physical impact
- `AWS::IAM::Policy`（DisruptionExecutor Lambda role）に `ssm:SendCommand` ステートメント **追加** = UPDATE（in-place）。Lambda code 更新 = UPDATE。新規/削除リソースなし。