### PR TITLE
feat(scoring): opt-in failurePenalty for uptime-flat (deduct on health-check failure)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-flat.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-flat.ts
@@ -78,9 +78,18 @@ export async function runUptimeFlatKind(
   // ADR-005 D2-A: 直前 tick が ok → 今 tick fail で attack-detected marker (= row 爆発防止)。
   const attackDetected = !allOk && deployment.lastResult === "ok";
 
+  // 失敗時の減点 (opt-in)。 failurePenalty は負値で減点 (uptime-multi と同契約)、 省略時 0 (= 従来挙動)。
+  const failureDelta = scoring.failurePenalty ?? 0;
+
   return {
-    scoreDelta: allOk ? scoring.pointsPerSuccess : 0,
-    scoreEvents: buildScoreEvents(allOk, attackDetected, scoring.pointsPerSuccess, nowIso),
+    scoreDelta: allOk ? scoring.pointsPerSuccess : failureDelta,
+    scoreEvents: buildScoreEvents(
+      allOk,
+      attackDetected,
+      scoring.pointsPerSuccess,
+      failureDelta,
+      nowIso,
+    ),
     endpointsHealthJson: JSON.stringify(newHealth),
     lastResult: allOk ? "ok" : "fail",
     ...(attackDetected ? { attackDetected: true } : {}),
@@ -91,9 +100,15 @@ function buildScoreEvents(
   allOk: boolean,
   attackDetected: boolean,
   points: number,
+  failureDelta: number,
   occurredAt: string,
 ): KindResult["scoreEvents"] {
   if (allOk) return [{ source: "uptime", points, occurredAt }];
+  // 減点が設定されていれば、 失敗 tick に -N の score event を残す (= 履歴に可視化、 監査痕跡)。
+  // 減点 0 のときは従来通り、 ok→fail 遷移の attack-detected marker のみ。
+  if (failureDelta !== 0) {
+    return [{ source: "uptime", points: failureDelta, occurredAt }];
+  }
   return attackDetected ? [{ source: "attack-detected", points: 0, occurredAt }] : [];
 }
 

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -72,6 +72,12 @@ export interface UptimeFlatScoringMetadata {
   readonly kind: "uptime-flat" | "uptime";
   readonly endpoints: readonly UptimeFlatEndpoint[];
   readonly pointsPerSuccess: number;
+  /**
+   * health-check 失敗 tick の score delta。 省略時 0 (= 加点しないだけ、 従来挙動)。 **負値で減点**
+   * (= uptime-multi.failurePenalty と同契約)。 Battle で「落とされたら減点」を opt-in したい問題が指定する
+   * (例: -100)。 endpoint が 1 つでも fail した tick に加算される。
+   */
+  readonly failurePenalty?: number;
   /** Issue #742 Phase 5: 全 5 種 builtin kind で hints を許容する共通 field。 */
   readonly hints?: readonly ProgressiveHint[];
 }
@@ -252,7 +258,12 @@ function parseUptimeFlat(
   value: unknown,
   kindLiteral: "uptime" | "uptime-flat",
 ): UptimeFlatScoringMetadata | undefined {
-  const u = value as { endpoints?: unknown; pointsPerSuccess?: unknown; hints?: unknown };
+  const u = value as {
+    endpoints?: unknown;
+    pointsPerSuccess?: unknown;
+    failurePenalty?: unknown;
+    hints?: unknown;
+  };
   if (!Array.isArray(u.endpoints) || u.endpoints.length === 0) return undefined;
   if (typeof u.pointsPerSuccess !== "number" || u.pointsPerSuccess <= 0) return undefined;
   const endpoints = u.endpoints
@@ -266,6 +277,8 @@ function parseUptimeFlat(
     kind: kindLiteral,
     endpoints,
     pointsPerSuccess: u.pointsPerSuccess,
+    // 失敗時の減点 (opt-in、 負値)。 uptime-multi.failurePenalty と同じく number のときだけ採用。
+    ...(typeof u.failurePenalty === "number" ? { failurePenalty: u.failurePenalty } : {}),
     ...(hints ? { hints } : {}),
   };
 }

--- a/infrastructure/test/problem-deploy/generic-scoring-uptime-flat.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-uptime-flat.test.ts
@@ -77,6 +77,47 @@ describe("uptime-flat kind (ADR-012 Phase 3.B、 legacy uptime probe 動作不�
     expect(result.lastResult).toBe("fail");
   });
 
+  it("should deduct failurePenalty (opt-in) on a failed tick and emit a negative uptime event", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 200, text: async () => "" })
+      .mockResolvedValueOnce({ status: 500, text: async () => "" });
+    const result = await runUptimeFlatKind(
+      buildInput({
+        scoring: {
+          kind: "uptime-flat",
+          endpoints: [
+            { outputKey: "FrontendUrl", path: "/", expectStatus: [200] },
+            { outputKey: "ApiUrl", path: "/healthz", expectStatus: [200] },
+          ],
+          pointsPerSuccess: 100,
+          failurePenalty: -100,
+        },
+      }),
+    );
+    expect(result.scoreDelta).toBe(-100);
+    expect(result.scoreEvents).toEqual([{ source: "uptime", points: -100, occurredAt: NOW_ISO }]);
+    expect(result.lastResult).toBe("fail");
+  });
+
+  it("should still award pointsPerSuccess when all endpoints are ok even with failurePenalty set", async () => {
+    fetchMock.mockResolvedValue({ status: 200, text: async () => "" });
+    const result = await runUptimeFlatKind(
+      buildInput({
+        scoring: {
+          kind: "uptime-flat",
+          endpoints: [
+            { outputKey: "FrontendUrl", path: "/", expectStatus: [200] },
+            { outputKey: "ApiUrl", path: "/healthz", expectStatus: [200] },
+          ],
+          pointsPerSuccess: 100,
+          failurePenalty: -100,
+        },
+      }),
+    );
+    expect(result.scoreDelta).toBe(100);
+    expect(result.scoreEvents).toEqual([{ source: "uptime", points: 100, occurredAt: NOW_ISO }]);
+  });
+
   it("should emit an attack-detected event when previous tick was ok and current tick fails (ADR-005 D2-A)", async () => {
     fetchMock.mockResolvedValue({ status: 500, text: async () => "" });
     const input = buildInput({

--- a/infrastructure/test/scoring-metadata.test.ts
+++ b/infrastructure/test/scoring-metadata.test.ts
@@ -206,6 +206,20 @@ describe("parseScoringMetadata", () => {
       expect(uf?.kind).toBe("uptime-flat");
       if (uf?.kind !== "uptime-flat") return;
       expect(uf.hints).toBeUndefined();
+      // failurePenalty 未指定は undefined (= 従来通り失敗時 0)。
+      expect(uf.failurePenalty).toBeUndefined();
+    });
+
+    it("uptime-flat should accept an opt-in failurePenalty (negative deduction on failed tick)", () => {
+      const uf = parseScoringMetadata({
+        kind: "uptime-flat",
+        endpoints: [{ slot: "main", path: "/", expectStatus: [200] }],
+        pointsPerSuccess: 100,
+        failurePenalty: -100,
+      });
+      expect(uf?.kind).toBe("uptime-flat");
+      if (uf?.kind !== "uptime-flat") return;
+      expect(uf.failurePenalty).toBe(-100);
     });
   });
 

--- a/infrastructure/test/scripts/scoring-dry-run.test.ts
+++ b/infrastructure/test/scripts/scoring-dry-run.test.ts
@@ -25,18 +25,19 @@ describe("scoring dry-run (#951 sub #3)", () => {
   });
 
   it("uptime-flat kind: 全 success cycles で `cycles × endpoints × pointsPerSuccess` 点", () => {
-    // hello-world-battle: 2 endpoints, 100 pt/success, failurePenalty=0
+    // hello-world-battle: 2 endpoints, 100 pt/success (failurePenalty=-100 だが全 success なので無関係)
     const r = runDryRun({ problemId: "hello-world-battle", cycles: 5, pattern: "sssss" });
     expect(r.ok).toBe(true);
     // 5 cycles × 2 endpoints × 100 pt = 1000
     expect(r.summary).toContain("earned=1000");
   });
 
-  it("uptime-flat kind: earned should drop on cycles with partial fail", () => {
+  it("uptime-flat kind: earned should drop on cycles with partial fail (failurePenalty deducts)", () => {
     const r = runDryRun({ problemId: "hello-world-battle", cycles: 4, pattern: "ssff" });
     expect(r.ok).toBe(true);
-    // 2 success cycles × 2 endpoints × 100 = 400 (failurePenalty=0)
-    expect(r.summary).toContain("earned=400");
+    // hello-world-battle は failurePenalty=-100 (2 endpoints)。
+    // 2 success × 2 × +100 = +400、 2 fail × 2 × -100 = -400 → 0。
+    expect(r.summary).toContain("earned=0");
   });
 
   it("uptime-flat kind: cycles=デフォルト=10 / pattern=デフォルト=all success", () => {

--- a/scripts/problem-cli/dry-run/uptime-flat.ts
+++ b/scripts/problem-cli/dry-run/uptime-flat.ts
@@ -34,7 +34,10 @@ export function runUptimeFlatDryRun(input: DryRunKindInput): DryRunResult {
       score += pointsPerSuccess * endpointCount;
       okCount += 1;
     } else {
-      score -= failurePenalty * endpointCount;
+      // failurePenalty は加算デルタ (負値で減点、 schema / runUptimeFlatKind と同契約)。
+      // 以前は `-= failurePenalty` で符号反転し、 負値が加点になっていた (= score=0 の問題でだけ
+      // 露見しなかった latent bug)。 `+=` で減点として正しく反映する。
+      score += failurePenalty * endpointCount;
       failCount += 1;
     }
   }

--- a/scripts/problem-cli/dry-run/uptime-multi.ts
+++ b/scripts/problem-cli/dry-run/uptime-multi.ts
@@ -32,7 +32,9 @@ export function runUptimeMultiDryRun(input: DryRunKindInput): DryRunResult {
       score += pointsAllOk;
       allOkCycles += 1;
     } else {
-      score -= failurePenalty;
+      // failurePenalty は加算デルタ (負値で減点、 runUptimeMultiKind と同契約)。 `-=` だと符号反転
+      // して負値が加点になる latent bug だった (= failurePenalty=0 の問題でだけ露見しなかった)。
+      score += failurePenalty;
       failCycles += 1;
     }
   }


### PR DESCRIPTION
## Summary
「Battle でヘルスチェック失敗時に減点ありを選べるように」のご要望。uptime-flat に **opt-in の `failurePenalty`** を追加します（失敗 tick の score delta、負値で減点、省略時 0 = 従来挙動）。`uptime-multi.failurePenalty` と同契約。

- **scoring engine** (`uptime-flat.ts`): 失敗 tick の scoreDelta を `failurePenalty ?? 0` に。減点が設定されていれば `-N` の `uptime` score event を残す → **score 履歴に減点が可視化**（= 障害注入が効いている裏付けにもなる）。
- **metadata 型 + parser** (`scoring-metadata.ts`): `failurePenalty?: number` を追加・parse。
- **catalog**（submodule #43、pin bump 同梱）: SCHEMA に `failurePenalty` を追加し、**hello-world-battle を `-100` で有効化**（nginx down 中は毎分 -100）。description(ja/en) も更新。
- **dry-run 符号バグ修正**: `scripts/problem-cli/dry-run/{uptime-flat,uptime-multi}.ts` が `score -= failurePenalty` で符号反転していた（負値が加点になる latent bug、failurePenalty=0 の問題でだけ露見せず）。実 handler と同じ `+=` に修正。

## 反映
problem-deploy backend の再デプロイで scoring Lambda が `failurePenalty` を読むようになります。hello-world-battle の `-100` は pin bump 込み。

## Test plan
- `generic-scoring-uptime-flat.test.ts`: 失敗 tick で `scoreDelta=-100` + `-100` の uptime event、全 ok 時は従来通り `+100`。
- `scoring-metadata.test.ts`: `failurePenalty` の parse（未指定→undefined / -100→保持）。
- `scoring-dry-run.test.ts`: hello-world-battle ssff → earned=0（success +400 / fail -400）に更新、符号修正を反映。
- `make harness` / `make before-commit`（全 workspace test + validate-problems + synth）green。

## Regression analysis
- **後方互換**: `failurePenalty` 未指定の問題は不変（失敗時 0）。`pointsPerSuccess` 加点も不変。
- **dry-run 符号修正**: failurePenalty=0 の既存問題（security-battle-royale 等）は ×0 で影響なし。hello-world-battle のみ挙動が変わる（意図通り）。
- SaaS/Lite 共通の scoring engine 変更。CFn/IAM への変更なし（Lambda code のみ）。

## Physical impact
- Lambda code（generic-scoring）更新 = UPDATE。problems submodule pin = 302aed52→01b385d3（gitlink）。CFn リソースの新規/削除なし。