### PR TITLE
fix(problem-deploy): inject disruptions on asymmetric (same-account) rows

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
@@ -106,15 +106,23 @@ export async function resolveDeployment(
     (d) => d.status === "COMPLETE" && typeof d.jobId === "string" && typeof d.region === "string",
   );
   if (!ready) return undefined;
+  // #1710: cross-account fields は both-or-neither で扱う (= assumeCompetitorRole と同契約)。
+  // deploy-handler は competitorRoleArn を行に永続化するが externalIdParameterName は
+  // event detail にしか載せない (deploy.ts:177 vs 259-261) ため、 実際の行は role 有・externalId 無
+  // の非対称になる。 片方だけを target に載せると assumeCompetitorRole が
+  // "must be provided together" で throw する。 両者揃ったときだけ cross-account injection、
+  // それ以外は same-account injection (executor 自身の credentials) 扱いにする。
+  const crossAccount =
+    typeof ready.competitorRoleArn === "string" &&
+    typeof ready.externalIdParameterName === "string";
   return {
     jobId: ready.jobId as string,
     region: ready.region as string,
-    // SaaS は両方 string、 Lite は両方 undefined (= same-account injection)。
-    ...(typeof ready.competitorRoleArn === "string"
-      ? { competitorRoleArn: ready.competitorRoleArn }
-      : {}),
-    ...(typeof ready.externalIdParameterName === "string"
-      ? { externalIdParameterName: ready.externalIdParameterName }
+    ...(crossAccount
+      ? {
+          competitorRoleArn: ready.competitorRoleArn as string,
+          externalIdParameterName: ready.externalIdParameterName as string,
+        }
       : {}),
     stackOutputs: parseStackOutputs(ready.stackOutputs),
   };

--- a/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
@@ -133,6 +133,31 @@ describe("resolveDeployment (ADR-031 #1419)", () => {
     expect(target?.externalIdParameterName).toBeUndefined();
   });
 
+  it("#1710: should treat an asymmetric row (role set, externalId absent) as same-account", async () => {
+    // deploy-handler は competitorRoleArn を行に永続化するが externalIdParameterName は
+    // event detail にしか載せない (deploy.ts:177 vs 259-261)。 結果、 実際の Lite/SaaS 行は
+    // 「role 有・externalId 無」の非対称になる。 片方だけでは AssumeRole できない
+    // (assumeCompetitorRole の both-or-neither 契約) ので same-account injection 扱いにする。
+    // role だけを target に載せると assumeCompetitorRole が "must be provided together" で throw する。
+    const send = vi.fn().mockResolvedValue({
+      Items: [
+        {
+          ...completeRow,
+          competitorRoleArn: "arn:aws:iam::672726205532:role/TenkaCloud-local-deploy-Role",
+          externalIdParameterName: undefined,
+        },
+      ],
+    });
+    const target = await resolveDeployment(makeResources(send), detail);
+    expect(target).toEqual({
+      jobId: "job-1",
+      region: "ap-northeast-1",
+      stackOutputs: { WorkerInstanceIds: "i-aaa,i-bbb" },
+    });
+    expect(target?.competitorRoleArn).toBeUndefined();
+    expect(target?.externalIdParameterName).toBeUndefined();
+  });
+
   it("should default stackOutputs to {} when the row has no stackOutputs", async () => {
     const send = vi
       .fn()


### PR DESCRIPTION
## Summary

PR-1711 のフォローアップ。Lite モードの障害注入が**まだ end-to-end で動かない**残りギャップを塞ぎます。Closes #1710。

PR-1711 は「Lite 行は `competitorRoleArn` / `externalIdParameterName` を両方持たない」前提で `resolveDeployment` を緩めましたが、実際の deployment 行はそうなっていません:

- deploy-handler は `competitorRoleArn` を行に**永続化する**(`deploy.ts:177`)
- `externalIdParameterName` は deploy event detail に**しか**載せず、行には書かない(`deploy.ts:259-261`)

→ 実際の COMPLETE 行は **「role 有・externalId 無」の非対称**(Lite の実機 DDB で確認済み。`competitorRoleArn=arn:…:role/TenkaCloud-local-deploy-Role`、`externalIdParameterName` 欠落)。

この行に対し PR-1711 後の `resolveDeployment` は lone `competitorRoleArn` を target に載せ、`assumeCompetitorRole` の both-or-neither ガード(`assume-competitor-role.ts:135-137`)が `competitorRoleArn and externalIdParameterName must be provided together` で **throw** します。注入は依然として走りません(no_deployment の silent no-op が throw に変わっただけ)。

### 修正

`resolveDeployment` が cross-account fields を `assumeCompetitorRole` と同じ **both-or-neither 契約**で扱うようにします:

- 両方 string → cross-account injection(SaaS、従来想定どおり)
- それ以外(両方欠落 or 片方だけ)→ **same-account injection**(target に role/externalId を載せない → executor 自身の credentials + PR-1711 で付与済みの `ssm:SendCommand` grant で注入)

片方だけの行はそもそも AssumeRole 不能なので、same-account 扱いが唯一の動作可能な解釈です。

### 実機検証(Lite, account 672726205532 / ap-northeast-1)

- `tc-hello-world-battle-team-1` の COMPLETE 行が非対称であることを DDB scan で確認
- 注入先 EC2 `i-046414a66bfb65dd7` は SSM-managed / Online、stack に `InstanceId` Output あり → executor が SendCommand を発行すれば着地する
- 反映には problem-deploy backend の再デプロイが必要(PR-1711 の IAM grant + 本修正の Lambda code)

### Follow-up(本 PR スコープ外)

SaaS (cross-account) の disruption は `externalIdParameterName` が行に永続化されていないため**従来から一度も動作していません**(旧実装でも常に `no_deployment`)。真の cross-account 注入には deploy-handler での externalId 永続化 + executor role への `sts:AssumeRole` 付与(IAM)が必要で、別 issue として扱うべきです。本 PR は SaaS の挙動を変えません(後述)。

## Test plan

- `disruption-executor-store.test.ts` に**非対称行**(role 有・externalId 無)→ same-account target を pin するテストを追加。修正前 FAIL(lone `competitorRoleArn` が target に混入することを実証)→ 修正後 PASS の両方向確認済み
- 既存の対称ケース(両方有 → cross-account target)・両方欠落ケース(PR-1711 追加)は変更なしで green
- `disruption-*.test.ts` 全 14 file / 186 tests green、`tsc --noEmit` clean、`make harness` no findings、biome clean
- pre-commit hook(audit-deps / cdk synth 検証 / IAM Latin-1)も全て OK

## Regression analysis

- **SaaS (cross-account)**: 行に externalId が無い現状、旧実装は `no_deployment`(no-op)、PR-1711 実装は throw、本修正は same-account injection 試行(対象 instance が control account に無く SendCommand が InvalidInstanceId で fail)。いずれも「注入されない」点は同じで、**動いていたものを壊す回帰はなし**。将来 externalId が永続化されれば両方 string → cross-account 経路が従来どおり機能する(既存テストで pin 済み)
- **Lite (same-account)**: 非対称行が same-account target になり初めて注入が通る。意図した挙動変更そのもの
- **claim / revert / scheduled fire**: 変更なし(`resolveDeployment` の戻り値構築のみの修正)

## Physical impact

- Lambda code(disruption-executor handler)= **UPDATE**(in-place)
- CFn リソースの CREATE / REPLACE / DELETE = **なし**(IAM・テーブル・イベント配線は不変。handler の TS ロジック + テストのみ)
- 反映には problem-deploy backend の再デプロイが必要(Lite: `make deploy`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment validation to treat cross-account authentication parameters as a coupled pair rather than independently.

* **Testing**
  * Added test coverage to verify deployment configuration handling with asymmetric parameter combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->