### PR TITLE
fix(portal): don't show "all cleared" during an active uptime Battle

### DIFF
--- a/apps/participant-portal/src/components/NextActionHero.tsx
+++ b/apps/participant-portal/src/components/NextActionHero.tsx
@@ -36,7 +36,11 @@ export type NextActionState =
       readonly unsolvedCount: number;
       readonly nextProblem?: ParticipantProblemView;
     }
-  | { readonly kind: "all_cleared" };
+  // all_cleared: 全 flag 問題を submit 済 (= Challenge 的な真の完了)。
+  // defending: deploy 済み問題はすべて稼働中だが、 uptime 等の継続採点問題があるため
+  //   「解き終わり」 は無く、 競技終了まで防衛を続ける (= Battle はまだ進行中)。
+  | { readonly kind: "all_cleared" }
+  | { readonly kind: "defending" };
 
 /**
  * 「次にやるべき問題」 を選ぶ pure function。
@@ -87,7 +91,11 @@ export function computeNextActionState(args: {
   }
   const unsolved = view.problems.filter(isProblemUnsolved);
   if (unsolved.length === 0 && view.problems.length > 0) {
-    return { kind: "all_cleared" };
+    // uptime / 継続採点問題は「解き終わる」概念が無く、 score>0 でも競技は続く。 全問題が flag
+    // (= 一発 capture) で submit 済のときだけ真の完了 (all_cleared)。 継続採点問題が 1 つでもあれば
+    // 競技継続中なので defending を出す (= 「全問クリア / 最終順位を待ちましょう」 の誤表示を防ぐ)。
+    const allClearable = view.problems.every((p) => p.scoring?.kind === "flag");
+    return allClearable ? { kind: "all_cleared" } : { kind: "defending" };
   }
   const next = pickNextProblem(view.problems);
   return { kind: "running", unsolvedCount: unsolved.length, nextProblem: next };
@@ -159,6 +167,22 @@ export function NextActionHero({
       >
         <Box variant="awsui-value-large" color="text-status-success">
           {t("next_action.all_cleared_body")}
+        </Box>
+      </Container>
+    );
+  }
+
+  if (state.kind === "defending") {
+    return (
+      <Container
+        header={
+          <Header variant="h2" description={t("next_action.defending_description")}>
+            {t("next_action.defending_header")}
+          </Header>
+        }
+      >
+        <Box variant="awsui-value-large" color="text-status-info">
+          {t("next_action.defending_body")}
         </Box>
       </Container>
     );

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -362,7 +362,10 @@
     "running_open_button": "Open this problem",
     "all_cleared_header": "All problems solved",
     "all_cleared_description": "You've cleared every problem deployed to your team. Keep an eye on the leaderboard until the event ends.",
-    "all_cleared_body": "Nicely done. Awaiting final ranking."
+    "all_cleared_body": "Nicely done. Awaiting final ranking.",
+    "defending_header": "Battle in progress",
+    "defending_description": "All your deployed problems are up and scoring. Uptime-style problems are never \"finished\" — you defend them until the event ends.",
+    "defending_body": "Keep your endpoints up to keep earning points. Defend them until the event ends."
   },
   "friendly_error": {
     "auth_expired": "Your session has expired. Please sign in again with the login key your operator re-distributed.",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -362,7 +362,10 @@
     "running_open_button": "この問題を開く",
     "all_cleared_header": "全問クリア",
     "all_cleared_description": "deploy 済の全問題を解き終えました。 競技終了まで leaderboard を見守りましょう。",
-    "all_cleared_body": "お見事。 最終順位を待ちましょう。"
+    "all_cleared_body": "お見事。 最終順位を待ちましょう。",
+    "defending_header": "競技継続中",
+    "defending_description": "deploy 済の問題はすべて稼働中です。 uptime 系の問題は「解き終わり」がなく、 競技終了まで防衛し続けます。",
+    "defending_body": "エンドポイントを稼働させ続けるほどスコアが伸びます。 競技終了まで守り抜きましょう。"
   },
   "friendly_error": {
     "auth_expired": "ログイン期限切れ。 organizer から再配布された login key で再ログインしてください。",

--- a/apps/participant-portal/test/components/NextActionHero.render.test.tsx
+++ b/apps/participant-portal/test/components/NextActionHero.render.test.tsx
@@ -38,6 +38,13 @@ const SOLVED = {
   score: 100,
   scoring: { kind: "flag", flagSubmitted: true },
 };
+const UPTIME_UP = {
+  problemId: "p3",
+  jobId: "job-3",
+  status: "COMPLETE",
+  score: 100,
+  scoring: { kind: "uptime" },
+};
 
 afterEach(() => vi.clearAllMocks());
 
@@ -84,11 +91,19 @@ describe("NextActionHero (render)", () => {
     expect(noRank.container.textContent).toContain("next_action.ended_no_rank");
   });
 
-  it("should show all-cleared when every problem is solved", () => {
+  it("should show all-cleared when every problem is a submitted flag", () => {
     const { container } = render(
       <NextActionHero view={view({ problems: [SOLVED] as never })} leaderboard={null} />,
     );
     expect(container.textContent).toContain("next_action.all_cleared");
+  });
+
+  it("should show defending (not all-cleared) for a scoring uptime Battle problem", () => {
+    const { container } = render(
+      <NextActionHero view={view({ problems: [UPTIME_UP] as never })} leaderboard={null} />,
+    );
+    expect(container.textContent).toContain("next_action.defending");
+    expect(container.textContent).not.toContain("next_action.all_cleared");
   });
 
   it("should suggest the next problem and navigate to it on click", () => {

--- a/apps/participant-portal/test/components/NextActionHero.test.ts
+++ b/apps/participant-portal/test/components/NextActionHero.test.ts
@@ -215,7 +215,7 @@ describe("computeNextActionState", () => {
     }
   });
 
-  it("should return all_cleared when every problem is solved", () => {
+  it("should return all_cleared only when every problem is a submitted flag", () => {
     const cleared = problem({
       jobId: "j-a",
       problemId: "p",
@@ -224,5 +224,37 @@ describe("computeNextActionState", () => {
     const v = view({ problems: [cleared], eventGate: { kind: "ok" } });
     const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
     expect(state).toEqual({ kind: "all_cleared" });
+  });
+
+  it("should return defending (not all_cleared) for a scoring uptime Battle problem", () => {
+    // uptime は score>0 でも「解き終わり」が無い。 競技中に all_cleared を出すのは誤り (#this)。
+    const upAndScoring = problem({
+      jobId: "j-a",
+      problemId: "hello-world-battle",
+      status: "COMPLETE",
+      scoring: { kind: "uptime" },
+      score: 100,
+    });
+    const v = view({ problems: [upAndScoring], eventGate: { kind: "ok" } });
+    const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
+    expect(state).toEqual({ kind: "defending" });
+  });
+
+  it("should return defending for a mixed event once all flags are submitted but uptime is up", () => {
+    const flagDone = problem({
+      jobId: "j-a",
+      problemId: "a-flag",
+      scoring: { kind: "flag", flagSubmitted: true },
+    });
+    const uptimeUp = problem({
+      jobId: "j-b",
+      problemId: "b-uptime",
+      status: "COMPLETE",
+      scoring: { kind: "uptime" },
+      score: 100,
+    });
+    const v = view({ problems: [flagDone, uptimeUp], eventGate: { kind: "ok" } });
+    const state = computeNextActionState({ view: v, leaderboard: null, nowMs: now });
+    expect(state).toEqual({ kind: "defending" });
   });
 });


### PR DESCRIPTION
## Summary
Battle 競技中なのに participant portal が「全問クリア / お見事。最終順位を待ちましょう」(= 完了メッセージ) を表示していた不具合を修正します。

**原因**: `isProblemUnsolved` は flag 以外の問題を **score > 0 で「解いた」扱い**にしていました。uptime Battle (uptime-flat) は +100/分で継続加点するため、最初の tick で「解いた」と判定 → `unsolved.length === 0` → `all_cleared`。しかし uptime は「解き終わる」概念が無く、競技終了までエンドポイントを防衛し続けるものです。

**修正**: `all_cleared` は **全問題が flag (一発 capture) で submit 済**のときだけ。uptime / uptime-multi / phased-polling / attack-detection など継続採点問題が 1 つでもあれば、新しい **`defending` 状態**（「競技継続中 — 競技終了までエンドポイントを維持しましょう」）を表示します。実際の競技終了は従来通り `ended` 状態が扱います。

## Before → After（競技中の uptime Battle）
| | Before | After |
|---|---|---|
| 表示 | 全問クリア / お見事。最終順位を待ちましょう | 競技継続中 / エンドポイントを稼働させ続けるほどスコアが伸びます |

## Test plan
- `NextActionHero.test.ts`: uptime(score>0) → `defending`、mixed(flag submit + uptime up) → `defending`、flag-only 全 submit → `all_cleared` を pin。
- `NextActionHero.render.test.tsx`: uptime scoring 問題で `defending` が出て `all_cleared` が出ないことを pin。
- participant-portal 597 テスト green、coverage 100%（statements/branches/functions/lines）。
- `make harness` green。biome / tsc clean。

## Regression analysis
- flag-only イベントの `all_cleared` は不変（テストで pin）。
- `ended`（競技終了）/ `not_started` / `running` 状態は不変。
- 変更は `computeNextActionState` の分岐 + `defending` の描画 + i18n(ja/en) のみ。バックエンド・採点ロジックに影響なし。

## Physical impact
- フロントエンド（participant-portal）のみ。CDK / CFn / IAM 変更なし → **NO-OP**。