### PR TITLE
feat(deploy): run make deploy via Docker for bun-less hosts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# The deploy image bakes only the toolchain (it does not COPY the repo — source comes in
+# via the docker-compose bind mount). Keep the build context tiny by excluding everything
+# heavy; only docker/entrypoint.sh is actually COPYed.
+node_modules
+**/node_modules
+**/dist
+infrastructure/cdk.out
+infrastructure/cdk.out.test
+.git
+**/*.log
+**/.env
+**/coverage

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ export JSII_DEPRECATED := quiet
         check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-cli-access \
         env-check env-check-lite env-init env-init-test synth check-synth diff bootstrap \
         deploy deploy-saas deploy-control-plane deploy-bootstrap destroy destroy-saas \
+        deploy-docker destroy-docker docker-shell docker-build \
         deploy-battles destroy-battles \
         lite-up lite-down lite-status lite-portal-url lite-console-url \
         ops-health
@@ -204,6 +205,23 @@ deploy-control-plane: env-check build ; $(CDK) deploy tenkacloud-control-plane $
 deploy-bootstrap:     env-check build ; $(CDK) deploy tenkacloud-bootstrap $(APPROVAL)
 destroy:              env-check-lite  ; bun run scripts/tenkacloud-lite.ts down
 destroy-saas:         env-check       ; bash scripts/cleanup.sh
+
+# ===== One-Docker deploy (host needs only Docker — no bun / node / aws-cli) =====
+# exe.dev / fresh machines often lack bun. These targets run the normal deploy inside a
+# toolchain container (Bun 1.3.11 + Node 24 + AWS CLI v2) defined by docker-compose.yml.
+# They are pure `docker compose` (no bun on the host) so they work on a bun-less host.
+# The repo is bind-mounted; ~/.aws is mounted read-only; env-var credentials also work.
+#   make deploy-docker                 # Lite deploy in the container (ENV=development)
+#   make deploy-docker ENV=production  # pick the target environment
+#   make destroy-docker                # tear it down
+#   make docker-shell                  # interactive shell in the toolchain image
+#   make docker-build                  # rebuild the image after editing docker/Dockerfile
+# Override DOCKER_COMPOSE=docker-compose for legacy Compose v1.
+DOCKER_COMPOSE ?= docker compose
+deploy-docker:    ; $(DOCKER_COMPOSE) run --rm tenkacloud make deploy ENV=$(ENV)
+destroy-docker:   ; $(DOCKER_COMPOSE) run --rm tenkacloud make destroy ENV=$(ENV)
+docker-shell:     ; $(DOCKER_COMPOSE) run --rm tenkacloud bash
+docker-build:     ; $(DOCKER_COMPOSE) build tenkacloud
 
 # ===== Problem deploy smoke test (MVP-0, ADR-001 PR-1.5) =====
 # 引数に問題フォルダを取り、順次 CFn deploy する開発者向け smoke test ツール。

--- a/Makefile
+++ b/Makefile
@@ -217,10 +217,13 @@ destroy-saas:         env-check       ; bash scripts/cleanup.sh
 #   make docker-shell                  # interactive shell in the toolchain image
 #   make docker-build                  # rebuild the image after editing docker/Dockerfile
 # Override DOCKER_COMPOSE=docker-compose for legacy Compose v1.
+# DOCKER_USER passes the host uid/gid so the container drops root and repo writes (cdk.out)
+# stay owned by the host user (see docker/entrypoint.sh).
 DOCKER_COMPOSE ?= docker compose
-deploy-docker:    ; $(DOCKER_COMPOSE) run --rm tenkacloud make deploy ENV=$(ENV)
-destroy-docker:   ; $(DOCKER_COMPOSE) run --rm tenkacloud make destroy ENV=$(ENV)
-docker-shell:     ; $(DOCKER_COMPOSE) run --rm tenkacloud bash
+DOCKER_USER = TENKACLOUD_UID=$(shell id -u) TENKACLOUD_GID=$(shell id -g)
+deploy-docker:    ; $(DOCKER_USER) $(DOCKER_COMPOSE) run --rm tenkacloud make deploy ENV=$(ENV)
+destroy-docker:   ; $(DOCKER_USER) $(DOCKER_COMPOSE) run --rm tenkacloud make destroy ENV=$(ENV)
+docker-shell:     ; $(DOCKER_USER) $(DOCKER_COMPOSE) run --rm tenkacloud bash
 docker-build:     ; $(DOCKER_COMPOSE) build tenkacloud
 
 # ===== Problem deploy smoke test (MVP-0, ADR-001 PR-1.5) =====

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ the SBT control plane entirely and stands up just the Application Admin Console,
 Participant Portal, and the deploy backend. From `git clone` to a first running event
 takes roughly 30 minutes — most of that time is `cdk deploy` waiting on AWS.
 
+### Option A — one-click deploy (CloudFormation)
+
+Don't want to install anything locally? Launch a self-contained deployment pipeline
+straight into your AWS account:
+
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://raw.githubusercontent.com/susumutomita/TenkaCloud/main/infrastructure/templates/lite-pipeline.yaml&stackName=tenkacloud-lite-pipeline)
+
+The stack ([`infrastructure/templates/lite-pipeline.yaml`](./infrastructure/templates/lite-pipeline.yaml))
+is a standalone single-file template — independent of the CDK app. It stands up a
+CodePipeline (`Source → optional Manual Approval → Build`) that clones the repo and
+runs `make deploy` (Lite mode) on CodeBuild. The one manual prerequisite is a
+**GitHub CodeStar Connection** (AWS Console → Developer Tools → Connections); paste
+its ARN and your admin email as stack parameters. Full walkthrough:
+[`infrastructure/templates/README.md`](./infrastructure/templates/README.md#one-click-lite-mode-deployment-pipeline).
+
+> If your console rejects the template URL, download `lite-pipeline.yaml` and use
+> CloudFormation's **Upload a template file** instead.
+
+### Option B — from your terminal
+
 ```bash
 git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
 cd TenkaCloud

--- a/README.md
+++ b/README.md
@@ -119,8 +119,10 @@ cp infrastructure/environments/development/.env.example \
 make deploy-docker     # builds the image (first run), installs deps, runs `make deploy`
 ```
 
-AWS auth comes from your `~/.aws` (mounted read-only) or from `AWS_PROFILE` /
-`AWS_ACCESS_KEY_ID` etc. in your shell. Pick the environment with
+AWS auth is automatic: run `aws sso login` (or `aws configure`) on the host first, then
+`make deploy-docker` reads your `~/.aws` (mounted read-only) — no `AWS_PROFILE` to set.
+Static/temporary keys in your shell (`AWS_ACCESS_KEY_ID` etc.) are inherited too. Pick the
+environment with
 `make deploy-docker ENV=production`. Teardown is `make destroy-docker`, and
 `make docker-shell` drops you into the toolchain container. See
 [`docker-compose.yml`](./docker-compose.yml) and [`docker/Dockerfile`](./docker/Dockerfile).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ When the deploy finishes you get:
 
 Teardown is a single command: `make destroy`.
 
+### Option C — deploy with only Docker (no bun/node on the host)
+
+On a machine where `bun` isn't installed (a fresh box, a CI runner, exe.dev), let Docker
+carry the toolchain. The only host dependency is Docker; the repo and your AWS
+credentials are mounted into a container that already has Bun, Node 24, and the AWS CLI.
+
+```bash
+git clone --recurse-submodules https://github.com/susumutomita/TenkaCloud.git
+cd TenkaCloud
+
+cp infrastructure/environments/development/.env.example \
+   infrastructure/environments/development/.env
+# edit AWS_ACCOUNT_ID and TENANT_ADMIN_EMAIL
+
+make deploy-docker     # builds the image (first run), installs deps, runs `make deploy`
+```
+
+AWS auth comes from your `~/.aws` (mounted read-only) or from `AWS_PROFILE` /
+`AWS_ACCESS_KEY_ID` etc. in your shell. Pick the environment with
+`make deploy-docker ENV=production`. Teardown is `make destroy-docker`, and
+`make docker-shell` drops you into the toolchain container. See
+[`docker-compose.yml`](./docker-compose.yml) and [`docker/Dockerfile`](./docker/Dockerfile).
+
 > [image needed: participant portal Quests page]
 > Place a screenshot at `docs/assets/screenshots/participant-portal-quests.png`
 > showing the deployed problem list with status badges and difficulty.

--- a/bun.lock
+++ b/bun.lock
@@ -173,6 +173,7 @@
         "typescript": "~6.0.3",
         "ulid": "^2.4.0",
         "vitest": "^4.1.6",
+        "yaml": "^1.10.3",
         "zod": "^3.25.76",
       },
     },
