### PR TITLE
feat(pitch): /pitchdeck skill + BootCamp#4 deck from repo state

### DIFF
--- a/.claude/skills/pitchdeck/SKILL.md
+++ b/.claude/skills/pitchdeck/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pitchdeck
+description: TenkaCloud のピッチデッキ (単一 HTML、自己完結) を「今のリポジトリの実態」から再生成する。問題カタログ数 / scoring kind / 障害注入の実証状況 / ADR の採択状況を読み取り、誇張せず（ハリボテ禁止）に landing/pitch/index.html を最新化する。登壇・営業・コミュニティ説明の前に `/pitchdeck` で更新する。
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git grep:*), Bash(git log:*), Bash(ls:*)
+---
+
+# pitchdeck — 「常に最新のコンテンツ状態」を提示するデッキ生成
+
+TenkaCloud のピッチデッキを **リポジトリの今の実態から** 再生成する skill。出力は
+`landing/pitch/index.html`（自己完結の単一 HTML、GitHub Pages で
+`https://susumutomita.github.io/TenkaCloud/pitch/` に配信される）。codewiki と同じ発想で、
+「聞かれたときに最新の状態を出す」 ために毎回ソースを読み直して数字と実証状況を更新する。
+
+正本（誇張しないための事実ソース）:
+
+- 位置づけ / タグライン: [`README.md`](../../../README.md) 冒頭、[`landing/llms.txt`](../../../landing/llms.txt)
+- 問題カタログ: `problems/<category>/<id>/metadata.json`（submodule。実体は
+  `/Users/susumu/product/TenkaCloudChallenge` の clone 側にあることが多い）
+- 採点エンジン: `infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/*.ts`
+- 障害注入 (赤チーム): `infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/`、
+  `disruption-executor-lambda.ts`、ADR-029/031/033/034
+- 旗艦シナリオ StackStack: `problems/battles/stackstack/README.ja.md` + `metadata.json`
+
+## 鉄則 — ハリボテを「完成」と書かない
+
+公開ピッチに載せる前に、各主張を必ず実態でラベル付けする。
+
+- `[実証済]` — E2E でテスト済み / 実際に動かして確認した（例: hello-world-battle の
+  frontend-down 注入 → 減点 → 自動復帰）。
+- `[実装済]` — handler の code path + テストが実在し、proven な機構と同型（例: StackStack の
+  組織イベント = SSM 注入 2 + 採点減点 3、いずれも実装済。残るは本番イベントでの通し検証）。
+- `[実装中]` — handler の code path が未完のもの（例: inter-team coordination plugin）。
+- `[構想]` — ADR で却下/将来扱い（例: provider federation の Azure/GCP runtime）。
+
+**ADR の Status badge を鵜呑みにしない。** badge が `Proposed` のままでも実装は出荷済のことがある
+（例: ADR-033 の採点側 disruption 効果は `disruption-effects.ts` + dispatcher 配線 + テストとして
+**#1668 で出荷済**だが、HTML の badge は一時 `Proposed` のまま残っていた）。判定は必ず
+**handler の code path（関数 + テスト）の実在**で行い、badge は補助情報として扱う。metadata.json に
+`effect`/`action` の宣言があっても、対応する code path が無ければ `[実証済]`/`[実装済]` にしない。
+
+## 手順
+
+1. **事実収集**（読み取りのみ）
+   - 問題カタログを列挙し、カテゴリ別・kind 別の件数、disruptions を宣言している問題数を数える。
+   - 採点 kind を 5 種列挙し、カタログで実使用されている kind を数える。
+   - 障害注入の実証状況を確認（fire→EventBridge→executor→SSM SendCommand→auto-revert の
+     どこまでが E2E か、failurePenalty の対応 kind）。
+   - 関連 ADR の Status を grep（特に ADR-033）。
+   - README / llms.txt から最新のタグラインを引く。
+2. **数字を差し込んで再生成**
+   - 下記「デッキの背骨」を固定の物語として保ち、件数・kind・実証ラベルだけを最新値に置換する。
+   - 日本語を主言語にする（BootCamp / 国内コミュニティ想定）。英語併記は任意。
+   - スタイルは landing のブランドトークンに合わせる（ink `#07111f` / blue `#0969da` /
+     green `#008a55`、font は Inter + Noto Sans JP 系、すべて inline `<style>`・外部依存なし）。
+     ネットワークが無くても登壇で崩れないよう web font fetch はしない（system fallback に倒す）。
+3. **検証**
+   - HTML が単一ファイルで完結し、外部 asset 参照が無いことを確認。
+   - 主張ラベル（実証済/実装中/構想）が事実ソースと一致することを確認。
+4. **公開はユーザー判断**
+   - ファイルを working tree に生成するところまで。commit / push（= 公開）はユーザーに確認する。
+     `landing/**` への push は Pages を更新する outward-facing 操作なので勝手に出さない。
+
+## デッキの背骨（固定の物語、数字だけ最新化）
+
+1. **タイトル** — TenkaCloud / 「AI 時代の GameDay を作る競技基盤」/ 旗艦 StackStack / 登壇情報。
+2. **課題（Vibe Coding 時代）** — 「AI で作れる。でも認証・セキュリティで“公開”できない」 ラストワンマイル。
+3. **TenkaCloud とは** — 本物の AWS でクラウド演習を回す OSS。Battle / Challenge。moat = 問題はプラグイン。
+4. **仕組み（90 秒）** — 各チームの隔離 AWS に CFn を deploy（AssumeRole+ExternalId）→ 毎分 probe → leaderboard。Lite は ~10–30 分。
+5. **StackStack（旗艦）** — AI→Production ラストワンマイル。5 統制軸表、EC2 100pt→managed 1000pt→全 managed +30,000pt、phases。
+6. **赤チーム / 障害注入 — 実態** — hello-world-battle で `[実証済]`。StackStack の組織イベント減点は `[実装中]`（ADR-033）。
+7. **今動くもの（正直な棚卸し）** — カタログ件数・kind・disruption・分離・Lite/SaaS を実証ラベル付きで。
+8. **BootCamp で検証したいこと** — Vibe Coder がどこで詰まるか / どの体験が刺さるか / StackStack を解いてもらう。
+9. **次の一手** — ADR-033 を仕上げて StackStack 完全 demo 化、初見で問題を作れるオーサリング整備、federation。
+10. **クローズ** — Apache-2.0 / self-hostable / 問題を一緒に作る CTA + リンク。
+
+## 出力先
+
+- `landing/pitch/index.html` — 単一ファイル。Pages で `/TenkaCloud/pitch/` に出る。

