### PR TITLE
docs(pitch): add why now slides

### DIFF
--- a/landing/pitch/index.html
+++ b/landing/pitch/index.html
@@ -634,7 +634,7 @@
 </head>
 <body>
 <div class="progress" id="progress"></div>
-<div class="counter" id="counter">1 / 7</div>
+<div class="counter" id="counter">1 / 9</div>
 
 <main class="deck" id="deck">
   <section class="slide">
@@ -714,9 +714,27 @@
 
   <section class="slide">
     <div class="canvas">
+      <div class="story-slide">
+        <div class="topbar">
+          <div class="section-label"><span class="badge">04</span><span>Why Now</span></div>
+          <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
+        </div>
+        <h2>作れなかったのではない。大変すぎて、作ろうと思えなかった。</h2>
+        <div class="three-grid">
+          <div class="card info-card"><span class="kind">RESEARCH</span><h3>未知領域を調べる</h3><p>IAM、ネットワーク、API、IaC、セキュリティ、運用の差分を追う。</p></div>
+          <div class="card info-card"><span class="kind">ABSTRACT</span><h3>共通仕様にする</h3><p>クラウドごとの差分を、問題作者が扱える形に抽象化する。</p></div>
+          <div class="card info-card"><span class="kind">SHIP</span><h3>作り切る</h3><p>実装、テスト、ドキュメント化まで少人数で前に進める。</p></div>
+        </div>
+        <div class="bottom-line">生成AIは、エンジニアが挑戦できる問題の大きさを広げる。</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="slide">
+    <div class="canvas">
       <div class="host-slide">
         <div class="topbar">
-          <div class="section-label"><span class="badge">04</span><span>仕組み</span></div>
+          <div class="section-label"><span class="badge">05</span><span>仕組み</span></div>
           <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
         </div>
         <h2>問題を、採点付きの演習にする OSS。</h2>
@@ -751,7 +769,7 @@
     <div class="canvas">
       <div class="story-slide">
         <div class="topbar">
-          <div class="section-label"><span class="badge">05</span><span>なぜ TenkaCloud か</span></div>
+          <div class="section-label"><span class="badge">06</span><span>なぜ TenkaCloud か</span></div>
           <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
         </div>
         <h2>たぶん誰もやってくれない。だから自分たちでやった。</h2>
@@ -769,7 +787,7 @@
     <div class="canvas">
       <div class="scenario">
         <div class="topbar">
-          <div class="section-label"><span class="badge">06</span><span>オリジナル問題</span></div>
+          <div class="section-label"><span class="badge">07</span><span>旗艦シナリオ</span></div>
           <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
         </div>
         <div class="scenario-grid">
@@ -795,7 +813,25 @@
     <div class="canvas">
       <div class="story-slide">
         <div class="topbar">
-          <div class="section-label"><span class="badge">07</span><span>こんな人が作っています</span></div>
+          <div class="section-label"><span class="badge">08</span><span>BootCamp 検証</span></div>
+          <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
+        </div>
+        <h2>StackStackで、公開のラストワンマイルを検証する。</h2>
+        <div class="three-grid">
+          <div class="card info-card"><span class="kind">BLOCKER</span><h3>どこで詰まるか</h3><p>AIで作ったアプリは、実際にどこで公開できなくなるのか。</p></div>
+          <div class="card info-card"><span class="kind">GAME</span><h3>ゲームとして楽しいか</h3><p>認証、IAM、監査、可用性を90分の競技として楽しめるか。</p></div>
+          <div class="card info-card"><span class="kind">LEARN</span><h3>持ち帰れるか</h3><p>競技後に、自分のアプリへ学びを持ち帰れるか。</p></div>
+        </div>
+        <div class="bottom-line">皆さんの「公開できなかった体験」を、StackStackの問題にしたい。</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="slide">
+    <div class="canvas">
+      <div class="story-slide">
+        <div class="topbar">
+          <div class="section-label"><span class="badge">09</span><span>こんな人が作っています</span></div>
           <div class="wordmark"><img src="./assets/tenkacloud-icon.svg" alt="" />TenkaCloud</div>
         </div>
         <h2>三人とも Game Day が大好きなメンバーが作っています。</h2>


### PR DESCRIPTION
## Summary
- Adds the Why Now slide from the stronger AI-expanded engineering message: `作れなかったのではない。大変すぎて、作ろうと思えなかった。`
- Adds a BootCamp validation slide that positions StackStack as the scenario for testing the publication last mile.
- Keeps the weaker GameDay-internalization slide out, leaving the deck at 9 slides instead of 10.

Closes #1731

## Regression analysis
This is a static pitch deck update. The main risk is slide overflow or muddy story order. I verified the rendered deck locally at `http://127.0.0.1:4173/`: 9 slides, counter `1 / 9`, all canvases reported no horizontal or vertical overflow, and the TenkaCloud icon loaded.

## Physical impact
No runtime, backend, infrastructure, CDK, IAM, deployment, or problem catalog changes are included. Only `landing/pitch/index.html` changes.

## Test plan
- `make harness` -> passed (`harness: no findings.`)
- `make before-commit` -> passed
- Browser layout check -> passed; 9 slides, no canvas overflow
- `git diff --cached --check` -> passed

## Notes
There are unrelated local unstaged documentation changes in the worktree (`AGENTS.md`, `README.md`, and generated architecture docs). They are intentionally excluded from this PR.