@@ -652,7 +653,7 @@
 
     "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
 
-    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+    "@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -2020,9 +2021,15 @@
 
     "@aws-sdk/client-budgets/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/client-budgets/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-cloudformation/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
 
+    "@aws-sdk/client-cloudformation/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-cloudwatch/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
+
+    "@aws-sdk/client-cloudwatch/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-cloudwatch-logs/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
@@ -2030,19 +2037,29 @@
 
     "@aws-sdk/client-cloudwatch-logs/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
+    "@aws-sdk/client-cloudwatch-logs/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-codebuild/@aws-sdk/core": ["@aws-sdk/core@3.974.12", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.24", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.2", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A=="],
 
     "@aws-sdk/client-codebuild/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.43", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.38", "@aws-sdk/credential-provider-http": "^3.972.40", "@aws-sdk/credential-provider-ini": "^3.972.42", "@aws-sdk/credential-provider-process": "^3.972.38", "@aws-sdk/credential-provider-sso": "^3.972.42", "@aws-sdk/credential-provider-web-identity": "^3.972.42", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA=="],
 
+    "@aws-sdk/client-codebuild/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-codepipeline/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
 
+    "@aws-sdk/client-codepipeline/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-cognito-identity-provider/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
+
+    "@aws-sdk/client-cognito-identity-provider/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-dynamodb/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
     "@aws-sdk/client-dynamodb/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.44", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.39", "@aws-sdk/credential-provider-http": "^3.972.41", "@aws-sdk/credential-provider-ini": "^3.972.43", "@aws-sdk/credential-provider-process": "^3.972.39", "@aws-sdk/credential-provider-sso": "^3.972.43", "@aws-sdk/credential-provider-web-identity": "^3.972.43", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ=="],
 
     "@aws-sdk/client-dynamodb/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/client-dynamodb/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-eventbridge/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2056,7 +2073,11 @@
 
     "@aws-sdk/client-eventbridge/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/client-eventbridge/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-lambda/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
+
+    "@aws-sdk/client-lambda/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-s3/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
@@ -2065,6 +2086,8 @@
     "@aws-sdk/client-s3/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.28", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q=="],
 
     "@aws-sdk/client-s3/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/client-s3/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-scheduler/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2076,11 +2099,15 @@
 
     "@aws-sdk/client-scheduler/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/client-scheduler/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/client-sfn/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
 
     "@aws-sdk/client-sfn/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.42", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.37", "@aws-sdk/credential-provider-http": "^3.972.39", "@aws-sdk/credential-provider-ini": "^3.972.41", "@aws-sdk/credential-provider-process": "^3.972.37", "@aws-sdk/credential-provider-sso": "^3.972.41", "@aws-sdk/credential-provider-web-identity": "^3.972.41", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ=="],
+
+    "@aws-sdk/client-ssm/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/client-sts/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2094,13 +2121,21 @@
 
     "@aws-sdk/client-sts/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/client-sts/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.4.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g=="],
+
+    "@aws-sdk/core/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/crc64-nvme/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-env/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
     "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-http/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2112,11 +2147,15 @@
 
     "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/credential-provider-http/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/credential-provider-ini/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
     "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-login/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2124,9 +2163,13 @@
 
     "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
 
+    "@aws-sdk/credential-provider-login/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-process/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2134,11 +2177,15 @@
 
     "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
 
+    "@aws-sdk/credential-provider-process/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/credential-provider-sso/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-web-identity/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2146,21 +2193,37 @@
 
     "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
 
+    "@aws-sdk/credential-provider-web-identity/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/dynamodb-codec/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
+
+    "@aws-sdk/dynamodb-codec/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/middleware-bucket-endpoint/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
     "@aws-sdk/middleware-bucket-endpoint/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
+    "@aws-sdk/middleware-bucket-endpoint/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/middleware-endpoint-discovery/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
+    "@aws-sdk/middleware-endpoint-discovery/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/middleware-expect-continue/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/middleware-expect-continue/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/middleware-flexible-checksums/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
     "@aws-sdk/middleware-flexible-checksums/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
+    "@aws-sdk/middleware-flexible-checksums/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/middleware-location-constraint/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/middleware-location-constraint/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/middleware-sdk-s3/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
@@ -2170,7 +2233,11 @@
 
     "@aws-sdk/middleware-sdk-s3/@smithy/signature-v4": ["@smithy/signature-v4@5.4.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g=="],
 
+    "@aws-sdk/middleware-sdk-s3/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/middleware-ssec/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/middleware-ssec/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/nested-clients/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2182,13 +2249,19 @@
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
 
+    "@aws-sdk/nested-clients/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/s3-request-presigner/@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
     "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.28", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q=="],
 
     "@aws-sdk/s3-request-presigner/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
+    "@aws-sdk/s3-request-presigner/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/signature-v4-multi-region/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/token-providers/@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
@@ -2196,7 +2269,11 @@
 
     "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
 
+    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@aws-sdk/xml-builder/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -2208,11 +2285,23 @@
 
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
 
+    "@smithy/core/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/credential-provider-imds/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/fetch-http-handler/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/middleware-compression/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@smithy/protocol-http/@smithy/core": ["@smithy/core@3.24.6", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug=="],
 
     "@smithy/signature-v4/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/signature-v4/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
@@ -2573,8 +2662,6 @@
     "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.4.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g=="],
 
     "@aws-sdk/token-providers/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
-
-    "@smithy/protocol-http/@smithy/core/@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
     "@textlint/markdown-to-ast/unified/is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,12 @@ services:
       # never leak into the Linux container. Populated by the entrypoint on first run.
       - tenkacloud-node-modules:/workspace/node_modules
       - tenkacloud-infra-node-modules:/workspace/infrastructure/node_modules
