### PR TITLE
fix(lite): resolve region from AWS env vars in source bundle prep

### DIFF
--- a/infrastructure/test/scripts/prepare-source-bundle.test.ts
+++ b/infrastructure/test/scripts/prepare-source-bundle.test.ts
@@ -1,0 +1,113 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const PREPARE_SCRIPT = resolve(__dirname, "..", "..", "..", "scripts", "prepare-source-bundle.sh");
+
+const tempDirs: string[] = [];
+
+/**
+ * Drop a fake `aws` on PATH so the resolution logic runs with no real credentials.
+ * It mimics CodeBuild: `aws configure get region` exits non-zero (no config file)
+ * unless FAKE_AWS_CONFIGURE_REGION is provided; `aws sts get-caller-identity`
+ * returns FAKE_AWS_ACCOUNT_ID.
+ */
+function fakeAwsBinDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "tenkacloud-fake-aws-"));
+  tempDirs.push(dir);
+  const aws = join(dir, "aws");
+  // Brace-less $VAR refs (not ${VAR}) keep this bash readable to biome's
+  // noTemplateCurlyInString rule while behaving identically for an unset var.
+  writeFileSync(
+    aws,
+    [
+      "#!/usr/bin/env bash",
+      'if [ "$1" = "configure" ] && [ "$2" = "get" ] && [ "$3" = "region" ]; then',
+      '  if [ -n "$FAKE_AWS_CONFIGURE_REGION" ]; then',
+      '    echo "$FAKE_AWS_CONFIGURE_REGION"; exit 0',
+      "  fi",
+      "  exit 1", // CodeBuild: no config file -> empty + non-zero
+      "fi",
+      'if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then',
+      '  if [ -n "$FAKE_AWS_ACCOUNT_ID" ]; then echo "$FAKE_AWS_ACCOUNT_ID"; exit 0; fi',
+      "  exit 1",
+      "fi",
+      'echo "unexpected aws call: $*" >&2',
+      "exit 99",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(aws, 0o755);
+  return dir;
+}
+
+function resolveBundleEnv(env: Record<string, string>): ReturnType<typeof spawnSync> {
+  const binDir = fakeAwsBinDir();
+  return spawnSync("bash", [PREPARE_SCRIPT], {
+    encoding: "utf8",
+    env: {
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY: "1",
+      // Treat empty as unset (the script uses ${VAR:-...}); each test sets what it needs.
+      REGION: "",
+      AWS_REGION: "",
+      AWS_DEFAULT_REGION: "",
+      FAKE_AWS_ACCOUNT_ID: "111122223333",
+      ...env,
+    },
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("scripts/prepare-source-bundle.sh region resolution", () => {
+  it("should resolve region from AWS_REGION when no aws config profile exists", () => {
+    // Reproduces the CodeBuild Lite-deploy failure: AWS_REGION is injected by the
+    // build environment but `aws configure get region` has no config file.
+    const result = resolveBundleEnv({ AWS_REGION: "ap-northeast-1" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("REGION=ap-northeast-1");
+    expect(result.stdout).toContain("ACCOUNT_ID=111122223333");
+    expect(result.stdout).toContain(
+      "CDK_PARAM_S3_BUCKET_NAME=tenkacloud-source-111122223333-ap-northeast-1",
+    );
+  });
+
+  it("should fall back to AWS_DEFAULT_REGION when AWS_REGION is unset", () => {
+    const result = resolveBundleEnv({ AWS_DEFAULT_REGION: "us-east-1" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("REGION=us-east-1");
+  });
+
+  it("should prefer an explicit REGION override over the AWS env vars", () => {
+    const result = resolveBundleEnv({
+      REGION: "eu-west-1",
+      AWS_REGION: "ap-northeast-1",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("REGION=eu-west-1");
+  });
+
+  it("should still honor the local aws configure profile when no env region is set", () => {
+    const result = resolveBundleEnv({ FAKE_AWS_CONFIGURE_REGION: "ap-southeast-2" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("REGION=ap-southeast-2");
+  });
+
+  it("should fail with a clear error when region cannot be resolved at all", () => {
+    const result = resolveBundleEnv({});
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("REGION / ACCOUNT_ID を解決できません");
+  });
+});

--- a/scripts/prepare-source-bundle.sh
+++ b/scripts/prepare-source-bundle.sh
@@ -21,16 +21,33 @@
 #   - `<bucket>/source.zip` を upload
 set -euo pipefail
 
-REGION=${REGION:-$(aws configure get region)}
-ACCOUNT_ID=${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}
+# Region resolution order: explicit REGION override → the standard AWS SDK env vars
+# (CodeBuild / Lambda / ECS all inject AWS_REGION + AWS_DEFAULT_REGION) → the local
+# `aws configure` profile. `aws configure get region` exits non-zero when there is no
+# config file (= the case in CodeBuild), so it must be guarded with `|| true`; left
+# bare it aborts this `set -e` script before the explicit error check below — which is
+# exactly how Lite mode `make deploy` failed in the CodeBuild pipeline.
+REGION="${REGION:-${AWS_REGION:-${AWS_DEFAULT_REGION:-}}}"
+if [ -z "${REGION}" ]; then
+  REGION="$(aws configure get region || true)"
+fi
+ACCOUNT_ID="${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text || true)}"
 
 if [ -z "${REGION}" ] || [ -z "${ACCOUNT_ID}" ]; then
-  echo "ERROR: REGION / ACCOUNT_ID を解決できません。 AWS CLI が configure 済か、 env 変数を export してください。"
+  echo "ERROR: REGION / ACCOUNT_ID を解決できません。 AWS_REGION / AWS_DEFAULT_REGION を export するか、 aws CLI を configure してください。"
   exit 1
 fi
 
 export CDK_PARAM_S3_BUCKET_NAME="${CDK_PARAM_S3_BUCKET_NAME:-tenkacloud-source-${ACCOUNT_ID}-${REGION}}"
 export CDK_SOURCE_NAME="${CDK_SOURCE_NAME:-source.zip}"
+
+# Resolve-only seam: stop after env resolution so the resolution contract can be
+# unit-tested without any AWS mutation (= infrastructure/test/scripts/prepare-source-bundle.test.ts).
+if [ -n "${PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY:-}" ]; then
+  printf 'REGION=%s\nACCOUNT_ID=%s\nCDK_PARAM_S3_BUCKET_NAME=%s\nCDK_SOURCE_NAME=%s\n' \
+    "${REGION}" "${ACCOUNT_ID}" "${CDK_PARAM_S3_BUCKET_NAME}" "${CDK_SOURCE_NAME}"
+  exit 0
+fi
 
 # repo root を決定 (= 本 script は repo の scripts/ 配下)。 bucket lifecycle JSON を参照するため、
 # bucket 作成 block より前に解決しておく。


### PR DESCRIPTION
## Summary

Fixes the Lite-mode `make deploy` failure in the **`tenkacloud-lite-development`** CodeBuild pipeline. The build failed at step **[1/3] prepare source bundle** with `prepare-source-bundle.sh failed with exit code 1` and no preceding output, which aborted the whole pipeline (steps 2/3 cdk deploy and 3/3 never ran).

### Root cause

`scripts/prepare-source-bundle.sh` resolved the AWS region only from `aws configure get region`. CodeBuild has no `~/.aws/config`, so that command prints nothing **and exits non-zero**. Under `set -euo pipefail` the bare command substitution aborts the script *before its first log line* — exactly matching the build log:

```
[lite] [1/3] preparing source bundle (= S3 bucket + source.zip)...
[lite] prepare-source-bundle.sh failed with exit code 1
```

CodeBuild *does* provide the region via the standard `AWS_REGION` / `AWS_DEFAULT_REGION` env vars (the buildspec even exports `AWS_REGION`), but the script ignored them.

### Fix

Resolve region in this order, and guard the profile lookup so it can never silently abort under `set -e`:

```
REGION override  ->  AWS_REGION  ->  AWS_DEFAULT_REGION  ->  aws configure get region (|| true)
```

If everything is empty, the explicit "cannot resolve" error now reports clearly instead of the script dying mid-resolution. Local SaaS-mode (`install.sh`, which sources this script) is unchanged — it still picks up the configured profile, since the env vars are simply unset there.

Adds a `PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY` seam and a vitest suite that drives the real script with a fake `aws` mimicking CodeBuild (no config file), covering AWS_REGION / AWS_DEFAULT_REGION / explicit-override / configure-profile / unresolvable paths.

## Test plan

- `bunx vitest run test/scripts/prepare-source-bundle.test.ts` → 5/5 pass
- Full script/install/source-bundle suites → 275/275 pass (no regression in SaaS install or packaging)
- Bidirectional repro with a fake `aws` (CodeBuild condition: `AWS_REGION` set, `aws configure get region` exit 1):
  - **old** logic → `REGION` empty → guard exit 1 (the failure)
  - **new** logic → `REGION=ap-northeast-1` → exit 0
- `make harness` → no findings; `biome check` → clean; `tsc --noEmit` → clean
- Next pipeline run validates steps 2/3 → 3/3 end-to-end (build never reached them before)

## Regression analysis

- Behavioral change is confined to region resolution in one deploy helper. The new chain is a strict superset of the old (adds two higher-priority env sources and a non-fatal fallback), so any environment that worked before still resolves the same region.
- `install.sh` (SaaS mode) sources this script and sets no region var → falls through to `aws configure get region` exactly as before. Covered by the existing `install-script.test.ts` (still green).
- `|| true` on the profile lookup only prevents an abort; the downstream `[ -z "$REGION" ]` guard still fails loudly when region is genuinely unresolvable (covered by a test).
- The resolve-only seam is gated behind an env var that no production path sets, so it cannot alter real deploys.

## Physical impact

**NO-OP** on synthesized infrastructure. No CloudFormation template, Lambda, or CDK construct changes — the diff is a shell deploy-helper and a new test file. The fix lets `cdk deploy` (CREATE/UPDATE of the existing Lite stacks) proceed; it does not itself add/replace/delete any AWS resource.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration mode that resolves and displays values without performing mutations.

* **Bug Fixes**
  * Strengthened region resolution with environment variable fallback mechanisms.
  * Improved tolerance of AWS CLI failures.

* **Tests**
  * Added test suite covering region resolution behavior across various environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->