### PR TITLE
fix(lite): scope source-bundle lifecycle expansion to its own config

### DIFF
--- a/infrastructure/test/scripts/print-source-bundle-lifecycle.test.ts
+++ b/infrastructure/test/scripts/print-source-bundle-lifecycle.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(__dirname, "..", "..", "..", "scripts", "print-source-bundle-lifecycle.ts");
+
+/**
+ * Run the emit script with a deterministic env. SYSTEM_ADMIN_EMAIL and the
+ * sourceBundle overrides are stripped first so the result does not depend on the
+ * developer's shell — `overrides` then sets exactly what each test needs.
+ */
+function runLifecycle(overrides: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.SYSTEM_ADMIN_EMAIL;
+  delete env.SOURCE_BUNDLE_KEEP_VERSIONS;
+  delete env.SOURCE_BUNDLE_EXPIRE_DAYS;
+  return spawnSync("bun", ["run", SCRIPT, "development"], {
+    encoding: "utf8",
+    env: { ...env, ...overrides },
+  });
+}
+
+describe("scripts/print-source-bundle-lifecycle.ts", () => {
+  it("should emit a policy in Lite mode without SYSTEM_ADMIN_EMAIL set", () => {
+    // Reproduces the CodeBuild Lite-deploy failure: the buildspec injects
+    // TENANT_ADMIN_EMAIL but not SYSTEM_ADMIN_EMAIL, and config.json's
+    // controlPlaneConfig.systemAdminEmail = ${SYSTEM_ADMIN_EMAIL} (no default).
+    // The lifecycle policy must not depend on that SaaS-only field.
+    const result = runLifecycle();
+
+    expect(result.status, result.stderr).toBe(0);
+    const policy = JSON.parse(result.stdout);
+    expect(policy.Rules[0].NoncurrentVersionExpiration.NewerNoncurrentVersions).toBe(5);
+    expect(policy.Rules[0].NoncurrentVersionExpiration.NoncurrentDays).toBe(1);
+    expect(result.stderr).not.toContain("SYSTEM_ADMIN_EMAIL");
+  });
+
+  it("should honor sourceBundleConfig env overrides", () => {
+    const result = runLifecycle({
+      SOURCE_BUNDLE_KEEP_VERSIONS: "9",
+      SOURCE_BUNDLE_EXPIRE_DAYS: "4",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const policy = JSON.parse(result.stdout);
+    expect(policy.Rules[0].NoncurrentVersionExpiration.NewerNoncurrentVersions).toBe(9);
+    expect(policy.Rules[0].NoncurrentVersionExpiration.NoncurrentDays).toBe(4);
+  });
+});

--- a/scripts/print-source-bundle-lifecycle.ts
+++ b/scripts/print-source-bundle-lifecycle.ts
@@ -30,16 +30,32 @@ const configPath = path.resolve(
 );
 
 const content = readFileSync(configPath, "utf-8");
-const expanded = content.replace(/\$\{([^}]+)\}/g, (_, expression: string) => {
-  const [rawVarName, ...defaultParts] = expression.split(":-");
-  const varName = rawVarName.trim();
-  const defaultValue = defaultParts.length > 0 ? defaultParts.join(":-") : undefined;
-  const value = process.env[varName];
-  if (value !== undefined && value !== "") return JSON.stringify(value).slice(1, -1);
-  if (defaultValue !== undefined) return JSON.stringify(defaultValue).slice(1, -1);
-  throw new Error(`Environment variable ${varName} is not defined and no default provided`);
-});
 
-const config = JSON.parse(expanded) as { sourceBundleConfig?: SourceBundleConfig };
-const policy = buildSourceBundleLifecyclePolicy(config.sourceBundleConfig);
+// Expand ${VAR:-default} placeholders, but ONLY within the sourceBundleConfig
+// subtree. The rest of config.json carries placeholders that are irrelevant to
+// the lifecycle policy and unset in Lite mode — e.g. controlPlaneConfig.
+// systemAdminEmail = ${SYSTEM_ADMIN_EMAIL} (no default), which only SaaS mode
+// sets. Expanding the whole file would throw on those and break Lite `make
+// deploy`. The raw placeholders are valid JSON string values, so parse first,
+// then expand only the slice we actually consume.
+function expandPlaceholders(raw: string): string {
+  return raw.replace(/\$\{([^}]+)\}/g, (_, expression: string) => {
+    const [rawVarName, ...defaultParts] = expression.split(":-");
+    const varName = rawVarName.trim();
+    const defaultValue = defaultParts.length > 0 ? defaultParts.join(":-") : undefined;
+    const value = process.env[varName];
+    if (value !== undefined && value !== "") return JSON.stringify(value).slice(1, -1);
+    if (defaultValue !== undefined) return JSON.stringify(defaultValue).slice(1, -1);
+    throw new Error(`Environment variable ${varName} is not defined and no default provided`);
+  });
+}
+
+const rawConfig = JSON.parse(content) as { sourceBundleConfig?: SourceBundleConfig };
+const sourceBundleConfig =
+  rawConfig.sourceBundleConfig === undefined
+    ? undefined
+    : (JSON.parse(
+        expandPlaceholders(JSON.stringify(rawConfig.sourceBundleConfig)),
+      ) as SourceBundleConfig);
+const policy = buildSourceBundleLifecyclePolicy(sourceBundleConfig);
 console.log(JSON.stringify(policy));