--- a/.claude/skills/pitchdeck/SKILL.md
+++ b/.claude/skills/pitchdeck/SKILL.md
@@ -14,8 +14,10 @@ TenkaCloud のピッチデッキを **リポジトリの今の実態から** 再
 正本（誇張しないための事実ソース）:
 
 - 位置づけ / タグライン: [`README.md`](../../../README.md) 冒頭、[`landing/llms.txt`](../../../landing/llms.txt)
-- 問題カタログ: `problems/<category>/<id>/metadata.json`（submodule。実体は
-  `/Users/susumu/product/TenkaCloudChallenge` の clone 側にあることが多い）
+- 問題カタログ: `problems/<category>/<id>/metadata.json`（git submodule）。必ず**リポジトリ相対の
+  `problems/`** を読む。個人マシンの絶対パスや外部 clone には依存しない（どの環境でも同じパスで動くように）。
+  submodule 未取得だと空なので、先に `git submodule status problems` で確認し、空なら
+  `git submodule update --init problems` で展開してから数える。
 - 採点エンジン: `infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/*.ts`
 - 障害注入 (赤チーム): `infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/`、
   `disruption-executor-lambda.ts`、ADR-029/031/033/034

--- a/landing/pitch/index.html
+++ b/landing/pitch/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>TenkaCloud — AI 時代の GameDay を作る競技基盤 / StackStack ピッチ</title>
+<meta name="description" content="TenkaCloud は本物の AWS でクラウド演習を回す OSS 競技基盤。旗艦シナリオ StackStack は『AI で作れるが認証・セキュリティで公開できない』ラストワンマイルをゲーム化する。" />
+<style>
+  :root {
+    --ink:#07111f; --ink-2:#263241; --ink-3:#5d6877; --ink-4:#8a94a3;
+    --blue:#0969da; --green:#008a55; --amber:#9a6700; --red:#cf222e;
+    --line:#d9dee8; --line-soft:#edf0f5;
+    --paper:#ffffff; --paper-2:#fbfcfe; --paper-3:#f5f7fb; --dark:#07111f;
+    --font-sans:"Inter","Hiragino Sans","Noto Sans JP","Yu Gothic UI",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+    --font-mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+    --w:1080px;
+  }
+  * { box-sizing:border-box; }
+  html { scroll-behavior:smooth; }
+  body {
+    margin:0; color:var(--ink); background:var(--paper);
+    font-family:var(--font-sans); line-height:1.6;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  }
+  /* deck = vertical scroll-snap of full-height slides */
+  .deck { scroll-snap-type:y mandatory; height:100vh; overflow-y:scroll; }
+  .slide {
+    scroll-snap-align:start; min-height:100vh; width:100%;
+    display:flex; flex-direction:column; justify-content:center;
+    padding:6vh 7vw; position:relative;
+    border-bottom:1px solid var(--line-soft);
+  }
+  .slide .inner { max-width:var(--w); margin:0 auto; width:100%; }
+  .kicker { font-family:var(--font-mono); font-size:.8rem; letter-spacing:.08em;
+            text-transform:uppercase; color:var(--blue); margin:0 0 .9rem; font-weight:600; }
+  h1 { font-size:clamp(2.1rem,5vw,3.4rem); line-height:1.15; margin:.2rem 0 1rem; letter-spacing:-.01em; }
+  h2 { font-size:clamp(1.5rem,3.4vw,2.3rem); line-height:1.2; margin:.2rem 0 1.4rem; letter-spacing:-.01em; }
+  h3 { font-size:1.05rem; margin:1.4rem 0 .5rem; color:var(--ink-2); }
+  p { margin:.5rem 0; color:var(--ink-2); font-size:clamp(1rem,1.6vw,1.18rem); }
+  .lead { font-size:clamp(1.15rem,2.2vw,1.5rem); color:var(--ink); }
+  .muted { color:var(--ink-3); }
+  .mono { font-family:var(--font-mono); }
+  .accent { color:var(--blue); }
+  .ok { color:var(--green); }
+  strong { color:var(--ink); }
+  a { color:var(--blue); text-decoration:none; border-bottom:1px solid rgba(9,105,218,.3); }
+
+  /* title slide */
+  .title { background:
+      radial-gradient(circle at 18% 12%, rgba(9,105,218,.10), rgba(255,255,255,0) 46%),
+      radial-gradient(circle at 86% 88%, rgba(0,138,85,.10), rgba(255,255,255,0) 46%),
+      var(--paper); }
+  .wordmark { display:inline-flex; align-items:center; gap:.6rem; font-weight:800;
+              font-size:1.3rem; letter-spacing:-.02em; }
+  .wordmark .dot { width:.85rem; height:.85rem; border-radius:3px;
+                   background:linear-gradient(135deg,var(--blue),var(--green)); display:inline-block; }
+  .title-sub { font-size:clamp(1.1rem,2vw,1.45rem); color:var(--ink-2); margin-top:1.2rem; max-width:760px; }
+  .meta-row { margin-top:2.4rem; display:flex; flex-wrap:wrap; gap:.6rem 1.4rem;
+              font-family:var(--font-mono); font-size:.92rem; color:var(--ink-3); }
+  .meta-row b { color:var(--ink-2); font-weight:600; }
+
+  /* tags */
+  .tag { display:inline-block; padding:2px 9px; border-radius:999px; font-size:.74rem;
+         font-weight:700; font-family:var(--font-mono); line-height:1.5; white-space:nowrap; vertical-align:middle; }
+  .tag.proven { background:#ddf4e0; color:var(--green); }
+  .tag.wip    { background:#fff8c5; color:var(--amber); }
+  .tag.idea   { background:#eef1f5; color:var(--ink-3); }
+
+  /* grids & cards */
+  .grid { display:grid; gap:1rem; margin-top:1.3rem; }
+  .g2 { grid-template-columns:repeat(2,1fr); }
+  .g3 { grid-template-columns:repeat(3,1fr); }
+  .card { background:var(--paper-3); border:1px solid var(--line); border-radius:12px;
+          padding:1.1rem 1.2rem; }
+  .card h3 { margin:.1rem 0 .35rem; font-size:1rem; color:var(--ink); }
+  .card p { font-size:.96rem; margin:.2rem 0; color:var(--ink-3); }
+  .stat { font-family:var(--font-mono); font-size:2.2rem; font-weight:700; color:var(--blue); line-height:1; }
+  .stat.green { color:var(--green); }
+
+  /* tables */
+  table { border-collapse:collapse; width:100%; margin-top:1.2rem; font-size:.95rem; }
+  th,td { border:1px solid var(--line); padding:8px 11px; text-align:left; vertical-align:top; }
+  th { background:var(--paper-3); font-weight:700; color:var(--ink-2); }
+  td.mono, th.mono { font-family:var(--font-mono); font-size:.88rem; }
+
+  /* flow / arrows */
+  .flow { display:flex; flex-wrap:wrap; align-items:stretch; gap:.6rem; margin-top:1.3rem; }
+  .flow .step { background:var(--paper-3); border:1px solid var(--line); border-radius:10px;
+                padding:.7rem .9rem; font-size:.92rem; flex:1 1 140px; }
+  .flow .step b { display:block; color:var(--ink); font-size:.96rem; margin-bottom:.15rem; }
+  .arrow { color:var(--ink-4); align-self:center; font-family:var(--font-mono); }
+
+  ul.clean { margin:.8rem 0 0; padding-left:1.2rem; }
+  ul.clean li { margin:.45rem 0; color:var(--ink-2); font-size:clamp(1rem,1.5vw,1.14rem); }
+  .pill { display:inline-block; font-family:var(--font-mono); font-size:.82rem; background:var(--paper-3);
+          border:1px solid var(--line); border-radius:6px; padding:1px 7px; color:var(--ink-2); }
+
+  .quote { border-left:4px solid var(--blue); background:var(--paper-3); padding:.9rem 1.2rem;
+           border-radius:0 8px 8px 0; font-size:clamp(1.05rem,1.8vw,1.3rem); color:var(--ink); margin-top:1.2rem; }
+
+  /* fixed UI: progress + counter + hint */
+  .progress { position:fixed; top:0; left:0; height:3px; background:linear-gradient(90deg,var(--blue),var(--green));
+              width:0; z-index:100; transition:width .2s ease; }
+  .counter { position:fixed; bottom:14px; right:18px; z-index:100; font-family:var(--font-mono);
+             font-size:.8rem; color:var(--ink-3); background:rgba(255,255,255,.8);
+             border:1px solid var(--line); border-radius:999px; padding:3px 10px; backdrop-filter:blur(4px); }
+  .hint { position:fixed; bottom:14px; left:18px; z-index:100; font-family:var(--font-mono);
+          font-size:.74rem; color:var(--ink-4); }
+  .slide-no { position:absolute; top:5vh; right:7vw; font-family:var(--font-mono); font-size:.8rem; color:var(--ink-4); }
+
+  @media (max-width:720px){ .g2,.g3{grid-template-columns:1fr;} .slide{padding:7vh 8vw;} }
+
+  /* print → 1 slide per page (Cmd-P で配布用 PDF) */
+  @media print {
+    .deck{height:auto;overflow:visible;}
+    .slide{min-height:auto;page-break-after:always;border:none;padding:7mm 12mm;}
+    .progress,.counter,.hint{display:none;}
+    body{font-size:11pt;}
+  }
+</style>
+</head>
+<body>
+<div class="progress" id="progress"></div>
+<div class="counter" id="counter">1</div>
+<div class="hint">↓ / → / Space</div>
+
+<div class="deck" id="deck">
+
+  <!-- 1. TITLE -->
+  <section class="slide title">
+    <div class="inner">
+      <span class="wordmark"><span class="dot"></span>TenkaCloud</span>
+      <h1>AI 時代の GameDay を、<br>誰でも作れる競技基盤。</h1>
+      <p class="title-sub">本物の AWS でクラウド演習を回す OSS プラットフォーム。<br>
+        旗艦シナリオ <strong>StackStack</strong> — 「AI で作れる。でも“公開”できない」 ラストワンマイルをゲームにする。</p>
+      <div class="meta-row">
+        <span><b>SS BootCamp #4</b> Kickoff</span>
+        <span>2026-06-14 (日)</span>
+        <span>冨田 進</span>
+        <span class="mono">github.com/susumutomita/TenkaCloud</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2. PROBLEM -->
+  <section class="slide">
+    <span class="slide-no">02</span>
+    <div class="inner">
+      <p class="kicker">Vibe Coding 時代の壁</p>
+      <h2>AI で“動くもの”はもう作れる。<br>詰まるのは、その先だ。</h2>
+      <p class="lead">Claude でアプリは 1 時間で立つ。だが本番に出す瞬間、全員が同じ壁にぶつかる:</p>
+      <div class="grid g3">
+        <div class="card"><h3>🔐 認証 / 認可</h3><p>とりあえず Basic 認証。SSO も権限分離も後回しのまま公開できない。</p></div>
+        <div class="card"><h3>🛡️ セキュリティ</h3><p>公開 S3、ワイルドカード IAM、秘密鍵の commit、レート制限なし。</p></div>
+        <div class="card"><h3>📊 運用 / 監査</h3><p>ログは標準出力だけ。落ちても気づけない。監査に出せない。</p></div>
+      </div>
+      <div class="quote">「AI が書く速さに、<strong>“安全に公開する”側</strong>が追いつけていない。」<br>
+        <span class="muted" style="font-size:.9rem">— これは個人開発者も、社内 Platform チームも、まったく同じ構図。</span></div>
+    </div>
+  </section>
+
+  <!-- 3. WHAT IS TENKACLOUD -->
+  <section class="slide">
+    <span class="slide-no">03</span>
+    <div class="inner">
+      <p class="kicker">TenkaCloud とは</p>
+      <h2>その壁の越え方を、<br>採点付きの演習にする OSS。</h2>
+      <p class="lead">スライドでも野放しのサンドボックスでもない。<strong>本物の AWS に問題を deploy し、毎分採点し、順位を出す。</strong></p>
+      <div class="grid g2">
+        <div class="card"><h3>⚔️ Battle</h3><p>リアルタイム対戦。ヘルスプローブが全チームを毎分叩く。生き残った Platform チームが勝つ。</p></div>
+        <div class="card"><h3>🎯 Challenge</h3><p>自分のペースで 1 サービスずつ深掘り。flag 提出で採点。</p></div>
+      </div>
+      <h3 style="margin-top:1.6rem">moat = 問題はプラグイン</h3>
+      <p>1 問題 = <span class="pill">metadata.json</span> + <span class="pill">template.yaml</span>（CFn ペライチ）+ 任意の portal 部品。
+        platform は host、問題は plugin（ADR-012）。<strong>一度書いた問題は、再利用できる資産になり、コミュニティで育つ。</strong></p>
+    </div>
+  </section>
+
+  <!-- 4. HOW IT WORKS -->
+  <section class="slide">
+    <span class="slide-no">04</span>
+    <div class="inner">
+      <p class="kicker">仕組み — 90 秒で</p>
+      <h2>各チームの AWS に隔離 deploy → 毎分採点 → 順位</h2>
+      <div class="flow">
+        <div class="step"><b>① 主催者</b>問題を選び deploy</div>
+        <span class="arrow">→</span>
+        <div class="step"><b>② 隔離環境</b>各チームの AWS に CFn（AssumeRole + ExternalId）</div>
+        <span class="arrow">→</span>
+        <div class="step"><b>③ 採点エンジン</b>毎分エンドポイントを probe</div>
+        <span class="arrow">→</span>
+        <div class="step"><b>④ Portal</b>スコア履歴・leaderboard をリアルタイム表示</div>
+      </div>
+      <div class="grid g3" style="margin-top:1.8rem">
+        <div class="card"><div class="stat green">~10–30<span style="font-size:1rem"> 分</span></div><p>Lite モードで 1 主催者 / 1 イベントが立つまで</p></div>
+        <div class="card"><div class="stat">クロスアカウント</div><p>チーム間は IAM とスタック分離で完全隔離。他チームのリソースは触れない</p></div>
+        <div class="card"><div class="stat">$0 〜</div><p>自分の AWS で self-host。SaaS 費用も席課金もデータ流出もなし</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. STACKSTACK -->
+  <section class="slide">
+    <span class="slide-no">05</span>
+    <div class="inner">
+      <p class="kicker">旗艦シナリオ — BootCamp で検証する本体</p>
+      <h2>StackStack — AI → Production ラストワンマイル</h2>
+      <p class="lead">あなたは Platform チーム。AI Builder 100 人が量産したアプリが、5 つの統制軸すべて未整備・EC2 1 台同居で積まれている。
+        <strong>90–120 分で“公開していい状態”に持っていけ。</strong></p>
+      <table>
+        <thead><tr><th class="mono">slot</th><th>統制軸</th><th>初期（EC2）</th><th>hardened（managed）</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">auth</td><td>認証 / 認可</td><td>naive Basic 認証</td><td>Cognito / SSO</td></tr>
+          <tr><td class="mono">network</td><td>S3 / WAF / IAM</td><td>公開 S3 + ワイルドカード IAM</td><td>OAC + 絞った IAM</td></tr>
+          <tr><td class="mono">rate</td><td>レート制限 / DoS</td><td>無制限 Flask</td><td>API GW throttle</td></tr>
+          <tr><td class="mono">audit</td><td>ログ / 監査</td><td>標準出力のみ</td><td>CloudTrail + Athena + WORM</td></tr>
+          <tr><td class="mono">ux</td><td>可用性</td><td>EC2 1 台</td><td>Multi-AZ + ALB + Auto Scaling</td></tr>
+        </tbody>
+      </table>
+      <p style="margin-top:1.1rem"><strong class="accent">EC2 = 100pt/分</strong> → managed runtime に切り出すと <strong class="ok">1,000pt/分</strong>。
+        5 slot 全部 managed で <strong>+30,000pt（“production-ready” 認定、1 回）</strong>。
+        30 / 60 / 90 分で「公開期限」「PII 監査」「障害対応」フェーズが襲ってくる。</p>
+    </div>
+  </section>
+
+  <!-- 6. RED TEAM REALITY -->
+  <section class="slide">
+    <span class="slide-no">06</span>
+    <div class="inner">
+      <p class="kicker">赤チーム / 障害注入 — 実態（誇張なし）</p>
+      <h2>「混乱を注入する」 仕組みは、もう動いている。</h2>
+      <div class="grid g2">
+        <div class="card">
+          <h3><span class="tag proven">実証済</span> hello-world-battle の frontend-down</h3>
+          <p>operator が fire → EventBridge → executor Lambda が <span class="mono">SSM SendCommand</span> で nginx を停止 →
+            <span class="mono">failurePenalty -100</span> がスコア履歴に “谷” として現れる → 既定時間で <strong>自動復帰</strong>。
+            fire → 減点 → 復帰を実機で確認済み。ゲームが詰まることはない（idempotent な auto-revert）。</p>
+        </div>
+        <div class="card">
+          <h3><span class="tag proven">実装済</span> StackStack の組織イベント — 5 件すべて実体化</h3>
+          <p><strong>注入 2 件</strong>（<span class="mono">.env</span> 流出 / AI が秘密鍵を commit）は実 SSM action で該当 slot を停止し強制 revert（ADR-031）。
+            <strong>減点 3 件</strong>（CEO 5000 人デモ / MFA 必須化 / Legal PII）は採点 tick で実減点し、window 経過で自動失効（ADR-033、#1668 出荷済）。
+            残るは <strong>本番イベントでの通し検証</strong>のみ。</p>
+        </div>
+      </div>
+      <div class="flow" style="margin-top:1.5rem">
+        <div class="step"><b>fire</b>operator が発火</div><span class="arrow">→</span>
+        <div class="step"><b>EventBridge</b>*DisruptionFired</div><span class="arrow">→</span>
+        <div class="step"><b>executor</b>SSM / Lambda / CFn で注入</div><span class="arrow">→</span>
+        <div class="step"><b>auto-revert</b>Scheduler 1-shot で復帰</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 7. WHAT WORKS NOW -->
+  <section class="slide">
+    <span class="slide-no">07</span>
+    <div class="inner">
+      <p class="kicker">今動くもの — 正直な棚卸し</p>
+      <h2>ハリボテは出さない。実証済みだけ数える。</h2>
+      <div class="grid g3">
+        <div class="card"><div class="stat">4 + 3</div><p>Battle 4 問（hello-world / security-battle-royale / microservice-migration / StackStack）+ Challenge 3 問</p></div>
+        <div class="card"><div class="stat">5</div><p>採点 kind（flag / uptime-flat / uptime-multi / phased-polling / attack-detection）。うち 4 種をカタログで実使用</p></div>
+        <div class="card"><div class="stat green">10</div><p>宣言済み障害注入（赤チーム）。SSM 注入経路は実機で実証済み</p></div>
+      </div>
+      <ul class="clean">
+        <li><span class="tag proven">実証済</span> 障害注入 fire → EventBridge → executor → SSM 注入 → <strong>自動復帰</strong>（Lite / 同一アカウント・クロスアカウント両対応）</li>
+        <li><span class="tag proven">実証済</span> ヘルスチェック失敗で減点する <span class="mono">failurePenalty</span>（uptime 系 / phased-polling）— 障害が履歴に可視化される</li>
+        <li><span class="tag proven">実証済</span> クロスアカウント分離・参加者 Portal（スコア履歴ページング・leaderboard）・主催コンソール（deploy / disruptions / 監査ログ）</li>
+        <li><span class="tag proven">実装済</span> StackStack の組織イベント = 5 件すべて実体化（注入 2 / 採点減点 3、ADR-033 は #1668 で出荷済・window 自動失効）</li>
+        <li><span class="tag wip">実装中</span> inter-team coordination plugin（問題側 plugin として dispatch）</li>
+        <li><span class="tag idea">構想</span> Azure / GCP / さくらクラウドへの problem-target 拡張（ADR-026/027、AWS control plane は不変）</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- 8. BOOTCAMP VALIDATION -->
+  <section class="slide">
+    <span class="slide-no">08</span>
+    <div class="inner">
+      <p class="kicker">BootCamp で検証したいこと</p>
+      <h2>この場を、Vibe Coding の“詰まり”の実験場にしたい。</h2>
+      <p class="lead">いま AI でアプリを作っている参加者に、StackStack を実際に解いてもらう。知りたいのは 3 つ:</p>
+      <div class="grid g3">
+        <div class="card"><h3>① どこで詰まるか</h3><p>auth / 公開 S3 / 秘密情報 / レート制限 / 監視 — “公開の壁” のどれが一番きついか、実データで観たい。</p></div>
+        <div class="card"><h3>② どの体験が刺さるか</h3><p>毎分加点・順位・障害注入・“production-ready 認定” — どれが学びと熱量を生むか。</p></div>
+        <div class="card"><h3>③ 初見で問題を作れるか</h3><p><span class="pill">/new-problem</span> と AUTHORING で、参加者自身が自分の“詰まり”を問題として投稿できるか。</p></div>
+      </div>
+      <div class="quote">作って終わりにしない。<strong>参加者の詰まりが、そのまま次の問題カタログになる。</strong></div>
+    </div>
+  </section>
+
+  <!-- 9. NEXT -->
+  <section class="slide">
+    <span class="slide-no">09</span>
+    <div class="inner">
+      <p class="kicker">次の一手</p>
+      <h2>赤チームは実装済み。残るは本番での通し検証。</h2>
+      <ul class="clean">
+        <li><strong>本番 StackStack イベントの通し検証</strong> — 実 AWS で 5 slot を deploy → 組織イベントを fire → 注入（slot 停止→復帰）と減点（window 失効）を 1 イベント通して観測する。<span class="tag wip">本番検証</span></li>
+        <li><strong>初見で問題を作れるオーサリング</strong> — プロンプト / プラグインを足し、参加者が「自分が詰まった所」を 1 問にできる導線を太くする。</li>
+        <li><strong>このデッキ自体が最新を映す</strong> — <span class="pill">/pitchdeck</span> スキルでリポジトリの実態（件数・実証ラベル）から再生成。聞かれたら常に今の状態で話せる。</li>
+      </ul>
+      <h3 style="margin-top:1.6rem">先のロードマップ</h3>
+      <p>マルチクラウド problem-target（Azure / GCP / さくら）、inter-team coordination の問題側 plugin 化、large-event のスケール検証。</p>
+    </div>
+  </section>
+
+  <!-- 10. CLOSE -->
+  <section class="slide title">
+    <span class="slide-no">10</span>
+    <div class="inner">
+      <span class="wordmark"><span class="dot"></span>TenkaCloud</span>
+      <h1>一緒に、AI 時代の<br>クラウド演習を作りませんか。</h1>
+      <p class="title-sub">Apache-2.0 / self-hostable。問題はプラグイン、platform は host。
+        あなたの “公開できなかった経験” が、誰かの教材になる。</p>
+      <div class="meta-row">
+        <span><b>Repo</b> <span class="mono">github.com/susumutomita/TenkaCloud</span></span>
+        <span><b>Landing</b> <span class="mono">susumutomita.github.io/TenkaCloud</span></span>
+        <span><b>Mock</b> <span class="mono">/portal-demo/?demo=1</span></span>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  // 進捗バー + スライド番号。キーボードで次/前へスクロール（登壇操作）。
+  (function () {
+    var deck = document.getElementById("deck");
+    var slides = Array.prototype.slice.call(deck.querySelectorAll(".slide"));
+    var progress = document.getElementById("progress");
+    var counter = document.getElementById("counter");
+
+    function current() {
+      var top = deck.scrollTop, h = deck.clientHeight;
+      return Math.max(0, Math.min(slides.length - 1, Math.round(top / h)));
+    }
+    function paint() {
+      var i = current();
+      counter.textContent = (i + 1) + " / " + slides.length;
+      progress.style.width = ((i) / (slides.length - 1) * 100) + "%";
+    }
+    function go(i) {
+      i = Math.max(0, Math.min(slides.length - 1, i));
+      slides[i].scrollIntoView({ behavior: "smooth" });
+    }
+    deck.addEventListener("scroll", paint, { passive: true });
+    window.addEventListener("keydown", function (e) {
+      if (["ArrowDown", "ArrowRight", "PageDown", " "].indexOf(e.key) > -1) { e.preventDefault(); go(current() + 1); }
+      else if (["ArrowUp", "ArrowLeft", "PageUp"].indexOf(e.key) > -1) { e.preventDefault(); go(current() - 1); }
+      else if (e.key === "Home") { e.preventDefault(); go(0); }
+      else if (e.key === "End") { e.preventDefault(); go(slides.length - 1); }
+    });
+    paint();
+  })();
+</script>
+</body>
+</html>

--- a/landing/pitch/index.html
+++ b/landing/pitch/index.html
@@ -259,7 +259,7 @@
       <p class="kicker">今動くもの — 正直な棚卸し</p>
       <h2>ハリボテは出さない。実証済みだけ数える。</h2>
       <div class="grid g3">
-        <div class="card"><div class="stat">4 + 3</div><p>Battle 4 問（hello-world / security-battle-royale / microservice-migration / StackStack）+ Challenge 3 問</p></div>
+        <div class="card"><div class="stat">4 + 3</div><p>Battle 4 問（hello-world-battle / security-battle-royale / microservice-migration-battle / StackStack）+ Challenge 3 問</p></div>
         <div class="card"><div class="stat">5</div><p>採点 kind（flag / uptime-flat / uptime-multi / phased-polling / attack-detection）。うち 4 種をカタログで実使用</p></div>
         <div class="card"><div class="stat green">10</div><p>宣言済み障害注入（赤チーム）。SSM 注入経路は実機で実証済み</p></div>
       </div>


### PR DESCRIPTION
## Summary

Adds a `/pitchdeck` skill and a generated single-page pitch deck for the SS BootCamp#4 Kickoff (2026-06-14), where TenkaCloud + the flagship **StackStack** scenario are presented.

- **`.claude/skills/pitchdeck/SKILL.md`** — regenerates the deck from the repo's *actual* state (catalog counts, scoring kinds, disruption status, ADR `Status:`). Hard honesty rule: label each capability `実証済 / 実装中 / 構想`, and never claim a `Proposed`-ADR feature as done.
- **`landing/pitch/index.html`** — self-contained (no external assets → renders offline at the venue), 10 slides, arrow/Space nav + progress, `Cmd-P` → per-slide PDF. Under `landing/` so Pages serves it at `/TenkaCloud/pitch/`.

The narrative is anchored on what is genuinely verified: `hello-world-battle`'s frontend-down disruption (SSM injection → `failurePenalty` dip → auto-revert) is `実証済`; StackStack's org-event scoring effects are `実装中` because ADR-033 is still `Proposed`.

## Test plan

- Rendered `landing/pitch/index.html` in Chrome (title / StackStack table / red-team slides): renders correctly, **zero console errors**, fully self-contained (grep confirms no external `src`/`href`/`@import`).
- `make harness` — no findings. `make before-commit` — green (lint/typecheck/test/build/validate-problems/synth all pass).
- `.claude/**` is ignored by markdownlint + textlint; the deck is `.html` (outside textlint's `.md` scope) — no lint impact.

## Regression analysis

Adds only new files; touches no existing code, config, or CFn. No runtime path changes. The Pages workflow already uploads all of `landing/**`, so the new `pitch/` subdir is picked up without workflow edits. Only new surface is a new public URL `/TenkaCloud/pitch/`.

## Physical impact

- **Artifact CREATE**: `landing/pitch/index.html` (new public Pages path on merge), `.claude/skills/pitchdeck/SKILL.md` (dev tooling, runtime NO-OP).
- **CFn diff**: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive pitch-deck landing page with 10 full-screen slides, responsive design, scroll navigation, keyboard controls (arrow keys, page navigation), and print-optimized layout for single-slide-per-page output.

* **Documentation**
  * Added guidance for pitch-deck generation and maintenance procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->