### PR TITLE
refactor(scoring): share uptimeEvent helper across scoring kinds

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/phased-polling.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/phased-polling.ts
@@ -10,6 +10,7 @@ import {
   noopKindResult,
   probeUrl,
   resolveActivePhase,
+  uptimeEvent,
 } from "../shared.js";
 
 /**
@@ -184,10 +185,6 @@ function scoreFailurePenalty(
   return points === 0
     ? { scoreDelta: 0, scoreEvents: [] }
     : { scoreDelta: points, scoreEvents: [uptimeEvent(points, occurredAt)] };
-}
-
-function uptimeEvent(points: number, occurredAt: string): KindScoreEvent {
-  return { source: "uptime", points, occurredAt };
 }
 
 function scorePhasedBonuses(

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-flat.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/uptime-flat.ts
@@ -18,6 +18,7 @@ import {
   type KindResult,
   noopKindResult,
   probeUrl,
+  uptimeEvent,
 } from "../shared.js";
 
 /**
@@ -103,11 +104,11 @@ function buildScoreEvents(
   failureDelta: number,
   occurredAt: string,
 ): KindResult["scoreEvents"] {
-  if (allOk) return [{ source: "uptime", points, occurredAt }];
+  if (allOk) return [uptimeEvent(points, occurredAt)];
   // 減点が設定されていれば、 失敗 tick に -N の score event を残す (= 履歴に可視化、 監査痕跡)。
   // 減点 0 のときは従来通り、 ok→fail 遷移の attack-detected marker のみ。
   if (failureDelta !== 0) {
-    return [{ source: "uptime", points: failureDelta, occurredAt }];
+    return [uptimeEvent(failureDelta, occurredAt)];
   }
   return attackDetected ? [{ source: "attack-detected", points: 0, occurredAt }] : [];
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts
@@ -350,6 +350,14 @@ export interface KindScoreEvent {
   readonly occurredAt: string;
 }
 
+/**
+ * `source: "uptime"` の score event を組む共通ヘルパ。 uptime-flat / uptime-multi / phased-polling
+ * が同形の `{ source: "uptime", points, occurredAt }` を作るのを 1 箇所に集約する (= DRY)。
+ */
+export function uptimeEvent(points: number, occurredAt: string): KindScoreEvent {
+  return { source: "uptime", points, occurredAt };
+}
+
 export function noopKindResult(): KindResult {
   return { scoreDelta: 0, scoreEvents: [] };
 }


### PR DESCRIPTION
## Summary

Pure reuse cleanup surfaced by `/simplify` on the recent testing round. The `failurePenalty` handling added to `uptime-flat` (#1715) constructed the `{ source: "uptime", points, occurredAt }` score event inline — duplicating a private `uptimeEvent()` helper that already existed in `phased-polling`. Lift `uptimeEvent` into the shared module (next to `KindScoreEvent` / `noopKindResult`) and point both `phased-polling` and `uptime-flat` at it.

No behavior change — same objects produced; one duplicate definition removed.

## Test plan

- `infrastructure` typecheck clean.
- Scoring kind tests green: `generic-scoring-uptime-flat` / `-phased-polling` / `-shared` / `-uptime-multi` (63 tests).
- `make harness` no findings; `make before-commit` green.

## Regression analysis

`uptimeEvent` returns the identical `{ source: "uptime", points, occurredAt }` shape the two call sites built inline, so emitted score events are byte-identical. `uptime-flat`'s `attack-detected` fallback (when `failureDelta === 0`) is unchanged. No other kinds touched (`uptime-multi`'s interleaved `as const` construction left as-is, out of this diff's scope).

## Physical impact

- **Artifact**: scoring Lambda handler source only. Output behavior identical → **NO-OP** at runtime.
- **CFn diff**: none.