### PR DESCRIPTION
## Summary

Second fix for the **`tenkacloud-lite-development`** CodeBuild pipeline. With the region fix (#1742) merged, the Lite-mode `make deploy` got past region resolution and submodule checkout, then failed later in step **[1/3] prepare-source-bundle.sh** at the lifecycle-policy stage:

```
error: Environment variable SYSTEM_ADMIN_EMAIL is not defined and no default provided
  at scripts/print-source-bundle-lifecycle.ts
```

### Root cause

`print-source-bundle-lifecycle.ts` read the **entire** `config.json` and expanded **every** `${VAR}` placeholder — including `controlPlaneConfig.systemAdminEmail = ${SYSTEM_ADMIN_EMAIL}` (no default). That field is **SaaS-only**:

- `environments/development/.env.example` documents that Lite mode (`make deploy`) needs only `TENANT_ADMIN_EMAIL`; `SYSTEM_ADMIN_EMAIL` is not required.
- The Lite CDK app (`bin/tenkacloud-lite.ts`) loads config via `resolveAppConfig`, which uses `config-loader` with `tolerant: true` — unset placeholders without defaults are left as literals, never thrown. The Lite app never reads `systemAdminEmail`.

So the only thing in the Lite path that strict-expanded `config.json` was this lifecycle emit script. Local Lite deploys "worked" only because a developer `.env` carries `SYSTEM_ADMIN_EMAIL`; the pipeline injects only `TENANT_ADMIN_EMAIL`, which exposed the latent over-reach. **This was correctly diagnosed as a pipeline-exposed bug** — the right fix is to stop the lifecycle script from depending on a field it doesn't consume, not to inject a SaaS-only var into the Lite pipeline.

### Fix

Parse `config.json` first (raw placeholders are valid JSON string values), then expand placeholders **only within the `sourceBundleConfig` subtree**, which carries its own defaults (`${SOURCE_BUNDLE_KEEP_VERSIONS:-5}` / `${SOURCE_BUNDLE_EXPIRE_DAYS:-1}`). The lifecycle policy no longer references any field outside its own config.

Adds a script-level vitest suite running the real script with `SYSTEM_ADMIN_EMAIL` unset (the pipeline condition) and asserting it emits a valid policy, plus an override case.

## Test plan

- `bunx vitest run test/scripts/print-source-bundle-lifecycle.test.ts` → 2/2 pass
- Full source-bundle + scripts suites → green (262 tests)
- Direct repro of the fix:
  - `env -u SYSTEM_ADMIN_EMAIL bun run scripts/print-source-bundle-lifecycle.ts development` → emits policy JSON, exit 0 (was: throw)
  - same with `SYSTEM_ADMIN_EMAIL` set → identical output (no regression)
- `make harness` → no findings; `biome check` → clean; `tsc --noEmit` → clean
- Confirmed step 2/3 (cdk) tolerates unset `SYSTEM_ADMIN_EMAIL` (`config-loader` `tolerant: true`), so the deploy proceeds past prepare into cdk deploy after this lands.

## Regression analysis

- Change is confined to `print-source-bundle-lifecycle.ts`, which only ever consumed `sourceBundleConfig`. Output for any input that previously succeeded is byte-identical (verified with `SYSTEM_ADMIN_EMAIL` set/unset).
- **SaaS is unaffected**: the ControlPlane's `systemAdminEmail` is resolved through `resolveAppConfig`/`config-loader`, a separate path that still expands `${SYSTEM_ADMIN_EMAIL}` from the SaaS `.env`. This PR does not touch that path or `config.json`.
- If `sourceBundleConfig` is absent, the script passes `undefined` to the builder exactly as before (covered by the existing `buildSourceBundleLifecyclePolicy(undefined)` test).

## Physical impact

**NO-OP** on synthesized infrastructure. The diff is a build-time helper script plus a test. No CloudFormation/Lambda/CDK construct changes; no AWS resource CREATE/UPDATE/REPLACE/DELETE. The fix unblocks `prepare-source-bundle.sh` so the existing Lite stacks can deploy.
