### PR TITLE
fix(pitch): デッキを画面いっぱいに表示（フルスクリーン・フィット）

### DIFF
--- a/landing/pitch/index.html
+++ b/landing/pitch/index.html
@@ -44,14 +44,17 @@
     min-height:100vh;
     display:grid;
     place-items:center;
-    padding:22px;
+    padding:0;
+    overflow:hidden;
     scroll-snap-align:start;
   }
 
   .canvas {
     position:relative;
-    width:min(96vw,1180px);
-    aspect-ratio:16 / 9;
+    width:1280px;
+    height:720px;
+    transform:scale(var(--fit,1));
+    transform-origin:center center;
     overflow:hidden;
     padding:34px 42px 32px;
     background:
@@ -478,12 +481,12 @@
   }
 
   @media (max-width:760px) {
-    .slide { padding:10px; }
+    .slide { padding:10px; overflow:visible; }
     .canvas {
       width:calc(100vw - 20px);
       min-height:calc(100vh - 20px);
       height:auto;
-      aspect-ratio:auto;
+      transform:none;
       overflow:visible;
       padding:18px;
     }
@@ -508,7 +511,7 @@
     body { background:#fff; }
     .deck { height:auto; overflow:visible; }
     .slide { height:100vh; min-height:auto; padding:0; page-break-after:always; break-after:page; }
-    .canvas { width:100vw; height:100vh; border:0; box-shadow:none; }
+    .canvas { width:100vw; height:100vh; transform:none; border:0; box-shadow:none; }
     .progress,.counter { display:none; }
   }
 </style>
@@ -848,6 +851,12 @@
       else if (event.key === "Home") { event.preventDefault(); go(0); }
       else if (event.key === "End") { event.preventDefault(); go(slides.length - 1); }
     });
+    function fit(){
+      var s = Math.min(window.innerWidth / 1280, window.innerHeight / 720) * 0.99;
+      document.documentElement.style.setProperty("--fit", String(s));
+    }
+    window.addEventListener("resize", fit, { passive:true });
+    fit();
     paint();
   })();
 


### PR DESCRIPTION
## 背景
16:9 キャンバスが `min(96vw, 1180px)` で頭打ちになっており、大型ディスプレイで周囲にグレーの余白が大きく出ていた（登壇時に画面を埋められない）。

## 変更
- キャンバスを **固定デザインサイズ 1280×720** にし、`transform: scale(var(--fit))` で拡大縮小。
- JS で `--fit = min(innerWidth/1280, innerHeight/720) * 0.99` を load/resize 時に設定 → **フォントごと等倍で画面いっぱいにフィット**。
- モバイル / 印刷では transform を無効化（従来のフルイド / ページサイズ）。

## 効果
- 任意の画面サイズで 16:9 のまま最大表示。プロジェクタでも余白最小。
- 既存のレイアウト・ライブ採点デモ・QR はそのまま（内部は固定 1280×720 基準で不変）。

## 確認
`open landing/pitch/index.html` → `⌃⌘F`（または `--kiosk`）。↓/Space で送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)