### PR TITLE
feat(admin-console-ios): add native admin app

### DIFF
--- a/apps/admin-console-ios/.gitignore
+++ b/apps/admin-console-ios/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+DerivedData/

--- a/apps/admin-console-ios/Package.swift
+++ b/apps/admin-console-ios/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "TenkaCloudAdminIOS",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "TenkaCloudAdminCore", targets: ["TenkaCloudAdminCore"]),
+        .executable(name: "TenkaCloudAdminApp", targets: ["TenkaCloudAdminApp"]),
+        .executable(name: "TenkaCloudAdminCoreChecks", targets: ["TenkaCloudAdminCoreChecks"])
+    ],
+    targets: [
+        .target(name: "TenkaCloudAdminCore"),
+        .executableTarget(
+            name: "TenkaCloudAdminApp",
+            dependencies: ["TenkaCloudAdminCore"]
+        ),
+        .executableTarget(
+            name: "TenkaCloudAdminCoreChecks",
+            dependencies: ["TenkaCloudAdminCore"]
+        )
+    ]
+)

--- a/apps/admin-console-ios/README.md
+++ b/apps/admin-console-ios/README.md
@@ -1,0 +1,61 @@
+# @TenkaCloud/admin-console-ios
+
+SwiftUI native admin app for the SaaS Control Plane.
+
+This is the first native slice of `apps/admin-console`. It does not embed the
+React SPA in a web view. Instead, it talks to the same Control Plane contracts:
+
+- Cognito Hosted UI OAuth Code + PKCE through `ASWebAuthenticationSession`
+- Memory-only bearer tokens, with refresh-token revoke on sign-out
+- Tenant list, tenant creation, and tenant deprovision calls
+- Tenant detail metadata, including Application Plane links from `tenantConfig`
+- App Intent shortcut: "Open TenkaCloud Admin"
+
+## Required Cognito callback
+
+Add this callback URL to the Control Plane Cognito UserPoolClient:
+
+```text
+tenkacloud-admin://auth/callback
+```
+
+Infrastructure edits are intentionally not included here because CDK / IAM /
+CloudFormation ownership stays with the repository owner.
+
+## Local verification
+
+The package is self-contained and has no external Swift dependencies.
+
+```sh
+bun run --filter @TenkaCloud/admin-console-ios test
+bun run --filter @TenkaCloud/admin-console-ios build
+```
+
+Equivalent SwiftPM commands:
+
+```sh
+swift run TenkaCloudAdminCoreChecks
+swift build
+```
+
+## Running in Xcode
+
+Open `TenkaCloudAdmin.xcodeproj` in Xcode 16 or newer, select the
+`TenkaCloudAdmin` scheme, and run it on an iOS simulator.
+
+The Xcode project uses the local Swift package product
+`TenkaCloudAdminCore`, so the app and CLI checks share the same API and OAuth
+code.
+
+The app asks for:
+
+- Cognito domain: `https://<domain>.auth.<region>.amazoncognito.com`
+- Client ID: the Control Plane user pool app client ID
+- API base URL: the Control Plane API URL from `runtime-config.json`
+- Scope: defaults to `openid email profile`
+
+## Current scope
+
+This app currently covers the System Admin / Control Plane workflow. The
+Tenant Admin competition workflow in `apps/application-admin-console` remains a
+web SPA for now and can be added as the next native slice.

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/AdminAppModel.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/AdminAppModel.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftUI
+import TenkaCloudAdminCore
+
+@MainActor
+final class AdminAppModel: ObservableObject {
+    @Published var settings = AdminSettings()
+    @Published private(set) var tokens: TokenSet?
+    @Published private(set) var tenants: [Tenant] = []
+    @Published var errorMessage: String?
+    @Published var isLoading = false
+    @Published var showDeprovisioned = false
+
+    private let authenticator = WebAuthenticator()
+
+    var isSignedIn: Bool {
+        tokens?.isExpired == false
+    }
+
+    var visibleTenants: [Tenant] {
+        showDeprovisioned ? tenants : tenants.filter { !$0.isDeprovisioned }
+    }
+
+    func signIn() async {
+        guard let configuration = settings.configuration else {
+            errorMessage = settings.validationMessage ?? "Admin configuration is incomplete."
+            return
+        }
+
+        settings.save()
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let oauth = CognitoOAuthClient(configuration: configuration)
+            let session = try oauth.makeAuthorizationSession()
+            let callbackURL = try await authenticator.authenticate(
+                url: session.authorizationURL,
+                callbackURLScheme: "tenkacloud-admin"
+            )
+            tokens = try await oauth.exchangeCode(callbackURL: callbackURL, session: session)
+            await refreshTenants()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func signOut() async {
+        if let configuration = settings.configuration, let refreshToken = tokens?.refreshToken {
+            do {
+                try await CognitoOAuthClient(configuration: configuration).revoke(refreshToken: refreshToken)
+            } catch {
+                errorMessage = "Signed out locally. Cognito revoke failed: \(error.localizedDescription)"
+            }
+        }
+        tokens = nil
+        tenants = []
+    }
+
+    func refreshTenants() async {
+        guard let client = apiClient else {
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            tenants = try await client.listTenants()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func createTenant(name: String, email: String, tier: TenantTier) async -> Bool {
+        guard let client = apiClient else {
+            return false
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            _ = try await client.createTenant(
+                CreateTenantRequest(tenantName: name, email: email, tier: tier)
+            )
+            await refreshTenants()
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    func deleteTenant(_ tenant: Tenant) async {
+        guard let client = apiClient else {
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            try await client.deleteTenant(tenantId: tenant.tenantId)
+            await refreshTenants()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private var apiClient: AdminAPIClient? {
+        guard let configuration = settings.configuration, let tokens else {
+            return nil
+        }
+        return AdminAPIClient(baseURL: configuration.apiBaseURL, idToken: tokens.idToken)
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/AdminSettings.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/AdminSettings.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftUI
+import TenkaCloudAdminCore
+
+@MainActor
+final class AdminSettings: ObservableObject {
+    @Published var cognitoDomain: String
+    @Published var clientID: String
+    @Published var apiBaseURL: String
+    @Published var scope: String
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        cognitoDomain = defaults.string(forKey: Keys.cognitoDomain) ?? ""
+        clientID = defaults.string(forKey: Keys.clientID) ?? ""
+        apiBaseURL = defaults.string(forKey: Keys.apiBaseURL) ?? ""
+        scope = defaults.string(forKey: Keys.scope) ?? AdminConfiguration.defaultScope
+    }
+
+    var configuration: AdminConfiguration? {
+        try? AdminConfiguration(
+            cognitoDomain: cognitoDomain,
+            clientID: clientID,
+            apiBaseURL: apiBaseURL,
+            scope: scope
+        )
+    }
+
+    var validationMessage: String? {
+        if cognitoDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Cognito domain is required."
+        }
+        if clientID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Cognito client ID is required."
+        }
+        if apiBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "API base URL is required."
+        }
+        if scope.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "OAuth scope is required."
+        }
+        do {
+            _ = try AdminConfiguration(
+                cognitoDomain: cognitoDomain,
+                clientID: clientID,
+                apiBaseURL: apiBaseURL,
+                scope: scope
+            )
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    func save() {
+        defaults.set(cognitoDomain.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.cognitoDomain)
+        defaults.set(clientID.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.clientID)
+        defaults.set(apiBaseURL.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.apiBaseURL)
+        defaults.set(scope.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.scope)
+    }
+}
+
+private enum Keys {
+    static let cognitoDomain = "TenkaCloud.admin.cognitoDomain"
+    static let clientID = "TenkaCloud.admin.clientID"
+    static let apiBaseURL = "TenkaCloud.admin.apiBaseURL"
+    static let scope = "TenkaCloud.admin.scope"
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/ContentView.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/ContentView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var model: AdminAppModel
+    @State private var showingSettings = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if model.settings.configuration == nil {
+                    SettingsView(settings: model.settings, isRequired: true)
+                } else if model.isSignedIn {
+                    TenantListView(model: model)
+                } else {
+                    SignInView(model: model)
+                }
+            }
+            .navigationTitle("TenkaCloud")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showingSettings = true
+                    } label: {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingSettings) {
+                NavigationStack {
+                    SettingsView(settings: model.settings, isRequired: false)
+                }
+                .presentationDetents([.medium, .large])
+            }
+        }
+    }
+}
+
+private struct SignInView: View {
+    @ObservedObject var model: AdminAppModel
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Admin Console", systemImage: "person.badge.key")
+        } description: {
+            Text("Sign in with the Control Plane Cognito Hosted UI.")
+        } actions: {
+            Button {
+                Task { await model.signIn() }
+            } label: {
+                if model.isLoading {
+                    ProgressView()
+                } else {
+                    Text("Sign In")
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(model.isLoading)
+        }
+        .errorAlert(message: $model.errorMessage)
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/OpenAdminConsoleIntent.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/OpenAdminConsoleIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+
+struct OpenAdminConsoleIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open TenkaCloud Admin"
+    static let description = IntentDescription("Opens the TenkaCloud native admin console.")
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        .result()
+    }
+}
+
+struct TenkaCloudAdminShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenAdminConsoleIntent(),
+            phrases: [
+                "Open \(.applicationName)",
+                "Open TenkaCloud Admin"
+            ],
+            shortTitle: "Open Admin",
+            systemImageName: "person.badge.key"
+        )
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/SettingsView.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/SettingsView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var settings: AdminSettings
+    var isRequired: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Form {
+            Section("Cognito") {
+                TextField("Domain", text: $settings.cognitoDomain)
+                    .adminTextInputAutocapitalizationNever()
+                    .adminURLKeyboard()
+                TextField("Client ID", text: $settings.clientID)
+                    .adminTextInputAutocapitalizationNever()
+            }
+
+            Section("Control Plane API") {
+                TextField("Base URL", text: $settings.apiBaseURL)
+                    .adminTextInputAutocapitalizationNever()
+                    .adminURLKeyboard()
+                TextField("Scope", text: $settings.scope)
+                    .adminTextInputAutocapitalizationNever()
+            }
+
+            if let validationMessage = settings.validationMessage {
+                Section {
+                    Label(validationMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle(isRequired ? "Setup" : "Settings")
+        .toolbar {
+            if !isRequired {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    settings.save()
+                    if !isRequired {
+                        dismiss()
+                    }
+                }
+                .disabled(settings.validationMessage != nil)
+            }
+        }
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenantCreateView.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenantCreateView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import TenkaCloudAdminCore
+
+struct TenantCreateView: View {
+    @ObservedObject var model: AdminAppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var tenantName = ""
+    @State private var email = ""
+    @State private var tier = TenantTier.basic
+
+    var body: some View {
+        Form {
+            Section("Tenant") {
+                TextField("Name", text: $tenantName)
+                TextField("Admin email", text: $email)
+                    .adminTextInputAutocapitalizationNever()
+                    .adminEmailKeyboard()
+            }
+
+            Section("Tier") {
+                Picker("Tier", selection: $tier) {
+                    ForEach(TenantTier.allCases) { tier in
+                        Text(tier.rawValue.capitalized).tag(tier)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Create Tenant")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Create") {
+                    Task {
+                        let created = await model.createTenant(
+                            name: tenantName.trimmingCharacters(in: .whitespacesAndNewlines),
+                            email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+                            tier: tier
+                        )
+                        if created {
+                            dismiss()
+                        }
+                    }
+                }
+                .disabled(isSubmitDisabled || model.isLoading)
+            }
+        }
+    }
+
+    private var isSubmitDisabled: Bool {
+        tenantName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenantListView.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenantListView.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+import TenkaCloudAdminCore
+
+struct TenantListView: View {
+    @ObservedObject var model: AdminAppModel
+    @State private var showingCreateTenant = false
+    @State private var tenantPendingDelete: Tenant?
+
+    var body: some View {
+        List {
+            if model.tenants.contains(where: \.isDeprovisioned) {
+                Toggle("Show deprovisioned tenants", isOn: $model.showDeprovisioned)
+            }
+
+            ForEach(model.visibleTenants) { tenant in
+                NavigationLink {
+                    TenantDetailView(tenant: tenant)
+                } label: {
+                    TenantRowView(tenant: tenant)
+                }
+                .swipeActions {
+                    Button(role: .destructive) {
+                        tenantPendingDelete = tenant
+                    } label: {
+                        Label("Deprovision", systemImage: "archivebox")
+                    }
+                    .disabled(tenant.isDeprovisioned)
+                }
+            }
+        }
+        .overlay {
+            if model.isLoading && model.tenants.isEmpty {
+                ProgressView()
+            }
+        }
+        .refreshable {
+            await model.refreshTenants()
+        }
+        .navigationTitle("Tenants")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button {
+                    Task { await model.signOut() }
+                } label: {
+                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button {
+                    Task { await model.refreshTenants() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(model.isLoading)
+
+                Button {
+                    showingCreateTenant = true
+                } label: {
+                    Label("Create Tenant", systemImage: "plus")
+                }
+            }
+        }
+        .task {
+            if model.tenants.isEmpty {
+                await model.refreshTenants()
+            }
+        }
+        .sheet(isPresented: $showingCreateTenant) {
+            NavigationStack {
+                TenantCreateView(model: model)
+            }
+        }
+        .alert("Deprovision tenant?", isPresented: deleteAlertPresented) {
+            Button("Cancel", role: .cancel) {
+                tenantPendingDelete = nil
+            }
+            Button("Deprovision", role: .destructive) {
+                guard let tenant = tenantPendingDelete else {
+                    return
+                }
+                Task {
+                    await model.deleteTenant(tenant)
+                    tenantPendingDelete = nil
+                }
+            }
+        } message: {
+            Text(tenantPendingDelete?.tenantName ?? "")
+        }
+        .errorAlert(message: $model.errorMessage)
+    }
+
+    private var deleteAlertPresented: Binding<Bool> {
+        Binding(
+            get: { tenantPendingDelete != nil },
+            set: { isPresented in
+                if !isPresented {
+                    tenantPendingDelete = nil
+                }
+            }
+        )
+    }
+}
+
+private struct TenantRowView: View {
+    var tenant: Tenant
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(tenant.tenantName)
+                    .font(.headline)
+                Spacer()
+                StatusPill(text: tenant.tenantStatus, tone: tenant.statusTone)
+            }
+
+            Text(tenant.email)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                StatusPill(text: tenant.tier, tone: tenant.tierTone)
+                Text(tenant.tenantId)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct TenantDetailView: View {
+    var tenant: Tenant
+    private var tenantConfig: ParsedTenantConfig {
+        parseTenantConfig(tenant.tenantConfig)
+    }
+
+    var body: some View {
+        List {
+            Section("Tenant") {
+                LabeledContent("ID", value: tenant.tenantId)
+                LabeledContent("Name", value: tenant.tenantName)
+                LabeledContent("Email", value: tenant.email)
+                LabeledContent("Tier", value: tenant.tier)
+                LabeledContent("Status", value: tenant.tenantStatus)
+            }
+
+            if tenantConfig.applicationAdminConsoleUrl != nil || tenantConfig.apiGatewayUrl != nil {
+                Section("Application Plane") {
+                    if let url = tenantConfig.applicationAdminConsoleUrl {
+                        Link(url, destination: URL(string: url)!)
+                    }
+                    if let url = tenantConfig.apiGatewayUrl {
+                        LabeledContent("API", value: url)
+                    }
+                }
+            }
+        }
+        .navigationTitle(tenant.tenantName)
+    }
+}
+
+private struct StatusPill: View {
+    var text: String
+    var tone: StatusTone
+
+    var body: some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(foreground)
+            .background(background, in: Capsule())
+    }
+
+    private var foreground: Color {
+        switch tone {
+        case .success:
+            .green
+        case .inProgress:
+            .blue
+        case .failed:
+            .red
+        case .inactive:
+            .secondary
+        case .unknown:
+            .orange
+        }
+    }
+
+    private var background: Color {
+        foreground.opacity(0.12)
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenkaCloudAdminApp.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/TenkaCloudAdminApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct TenkaCloudAdminApp: App {
+    @StateObject private var model = AdminAppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(model: model)
+        }
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/View+ErrorAlert.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/View+ErrorAlert.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+extension View {
+    func errorAlert(message: Binding<String?>) -> some View {
+        alert("Error", isPresented: Binding(
+            get: { message.wrappedValue != nil },
+            set: { isPresented in
+                if !isPresented {
+                    message.wrappedValue = nil
+                }
+            }
+        )) {
+            Button("OK", role: .cancel) {
+                message.wrappedValue = nil
+            }
+        } message: {
+            Text(message.wrappedValue ?? "")
+        }
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/View+InputModifiers.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/View+InputModifiers.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func adminTextInputAutocapitalizationNever() -> some View {
+        #if os(iOS)
+        textInputAutocapitalization(.never)
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func adminURLKeyboard() -> some View {
+        #if os(iOS)
+        keyboardType(.URL)
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func adminEmailKeyboard() -> some View {
+        #if os(iOS)
+        keyboardType(.emailAddress)
+        #else
+        self
+        #endif
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminApp/WebAuthenticator.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminApp/WebAuthenticator.swift
@@ -1,0 +1,69 @@
+import AuthenticationServices
+import Foundation
+
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+@MainActor
+final class WebAuthenticator: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private var session: ASWebAuthenticationSession?
+
+    func authenticate(url: URL, callbackURLScheme: String) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: callbackURLScheme
+            ) { callbackURL, error in
+                self.session = nil
+                if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: error ?? WebAuthenticatorError.missingCallbackURL)
+                }
+            }
+
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            self.session = session
+
+            if !session.start() {
+                self.session = nil
+                continuation.resume(throwing: WebAuthenticatorError.failedToStart)
+            }
+        }
+    }
+
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        #if os(iOS)
+        MainActor.assumeIsolated {
+            UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap(\.windows)
+                .first { $0.isKeyWindow } ?? UIWindow()
+        }
+        #elseif os(macOS)
+        MainActor.assumeIsolated {
+            NSApplication.shared.windows.first ?? NSWindow()
+        }
+        #else
+        ASPresentationAnchor()
+        #endif
+    }
+}
+
+enum WebAuthenticatorError: Error, LocalizedError {
+    case failedToStart
+    case missingCallbackURL
+
+    var errorDescription: String? {
+        switch self {
+        case .failedToStart:
+            "Could not start the Cognito sign-in session."
+        case .missingCallbackURL:
+            "Cognito sign-in finished without a callback URL."
+        }
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/AdminAPIClient.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/AdminAPIClient.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public struct AdminAPIClient: Sendable {
+    public var baseURL: URL
+    public var idToken: String
+    public var urlSession: URLSessionProtocol
+
+    public init(baseURL: URL, idToken: String, urlSession: URLSessionProtocol = URLSession.shared) {
+        self.baseURL = baseURL
+        self.idToken = idToken
+        self.urlSession = urlSession
+    }
+
+    public func listTenants() async throws -> [Tenant] {
+        let request = try makeRequest(path: "tenants")
+        let (data, response) = try await urlSession.data(for: request)
+        try HTTPResponseValidator.validate(response: response, data: data)
+
+        if let direct = try? JSONDecoder().decode([Tenant].self, from: data) {
+            return direct
+        }
+        return try JSONDecoder().decode(TenantListEnvelope.self, from: data).data ?? []
+    }
+
+    @discardableResult
+    public func createTenant(_ requestBody: CreateTenantRequest) async throws -> Tenant {
+        var request = try makeRequest(path: "tenants")
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(requestBody)
+
+        let (data, response) = try await urlSession.data(for: request)
+        try HTTPResponseValidator.validate(response: response, data: data)
+        return try JSONDecoder().decode(TenantEnvelope.self, from: data).data
+    }
+
+    public func deleteTenant(tenantId: String) async throws {
+        var request = try makeRequest(path: "tenants/\(Self.urlPathComponent(tenantId))")
+        request.httpMethod = "DELETE"
+        let (data, response) = try await urlSession.data(for: request)
+        try HTTPResponseValidator.validate(response: response, data: data)
+    }
+
+    public func makeRequest(path: String) throws -> URLRequest {
+        guard let url = URL(string: path.trimmingCharacters(in: CharacterSet(charactersIn: "/")), relativeTo: baseURL.appendingPathComponent("")) else {
+            throw URLValidationError.invalidURL(path)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(idToken)", forHTTPHeaderField: "authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        return request
+    }
+
+    static func urlPathComponent(_ value: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+}
+
+private struct TenantEnvelope: Decodable {
+    var data: Tenant
+}
+
+private struct TenantListEnvelope: Decodable {
+    var data: [Tenant]?
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/AdminConfiguration.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/AdminConfiguration.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public struct AdminConfiguration: Codable, Equatable, Sendable {
+    public static let defaultRedirectURI = URL(string: "tenkacloud-admin://auth/callback")!
+    public static let defaultScope = "openid email profile"
+
+    public var cognitoDomain: URL
+    public var clientID: String
+    public var apiBaseURL: URL
+    public var redirectURI: URL
+    public var scope: String
+
+    public init(
+        cognitoDomain: URL,
+        clientID: String,
+        apiBaseURL: URL,
+        redirectURI: URL = Self.defaultRedirectURI,
+        scope: String = Self.defaultScope
+    ) {
+        self.cognitoDomain = cognitoDomain
+        self.clientID = clientID
+        self.apiBaseURL = apiBaseURL
+        self.redirectURI = redirectURI
+        self.scope = scope
+    }
+
+    public init(
+        cognitoDomain: String,
+        clientID: String,
+        apiBaseURL: String,
+        redirectURI: URL = Self.defaultRedirectURI,
+        scope: String = Self.defaultScope
+    ) throws {
+        self.init(
+            cognitoDomain: try URLValidation.normalizedCognitoDomain(cognitoDomain),
+            clientID: clientID.trimmingCharacters(in: .whitespacesAndNewlines),
+            apiBaseURL: try URLValidation.normalizedAPIBaseURL(apiBaseURL),
+            redirectURI: redirectURI,
+            scope: scope.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    public var authorizeEndpoint: URL {
+        cognitoDomain.appendingPathComponent("oauth2/authorize")
+    }
+
+    public var tokenEndpoint: URL {
+        cognitoDomain.appendingPathComponent("oauth2/token")
+    }
+
+    public var revokeEndpoint: URL {
+        cognitoDomain.appendingPathComponent("oauth2/revoke")
+    }
+
+    public var logoutEndpoint: URL {
+        cognitoDomain.appendingPathComponent("logout")
+    }
+
+    public var isComplete: Bool {
+        !clientID.isEmpty && !scope.isEmpty
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/HTTP.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/HTTP.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public protocol URLSessionProtocol: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+public struct APIError: Error, Equatable, LocalizedError {
+    public var statusCode: Int
+    public var detail: String
+
+    public init(statusCode: Int, detail: String) {
+        self.statusCode = statusCode
+        self.detail = detail
+    }
+
+    public var errorDescription: String? {
+        detail.isEmpty ? "API request failed with status \(statusCode)." : detail
+    }
+}
+
+enum HTTPResponseValidator {
+    static func validate(response: URLResponse, data: Data) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError(statusCode: 0, detail: "Response was not HTTP.")
+        }
+        guard HTTPStatusClass.isSuccess(httpResponse.statusCode) else {
+            let detail = String(data: data, encoding: .utf8) ?? httpResponse.description
+            throw APIError(statusCode: httpResponse.statusCode, detail: detail)
+        }
+    }
+}
+
+enum HTTPStatusClass {
+    static func isSuccess(_ statusCode: Int) -> Bool {
+        statusCode / 100 == 2
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/OAuth.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/OAuth.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+public struct OAuthAuthorizationSession: Equatable, Sendable {
+    public var verifier: String
+    public var state: String
+    public var authorizationURL: URL
+
+    public init(verifier: String, state: String, authorizationURL: URL) {
+        self.verifier = verifier
+        self.state = state
+        self.authorizationURL = authorizationURL
+    }
+}
+
+public struct TokenSet: Codable, Equatable, Sendable {
+    public var idToken: String
+    public var accessToken: String
+    public var refreshToken: String?
+    public var expiresAt: Date
+
+    public init(idToken: String, accessToken: String, refreshToken: String?, expiresAt: Date) {
+        self.idToken = idToken
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+    }
+
+    public var isExpired: Bool {
+        Date() >= expiresAt
+    }
+}
+
+public enum OAuthError: Error, Equatable, LocalizedError {
+    case callbackMissingCode
+    case stateMismatch
+    case invalidTokenResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .callbackMissingCode:
+            "OAuth callback did not include an authorization code."
+        case .stateMismatch:
+            "OAuth state mismatch."
+        case .invalidTokenResponse:
+            "Cognito token endpoint returned an invalid response."
+        }
+    }
+}
+
+public struct CognitoOAuthClient: Sendable {
+    public var configuration: AdminConfiguration
+    public var urlSession: URLSessionProtocol
+
+    public init(configuration: AdminConfiguration, urlSession: URLSessionProtocol = URLSession.shared) {
+        self.configuration = configuration
+        self.urlSession = urlSession
+    }
+
+    public func makeAuthorizationSession(identityProvider: String? = nil) throws -> OAuthAuthorizationSession {
+        let verifier = try PKCE.generateVerifier()
+        let state = try PKCE.generateVerifier(length: 32)
+        return try makeAuthorizationSession(
+            verifier: verifier,
+            state: state,
+            identityProvider: identityProvider
+        )
+    }
+
+    public func makeAuthorizationSession(
+        verifier: String,
+        state: String,
+        identityProvider: String? = nil
+    ) throws -> OAuthAuthorizationSession {
+        var components = URLComponents(url: configuration.authorizeEndpoint, resolvingAgainstBaseURL: false)!
+        var queryItems = [
+            URLQueryItem(name: "client_id", value: configuration.clientID),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: configuration.redirectURI.absoluteString),
+            URLQueryItem(name: "scope", value: configuration.scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "code_challenge", value: PKCE.deriveChallenge(verifier: verifier))
+        ]
+        if let identityProvider, !identityProvider.isEmpty {
+            queryItems.append(URLQueryItem(name: "identity_provider", value: identityProvider))
+        }
+        components.queryItems = queryItems
+
+        guard let authorizationURL = components.url else {
+            throw URLValidationError.invalidURL(configuration.authorizeEndpoint.absoluteString)
+        }
+        return OAuthAuthorizationSession(
+            verifier: verifier,
+            state: state,
+            authorizationURL: authorizationURL
+        )
+    }
+
+    public func tokenRequest(callbackURL: URL, session: OAuthAuthorizationSession) throws -> URLRequest {
+        let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+        let code = components?.queryItems?.first(where: { $0.name == "code" })?.value
+        let returnedState = components?.queryItems?.first(where: { $0.name == "state" })?.value
+
+        guard let code, !code.isEmpty else {
+            throw OAuthError.callbackMissingCode
+        }
+        guard returnedState == session.state else {
+            throw OAuthError.stateMismatch
+        }
+
+        var request = URLRequest(url: configuration.tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "content-type")
+        request.httpBody = URLComponents.formURLEncodedBody([
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "client_id", value: configuration.clientID),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "redirect_uri", value: configuration.redirectURI.absoluteString),
+            URLQueryItem(name: "code_verifier", value: session.verifier)
+        ])
+        return request
+    }
+
+    public func exchangeCode(callbackURL: URL, session: OAuthAuthorizationSession) async throws -> TokenSet {
+        let request = try tokenRequest(callbackURL: callbackURL, session: session)
+        let (data, response) = try await urlSession.data(for: request)
+        try HTTPResponseValidator.validate(response: response, data: data)
+        let decoded = try JSONDecoder().decode(TokenEndpointResponse.self, from: data)
+        guard !decoded.idToken.isEmpty, !decoded.accessToken.isEmpty else {
+            throw OAuthError.invalidTokenResponse
+        }
+        return TokenSet(
+            idToken: decoded.idToken,
+            accessToken: decoded.accessToken,
+            refreshToken: decoded.refreshToken,
+            expiresAt: Date().addingTimeInterval(TimeInterval(decoded.expiresIn))
+        )
+    }
+
+    public func revokeRequest(refreshToken: String) -> URLRequest {
+        var request = URLRequest(url: configuration.revokeEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "content-type")
+        request.httpBody = URLComponents.formURLEncodedBody([
+            URLQueryItem(name: "token", value: refreshToken),
+            URLQueryItem(name: "client_id", value: configuration.clientID)
+        ])
+        return request
+    }
+
+    public func revoke(refreshToken: String) async throws {
+        let request = revokeRequest(refreshToken: refreshToken)
+        let (data, response) = try await urlSession.data(for: request)
+        try HTTPResponseValidator.validate(response: response, data: data)
+    }
+}
+
+private struct TokenEndpointResponse: Decodable {
+    var idToken: String
+    var accessToken: String
+    var refreshToken: String?
+    var expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case idToken = "id_token"
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+    }
+}
+
+private extension URLComponents {
+    static func formURLEncodedBody(_ items: [URLQueryItem]) -> Data {
+        var components = URLComponents()
+        components.queryItems = items
+        return Data((components.percentEncodedQuery ?? "").utf8)
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/PKCE.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/PKCE.swift
@@ -1,0 +1,30 @@
+import CryptoKit
+import Foundation
+import Security
+
+public enum PKCEError: Error, Equatable {
+    case randomGenerationFailed
+}
+
+public enum PKCE {
+    public static func generateVerifier(length: Int = 64) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: length)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw PKCEError.randomGenerationFailed
+        }
+        return base64URLEncoded(Data(bytes)).prefix(length).description
+    }
+
+    public static func deriveChallenge(verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URLEncoded(Data(digest))
+    }
+
+    static func base64URLEncoded(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/Tenant.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/Tenant.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+public enum TenantTier: String, CaseIterable, Codable, Identifiable, Sendable {
+    case basic
+    case advanced
+    case platinum
+
+    public var id: String { rawValue }
+}
+
+public enum StatusTone: String, Equatable, Sendable {
+    case success
+    case inProgress
+    case failed
+    case inactive
+    case unknown
+}
+
+public struct Tenant: Codable, Equatable, Identifiable, Sendable {
+    public var tenantId: String
+    public var tenantName: String
+    public var email: String
+    public var tier: String
+    public var tenantStatus: String
+    public var isActive: Bool?
+    public var tenantConfig: String?
+    public var tenantPhone: String?
+    public var tenantAddress: String?
+    public var createdAt: String?
+
+    public init(
+        tenantId: String,
+        tenantName: String,
+        email: String,
+        tier: String,
+        tenantStatus: String,
+        isActive: Bool? = nil,
+        tenantConfig: String? = nil,
+        tenantPhone: String? = nil,
+        tenantAddress: String? = nil,
+        createdAt: String? = nil
+    ) {
+        self.tenantId = tenantId
+        self.tenantName = tenantName
+        self.email = email
+        self.tier = tier
+        self.tenantStatus = tenantStatus
+        self.isActive = isActive
+        self.tenantConfig = tenantConfig
+        self.tenantPhone = tenantPhone
+        self.tenantAddress = tenantAddress
+        self.createdAt = createdAt
+    }
+
+    public var id: String { tenantId }
+
+    public var isDeprovisioned: Bool {
+        let normalized = tenantStatus.lowercased()
+        return normalized == "deleted" || normalized == "deprovisioned" || isActive == false
+    }
+
+    public var statusTone: StatusTone {
+        if isDeprovisioned {
+            return .inactive
+        }
+        switch tenantStatus.lowercased() {
+        case "complete":
+            return .success
+        case "in progress":
+            return .inProgress
+        case "failed":
+            return .failed
+        default:
+            return .unknown
+        }
+    }
+
+    public var tierTone: StatusTone {
+        switch tier.lowercased() {
+        case TenantTier.platinum.rawValue:
+            return .success
+        case TenantTier.advanced.rawValue:
+            return .inProgress
+        case TenantTier.basic.rawValue:
+            return .inactive
+        default:
+            return .unknown
+        }
+    }
+}
+
+public struct ParsedTenantConfig: Codable, Equatable, Sendable {
+    public var userPoolId: String?
+    public var appClientId: String?
+    public var apiGatewayUrl: String?
+    public var applicationAdminConsoleUrl: String?
+    public var provisioningBuildId: String?
+    public var provisioningProjectName: String?
+    public var provisioningRegion: String?
+    public var provisioningAccountId: String?
+
+    public init(
+        userPoolId: String? = nil,
+        appClientId: String? = nil,
+        apiGatewayUrl: String? = nil,
+        applicationAdminConsoleUrl: String? = nil,
+        provisioningBuildId: String? = nil,
+        provisioningProjectName: String? = nil,
+        provisioningRegion: String? = nil,
+        provisioningAccountId: String? = nil
+    ) {
+        self.userPoolId = userPoolId
+        self.appClientId = appClientId
+        self.apiGatewayUrl = apiGatewayUrl
+        self.applicationAdminConsoleUrl = applicationAdminConsoleUrl
+        self.provisioningBuildId = provisioningBuildId
+        self.provisioningProjectName = provisioningProjectName
+        self.provisioningRegion = provisioningRegion
+        self.provisioningAccountId = provisioningAccountId
+    }
+}
+
+public func parseTenantConfig(_ raw: String?) -> ParsedTenantConfig {
+    guard let raw, let data = raw.data(using: .utf8) else {
+        return ParsedTenantConfig()
+    }
+    return (try? JSONDecoder().decode(ParsedTenantConfig.self, from: data)) ?? ParsedTenantConfig()
+}
+
+public struct CreateTenantRequest: Codable, Equatable, Sendable {
+    public var tenantName: String
+    public var email: String
+    public var tier: TenantTier
+    public var tenantStatus: String
+
+    public init(tenantName: String, email: String, tier: TenantTier) {
+        self.tenantName = tenantName
+        self.email = email
+        self.tier = tier
+        self.tenantStatus = "In progress"
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCore/URLValidation.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCore/URLValidation.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum URLValidationError: Error, Equatable, LocalizedError {
+    case invalidURL(String)
+    case nonHTTPSURL(String)
+    case nonCognitoDomain(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidURL(value):
+            "Invalid URL: \(value)"
+        case let .nonHTTPSURL(value):
+            "URL must use HTTPS: \(value)"
+        case let .nonCognitoDomain(value):
+            "Cognito domain must end with .amazoncognito.com: \(value)"
+        }
+    }
+}
+
+public enum URLValidation {
+    public static func normalizedCognitoDomain(_ value: String) throws -> URL {
+        let url = try normalizedHTTPSURL(value)
+        guard url.host?.hasSuffix(".amazoncognito.com") == true else {
+            throw URLValidationError.nonCognitoDomain(value)
+        }
+        return url
+    }
+
+    public static func normalizedAPIBaseURL(_ value: String) throws -> URL {
+        try normalizedHTTPSURL(value)
+    }
+
+    public static func normalizedHTTPSURL(_ value: String) throws -> URL {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard var components = URLComponents(string: candidate), components.host?.isEmpty == false else {
+            throw URLValidationError.invalidURL(value)
+        }
+        guard components.scheme == "https" else {
+            throw URLValidationError.nonHTTPSURL(value)
+        }
+        components.path = components.path.trimmingTrailingSlashes()
+        guard let url = components.url else {
+            throw URLValidationError.invalidURL(value)
+        }
+        return url
+    }
+}
+
+private extension String {
+    func trimmingTrailingSlashes() -> String {
+        var copy = self
+        while copy.count > 1 && copy.last == "/" {
+            copy.removeLast()
+        }
+        return copy
+    }
+}

--- a/apps/admin-console-ios/Sources/TenkaCloudAdminCoreChecks/main.swift
+++ b/apps/admin-console-ios/Sources/TenkaCloudAdminCoreChecks/main.swift
@@ -1,0 +1,485 @@
+import Darwin
+import Foundation
+import TenkaCloudAdminCore
+
+@main
+enum CheckRunner {
+    static func main() async {
+        do {
+            try await runAllChecks()
+            print("OK TenkaCloudAdminCoreChecks")
+        } catch {
+            fputs("FAIL \(error)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+    }
+}
+
+private func runAllChecks() async throws {
+    try shouldNormalizeCognitoDomainsWithoutScheme()
+    try shouldRejectNonCognitoDomains()
+    try shouldRejectNonHTTPSAPIURLs()
+    try shouldGenerateVerifierWithURLSafeCharacters()
+    try shouldDeriveRFC7636Challenge()
+    try shouldBuildAuthorizeURLForCognitoCodePKCE()
+    try shouldIncludeIdentityProviderWhenSupplied()
+    try shouldBuildTokenRequestFromValidCallback()
+    try shouldBuildRevokeRequest()
+    try shouldRejectCallbacksWithMismatchedState()
+    try shouldMapTenantStatusToTones()
+    try shouldTreatInactiveTenantsAsDeprovisioned()
+    try shouldParseTenantConfigJSON()
+    try shouldReturnEmptyParsedConfigForInvalidJSON()
+    try shouldCreateTenantsWithSBTInitialStatus()
+    try await shouldCallGetTenantsWithIDToken()
+    try await shouldAcceptDirectTenantArrays()
+    try await shouldSendTenantCreationAsFlatSBTShape()
+    try await shouldURLEncodeTenantIDsForDelete()
+    try await shouldURLEncodeSlashInTenantIDsForDelete()
+    try await shouldSurfaceAPIErrorDetails()
+}
+
+private func shouldNormalizeCognitoDomainsWithoutScheme() throws {
+    let config = try AdminConfiguration(
+        cognitoDomain: "tenkacloud.auth.ap-northeast-1.amazoncognito.com/",
+        clientID: "client",
+        apiBaseURL: "https://api.example.com/prod/"
+    )
+
+    try expectEqual(
+        config.cognitoDomain.absoluteString,
+        "https://tenkacloud.auth.ap-northeast-1.amazoncognito.com/"
+    )
+    try expectEqual(config.apiBaseURL.absoluteString, "https://api.example.com/prod")
+}
+
+private func shouldRejectNonCognitoDomains() throws {
+    try expectThrows(URLValidationError.nonCognitoDomain("https://example.com")) {
+        _ = try AdminConfiguration(
+            cognitoDomain: "https://example.com",
+            clientID: "client",
+            apiBaseURL: "https://api.example.com"
+        )
+    }
+}
+
+private func shouldRejectNonHTTPSAPIURLs() throws {
+    try expectThrows(URLValidationError.nonHTTPSURL("http://api.example.com")) {
+        _ = try AdminConfiguration(
+            cognitoDomain: "https://tenkacloud.auth.ap-northeast-1.amazoncognito.com",
+            clientID: "client",
+            apiBaseURL: "http://api.example.com"
+        )
+    }
+}
+
+private func shouldGenerateVerifierWithURLSafeCharacters() throws {
+    let verifier = try PKCE.generateVerifier()
+
+    try expectEqual(verifier.count, 64)
+    try expect(
+        verifier.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil,
+        "Verifier contains only URL-safe characters"
+    )
+}
+
+private func shouldDeriveRFC7636Challenge() throws {
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+    let challenge = PKCE.deriveChallenge(verifier: verifier)
+
+    try expectEqual(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+}
+
+private func shouldBuildAuthorizeURLForCognitoCodePKCE() throws {
+    let client = CognitoOAuthClient(configuration: try fixtureConfiguration())
+    let session = try client.makeAuthorizationSession(verifier: "verifier", state: "state")
+    let components = URLComponents(url: session.authorizationURL, resolvingAgainstBaseURL: false)
+    let params = Dictionary(
+        uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") }
+    )
+
+    try expectEqual(components?.scheme, "https")
+    try expectEqual(components?.host, "tenkacloud.auth.ap-northeast-1.amazoncognito.com")
+    try expectEqual(components?.path, "/oauth2/authorize")
+    try expectEqual(params["client_id"], "client")
+    try expectEqual(params["response_type"], "code")
+    try expectEqual(params["redirect_uri"], "tenkacloud-admin://auth/callback")
+    try expectEqual(params["scope"], "openid email profile")
+    try expectEqual(params["state"], "state")
+    try expectEqual(params["code_challenge_method"], "S256")
+    try expectEqual(params["code_challenge"], PKCE.deriveChallenge(verifier: "verifier"))
+}
+
+private func shouldIncludeIdentityProviderWhenSupplied() throws {
+    let client = CognitoOAuthClient(configuration: try fixtureConfiguration())
+
+    let session = try client.makeAuthorizationSession(
+        verifier: "verifier",
+        state: "state",
+        identityProvider: "ExampleSAML"
+    )
+    let params = Dictionary(
+        uniqueKeysWithValues: (URLComponents(
+            url: session.authorizationURL,
+            resolvingAgainstBaseURL: false
+        )?.queryItems ?? []).map { ($0.name, $0.value ?? "") }
+    )
+
+    try expectEqual(params["identity_provider"], "ExampleSAML")
+}
+
+private func shouldBuildTokenRequestFromValidCallback() throws {
+    let client = CognitoOAuthClient(configuration: try fixtureConfiguration())
+    let session = OAuthAuthorizationSession(
+        verifier: "verifier",
+        state: "state",
+        authorizationURL: URL(string: "https://example.com")!
+    )
+
+    let request = try client.tokenRequest(
+        callbackURL: URL(string: "tenkacloud-admin://auth/callback?code=abc&state=state")!,
+        session: session
+    )
+    let body = String(data: request.httpBody ?? Data(), encoding: .utf8)
+
+    try expectEqual(
+        request.url?.absoluteString,
+        "https://tenkacloud.auth.ap-northeast-1.amazoncognito.com/oauth2/token"
+    )
+    try expectEqual(request.httpMethod, "POST")
+    try expect(body?.contains("grant_type=authorization_code") == true, "Token body includes grant_type")
+    try expect(body?.contains("client_id=client") == true, "Token body includes client_id")
+    try expect(body?.contains("code=abc") == true, "Token body includes code")
+    try expect(
+        body?.contains("redirect_uri=tenkacloud-admin://auth/callback") == true,
+        "Token body includes redirect_uri"
+    )
+    try expect(body?.contains("code_verifier=verifier") == true, "Token body includes code_verifier")
+}
+
+private func shouldRejectCallbacksWithMismatchedState() throws {
+    let client = CognitoOAuthClient(configuration: try fixtureConfiguration())
+    let session = OAuthAuthorizationSession(
+        verifier: "verifier",
+        state: "expected",
+        authorizationURL: URL(string: "https://example.com")!
+    )
+
+    try expectThrows(OAuthError.stateMismatch) {
+        _ = try client.tokenRequest(
+            callbackURL: URL(string: "tenkacloud-admin://auth/callback?code=abc&state=actual")!,
+            session: session
+        )
+    }
+}
+
+private func shouldBuildRevokeRequest() throws {
+    let client = CognitoOAuthClient(configuration: try fixtureConfiguration())
+
+    let request = client.revokeRequest(refreshToken: "refresh-token")
+    let body = String(data: request.httpBody ?? Data(), encoding: .utf8)
+
+    try expectEqual(
+        request.url?.absoluteString,
+        "https://tenkacloud.auth.ap-northeast-1.amazoncognito.com/oauth2/revoke"
+    )
+    try expectEqual(request.httpMethod, "POST")
+    try expect(body?.contains("token=refresh-token") == true, "Revoke body includes token")
+    try expect(body?.contains("client_id=client") == true, "Revoke body includes client_id")
+}
+
+private func shouldMapTenantStatusToTones() throws {
+    try expectEqual(
+        Tenant(tenantId: "t1", tenantName: "A", email: "a@example.com", tier: "basic", tenantStatus: "Complete").statusTone,
+        .success
+    )
+    try expectEqual(
+        Tenant(tenantId: "t1", tenantName: "A", email: "a@example.com", tier: "basic", tenantStatus: "In progress").statusTone,
+        .inProgress
+    )
+    try expectEqual(
+        Tenant(tenantId: "t1", tenantName: "A", email: "a@example.com", tier: "basic", tenantStatus: "Failed").statusTone,
+        .failed
+    )
+    try expectEqual(
+        Tenant(tenantId: "t1", tenantName: "A", email: "a@example.com", tier: "basic", tenantStatus: "Deleted").statusTone,
+        .inactive
+    )
+    try expectEqual(
+        Tenant(tenantId: "t1", tenantName: "A", email: "a@example.com", tier: "basic", tenantStatus: "Mystery").statusTone,
+        .unknown
+    )
+}
+
+private func shouldTreatInactiveTenantsAsDeprovisioned() throws {
+    let tenant = Tenant(
+        tenantId: "t1",
+        tenantName: "A",
+        email: "a@example.com",
+        tier: "basic",
+        tenantStatus: "Complete",
+        isActive: false
+    )
+
+    try expect(tenant.isDeprovisioned, "Inactive tenants are deprovisioned")
+    try expectEqual(tenant.statusTone, .inactive)
+}
+
+private func shouldParseTenantConfigJSON() throws {
+    let raw = """
+    {
+      "userPoolId": "ap-northeast-1_xxx",
+      "appClientId": "client",
+      "apiGatewayUrl": "https://api.example.com",
+      "applicationAdminConsoleUrl": "https://console.example.com",
+      "provisioningBuildId": "proj:abc",
+      "provisioningProjectName": "proj",
+      "provisioningRegion": "ap-northeast-1",
+      "provisioningAccountId": "123456789012"
+    }
+    """
+
+    let parsed = parseTenantConfig(raw)
+
+    try expectEqual(parsed.userPoolId, "ap-northeast-1_xxx")
+    try expectEqual(parsed.appClientId, "client")
+    try expectEqual(parsed.apiGatewayUrl, "https://api.example.com")
+    try expectEqual(parsed.applicationAdminConsoleUrl, "https://console.example.com")
+    try expectEqual(parsed.provisioningBuildId, "proj:abc")
+}
+
+private func shouldReturnEmptyParsedConfigForInvalidJSON() throws {
+    try expectEqual(parseTenantConfig("not json"), ParsedTenantConfig())
+}
+
+private func shouldCreateTenantsWithSBTInitialStatus() throws {
+    let request = CreateTenantRequest(
+        tenantName: "ACME",
+        email: "admin@example.com",
+        tier: .platinum
+    )
+
+    try expectEqual(request.tenantStatus, "In progress")
+}
+
+private func shouldCallGetTenantsWithIDToken() async throws {
+    let http = MockURLSession(data: tenantsEnvelopeData(), statusCode: HTTPStatus.ok.rawValue)
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    let tenants = try await client.listTenants()
+
+    try expectEqual(tenants.map(\.tenantId), ["t1"])
+    try expectEqual(http.requests.first?.url?.absoluteString, "https://api.example.com/prod/tenants")
+    try expectEqual(http.requests.first?.value(forHTTPHeaderField: "authorization"), "Bearer id-token")
+}
+
+private func shouldAcceptDirectTenantArrays() async throws {
+    let data = """
+    [
+      {
+        "tenantId": "t1",
+        "tenantName": "ACME",
+        "email": "admin@example.com",
+        "tier": "basic",
+        "tenantStatus": "Complete"
+      }
+    ]
+    """.data(using: .utf8)!
+    let http = MockURLSession(data: data, statusCode: HTTPStatus.ok.rawValue)
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    let tenants = try await client.listTenants()
+
+    try expectEqual(tenants.count, 1)
+    try expectEqual(tenants[0].tenantName, "ACME")
+}
+
+private func shouldSendTenantCreationAsFlatSBTShape() async throws {
+    let http = MockURLSession(data: tenantEnvelopeData(), statusCode: HTTPStatus.ok.rawValue)
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    _ = try await client.createTenant(
+        CreateTenantRequest(tenantName: "ACME", email: "admin@example.com", tier: .advanced)
+    )
+    let body = try unwrap(http.requests.first?.httpBody, "Missing request body")
+    let json = try unwrap(
+        JSONSerialization.jsonObject(with: body) as? [String: String],
+        "Request body was not a string JSON object"
+    )
+
+    try expectEqual(http.requests.first?.httpMethod, "POST")
+    try expectEqual(http.requests.first?.url?.absoluteString, "https://api.example.com/prod/tenants")
+    try expectEqual(json["tenantName"], "ACME")
+    try expectEqual(json["email"], "admin@example.com")
+    try expectEqual(json["tier"], "advanced")
+    try expectEqual(json["tenantStatus"], "In progress")
+}
+
+private func shouldURLEncodeTenantIDsForDelete() async throws {
+    let http = MockURLSession(data: Data(), statusCode: HTTPStatus.noContent.rawValue)
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    try await client.deleteTenant(tenantId: "tenant with space")
+
+    try expectEqual(http.requests.first?.httpMethod, "DELETE")
+    try expectEqual(
+        http.requests.first?.url?.absoluteString,
+        "https://api.example.com/prod/tenants/tenant%20with%20space"
+    )
+}
+
+private func shouldURLEncodeSlashInTenantIDsForDelete() async throws {
+    let http = MockURLSession(data: Data(), statusCode: HTTPStatus.noContent.rawValue)
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    try await client.deleteTenant(tenantId: "tenant/with/slash")
+
+    try expectEqual(http.requests.first?.httpMethod, "DELETE")
+    try expectEqual(
+        http.requests.first?.url?.absoluteString,
+        "https://api.example.com/prod/tenants/tenant%2Fwith%2Fslash"
+    )
+}
+
+private func shouldSurfaceAPIErrorDetails() async throws {
+    let http = MockURLSession(
+        data: Data("forbidden".utf8),
+        statusCode: HTTPStatus.forbidden.rawValue
+    )
+    let client = AdminAPIClient(
+        baseURL: URL(string: "https://api.example.com/prod")!,
+        idToken: "id-token",
+        urlSession: http
+    )
+
+    do {
+        _ = try await client.listTenants()
+        throw CheckFailure("Expected APIError")
+    } catch let error as APIError {
+        try expectEqual(error, APIError(statusCode: HTTPStatus.forbidden.rawValue, detail: "forbidden"))
+    }
+}
+
+private func fixtureConfiguration() throws -> AdminConfiguration {
+    try AdminConfiguration(
+        cognitoDomain: "https://tenkacloud.auth.ap-northeast-1.amazoncognito.com",
+        clientID: "client",
+        apiBaseURL: "https://api.example.com/prod"
+    )
+}
+
+private enum HTTPStatus: Int {
+    case ok = 200
+    case noContent = 204
+    case forbidden = 403
+}
+
+private final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
+    private let data: Data
+    private let statusCode: Int
+    private(set) var requests: [URLRequest] = []
+
+    init(data: Data, statusCode: Int) {
+        self.data = data
+        self.statusCode = statusCode
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (data, response)
+    }
+}
+
+private func tenantsEnvelopeData() -> Data {
+    """
+    {
+      "data": [
+        {
+          "tenantId": "t1",
+          "tenantName": "ACME",
+          "email": "admin@example.com",
+          "tier": "basic",
+          "tenantStatus": "Complete"
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+}
+
+private func tenantEnvelopeData() -> Data {
+    """
+    {
+      "data": {
+        "tenantId": "t1",
+        "tenantName": "ACME",
+        "email": "admin@example.com",
+        "tier": "advanced",
+        "tenantStatus": "In progress"
+      }
+    }
+    """.data(using: .utf8)!
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() {
+        throw CheckFailure(message)
+    }
+}
+
+private func expectEqual<T: Equatable>(_ actual: T, _ expected: T) throws {
+    if actual != expected {
+        throw CheckFailure("Expected \(expected), got \(actual)")
+    }
+}
+
+private func expectThrows<E: Error & Equatable>(_ expected: E, _ operation: () throws -> Void) throws {
+    do {
+        try operation()
+    } catch let error as E {
+        try expectEqual(error, expected)
+        return
+    }
+    throw CheckFailure("Expected \(expected) to be thrown")
+}
+
+private func unwrap<T>(_ value: T?, _ message: String) throws -> T {
+    guard let value else {
+        throw CheckFailure(message)
+    }
+    return value
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    var description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/apps/admin-console-ios/TenkaCloudAdmin.xcodeproj/project.pbxproj
+++ b/apps/admin-console-ios/TenkaCloudAdmin.xcodeproj/project.pbxproj
@@ -1,0 +1,386 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A00000000000000000000001 /* AdminAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000101 /* AdminAppModel.swift */; };
+		A00000000000000000000002 /* AdminSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000102 /* AdminSettings.swift */; };
+		A00000000000000000000003 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000103 /* ContentView.swift */; };
+		A00000000000000000000004 /* OpenAdminConsoleIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000104 /* OpenAdminConsoleIntent.swift */; };
+		A00000000000000000000005 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000105 /* SettingsView.swift */; };
+		A00000000000000000000006 /* TenantCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000106 /* TenantCreateView.swift */; };
+		A00000000000000000000007 /* TenantListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000107 /* TenantListView.swift */; };
+		A00000000000000000000008 /* TenkaCloudAdminApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000108 /* TenkaCloudAdminApp.swift */; };
+		A00000000000000000000009 /* View+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00000000000000000000109 /* View+ErrorAlert.swift */; };
+		A0000000000000000000000A /* View+InputModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000000000000000000010A /* View+InputModifiers.swift */; };
+		A0000000000000000000000B /* WebAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000000000000000000010B /* WebAuthenticator.swift */; };
+		A0000000000000000000000C /* TenkaCloudAdminCore in Frameworks */ = {isa = PBXBuildFile; productRef = A00000000000000000000301 /* TenkaCloudAdminCore */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A00000000000000000000101 /* AdminAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/AdminAppModel.swift; sourceTree = "<group>"; };
+		A00000000000000000000102 /* AdminSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/AdminSettings.swift; sourceTree = "<group>"; };
+		A00000000000000000000103 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/ContentView.swift; sourceTree = "<group>"; };
+		A00000000000000000000104 /* OpenAdminConsoleIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/OpenAdminConsoleIntent.swift; sourceTree = "<group>"; };
+		A00000000000000000000105 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/SettingsView.swift; sourceTree = "<group>"; };
+		A00000000000000000000106 /* TenantCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/TenantCreateView.swift; sourceTree = "<group>"; };
+		A00000000000000000000107 /* TenantListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/TenantListView.swift; sourceTree = "<group>"; };
+		A00000000000000000000108 /* TenkaCloudAdminApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/TenkaCloudAdminApp.swift; sourceTree = "<group>"; };
+		A00000000000000000000109 /* View+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/View+ErrorAlert.swift; sourceTree = "<group>"; };
+		A0000000000000000000010A /* View+InputModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/View+InputModifiers.swift; sourceTree = "<group>"; };
+		A0000000000000000000010B /* WebAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/TenkaCloudAdminApp/WebAuthenticator.swift; sourceTree = "<group>"; };
+		A0000000000000000000010C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TenkaCloudAdmin/Info.plist; sourceTree = "<group>"; };
+		A0000000000000000000010D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		A0000000000000000000010E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		A00000000000000000000201 /* TenkaCloudAdmin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TenkaCloudAdmin.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A00000000000000000000401 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0000000000000000000000C /* TenkaCloudAdminCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A00000000000000000000501 = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000502 /* App */,
+				A0000000000000000000010C /* Info.plist */,
+				A0000000000000000000010D /* Package.swift */,
+				A0000000000000000000010E /* README.md */,
+				A00000000000000000000503 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A00000000000000000000502 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000101 /* AdminAppModel.swift */,
+				A00000000000000000000102 /* AdminSettings.swift */,
+				A00000000000000000000103 /* ContentView.swift */,
+				A00000000000000000000104 /* OpenAdminConsoleIntent.swift */,
+				A00000000000000000000105 /* SettingsView.swift */,
+				A00000000000000000000106 /* TenantCreateView.swift */,
+				A00000000000000000000107 /* TenantListView.swift */,
+				A00000000000000000000108 /* TenkaCloudAdminApp.swift */,
+				A00000000000000000000109 /* View+ErrorAlert.swift */,
+				A0000000000000000000010A /* View+InputModifiers.swift */,
+				A0000000000000000000010B /* WebAuthenticator.swift */,
+			);
+			name = App;
+			sourceTree = "<group>";
+		};
+		A00000000000000000000503 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000201 /* TenkaCloudAdmin.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A00000000000000000000601 /* TenkaCloudAdmin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A00000000000000000000701 /* Build configuration list for PBXNativeTarget "TenkaCloudAdmin" */;
+			buildPhases = (
+				A00000000000000000000402 /* Sources */,
+				A00000000000000000000401 /* Frameworks */,
+				A00000000000000000000403 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TenkaCloudAdmin;
+			packageProductDependencies = (
+				A00000000000000000000301 /* TenkaCloudAdminCore */,
+			);
+			productName = TenkaCloudAdmin;
+			productReference = A00000000000000000000201 /* TenkaCloudAdmin.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A00000000000000000000801 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A00000000000000000000601 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = A00000000000000000000704 /* Build configuration list for PBXProject "TenkaCloudAdmin" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A00000000000000000000501;
+			packageReferences = (
+				A00000000000000000000302 /* XCLocalSwiftPackageReference "." */,
+			);
+			productRefGroup = A00000000000000000000503 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A00000000000000000000601 /* TenkaCloudAdmin */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A00000000000000000000403 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A00000000000000000000402 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A00000000000000000000001 /* AdminAppModel.swift in Sources */,
+				A00000000000000000000002 /* AdminSettings.swift in Sources */,
+				A00000000000000000000003 /* ContentView.swift in Sources */,
+				A00000000000000000000004 /* OpenAdminConsoleIntent.swift in Sources */,
+				A00000000000000000000005 /* SettingsView.swift in Sources */,
+				A00000000000000000000006 /* TenantCreateView.swift in Sources */,
+				A00000000000000000000007 /* TenantListView.swift in Sources */,
+				A00000000000000000000008 /* TenkaCloudAdminApp.swift in Sources */,
+				A00000000000000000000009 /* View+ErrorAlert.swift in Sources */,
+				A0000000000000000000000A /* View+InputModifiers.swift in Sources */,
+				A0000000000000000000000B /* WebAuthenticator.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A00000000000000000000702 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TenkaCloudAdmin/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.tenkacloud.admin;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A00000000000000000000703 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TenkaCloudAdmin/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.tenkacloud.admin;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A00000000000000000000705 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A00000000000000000000706 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A00000000000000000000701 /* Build configuration list for PBXNativeTarget "TenkaCloudAdmin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A00000000000000000000702 /* Debug */,
+				A00000000000000000000703 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A00000000000000000000704 /* Build configuration list for PBXProject "TenkaCloudAdmin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A00000000000000000000705 /* Debug */,
+				A00000000000000000000706 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A00000000000000000000302 /* XCLocalSwiftPackageReference "." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = .;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A00000000000000000000301 /* TenkaCloudAdminCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A00000000000000000000302 /* XCLocalSwiftPackageReference "." */;
+			productName = TenkaCloudAdminCore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A00000000000000000000801 /* Project object */;
+}

--- a/apps/admin-console-ios/TenkaCloudAdmin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/admin-console-ios/TenkaCloudAdmin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace version="1.0">
+  <FileRef location="self:"/>
+</Workspace>

--- a/apps/admin-console-ios/TenkaCloudAdmin/Info.plist
+++ b/apps/admin-console-ios/TenkaCloudAdmin/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleDisplayName</key>
+  <string>TenkaCloud Admin</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>net.tenkacloud.admin.auth</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>tenkacloud-admin</string>
+      </array>
+    </dict>
+  </array>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
+  <key>UIApplicationSupportsIndirectInputEvents</key>
+  <true/>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+</dict>
+</plist>

--- a/apps/admin-console-ios/package.json
+++ b/apps/admin-console-ios/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@TenkaCloud/admin-console-ios",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "swift build",
+    "test": "swift run TenkaCloudAdminCoreChecks"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a SwiftUI native System Admin app under `apps/admin-console-ios`.
- Implement Cognito Hosted UI OAuth Code + PKCE, memory-only tokens, best-effort refresh-token revoke, tenant list/create/deprovision, tenant detail, and an App Intent shortcut.
- Add a local Swift package core plus `TenkaCloudAdminCoreChecks`, an Xcode project, callback URL registration docs, and SwiftPM/Bun scripts.

## Test plan
- `make harness`
- `bun run --filter @TenkaCloud/admin-console-ios test`
- `bun run --filter @TenkaCloud/admin-console-ios build`
- `make before-commit` via commit hook: passed on retry. The first manual run hit unrelated infrastructure test timeouts, then the hook rerun completed successfully.

## Regression analysis
- Existing web admin consoles are unchanged.
- Native API requests follow the same Control Plane tenant API contracts as `apps/admin-console`.
- Tenant ID path encoding is covered for spaces and slashes to avoid changing REST route semantics.
- OAuth state validation and PKCE are checked by the native core checks.

## Physical impact
- CREATE: new `apps/admin-console-ios` source, Xcode project, Swift package, and README.
- NO-OP: CloudFormation/CDK templates, IAM, deployed web artifacts, and existing runtime-config injection.
- Manual infra follow-up required before real sign-in: add `tenkacloud-admin://auth/callback` to the Control Plane Cognito UserPoolClient allowed callback URLs.