### PR TITLE
fix(lite): derive system admin email from tenant admin for cdk deploy

### DIFF
--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -477,4 +477,74 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
       }
     });
   });
+
+  // The shared CDK app (bin/tenkacloud-lite.ts -> resolveAppConfig ->
+  // requireSystemAdminEmail) requires CDK_PARAM_SYSTEM_ADMIN_EMAIL. Lite mode must
+  // derive it from the tenant admin email so `make deploy` works with only
+  // TENANT_ADMIN_EMAIL set; otherwise cdk deploy throws "Please provide system
+  // admin email" (the CodeBuild Lite-pipeline failure).
+  describe("up should wire CDK_PARAM_SYSTEM_ADMIN_EMAIL for cdk deploy", () => {
+    const original = {
+      tenant: process.env.TENANT_ADMIN_EMAIL,
+      system: process.env.SYSTEM_ADMIN_EMAIL,
+      cdkSystem: process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL,
+    };
+
+    function restore(): void {
+      const entries: ReadonlyArray<readonly [string, string | undefined]> = [
+        ["TENANT_ADMIN_EMAIL", original.tenant],
+        ["SYSTEM_ADMIN_EMAIL", original.system],
+        ["CDK_PARAM_SYSTEM_ADMIN_EMAIL", original.cdkSystem],
+      ];
+      for (const [key, value] of entries) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+
+    function captureSystemEmailAtCdkSpawn(): {
+      readonly io: CliIO;
+      seen: () => string | undefined;
+    } {
+      let seenAtCdk: string | undefined;
+      const { io } = buildIO({
+        inheritExitCode: 0,
+        capture: tenantAdminUpCapture({ adminGetUserCode: 0 }),
+      });
+      const wrapped: CliIO = {
+        ...io,
+        spawnInherit: async (cmd, args) => {
+          if (cmd.includes("cdk")) seenAtCdk = process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL;
+          return io.spawnInherit(cmd, args);
+        },
+      };
+      return { io: wrapped, seen: () => seenAtCdk };
+    }
+
+    it("should derive it from TENANT_ADMIN_EMAIL when unset", async () => {
+      process.env.TENANT_ADMIN_EMAIL = "organizer@example.com";
+      delete process.env.SYSTEM_ADMIN_EMAIL;
+      delete process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL;
+      try {
+        const { io, seen } = captureSystemEmailAtCdkSpawn();
+        const code = await main(["up"], io);
+        expect(code).toBe(0);
+        expect(seen()).toBe("organizer@example.com");
+      } finally {
+        restore();
+      }
+    });
+
+    it("should not override an explicit CDK_PARAM_SYSTEM_ADMIN_EMAIL (SaaS-shared env)", async () => {
+      process.env.TENANT_ADMIN_EMAIL = "organizer@example.com";
+      process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL = "sysadmin@example.com";
+      try {
+        const { io, seen } = captureSystemEmailAtCdkSpawn();
+        await main(["up"], io);
+        expect(seen()).toBe("sysadmin@example.com");
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -146,6 +146,15 @@ async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
     );
   }
 
+  // Lite mode has no SBT Control Plane / system admin, but the shared CDK app
+  // (bin/tenkacloud-lite.ts → resolveAppConfig → requireSystemAdminEmail) still
+  // requires CDK_PARAM_SYSTEM_ADMIN_EMAIL. Derive it from the Lite tenant admin
+  // email so `make deploy` works with only TENANT_ADMIN_EMAIL set (the pipeline /
+  // Lite .env case). Never override an explicit value (SaaS-shared env).
+  if (tenantAdminEmail && !process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL) {
+    process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL = tenantAdminEmail;
+  }
+
   // Issue #1345: 30-min first-run UX — 各 phase を「[i/N] ...」 で示す。
   const totalSteps = 3;
   io.stdout(`\n[lite] [1/${totalSteps}] preparing source bundle (= S3 bucket + source.zip)...\n`);


### PR DESCRIPTION
## Summary

Third and (expected) final fix for the **`tenkacloud-lite-development`** CodeBuild pipeline. With the region (#1742) and lifecycle (#1744) fixes merged, Lite `make deploy` now clears **step [1/3]** entirely (submodule checkout, bucket, apps build, `source.zip` upload) and reaches **step [2/3] cdk deploy**, which fails:

```
Error: Please provide system admin email
  at requireSystemAdminEmail (lib/app-config/resolve.ts:143)
  at resolveAppConfig (resolve.ts:52)
  at bin/tenkacloud-lite.ts:31
```

### Root cause (exactly the SYSTEM_ADMIN_EMAIL ↔ TenantAdminEmail issue raised in review)

`resolveAppConfig` — shared by SaaS and Lite — calls `requireSystemAdminEmail`, which reads `CDK_PARAM_SYSTEM_ADMIN_EMAIL` and throws if empty. Lite mode has **no** SBT Control Plane / system admin: it is documented to need only `TENANT_ADMIN_EMAIL` (`environments/development/.env.example`), and the pipeline buildspec injects only that.

`scripts/tenkacloud-lite.ts` `cmdUp` already resolves the organizer email (`TENANT_ADMIN_EMAIL`, falling back to `SYSTEM_ADMIN_EMAIL`) — but only used it *after* deploy for `admin-create-user`. It never passed it to the cdk child, so synth threw. Local Lite deploys "worked" only because a developer `.env` carries `SYSTEM_ADMIN_EMAIL`; the clean pipeline env exposed it.

### Fix

In `cmdUp`, set `CDK_PARAM_SYSTEM_ADMIN_EMAIL` from the resolved tenant admin email **before spawning cdk**, without overriding an explicit value (SaaS-shared env). The cdk child inherits `process.env`, so `requireSystemAdminEmail` resolves. **No `infrastructure/lib` change** — the existing contract is satisfied purely from the scripts/orchestration layer.

## Test plan

- `bunx vitest run test/scripts/tenkacloud-lite.test.ts` → 25/25 pass, including two new cases:
  - derives `CDK_PARAM_SYSTEM_ADMIN_EMAIL` from `TENANT_ADMIN_EMAIL` (captured at cdk-spawn time)
  - does **not** override an explicit `CDK_PARAM_SYSTEM_ADMIN_EMAIL`
- `make harness` → no findings; `biome check` → clean; `tsc --noEmit` → clean

## Regression analysis

- Change is one orchestration script (`scripts/tenkacloud-lite.ts`). It only *adds* an env var when absent; it never overrides an explicit `CDK_PARAM_SYSTEM_ADMIN_EMAIL`, so SaaS (`make deploy-saas` / `install.sh`, which provides the real system admin email) is byte-for-byte unaffected — verified by the no-override test.
- When neither `TENANT_ADMIN_EMAIL` nor `SYSTEM_ADMIN_EMAIL` is set, behavior is unchanged (the pre-existing warning path; cdk still requires an email).
- No `infrastructure/lib` / CDK construct edits, so synthesized templates are identical for any input that previously synthesized.

## Physical impact

**NO-OP** on synthesized infrastructure. The diff is one deploy-orchestration script plus tests; it sets a CDK context env var that feeds `systemAdminEmail` into the same AppConfig the deploy already used. No new/changed/removed AWS resources — it unblocks `cdk deploy` of the existing Lite stacks (AppPlaneCore + ProblemDeploy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lite mode deployments now automatically use tenant admin email for system configuration when not explicitly set separately, simplifying deployment setup.

* **Tests**
  * Added validation tests for email configuration handling during deployment to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->