### PR TITLE
refactor(problems): decouple template ref tests

### DIFF
--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -20,26 +20,45 @@ import {
  *
  * test 戦略:
  *   - 一時ディレクトリに problems/<category>/<id>/template.yaml を仕込んで script を回す
- *   - script は `problems/` 直下を絶対 path で見るため、 PROBLEMS_DIR を env で上書き...は本実装には
- *     無いので、 「 既存 problem template (= main repo の 5 個) を抜けるかどうか」 だけ smoke test
+ *   - PROBLEMS_DIR で fixture catalog を明示し、 live submodule / catalog の problem 数には依存しない
  */
 
 const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
 
 describe("check-template-cfn-refs script (#951 sub-2)", () => {
-  // Smoke test against the live problems/ catalog. The count grows with each
-  // new problem added; bump this assertion when adding a new template (so the
-  // test remains a regression boundary instead of a moving target).
-  // Current count: 112 (= the 7-template starter catalog plus the 105 AWS
-  // certification Challenges added in TenkaCloudChallenge #46).
-  it("all existing problem templates should pass (smoke test)", () => {
+  it("should scan only the configured problems directory", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "tc-cfn-refs-cli-"));
+    const problemsDir = join(fixtureRoot, "problems");
+    const problemDir = join(problemsDir, "challenges/test-problem");
+    mkdirSync(problemDir, { recursive: true });
+    writeFileSync(
+      join(problemDir, "template.yaml"),
+      `AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  NamePrefix:
+    Type: String
+Resources:
+  ParticipantViewerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "\${NamePrefix}-participant-viewer"
+Outputs:
+  ParticipantViewerRoleArn:
+    Value: !GetAtt ParticipantViewerRole.Arn
+`,
+    );
     const result = spawnSync("bun", ["run", "scripts/check-template-cfn-refs.ts"], {
       cwd: REPO_ROOT,
       encoding: "utf-8",
+      env: { ...process.env, PROBLEMS_DIR: problemsDir },
     });
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("OK:");
-    expect(result.stdout).toContain("112 template(s)");
+    try {
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("OK:");
+      expect(result.stdout).toContain("1 template(s)");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/check-template-cfn-refs.ts
+++ b/scripts/check-template-cfn-refs.ts
@@ -23,12 +23,15 @@
  * 任せる。
  */
 
-import { readFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
-const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+const DEFAULT_PROBLEMS_DIR = join(REPO_ROOT, "problems");
+const PROBLEMS_DIR = process.env.PROBLEMS_DIR
+  ? resolve(process.env.PROBLEMS_DIR)
+  : DEFAULT_PROBLEMS_DIR;
 
 interface Finding {
   readonly templatePath: string;
@@ -239,7 +242,7 @@ function checkUnresolvedGetAttResources(
 }
 
 export type { Finding };
-export { collectGetAttResources, collectRefs, collectSubRefs, parseSections };
+export { collectGetAttResources, collectRefs, collectSubRefs, findTemplates, parseSections };
 
 export function checkTemplate(templatePath: string): Finding[] {
   const yaml = readFileSync(templatePath, "utf8");
@@ -262,22 +265,21 @@ export function checkTemplate(templatePath: string): Finding[] {
   ];
 }
 
-function findTemplates(): string[] {
+function findTemplates(problemsDir: string = PROBLEMS_DIR): string[] {
   const out: string[] = [];
   const walk = (dir: string): void => {
-    const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
     for (const entry of readdirSync(dir)) {
       const full = join(dir, entry);
       if (statSync(full).isDirectory()) walk(full);
       else if (entry === "template.yaml" || entry === "template.yml") out.push(full);
     }
   };
-  walk(PROBLEMS_DIR);
+  walk(problemsDir);
   return out;
 }
 
 function main(): void {
-  const templates = findTemplates();
+  const templates = findTemplates(PROBLEMS_DIR);
   if (templates.length === 0) {
     console.log("No template.yaml found under problems/.");
     return;


### PR DESCRIPTION
## Summary

- Update the `problems` submodule pointer to the curated catalog that removes low-quality challenges and stale catalog references.
- Decouple `check-template-cfn-refs` CLI tests from the live `problems` catalog by adding a `PROBLEMS_DIR` override and testing against a fixture catalog.
- Remove the brittle fixed `112 template(s)` assertion so the root repo test no longer fails when the submodule catalog size changes.

## Root cause

The smoke test asserted the exact number of templates in the live `problems` submodule. That made a root repository test depend on the checkout state and contents of a separate catalog, so a valid catalog reduction made `make before-commit` fail even though the checker still behaved correctly.

## Test plan

- `make harness`
- `bun run test/run-vitest.ts run test/scripts/check-template-cfn-refs.test.ts`
- `make before-commit`
- commit hook reran the local pre-commit checks successfully

## Regression analysis

The CLI still scans the repository `problems/` directory by default, so existing `make check-template-cfn-refs` and `make before-commit` behavior is unchanged for normal usage. The new override is only used by tests and allows future fixture-based coverage without depending on the submodule catalog size.

## Physical impact

No runtime infrastructure or deployed application resources change in the root repo. The only physical content change is the `problems` submodule pointer moving to a catalog commit with fewer bundled problem templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for template validation with isolated test cases.

* **Refactor**
  * Modernized template discovery process with improved filesystem operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->