### PR TITLE
docs(adr-033): mark Accepted — shipped in #1668

### DIFF
--- a/docs/architecture/adr-033-scoring-side-disruption-effects.html
+++ b/docs/architecture/adr-033-scoring-side-disruption-effects.html
@@ -51,14 +51,14 @@
   <h1>ADR-033: Scoring-side disruption effects</h1>
   <p><em>fire しても採点が動かない disruption に、 実クラウドへの fault 注入を伴わずに「採点上の効果 (減点 / 可用性ダウン)」を与えるための宣言契約と評価経路</em></p>
   <div class="meta">
-    <div><b>Status:</b> <span class="badge draft">Proposed</span> 2026-06-03</div>
+    <div><b>Status:</b> <span class="badge accept">Accepted</span> 2026-06-03</div>
     <div><b>Related:</b>
       <a href="./adr-013-disruption-phase2-condition-triggered.html">ADR-013</a> (disruption 宣言 / Phase A→B / condition trigger),
       <a href="./adr-031-cross-account-disruption-dispatch.html">ADR-031</a> (cross-account の実 fault 注入 <code>action</code>),
       <a href="./adr-029-attack-resilience-game-always-ends.html">ADR-029</a> (game always ends),
       <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin, platform = host)
     </div>
-    <div><b>Issue:</b> #1665 (#1417 の子)</div>
+    <div><b>Issue:</b> #1665 (#1417 の子) — 実装: #1668（condition + operator fired）</div>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary

ADR-033's status badge still read `Proposed`, but the decision it describes is **implemented and tested** — flip it to `Accepted`.

The scoring-side disruption effect mechanism shipped in **#1668**:
- `infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/disruption-effects.ts` — `applyDisruptionEffects` (subtract active penalty per tick), `buildActiveDisruptionEffect` (condition-triggered), `resolveOperatorEffects` (operator-fired, from audit rows, window-bounded).
- Dispatcher wiring in `index.ts` — `loadOperatorEffects` queries the disruptions audit table (1h window) and `foldActiveDisruptionEffects` applies effects per `${eventId}#${teamId}#${problemId}`.
- `test/problem-deploy/disruption-effects.test.ts` — 12 tests, green.

This surfaced while building the `/pitchdeck` deck (the skill reads ADR `Status:` lines, so a stale badge mislabels StackStack's red team). The implementing PR is now referenced on the Issue line.

## Test plan

- `make harness` — no findings (incl. `adr-must-be-html` / `adr-self-contained`).
- Verified the referenced code paths + tests exist and pass (`disruption-effects.test.ts` 12/12).

## Regression analysis

Docs-only change to one ADR HTML file (status badge `draft→accept`, implementing-PR reference on the Issue line). No code, config, or runtime impact.

## Physical impact

- **Artifact**: one ADR HTML file. **NO-OP** at runtime.
- **CFn diff**: none.