-      # AWS credentials/config, read-only. Env-var credentials below also work.
+      # AWS credentials/config, read-only. After a local `aws login` (or `aws configure`)
+      # the default profile / SSO cache here is used automatically — no AWS_PROFILE to set.
       - ${HOME}/.aws:/root/.aws:ro
     environment:
-      # Host AWS auth — profile/region/keys win over the mounted files when set.
-      - AWS_PROFILE
+      # Host AWS auth. The mounted ~/.aws default profile is picked up automatically;
+      # static/temporary keys in the shell are inherited too, but are optional.
       - AWS_REGION
       - AWS_DEFAULT_REGION
       - AWS_ACCESS_KEY_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# One-Docker-dependency deploy for TenkaCloud.
+#
+# A host with only Docker installed can deploy without bun / node / the AWS CLI:
+#
+#   make deploy-docker     # Lite mode (`make deploy`) inside the toolchain container
+#   make destroy-docker    # tear it down (`make destroy`)
+#   make docker-shell      # interactive shell in the toolchain image
+#
+# The repo is bind-mounted at /workspace; AWS credentials are bind-mounted read-only.
+# node_modules are kept on named volumes so the container always uses Linux-native
+# dependencies regardless of the host OS (and so repeat runs are fast).
+services:
+  tenkacloud:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    image: tenkacloud-deploy:local
+    working_dir: /workspace
+    # Forward Ctrl-C cleanly to a long-running cdk deploy.
+    init: true
+    volumes:
+      - .:/workspace
+      # Shadow host node_modules so macOS/Windows-built native binaries (esbuild etc.)
+      # never leak into the Linux container. Populated by the entrypoint on first run.
+      - tenkacloud-node-modules:/workspace/node_modules
+      - tenkacloud-infra-node-modules:/workspace/infrastructure/node_modules
+      # AWS credentials/config, read-only. Env-var credentials below also work.
+      - ${HOME}/.aws:/root/.aws:ro
+    environment:
+      # Host AWS auth — profile/region/keys win over the mounted files when set.
+      - AWS_PROFILE
+      - AWS_REGION
+      - AWS_DEFAULT_REGION
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      # Target environment (development | staging | production). Defaults to development.
+      - ENV
+      # Quiet CDK/JSII deprecation noise the same way the Makefile does.
+      - JSII_DEPRECATED=quiet
+
+volumes:
+  tenkacloud-node-modules:
+  tenkacloud-infra-node-modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,11 @@ services:
       # never leak into the Linux container. Populated by the entrypoint on first run.
       - tenkacloud-node-modules:/workspace/node_modules
       - tenkacloud-infra-node-modules:/workspace/infrastructure/node_modules
-      # AWS credentials/config, read-only. After a local `aws login` (or `aws configure`)
-      # the default profile / SSO cache here is used automatically — no AWS_PROFILE to set.
-      - ${HOME}/.aws:/root/.aws:ro
+      # AWS credentials/config, read-only, mounted at the container HOME (/home/tenkacloud)
+      # so it resolves for the non-root host user the entrypoint drops to. After a local
+      # `aws login` (or `aws configure`) the default profile / SSO cache here is used
+      # automatically — no AWS_PROFILE to set.
+      - ${HOME}/.aws:/home/tenkacloud/.aws:ro
     environment:
       # Host AWS auth. The mounted ~/.aws default profile is picked up automatically;
       # static/temporary keys in the shell are inherited too, but are optional.
@@ -35,6 +37,10 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
+      # Host uid/gid the entrypoint drops to (set by the Makefile docker targets) so the
+      # toolchain runs non-root and repo writes stay owned by the host user.
+      - TENKACLOUD_UID
+      - TENKACLOUD_GID
       # Target environment (development | staging | production). Defaults to development.
       - ENV
       # Quiet CDK/JSII deprecation noise the same way the Makefile does.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,17 +16,20 @@ FROM node:24-bookworm-slim
 ARG BUN_VERSION=1.3.11
 
 # Base packages: certificates + curl/unzip for the installers below, git for the bun
