### PR TITLE
feat(templates): one-click Lite mode deploy pipeline + Launch Stack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ the SBT control plane entirely and stands up just the Application Admin Console,
 Participant Portal, and the deploy backend. From `git clone` to a first running event
 takes roughly 30 minutes — most of that time is `cdk deploy` waiting on AWS.
 
+### Option A — one-click deploy (CloudFormation)
+
+Don't want to install anything locally? Launch a self-contained deployment pipeline
+straight into your AWS account:
+
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://raw.githubusercontent.com/susumutomita/TenkaCloud/main/infrastructure/templates/lite-pipeline.yaml&stackName=tenkacloud-lite-pipeline)
+
+The stack ([`infrastructure/templates/lite-pipeline.yaml`](./infrastructure/templates/lite-pipeline.yaml))
+is a standalone single-file template — independent of the CDK app. It stands up a
+CodePipeline (`Source → optional Manual Approval → Build`) that clones the repo and
+runs `make deploy` (Lite mode) on CodeBuild. The one manual prerequisite is a
+**GitHub CodeStar Connection** (AWS Console → Developer Tools → Connections); paste
+its ARN and your admin email as stack parameters. Full walkthrough:
+[`infrastructure/templates/README.md`](./infrastructure/templates/README.md#one-click-lite-mode-deployment-pipeline).
+
+> If your console rejects the template URL, download `lite-pipeline.yaml` and use
+> CloudFormation's **Upload a template file** instead.
+
+### Option B — from your terminal
+
 ```bash
 git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
 cd TenkaCloud

--- a/infrastructure/templates/README.md
+++ b/infrastructure/templates/README.md
@@ -100,6 +100,52 @@ trust を即時撤回できます。 削除後はあらためて生成した Ext
   CloudTrail でその AssumeRole / 後続の CFn / EC2 操作を監査できる。
 - スタック削除で権限を即時撤回できるので、競技終了後はスタックを消すと安全。
 
+## One-click Lite mode deployment pipeline
+
+### 概要
+
+`lite-pipeline.yaml` は、README の **Launch Stack** ボタンから 1 クリックで起動できる
+独立したペライチ CloudFormation テンプレート。CDK アプリとは切り離されており、
+作るのは「デプロイ用パイプライン」だけ (= TenkaCloud 本体のスタックはパイプラインの
+Build ステップが `make deploy` を実行して作る)。
+
+パイプライン構成: `Source (GitHub) → Manual Approval (任意) → Build (CodeBuild で make deploy)`。
+CodeBuild は repo を clone → `bun install` → `make build` → `cdk bootstrap` → Lite mode の
+`make deploy` を流す。`infrastructure/environments/<env>/.env` はビルド中に
+`TenantAdminEmail` パラメータから自動生成される。
+
+### 事前準備 (1 回だけ)
+
+GitHub への OAuth ハンドシェイクだけは CloudFormation で自動化できないため、
+**CodeStar Connection** を先に手動で作る。
+
+1. AWS Console → Developer Tools → Connections →「Create connection」→ GitHub を選択
+2. 認可フローを完了し、ステータスが **Available** になった接続の ARN を控える
+
+### デプロイ手順
+
+1. README の [Launch Stack](../../README.md#option-a--one-click-deploy-cloudformation) ボタンを押す (または Console の CloudFormation でこの yaml を upload する)
+2. 下表のパラメータを入力する
+3. 「IAM 権限変更を承認」にチェックして作成する。スタック作成時にパイプラインが 1 回自動実行されるので、承認ステージで承認すれば Lite デプロイが走る
+
+| パラメータ            | 必須 | 説明                                                          |
+| --------------------- | ---- | ----------------------------------------------------------- |
+| `TenantAdminEmail`    | 必須 | Application Admin Console の初期ユーザー宛先                 |
+| `GitHubConnectionArn` | 必須 | 上で控えた CodeStar Connection の ARN                       |
+| `GitHubRepositoryId`  | 任意 | デフォルト `susumutomita/TenkaCloud` (fork したなら自分の owner/repo) |
+| `EnableManualApproval`| 任意 | `false` にすると承認なしの完全自動デプロイ                  |
+| `DeployExternalId`    | 任意 | 競技者アカウントへ AssumeRole する場合のみ                  |
+
+完了後、CodeBuild ログ末尾に Application Admin Console / Participant Portal の URL が出る。
+パイプライン自体は CloudFormation スタックを削除すれば消える (TenkaCloud 本体は
+`make destroy` で別途撤去する)。
+
+### コストの注意
+
+問題テンプレート (`problems/**/template.yaml`) は AWS 無料枠 0 円に収めているが、
+このパイプラインは CodePipeline V2 + CodeBuild + 小さな S3 を使うため厳密な 0 円ではない
+(月数回のデプロイで 1 ドル未満)。使い終えたらスタックを削除すれば課金は止まる。
+
 ## 関連
 
 - [`/problems/README.md`](../../problems/README.md) — 問題カタログ規約

--- a/infrastructure/templates/lite-pipeline.yaml
+++ b/infrastructure/templates/lite-pipeline.yaml
@@ -1,0 +1,464 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  TenkaCloud Lite mode one-click deployment pipeline. Stands up a self-contained
+  CodePipeline (Source GitHub -> optional Manual Approval -> Build on CodeBuild)
+  that runs `make deploy` (Lite mode) to deploy TenkaCloud into this AWS account.
+  This template is independent from the CDK app: it provisions only the pipeline,
+  not the TenkaCloud stacks themselves (those are created by the build step).
+
+# This is a single-file ("perapeti") template meant to be launched from the README
+# "Launch Stack" button. The only manual prerequisite is a GitHub CodeStar
+# Connection (AWS Console -> Developer Tools -> Connections), because OAuth handshake
+# to GitHub cannot be automated inside CloudFormation.
+#
+# Cost note: unlike the problem templates (which are forced to the AWS Free Tier),
+# this pipeline uses CodePipeline V2 (per-action-execution pricing) + CodeBuild
+# (per-build-minute) + a small versioned S3 artifact bucket. A handful of Lite
+# deploys per month costs well under a dollar; delete this stack to stop all charges.
+#
+# IAM Role / Policy "Description" fields only accept ASCII (0x20-0x7E) + Latin-1
+# (0xA1-0xFF); CJK characters cause CREATE_FAILED. All comments in this file are
+# ASCII so `make check-template-ascii` (which walks infrastructure/templates/) passes.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: development
+    AllowedValues:
+      - development
+      - staging
+      - production
+    Description: >-
+      Target environment. Selects infrastructure/environments/{env}/config.json
+      and writes infrastructure/environments/{env}/.env during the build.
+
+  TenantAdminEmail:
+    Type: String
+    Description: >-
+      Application Admin Console initial user (Tenant Admin). After the Lite deploy,
+      tenkacloud-lite.ts creates this Cognito user and emails an invitation.
+    AllowedPattern: ^[^\s@]+@[^\s@]+\.[^\s@]+$
+    ConstraintDescription: Must be a valid email address.
+
+  GitHubConnectionArn:
+    Type: String
+    AllowedPattern: ^arn:aws:codestar-connections:.*|^arn:aws:codeconnections:.*
+    Description: >-
+      ARN of a GitHub CodeStar/CodeConnections connection in AVAILABLE status.
+      Create one in AWS Console -> Developer Tools -> Connections before launching.
+
+  GitHubRepositoryId:
+    Type: String
+    Default: susumutomita/TenkaCloud
+    Description: GitHub repository id in owner/repository format.
+
+  SourceBranchName:
+    Type: String
+    Default: main
+    Description: Branch to deploy from.
+
+  DeployExternalId:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >-
+      Optional CDK_PARAM_DEPLOY_EXTERNAL_ID for AssumeRole into competitor accounts
+      (problem deploy backend). Leave empty for a local-only Lite trial.
+
+  EnableManualApproval:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: >-
+      If true, the pipeline pauses for a manual approval before deploying. Set to
+      false for a fully automatic one-click deploy.
+
+  BunVersion:
+    Type: String
+    Default: 1.3.11
+    Description: Bun version installed in the build (matches the repo toolchain).
+
+  CodeBuildTimeoutMinutes:
+    Type: Number
+    Default: 90
+    MinValue: 15
+    MaxValue: 480
+    Description: CodeBuild timeout in minutes (a Lite deploy usually finishes in 15-30).
+
+Conditions:
+  IncludeManualApproval: !Equals [!Ref EnableManualApproval, "true"]
+  HasExternalId: !Not [!Equals [!Ref DeployExternalId, ""]]
+
+Resources:
+  # =====================================
+  # S3 artifact store (pipeline working area)
+  # =====================================
+  ArtifactStoreBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub tenkacloud-lite-${Environment}-pipeline-artifacts-${AWS::AccountId}
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldArtifacts
+            Status: Enabled
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 7
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  # =====================================
+  # CodeBuild project: installs bun, builds the SPAs, bootstraps CDK, runs `make deploy`
+  # =====================================
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        Image: aws/codebuild/amazonlinux-x86_64-standard:5.0
+        ComputeType: BUILD_GENERAL1_MEDIUM
+        # CDK asset bundling can fall back to Docker; PrivilegedMode keeps it reliable.
+        PrivilegedMode: true
+        ImagePullCredentialsType: CODEBUILD
+        EnvironmentVariables:
+          - Name: ENVIRONMENT
+            Value: !Ref Environment
+            Type: PLAINTEXT
+          - Name: TENANT_ADMIN_EMAIL
+            Value: !Ref TenantAdminEmail
+            Type: PLAINTEXT
+          - Name: DEPLOY_EXTERNAL_ID
+            Value: !If [HasExternalId, !Ref DeployExternalId, ""]
+            Type: PLAINTEXT
+          - Name: BUN_VERSION
+            Value: !Ref BunVersion
+            Type: PLAINTEXT
+          - Name: JSII_DEPRECATED
+            Value: quiet
+            Type: PLAINTEXT
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                nodejs: 22
+              commands:
+                - echo "Installing bun ${BUN_VERSION}"
+                - npm install -g "bun@${BUN_VERSION}"
+                - bun --version
+                # Frozen + ignore-scripts matches the repo supply-chain policy (make install_ci).
+                - bun install --frozen-lockfile --ignore-scripts
+                # The problem catalog lives in a git submodule; pull it so `make deploy` ships it.
+                - git submodule update --init --recursive || echo "no submodules or already initialized"
+            pre_build:
+              commands:
+                - export AWS_REGION="${AWS_DEFAULT_REGION}"
+                - export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+                - ENV_DIR="infrastructure/environments/${ENVIRONMENT}"
+                - mkdir -p "${ENV_DIR}"
+                - |
+                  {
+                    echo "TENANT_ADMIN_EMAIL=${TENANT_ADMIN_EMAIL}"
+                    echo "AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID}"
+                    echo "AWS_REGION=${AWS_REGION}"
+                    if [ -n "${DEPLOY_EXTERNAL_ID}" ]; then
+                      echo "CDK_PARAM_DEPLOY_EXTERNAL_ID=${DEPLOY_EXTERNAL_ID}"
+                    fi
+                  } > "${ENV_DIR}/.env"
+                - echo "Wrote ${ENV_DIR}/.env (TENANT_ADMIN_EMAIL / AWS_ACCOUNT_ID / AWS_REGION)"
+                # CDK bootstrap is idempotent; safe to run on every build.
+                - ./node_modules/aws-cdk/bin/cdk bootstrap "aws://${AWS_ACCOUNT_ID}/${AWS_REGION}"
+            build:
+              commands:
+                - make build
+                - make deploy ENV="${ENVIRONMENT}"
+            post_build:
+              commands:
+                - echo "Lite deploy finished. Console / Portal URLs:"
+                - make lite-console-url ENV="${ENVIRONMENT}" || true
+                - make lite-portal-url ENV="${ENVIRONMENT}" || true
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Sub /aws/codebuild/tenkacloud-lite-${Environment}
+      TimeoutInMinutes: !Ref CodeBuildTimeoutMinutes
+
+  # =====================================
+  # CodePipeline: Source -> (Manual Approval) -> Build
+  # =====================================
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}
+      RoleArn: !GetAtt CodePipelineRole.Arn
+      PipelineType: V2
+      ExecutionMode: QUEUED
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactStoreBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeStarSourceConnection
+                Version: "1"
+              Configuration:
+                ConnectionArn: !Ref GitHubConnectionArn
+                FullRepositoryId: !Ref GitHubRepositoryId
+                BranchName: !Ref SourceBranchName
+                DetectChanges: "false"
+                OutputArtifactFormat: CODEBUILD_CLONE_REF
+              OutputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+        - !If
+          - IncludeManualApproval
+          - Name: Approve
+            Actions:
+              - Name: ManualApproval
+                ActionTypeId:
+                  Category: Approval
+                  Owner: AWS
+                  Provider: Manual
+                  Version: "1"
+                Configuration:
+                  CustomData: !Sub Approve to deploy TenkaCloud Lite (${Environment}) into account ${AWS::AccountId}.
+                RunOrder: 1
+          - !Ref AWS::NoValue
+        - Name: Deploy
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: !Ref CodeBuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              OutputArtifacts:
+                - Name: BuildArtifact
+              RunOrder: 1
+
+  # =====================================
+  # IAM roles
+  # =====================================
+  # CodeBuild role: `make deploy` (Lite) drives `cdk deploy`, which stands up the whole
+  # platform (Lambda + Cognito + DynamoDB + S3 + CloudFront + API Gateway + Step Functions
+  # + EventBridge + the in-app CodeBuild for problem deploy + SSM). cdk also bootstraps and
+  # assumes the cdk-* execution roles, so the role needs broad service access. This role is
+  # the deploy operator, distinct from competitor-bootstrap.yaml which stays least-privilege.
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub tenkacloud-lite-${Environment}-codebuild-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodeBuildPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: OwnLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/tenkacloud-lite-${Environment}
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/tenkacloud-lite-${Environment}:*
+              - Sid: ArtifactStore
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                Resource:
+                  - !Sub ${ArtifactStoreBucket.Arn}/*
+              - Sid: UseGitHubConnection
+                Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref GitHubConnectionArn
+              # Services that `cdk deploy` (Lite) and `cdk bootstrap` create/manage.
+              - Sid: DeployServices
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                  - iam:*
+                  - lambda:*
+                  - apigateway:*
+                  - cognito-idp:*
+                  - cognito-identity:*
+                  - dynamodb:*
+                  - s3:*
+                  - cloudfront:*
+                  - states:*
+                  - events:*
+                  - sns:*
+                  - sqs:*
+                  - ecr:*
+                  - codebuild:*
+                  - logs:*
+                Resource: "*"
+              # Cost-zero principle: secrets live in SSM Parameter Store, not Secrets Manager.
+              - Sid: SsmParameters
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:AddTagsToResource
+                Resource:
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/TenkaCloud/*
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-bootstrap/*
+              - Sid: KmsForBootstrapAndAssets
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey
+                Resource: "*"
+              # cdk deploy assumes the bootstrap roles to publish assets / run the change set.
+              - Sid: AssumeCdkRoles
+                Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource:
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-*
+              - Sid: Identity
+                Effect: Allow
+                Action:
+                  - sts:GetCallerIdentity
+                Resource: "*"
+
+  CodePipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub tenkacloud-lite-${Environment}-pipeline-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodePipelinePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                  - s3:GetBucketVersioning
+                Resource:
+                  - !GetAtt ArtifactStoreBucket.Arn
+                  - !Sub ${ArtifactStoreBucket.Arn}/*
+              - Effect: Allow
+                Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+                Resource:
+                  - !GetAtt CodeBuildProject.Arn
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref GitHubConnectionArn
+
+  # =====================================
+  # SNS notifications (subscribe an email after deploy to watch pipeline state)
+  # =====================================
+  PipelineNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub tenkacloud-lite-${Environment}-pipeline-notification
+      DisplayName: !Sub TenkaCloud Lite ${Environment} Pipeline
+
+  PipelineNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCodeStarNotifications
+            Effect: Allow
+            Principal:
+              Service: codestar-notifications.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref PipelineNotificationTopic
+      Topics:
+        - !Ref PipelineNotificationTopic
+
+  PipelineNotificationRule:
+    Type: AWS::CodeStarNotifications::NotificationRule
+    DependsOn:
+      - Pipeline
+      - PipelineNotificationTopicPolicy
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}-pipeline-events
+      DetailType: FULL
+      Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}
+      EventTypeIds:
+        - codepipeline-pipeline-pipeline-execution-started
+        - codepipeline-pipeline-pipeline-execution-succeeded
+        - codepipeline-pipeline-pipeline-execution-failed
+        - codepipeline-pipeline-manual-approval-needed
+        - codepipeline-pipeline-manual-approval-succeeded
+      Targets:
+        - TargetType: SNS
+          TargetAddress: !Ref PipelineNotificationTopic
+      Status: ENABLED
+
+Outputs:
+  PipelineName:
+    Description: CodePipeline name
+    Value: !Ref Pipeline
+
+  PipelineConsoleUrl:
+    Description: Open the pipeline in the AWS console (approve / re-run here)
+    Value: !Sub https://${AWS::Region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${Pipeline}/view?region=${AWS::Region}
+
+  CodeBuildProjectName:
+    Description: CodeBuild project name
+    Value: !Ref CodeBuildProject
+
+  ArtifactBucketName:
+    Description: S3 bucket for pipeline artifacts
+    Value: !Ref ArtifactStoreBucket
+
+  NotificationTopicArn:
+    Description: SNS topic ARN for pipeline notifications (subscribe an email manually)
+    Value: !Ref PipelineNotificationTopic


### PR DESCRIPTION
## Summary

Make Lite-mode deploy a one-click experience straight from the README.

- **`infrastructure/templates/lite-pipeline.yaml`** — a standalone, single-file ("ペライチ") CloudFormation template, **independent of the CDK app**. It provisions only a deployment pipeline:
  `Source (GitHub CodeStar Connection) → optional Manual Approval → Build (CodeBuild)`.
  The Build step clones the repo (with the `problems/` submodule), installs bun, runs `make build`, `cdk bootstrap`, then **`make deploy` (Lite mode)** — which stands up the actual TenkaCloud Lite stacks (`tenkacloud-lite` + `tenkacloud-lite-problem-deploy`). The build writes `infrastructure/environments/<env>/.env` from the `TenantAdminEmail` parameter, so no local setup is needed.
- **README** — a CloudFormation **Launch Stack** button (Option A one-click) alongside the existing local CLI flow (Option B).
- **`infrastructure/templates/README.md`** — a walkthrough (CodeStar Connection prerequisite, parameter table, cost note).

The only manual prerequisite is a GitHub CodeStar/CodeConnections connection (the GitHub OAuth handshake can't be automated inside CloudFormation). Its ARN and the admin email are stack parameters. `EnableManualApproval=false` gives a fully automatic deploy.

## Test plan

- `make check-template-ascii` — passes (template is ASCII/Latin-1 only; the checker walks `infrastructure/templates/`).
- `bun run lint:md` + `textlint` — pass on `README.md` and `infrastructure/templates/README.md`.
- `make harness` (staged) — no findings beyond the informational `cdk.out` note.
- Template parsed with a CFn-tag-aware YAML parser: 8 resources, the `!If` manual-approval stage resolves to a stage or `AWS::NoValue` correctly.
- Pipeline mirrors the proven CodePipeline V2 + CodeBuild + CodeStar-connection pattern; buildspec uses `make deploy` (the repo's Lite entry point) and `bun install --frozen-lockfile --ignore-scripts` (supply-chain policy).

## Regression analysis

- **Additive only.** One new template file plus two README edits. No CDK stack, Lambda, Makefile, or CI workflow is touched, so existing deploys (`make deploy` / `make deploy-saas`) are unchanged.
- The template is **not** wired into `bin/infrastructure.ts`; it is launched manually, so it cannot affect `cdk synth`/`cdk deploy` of the app.
- The CodeBuild role is broad (the Lite deploy creates the whole platform + assumes the `cdk-*` bootstrap roles), but it is the deploy operator's role, created only in the launcher's own account, and is distinct from the least-privilege `competitor-bootstrap.yaml`. `check-template-security` only scans `problems/`, so this is by design and not a regression there.
- The Launch Stack button points at `raw.githubusercontent.com/.../main/...`; it resolves only after this merges to `main`. A fallback note covers consoles that require an S3-hosted template URL.

## Physical impact

- **CREATE** (only when a user clicks Launch Stack): `AWS::S3::Bucket` (artifacts), `AWS::CodeBuild::Project`, `AWS::CodePipeline::Pipeline` (V2), 2× `AWS::IAM::Role`, `AWS::SNS::Topic` + policy + `AWS::CodeStarNotifications::NotificationRule`. Small CodePipeline/CodeBuild/S3 cost (not free-tier-zero); deleting the stack stops all charges.
- **NO-OP**: all CDK stacks, Lambdas, CI, and existing problems — unchanged. This PR adds files only.

Relates #955

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added one-click CloudFormation deployment guide in README
  * Added Lite mode deployment pipeline documentation with step-by-step setup instructions

* **New Features**
  * Introduced CloudFormation-based one-click deployment pipeline for simplified infrastructure setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->