-# workspace, bash for the entrypoint, and make to drive the inner targets.
+# workspace, bash for the entrypoint, make to drive the inner targets, and gosu so the
+# entrypoint can drop from root to the host user's uid at runtime (docker/entrypoint.sh).
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-       ca-certificates curl unzip git bash make \
+       ca-certificates curl unzip git bash make gosu \
   && rm -rf /var/lib/apt/lists/*
 
-# Bun (pinned). The official installer drops the binary in /root/.bun/bin.
-ENV BUN_INSTALL=/root/.bun
-ENV PATH=/root/.bun/bin:$PATH
+# Bun (pinned). Installed to a world-readable path so it stays runnable after the
+# entrypoint drops from root to the (arbitrary) host uid; the binary lands in /opt/bun/bin.
+ENV BUN_INSTALL=/opt/bun
+ENV PATH=/opt/bun/bin:$PATH
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
-  && bun --version
+  && bun --version \
+  && chmod -R a+rx /opt/bun
 
 # AWS CLI v2 (architecture-aware: x86_64 / aarch64). The deploy scripts
 # (tenkacloud-lite.ts / install.sh / cleanup.sh) shell out to `aws` for CFn outputs,
@@ -39,6 +42,12 @@ RUN arch="$(uname -m)" \
   && rm -rf /tmp/aws /tmp/awscliv2.zip
 
 WORKDIR /workspace
+
+# HOME for the runtime user. The container starts as root only long enough to chown the
+# volume-backed node_modules + this dir to the host uid, then gosu-drops to that uid
+# (docker/entrypoint.sh). docker-compose.yml mounts the host ~/.aws here read-only.
+ENV HOME=/home/tenkacloud
+RUN mkdir -p /home/tenkacloud
 
 # Install deps into the (volume-backed) node_modules, then exec the requested command.
 COPY docker/entrypoint.sh /usr/local/bin/tenkacloud-entrypoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+# TenkaCloud deploy toolchain image.
+#
+# Goal: a host with ONLY Docker installed can run `make deploy-docker` / `make destroy-docker`
+# with no bun, node, or AWS CLI on the host. This image carries the exact toolchain the
+# deploy path needs and runs the repo from inside the container. The repo is bind-mounted
+# at /workspace by docker-compose.yml, so local working changes deploy as-is — the image
+# deliberately does NOT COPY the source, only the toolchain.
+
+# Node 24 matches package.json "engines": { "node": ">=24" }. The CDK CLI shebang is
+# `#!/usr/bin/env node` and NodejsFunction bundles Lambdas with local esbuild, so a real
+# Node runtime must sit alongside Bun.
+FROM node:24-bookworm-slim
+
+# Bun is pinned to package.json "packageManager": "bun@1.3.11" so the container resolves
+# the committed bun.lock exactly like CI does.
+ARG BUN_VERSION=1.3.11
+
+# Base packages: certificates + curl/unzip for the installers below, git for the bun
+# workspace, bash for the entrypoint, and make to drive the inner targets.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ca-certificates curl unzip git bash make \
+  && rm -rf /var/lib/apt/lists/*
+
+# Bun (pinned). The official installer drops the binary in /root/.bun/bin.
+ENV BUN_INSTALL=/root/.bun
+ENV PATH=/root/.bun/bin:$PATH
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+  && bun --version
+
+# AWS CLI v2 (architecture-aware: x86_64 / aarch64). The deploy scripts
+# (tenkacloud-lite.ts / install.sh / cleanup.sh) shell out to `aws` for CFn outputs,
+# STS identity, and S3 source upload.
+RUN arch="$(uname -m)" \
+  && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip" -o /tmp/awscliv2.zip \
+  && unzip -q /tmp/awscliv2.zip -d /tmp \
+  && /tmp/aws/install \
+  && aws --version \
+  && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+WORKDIR /workspace
+
+# Install deps into the (volume-backed) node_modules, then exec the requested command.
+COPY docker/entrypoint.sh /usr/local/bin/tenkacloud-entrypoint
+RUN chmod +x /usr/local/bin/tenkacloud-entrypoint
+ENTRYPOINT ["/usr/local/bin/tenkacloud-entrypoint"]
+CMD ["make", "deploy"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,6 +12,17 @@
 # --ignore-scripts: same supply-chain posture as `make install` / `make install_ci`.
 set -euo pipefail
 
+# When started as root with a host uid (the Makefile passes TENKACLOUD_UID/GID), make the
+# volume-backed node_modules and HOME writable by that uid, then drop privileges to it with
+# gosu. This keeps writes to the bind-mounted repo (cdk.out, etc.) owned by the host user
+# and runs the toolchain as non-root. A plain `docker compose run` (no uid) stays root.
+if [ "$(id -u)" = "0" ] && [ -n "${TENKACLOUD_UID:-}" ]; then
+  target="${TENKACLOUD_UID}:${TENKACLOUD_GID:-$TENKACLOUD_UID}"
+  chown "${target}" "${HOME:-/home/tenkacloud}" 2>/dev/null || true
+  chown -R "${target}" /workspace/node_modules /workspace/infrastructure/node_modules 2>/dev/null || true
+  exec gosu "${target}" "$0" "$@"
+fi
+
 echo "==> Installing dependencies into the container (Linux-native, volume-backed node_modules)"
 bun install --frozen-lockfile --ignore-scripts
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the TenkaCloud deploy container (docker/Dockerfile).
+#
+# node_modules live on named volumes (see docker-compose.yml) so the host's
+# possibly-foreign-platform binaries never leak into the Linux container. On first run
+# those volumes are empty, so dependencies are installed before handing control to the
+# requested command (default: `make deploy`).
+#
+# --frozen-lockfile: never mutate the bind-mounted bun.lock on the host, and fail loudly
+#   if the lockfile is stale (no silent fallback).
+# --ignore-scripts: same supply-chain posture as `make install` / `make install_ci`.
+set -euo pipefail
+
+echo "==> Installing dependencies into the container (Linux-native, volume-backed node_modules)"
+bun install --frozen-lockfile --ignore-scripts
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,4 +15,13 @@ set -euo pipefail
 echo "==> Installing dependencies into the container (Linux-native, volume-backed node_modules)"
 bun install --frozen-lockfile --ignore-scripts
 
+# A local `aws login` (the mounted ~/.aws default profile / SSO cache) is the intended
+# credential source. docker-compose forwards AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+# AWS_SESSION_TOKEN, but an empty or partial pair (e.g. a host that exports an empty
+# AWS_ACCESS_KEY_ID) would shadow that profile and make the AWS SDK / CLI fail instead of
+# falling back. Drop them unless a complete static key pair is actually present.
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+fi
+
 exec "$@"

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -41,6 +41,7 @@
     "typescript": "~6.0.3",
     "ulid": "^2.4.0",
     "vitest": "^4.1.6",
+    "yaml": "^1.10.3",
     "zod": "^3.25.76"
   },
   "dependencies": {

--- a/infrastructure/templates/README.md
+++ b/infrastructure/templates/README.md
@@ -100,6 +100,52 @@ trust を即時撤回できます。 削除後はあらためて生成した Ext
   CloudTrail でその AssumeRole / 後続の CFn / EC2 操作を監査できる。
 - スタック削除で権限を即時撤回できるので、競技終了後はスタックを消すと安全。
 
+## One-click Lite mode deployment pipeline
+
+### 概要
+
+`lite-pipeline.yaml` は、README の **Launch Stack** ボタンから 1 クリックで起動できる
+独立したペライチ CloudFormation テンプレート。CDK アプリとは切り離されており、
+作るのは「デプロイ用パイプライン」だけ (= TenkaCloud 本体のスタックはパイプラインの
+Build ステップが `make deploy` を実行して作る)。
+
+パイプライン構成: `Source (GitHub) → Manual Approval (任意) → Build (CodeBuild で make deploy)`。
+CodeBuild は repo を clone → `bun install` → `make build` → `cdk bootstrap` → Lite mode の
+`make deploy` を流す。`infrastructure/environments/<env>/.env` はビルド中に
+`TenantAdminEmail` パラメータから自動生成される。
+
+### 事前準備 (1 回だけ)
+
+GitHub への OAuth ハンドシェイクだけは CloudFormation で自動化できないため、
+**CodeStar Connection** を先に手動で作る。
+
+1. AWS Console → Developer Tools → Connections →「Create connection」→ GitHub を選択
+2. 認可フローを完了し、ステータスが **Available** になった接続の ARN を控える
+
+### デプロイ手順
+
+1. README の [Launch Stack](../../README.md#option-a--one-click-deploy-cloudformation) ボタンを押す (または Console の CloudFormation でこの yaml を upload する)
+2. 下表のパラメータを入力する
+3. 「IAM 権限変更を承認」にチェックして作成する。スタック作成時にパイプラインが 1 回自動実行されるので、承認ステージで承認すれば Lite デプロイが走る
+
+| パラメータ            | 必須 | 説明                                                          |
+| --------------------- | ---- | ----------------------------------------------------------- |
+| `TenantAdminEmail`    | 必須 | Application Admin Console の初期ユーザー宛先                 |
+| `GitHubConnectionArn` | 必須 | 上で控えた CodeStar Connection の ARN                       |
+| `GitHubRepositoryId`  | 任意 | デフォルト `susumutomita/TenkaCloud` (fork したなら自分の owner/repo) |
+| `EnableManualApproval`| 任意 | `false` にすると承認なしの完全自動デプロイ                  |
+| `DeployExternalId`    | 任意 | 競技者アカウントへ AssumeRole する場合のみ                  |
+
+完了後、CodeBuild ログ末尾に Application Admin Console / Participant Portal の URL が出る。
+パイプライン自体は CloudFormation スタックを削除すれば消える (TenkaCloud 本体は
+`make destroy` で別途撤去する)。
+
+### コストの注意
+
+問題テンプレート (`problems/**/template.yaml`) は AWS 無料枠 0 円に収めているが、
+このパイプラインは CodePipeline V2 + CodeBuild + 小さな S3 を使うため厳密な 0 円ではない
+(月数回のデプロイで 1 ドル未満)。使い終えたらスタックを削除すれば課金は止まる。
+
 ## 関連
 
 - [`/problems/README.md`](../../problems/README.md) — 問題カタログ規約

--- a/infrastructure/templates/lite-pipeline.yaml
+++ b/infrastructure/templates/lite-pipeline.yaml
@@ -157,6 +157,10 @@ Resources:
           version: 0.2
           phases:
             install:
+              # Node 22 is the newest version the managed CodeBuild standard image ships;
+              # node 24 is not yet a managed runtime (aws/aws-codebuild-docker-images#795).
+              # bun drives the toolchain and Node only backs the CDK CLI shebang + esbuild,
+              # which run on 22. Bump to 24 once CodeBuild offers it as a managed runtime.
               runtime-versions:
                 nodejs: 22
               commands:

--- a/infrastructure/templates/lite-pipeline.yaml
+++ b/infrastructure/templates/lite-pipeline.yaml
@@ -1,0 +1,464 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  TenkaCloud Lite mode one-click deployment pipeline. Stands up a self-contained
+  CodePipeline (Source GitHub -> optional Manual Approval -> Build on CodeBuild)
+  that runs `make deploy` (Lite mode) to deploy TenkaCloud into this AWS account.
+  This template is independent from the CDK app: it provisions only the pipeline,
+  not the TenkaCloud stacks themselves (those are created by the build step).
+
+# This is a single-file ("perapeti") template meant to be launched from the README
+# "Launch Stack" button. The only manual prerequisite is a GitHub CodeStar
+# Connection (AWS Console -> Developer Tools -> Connections), because OAuth handshake
+# to GitHub cannot be automated inside CloudFormation.
+#
+# Cost note: unlike the problem templates (which are forced to the AWS Free Tier),
+# this pipeline uses CodePipeline V2 (per-action-execution pricing) + CodeBuild
+# (per-build-minute) + a small versioned S3 artifact bucket. A handful of Lite
+# deploys per month costs well under a dollar; delete this stack to stop all charges.
+#
+# IAM Role / Policy "Description" fields only accept ASCII (0x20-0x7E) + Latin-1
+# (0xA1-0xFF); CJK characters cause CREATE_FAILED. All comments in this file are
+# ASCII so `make check-template-ascii` (which walks infrastructure/templates/) passes.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: development
+    AllowedValues:
+      - development
+      - staging
+      - production
+    Description: >-
+      Target environment. Selects infrastructure/environments/{env}/config.json
+      and writes infrastructure/environments/{env}/.env during the build.
+
+  TenantAdminEmail:
+    Type: String
+    Description: >-
+      Application Admin Console initial user (Tenant Admin). After the Lite deploy,
+      tenkacloud-lite.ts creates this Cognito user and emails an invitation.
+    AllowedPattern: ^[^\s@]+@[^\s@]+\.[^\s@]+$
+    ConstraintDescription: Must be a valid email address.
+
+  GitHubConnectionArn:
+    Type: String
+    AllowedPattern: ^arn:aws:codestar-connections:.*|^arn:aws:codeconnections:.*
+    Description: >-
+      ARN of a GitHub CodeStar/CodeConnections connection in AVAILABLE status.
+      Create one in AWS Console -> Developer Tools -> Connections before launching.
+
+  GitHubRepositoryId:
+    Type: String
+    Default: susumutomita/TenkaCloud
+    Description: GitHub repository id in owner/repository format.
+
+  SourceBranchName:
+    Type: String
+    Default: main
+    Description: Branch to deploy from.
+
+  DeployExternalId:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >-
+      Optional CDK_PARAM_DEPLOY_EXTERNAL_ID for AssumeRole into competitor accounts
+      (problem deploy backend). Leave empty for a local-only Lite trial.
+
+  EnableManualApproval:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: >-
+      If true, the pipeline pauses for a manual approval before deploying. Set to
+      false for a fully automatic one-click deploy.
+
+  BunVersion:
+    Type: String
+    Default: 1.3.11
+    Description: Bun version installed in the build (matches the repo toolchain).
+
+  CodeBuildTimeoutMinutes:
+    Type: Number
+    Default: 90
+    MinValue: 15
+    MaxValue: 480
+    Description: CodeBuild timeout in minutes (a Lite deploy usually finishes in 15-30).
+
+Conditions:
+  IncludeManualApproval: !Equals [!Ref EnableManualApproval, "true"]
+  HasExternalId: !Not [!Equals [!Ref DeployExternalId, ""]]
+
+Resources:
+  # =====================================
+  # S3 artifact store (pipeline working area)
+  # =====================================
+  ArtifactStoreBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub tenkacloud-lite-${Environment}-pipeline-artifacts-${AWS::AccountId}
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldArtifacts
+            Status: Enabled
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 7
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  # =====================================
+  # CodeBuild project: installs bun, builds the SPAs, bootstraps CDK, runs `make deploy`
+  # =====================================
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        Image: aws/codebuild/amazonlinux-x86_64-standard:5.0
+        ComputeType: BUILD_GENERAL1_MEDIUM
+        # CDK asset bundling can fall back to Docker; PrivilegedMode keeps it reliable.
+        PrivilegedMode: true
+        ImagePullCredentialsType: CODEBUILD
+        EnvironmentVariables:
+          - Name: ENVIRONMENT
+            Value: !Ref Environment
+            Type: PLAINTEXT
+          - Name: TENANT_ADMIN_EMAIL
+            Value: !Ref TenantAdminEmail
+            Type: PLAINTEXT
+          - Name: DEPLOY_EXTERNAL_ID
+            Value: !If [HasExternalId, !Ref DeployExternalId, ""]
+            Type: PLAINTEXT
+          - Name: BUN_VERSION
+            Value: !Ref BunVersion
+            Type: PLAINTEXT
+          - Name: JSII_DEPRECATED
+            Value: quiet
+            Type: PLAINTEXT
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                nodejs: 22
+              commands:
+                - echo "Installing bun ${BUN_VERSION}"
+                - npm install -g "bun@${BUN_VERSION}"
+                - bun --version
+                # Frozen + ignore-scripts matches the repo supply-chain policy (make install_ci).
+                - bun install --frozen-lockfile --ignore-scripts
+                # The problem catalog lives in a git submodule; pull it so `make deploy` ships it.
+                - git submodule update --init --recursive || echo "no submodules or already initialized"
+            pre_build:
+              commands:
+                - export AWS_REGION="${AWS_DEFAULT_REGION}"
+                - export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+                - ENV_DIR="infrastructure/environments/${ENVIRONMENT}"
+                - mkdir -p "${ENV_DIR}"
+                - |
+                  {
+                    echo "TENANT_ADMIN_EMAIL=${TENANT_ADMIN_EMAIL}"
+                    echo "AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID}"
+                    echo "AWS_REGION=${AWS_REGION}"
+                    if [ -n "${DEPLOY_EXTERNAL_ID}" ]; then
+                      echo "CDK_PARAM_DEPLOY_EXTERNAL_ID=${DEPLOY_EXTERNAL_ID}"
+                    fi
+                  } > "${ENV_DIR}/.env"
+                - echo "Wrote ${ENV_DIR}/.env (TENANT_ADMIN_EMAIL / AWS_ACCOUNT_ID / AWS_REGION)"
+                # CDK bootstrap is idempotent; safe to run on every build.
+                - ./node_modules/aws-cdk/bin/cdk bootstrap "aws://${AWS_ACCOUNT_ID}/${AWS_REGION}"
+            build:
+              commands:
+                - make build
+                - make deploy ENV="${ENVIRONMENT}"
+            post_build:
+              commands:
+                - echo "Lite deploy finished. Console / Portal URLs:"
+                - make lite-console-url ENV="${ENVIRONMENT}" || true
+                - make lite-portal-url ENV="${ENVIRONMENT}" || true
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Sub /aws/codebuild/tenkacloud-lite-${Environment}
+      TimeoutInMinutes: !Ref CodeBuildTimeoutMinutes
+
+  # =====================================
+  # CodePipeline: Source -> (Manual Approval) -> Build
+  # =====================================
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}
+      RoleArn: !GetAtt CodePipelineRole.Arn
+      PipelineType: V2
+      ExecutionMode: QUEUED
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactStoreBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeStarSourceConnection
+                Version: "1"
+              Configuration:
+                ConnectionArn: !Ref GitHubConnectionArn
+                FullRepositoryId: !Ref GitHubRepositoryId
+                BranchName: !Ref SourceBranchName
+                DetectChanges: "false"
+                OutputArtifactFormat: CODEBUILD_CLONE_REF
+              OutputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+        - !If
+          - IncludeManualApproval
+          - Name: Approve
+            Actions:
+              - Name: ManualApproval
+                ActionTypeId:
+                  Category: Approval
+                  Owner: AWS
+                  Provider: Manual
+                  Version: "1"
+                Configuration:
+                  CustomData: !Sub Approve to deploy TenkaCloud Lite (${Environment}) into account ${AWS::AccountId}.
+                RunOrder: 1
+          - !Ref AWS::NoValue
+        - Name: Deploy
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: !Ref CodeBuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              OutputArtifacts:
+                - Name: BuildArtifact
+              RunOrder: 1
+
+  # =====================================
+  # IAM roles
+  # =====================================
+  # CodeBuild role: `make deploy` (Lite) drives `cdk deploy`, which stands up the whole
+  # platform (Lambda + Cognito + DynamoDB + S3 + CloudFront + API Gateway + Step Functions
+  # + EventBridge + the in-app CodeBuild for problem deploy + SSM). cdk also bootstraps and
+  # assumes the cdk-* execution roles, so the role needs broad service access. This role is
+  # the deploy operator, distinct from competitor-bootstrap.yaml which stays least-privilege.
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub tenkacloud-lite-${Environment}-codebuild-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodeBuildPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: OwnLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/tenkacloud-lite-${Environment}
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/tenkacloud-lite-${Environment}:*
+              - Sid: ArtifactStore
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                Resource:
+                  - !Sub ${ArtifactStoreBucket.Arn}/*
+              - Sid: UseGitHubConnection
+                Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref GitHubConnectionArn
+              # Services that `cdk deploy` (Lite) and `cdk bootstrap` create/manage.
+              - Sid: DeployServices
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                  - iam:*
+                  - lambda:*
+                  - apigateway:*
+                  - cognito-idp:*
+                  - cognito-identity:*
+                  - dynamodb:*
+                  - s3:*
+                  - cloudfront:*
+                  - states:*
+                  - events:*
+                  - sns:*
+                  - sqs:*
+                  - ecr:*
+                  - codebuild:*
+                  - logs:*
+                Resource: "*"
+              # Cost-zero principle: secrets live in SSM Parameter Store, not Secrets Manager.
+              - Sid: SsmParameters
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:AddTagsToResource
+                Resource:
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/TenkaCloud/*
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-bootstrap/*
+              - Sid: KmsForBootstrapAndAssets
+                Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey
+                Resource: "*"
+              # cdk deploy assumes the bootstrap roles to publish assets / run the change set.
+              - Sid: AssumeCdkRoles
+                Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource:
+                  - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-*
+              - Sid: Identity
+                Effect: Allow
+                Action:
+                  - sts:GetCallerIdentity
+                Resource: "*"
+
+  CodePipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub tenkacloud-lite-${Environment}-pipeline-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodePipelinePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                  - s3:GetBucketVersioning
+                Resource:
+                  - !GetAtt ArtifactStoreBucket.Arn
+                  - !Sub ${ArtifactStoreBucket.Arn}/*
+              - Effect: Allow
+                Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+                Resource:
+                  - !GetAtt CodeBuildProject.Arn
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref GitHubConnectionArn
+
+  # =====================================
+  # SNS notifications (subscribe an email after deploy to watch pipeline state)
+  # =====================================
+  PipelineNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub tenkacloud-lite-${Environment}-pipeline-notification
+      DisplayName: !Sub TenkaCloud Lite ${Environment} Pipeline
+
+  PipelineNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCodeStarNotifications
+            Effect: Allow
+            Principal:
+              Service: codestar-notifications.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref PipelineNotificationTopic
+      Topics:
+        - !Ref PipelineNotificationTopic
+
+  PipelineNotificationRule:
+    Type: AWS::CodeStarNotifications::NotificationRule
+    DependsOn:
+      - Pipeline
+      - PipelineNotificationTopicPolicy
+    Properties:
+      Name: !Sub tenkacloud-lite-${Environment}-pipeline-events
+      DetailType: FULL
+      Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}
+      EventTypeIds:
+        - codepipeline-pipeline-pipeline-execution-started
+        - codepipeline-pipeline-pipeline-execution-succeeded
+        - codepipeline-pipeline-pipeline-execution-failed
+        - codepipeline-pipeline-manual-approval-needed
+        - codepipeline-pipeline-manual-approval-succeeded
+      Targets:
+        - TargetType: SNS
+          TargetAddress: !Ref PipelineNotificationTopic
+      Status: ENABLED
+
+Outputs:
+  PipelineName:
+    Description: CodePipeline name
+    Value: !Ref Pipeline
+
+  PipelineConsoleUrl:
+    Description: Open the pipeline in the AWS console (approve / re-run here)
+    Value: !Sub https://${AWS::Region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${Pipeline}/view?region=${AWS::Region}
+
+  CodeBuildProjectName:
+    Description: CodeBuild project name
+    Value: !Ref CodeBuildProject
+
+  ArtifactBucketName:
+    Description: S3 bucket for pipeline artifacts
+    Value: !Ref ArtifactStoreBucket
+
+  NotificationTopicArn:
+    Description: SNS topic ARN for pipeline notifications (subscribe an email manually)
+    Value: !Ref PipelineNotificationTopic

--- a/infrastructure/templates/lite-pipeline.yaml
+++ b/infrastructure/templates/lite-pipeline.yaml
@@ -170,7 +170,12 @@ Resources:
                 # Frozen + ignore-scripts matches the repo supply-chain policy (make install_ci).
                 - bun install --frozen-lockfile --ignore-scripts
                 # The problem catalog lives in a git submodule; pull it so `make deploy` ships it.
-                - git submodule update --init --recursive || echo "no submodules or already initialized"
+                # Only run when submodules are configured, but let a real checkout failure
+                # (auth/network) fail the build instead of masking it.
+                - |
+                  if [ -f .gitmodules ]; then
+                    git submodule update --init --recursive
+                  fi
             pre_build:
               commands:
                 - export AWS_REGION="${AWS_DEFAULT_REGION}"

--- a/infrastructure/test/scripts/docker-deploy.test.ts
+++ b/infrastructure/test/scripts/docker-deploy.test.ts
@@ -47,8 +47,10 @@ describe("one-Docker deploy wrapper", () => {
       expect(service.volumes).toContain(".:/workspace");
     });
 
-    it("should mount AWS credentials read-only so the deploy can authenticate", () => {
-      const awsMount = service.volumes?.find((v) => v.endsWith(":/root/.aws:ro"));
+    it("should mount AWS credentials read-only at the runtime HOME so the deploy can authenticate", () => {
+      // Mounted at the non-root user's HOME (not /root) so ~/.aws resolves after the
+      // entrypoint drops privileges to the host uid.
+      const awsMount = service.volumes?.find((v) => v.endsWith(":/home/tenkacloud/.aws:ro"));
       expect(awsMount).toBeDefined();
     });
 
@@ -81,6 +83,12 @@ describe("one-Docker deploy wrapper", () => {
     it("should not require AWS_PROFILE (a local `aws login` default profile is used automatically)", () => {
       expect(service.environment).not.toContain("AWS_PROFILE");
     });
+
+    it("should pass the host uid/gid through so the container can drop root", () => {
+      for (const key of ["TENKACLOUD_UID", "TENKACLOUD_GID"]) {
+        expect(service.environment).toContain(key);
+      }
+    });
   });
 
   describe("docker/entrypoint.sh", () => {
@@ -91,6 +99,13 @@ describe("one-Docker deploy wrapper", () => {
       // would otherwise shadow the mounted profile and make the AWS SDK fail rather than
       // fall back. The entrypoint must unset them unless a complete key pair is present.
       expect(entrypoint).toMatch(/unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN/);
+    });
+
+    it("should drop root to the host uid via gosu so repo writes stay host-owned", () => {
+      // chown the volume-backed node_modules, then hand off to the host uid. Without this,
+      // running non-root would fail to write cdk.out into the bind-mounted host repo.
+      expect(entrypoint).toMatch(/gosu /);
+      expect(entrypoint).toContain("TENKACLOUD_UID");
     });
   });
 
@@ -110,6 +125,10 @@ describe("one-Docker deploy wrapper", () => {
     it("should install the AWS CLI (deploy scripts shell out to `aws`)", () => {
       expect(dockerfile).toMatch(/awscli/);
     });
+
+    it("should install gosu so the entrypoint can drop to the host user", () => {
+      expect(dockerfile).toMatch(/gosu/);
+    });
   });
 
   describe("Makefile docker targets", () => {
@@ -126,6 +145,11 @@ describe("one-Docker deploy wrapper", () => {
       const recipe = recipeFor("deploy-docker");
       expect(recipe).toContain("$(DOCKER_COMPOSE)");
       expect(recipe).not.toContain("bun");
+    });
+
+    it("should run docker targets as the host user (non-root) via the host uid/gid", () => {
+      expect(makefile).toContain("id -u");
+      expect(recipeFor("deploy-docker")).toContain("$(DOCKER_USER)");
     });
 
     it("should declare the docker targets as .PHONY", () => {

--- a/infrastructure/test/scripts/docker-deploy.test.ts
+++ b/infrastructure/test/scripts/docker-deploy.test.ts
@@ -61,7 +61,8 @@ describe("one-Docker deploy wrapper", () => {
 
     it("should declare the named node_modules volumes at the top level", () => {
       const declared = Object.keys(compose.volumes ?? {});
-      expect(declared.length).toBeGreaterThanOrEqual(2);
+      expect(declared).toContain("tenkacloud-node-modules");
+      expect(declared).toContain("tenkacloud-infra-node-modules");
     });
 
     it("should pass host AWS auth and the target ENV through to the container", () => {
@@ -79,6 +80,17 @@ describe("one-Docker deploy wrapper", () => {
 
     it("should not require AWS_PROFILE (a local `aws login` default profile is used automatically)", () => {
       expect(service.environment).not.toContain("AWS_PROFILE");
+    });
+  });
+
+  describe("docker/entrypoint.sh", () => {
+    const entrypoint = read("docker/entrypoint.sh");
+
+    it("should drop empty or partial static AWS keys so the mounted ~/.aws login is used", () => {
+      // An empty/partial AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY forwarded from the host
+      // would otherwise shadow the mounted profile and make the AWS SDK fail rather than
+      // fall back. The entrypoint must unset them unless a complete key pair is present.
+      expect(entrypoint).toMatch(/unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN/);
     });
   });
 

--- a/infrastructure/test/scripts/docker-deploy.test.ts
+++ b/infrastructure/test/scripts/docker-deploy.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * One-Docker deploy wrapper (host needs only Docker — no bun / node / aws-cli).
+ *
+ * The deliverable is `make deploy-docker`: a host with nothing but Docker installed can
+ * still run the normal deploy. The wrapper is declarative (docker-compose.yml +
+ * docker/Dockerfile) plus thin Makefile targets, so the test pins the *contract* those
+ * files must satisfy rather than executing Docker (which is unavailable in CI):
+ *
+ *   - the toolchain image carries the exact versions the deploy path needs
+ *   - the container can see the repo and authenticate to AWS
+ *   - host node_modules (possibly built for another OS) never leak into the Linux container
+ *   - the Makefile targets are pure `docker compose` so they run on a bun-less host
+ */
+
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const read = (rel: string): string => readFileSync(join(REPO_ROOT, rel), "utf8");
+
+interface ComposeFile {
+  services: Record<
+    string,
+    {
+      build?: { dockerfile?: string };
+      volumes?: string[];
+      environment?: string[];
+    }
+  >;
+  volumes?: Record<string, unknown>;
+}
+
+describe("one-Docker deploy wrapper", () => {
+  describe("docker-compose.yml", () => {
+    const compose = parseYaml(read("docker-compose.yml")) as ComposeFile;
+    const service = compose.services?.tenkacloud;
+
+    it("should define a 'tenkacloud' service built from docker/Dockerfile", () => {
+      expect(service).toBeDefined();
+      expect(service.build?.dockerfile).toBe("docker/Dockerfile");
+    });
+
+    it("should bind-mount the repo at /workspace so local changes deploy as-is", () => {
+      expect(service.volumes).toContain(".:/workspace");
+    });
+
+    it("should mount AWS credentials read-only so the deploy can authenticate", () => {
+      const awsMount = service.volumes?.find((v) => v.endsWith(":/root/.aws:ro"));
+      expect(awsMount).toBeDefined();
+    });
+
+    it("should shadow host node_modules with named volumes (no foreign-platform binaries leak in)", () => {
+      for (const target of ["/workspace/node_modules", "/workspace/infrastructure/node_modules"]) {
+        const shadowed = service.volumes?.some((v) => v.endsWith(`:${target}`));
+        expect(shadowed, `expected a named volume mounted at ${target}`).toBe(true);
+      }
+    });
+
+    it("should declare the named node_modules volumes at the top level", () => {
+      const declared = Object.keys(compose.volumes ?? {});
+      expect(declared.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should pass host AWS auth and the target ENV through to the container", () => {
+      for (const key of [
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "ENV",
+      ]) {
+        expect(service.environment).toContain(key);
+      }
+    });
+  });
+
+  describe("docker/Dockerfile", () => {
+    const dockerfile = read("docker/Dockerfile");
+
+    it("should base on Node 24 (the CDK CLI shebang and esbuild need a real Node runtime)", () => {
+      expect(dockerfile).toMatch(/FROM node:24/);
+    });
+
+    it("should pin Bun to the package.json packageManager version", () => {
+      const pkg = JSON.parse(read("package.json")) as { packageManager: string };
+      const bunVersion = pkg.packageManager.replace("bun@", "");
+      expect(dockerfile).toContain(bunVersion);
+    });
+
+    it("should install the AWS CLI (deploy scripts shell out to `aws`)", () => {
+      expect(dockerfile).toMatch(/awscli/);
+    });
+  });
+
+  describe("Makefile docker targets", () => {
+    const makefile = read("Makefile");
+    const recipeFor = (target: string): string =>
+      makefile.split("\n").find((line) => line.startsWith(`${target}:`)) ?? "";
+
+    it("should expose deploy-docker and destroy-docker targets", () => {
+      expect(recipeFor("deploy-docker")).not.toBe("");
+      expect(recipeFor("destroy-docker")).not.toBe("");
+    });
+
+    it("should drive deploy-docker through docker compose, never bun (host has no bun)", () => {
+      const recipe = recipeFor("deploy-docker");
+      expect(recipe).toContain("$(DOCKER_COMPOSE)");
+      expect(recipe).not.toContain("bun");
+    });
+
+    it("should declare the docker targets as .PHONY", () => {
+      const phony = makefile
+        .split("\n")
+        .filter((line) => line.includes(".PHONY") || line.trimStart().startsWith("deploy-docker"))
+        .join(" ");
+      expect(phony).toContain("deploy-docker");
+      expect(phony).toContain("destroy-docker");
+    });
+  });
+});

--- a/infrastructure/test/scripts/docker-deploy.test.ts
+++ b/infrastructure/test/scripts/docker-deploy.test.ts
@@ -66,7 +66,6 @@ describe("one-Docker deploy wrapper", () => {
 
     it("should pass host AWS auth and the target ENV through to the container", () => {
       for (const key of [
-        "AWS_PROFILE",
         "AWS_REGION",
         "AWS_DEFAULT_REGION",
         "AWS_ACCESS_KEY_ID",
@@ -76,6 +75,10 @@ describe("one-Docker deploy wrapper", () => {
       ]) {
         expect(service.environment).toContain(key);
       }
+    });
+
+    it("should not require AWS_PROFILE (a local `aws login` default profile is used automatically)", () => {
+      expect(service.environment).not.toContain("AWS_PROFILE");
     });
   });
 


### PR DESCRIPTION
## Summary

On a host where `bun` isn't installed (a fresh box, a CI runner, exe.dev), deploying
TenkaCloud previously failed at the first `make` target. This adds a one-Docker-dependency
path: the toolchain rides in a container so the only host requirement is Docker.

```bash
cp infrastructure/environments/development/.env.example \
   infrastructure/environments/development/.env   # edit AWS_ACCOUNT_ID + TENANT_ADMIN_EMAIL
make deploy-docker            # builds image, installs deps, runs `make deploy`
make deploy-docker ENV=production
make destroy-docker
make docker-shell
```

### What's in the box

| File | Role |
| --- | --- |
| `docker/Dockerfile` | Toolchain image — Node 24 (CDK CLI shebang + esbuild) + Bun 1.3.11 (pinned to `packageManager`) + AWS CLI v2. Does **not** COPY the repo; source arrives via bind mount. |
| `docker/entrypoint.sh` | `bun install --frozen-lockfile --ignore-scripts`, then `exec "$@"`. Frozen so the bind-mounted `bun.lock` is never mutated and a stale lock fails loudly. |
| `docker-compose.yml` | Bind-mounts the repo at `/workspace` and `~/.aws` read-only; passes `AWS_*` / `ENV` through; keeps `node_modules` on named volumes so host binaries built for another OS never leak into the Linux container. |
| `.dockerignore` | Keeps the build context tiny (only `docker/entrypoint.sh` is COPYed). |
| `Makefile` | `deploy-docker` / `destroy-docker` / `docker-shell` / `docker-build` — pure `docker compose`, no `bun` on the host (that's the whole point). `DOCKER_COMPOSE ?= docker compose` allows Compose v1 override. |
| `README.md` | "Option C — deploy with only Docker". |

The container runs the **existing** make targets unchanged — `deploy-docker` is just
`docker compose run --rm tenkacloud make deploy ENV=$(ENV)`. No deploy logic is duplicated.

## Test plan

- New `infrastructure/test/scripts/docker-deploy.test.ts` (12 tests) pins the contract:
  the service builds from `docker/Dockerfile`, bind-mounts the repo, mounts `~/.aws`
  read-only, shadows `node_modules` with named volumes, passes AWS auth + `ENV` through;
  the Dockerfile bases on Node 24, pins Bun to `packageManager`, installs the AWS CLI;
  the Makefile targets are pure `docker compose` (no `bun`).
- `make harness` clean (only an `[info]` about un-synthed `cdk.out`).
- `make lint` (pre-existing warnings only) + `make typecheck` green across all workspaces.
- `docker compose config` renders correctly (`${HOME}/.aws` → host path, named volumes).
- A live `docker build` / deploy was not run here: the CI/sandbox has no Docker daemon
  socket, and an actual deploy is a real AWS side effect.

## Regression analysis

- **Additive only.** All new files plus a new Makefile section and a README subsection.
  No existing target, script, or stack is modified, so the normal `make deploy` (Lite) and
  `make deploy-saas` paths are untouched.
- The new `node_modules` named volumes are container-scoped; they cannot affect a host's
  local `node_modules` or an existing `make install`.
- `.dockerignore` only influences the image build context — it has no effect on git, CI,
  or any non-Docker workflow.
- Unrelated `package-source-bundle.test.ts` failures seen locally are environmental
  (`rsync` not installed in this sandbox); they are not touched by this change and pass in CI.

## Physical impact

- **NO-OP on AWS / CloudFormation.** This PR ships developer tooling only (Dockerfile,
  compose, Makefile targets, docs, a unit test). It provisions nothing.
- When `make deploy-docker` is eventually run, it produces the **identical** CloudFormation
  to `make deploy` — same stacks, same resources — because it invokes the same target inside
  the container. No new, replaced, or deleted cloud resources originate from this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click CloudFormation deployment option for simplified stack creation.
  * Added Docker-based deployment workflow, eliminating the need for local Bun, Node, or AWS CLI installation.
  * Added automated CI/CD pipeline for GitHub-integrated deployments with optional manual approval.

* **Documentation**
  * Updated deployment guides with multiple deployment path options and Docker setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->