### PR TITLE
docs: fix cross-doc inconsistencies found in a full audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ We don't use a single-table DynamoDB design. Each stack owns its own tables (Ten
 | `make synth`            | `cdk synth` (defaults to `ENV=development`)                              |
 | `make diff`             | `cdk diff --all`                                                         |
 | `make bootstrap`        | `cdk bootstrap`                                                          |
-| `make deploy`           | **Lite mode** (single-tenant) deploy. Stands up AppPlaneCore + Participant Portal via `bin/tenkacloud-lite.ts` (#955) |
+| `make deploy`           | **Lite mode** (single-tenant) deploy. Stands up AppPlaneCore + Participant Portal via `infrastructure/bin/tenkacloud-lite.ts` (#955) |
 | `make deploy-saas`      | **SaaS mode** (multi-tenant) deploy. Runs `scripts/install.sh` (3-phase deploy, stands up SBT ControlPlane) |
 | `make destroy`          | Tear down Lite mode (`make lite-down`)                                   |
 | `make destroy-saas`     | Tear down SaaS mode (`scripts/cleanup.sh` idempotently removes every stack + S3) |
@@ -218,7 +218,7 @@ Add packages to `trustedDependencies` in a stand-alone PR. Manually verify the s
 
 ### Lite mode (default, `make deploy`)
 
-Issue #955 switched the default for `make deploy` to single-tenant Lite mode. It skips the SBT ControlPlane / tenant pipeline / SystemAdmin invitation entirely and deploys just two stacks via `bin/tenkacloud-lite.ts`: AppPlaneCore (`tenantId="local"`) + ProblemDeployBackend (Participant Portal). It is the shortest path for "one organizer running one event" (about 10 minutes). Teardown is `make destroy` (`make lite-down`).
+Issue #955 switched the default for `make deploy` to single-tenant Lite mode. It skips the SBT ControlPlane / tenant pipeline / SystemAdmin invitation entirely and deploys just two stacks via `infrastructure/bin/tenkacloud-lite.ts`: AppPlaneCore (`tenantId="local"`) + ProblemDeployBackend (Participant Portal). It is the shortest path for "one organizer running one event" (about 10 minutes). Teardown is `make destroy` (`make lite-down`).
 
 ### SaaS mode (opt-in, `make deploy-saas`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,12 @@ Contributions to TenkaCloud are welcome.
 git clone --recurse-submodules https://github.com/<your-username>/TenkaCloud.git
 cd TenkaCloud
 make install
-make start
+make build   # verify the toolchain compiles
 ```
+
+To run a single SPA locally, start its dev server from the app directory, e.g.
+`cd apps/application-admin-console && make dev`. To deploy into AWS, follow the
+[Quickstart](./README.md#quickstart).
 
 ## Where to start (under 15 minutes)
 

--- a/README.md
+++ b/README.md
@@ -209,13 +209,14 @@ catalog PR merges.
 
 ## Architecture
 
-TenkaCloud has three planes:
+TenkaCloud has four planes that talk through an EventBridge bus:
 
 | Plane | What it owns |
 | --- | --- |
 | **Control Plane** | SaaS tenant onboarding, pooled / silo tenant routing, and SBT integration |
-| **Application Plane** | Tenant Admin Console, Participant Portal, Cognito, runtime config, and per-tenant app data |
+| **Application Plane** | Tenant Admin Console, Cognito, runtime config, and per-tenant app data |
 | **Problem Deploy Backend** | Cross-account problem deploy jobs, state machines, worker Lambdas, audit, and EventBridge reconciliation |
+| **Participant Portal** | Per-team UI: problem endpoints, hints, submissions, scores, and AWS Console federation |
 
 ![TenkaCloud Lite demo flow](./docs/assets/tenkacloud-lite-demo.svg)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,53 @@
 # Security Policy
 
-## Supported Versions
+TenkaCloud is a self-hostable, Apache-2.0 platform. It is deployed from source
+(there are no published version artifacts), so security fixes land on `main`.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+## Supported versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| --- | --- |
+| `main` (latest) | ✅ |
+| Older commits / forks | Update to the latest `main` |
 
-## Reporting a Vulnerability
+Self-hosters should track `main` and redeploy to pick up fixes. Dependencies are
+kept current by Renovate / Dependabot, and CI scans for malicious packages
+(Aikido Safe Chain) on every install.
 
-Use this section to tell people how to report a vulnerability.
+## Reporting a vulnerability
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through GitHub's
+**[Report a vulnerability](https://github.com/susumutomita/TenkaCloud/security/advisories/new)**
+(Security → Advisories → Report a vulnerability) on this repository. Include:
+
+- the affected component (file path or endpoint),
+- reproduction steps or a proof of concept,
+- the impact (what an attacker can do), and
+- any suggested remediation.
+
+We aim to acknowledge a report within a few days and to keep you updated as we
+triage, fix, and — when appropriate — publish an advisory. Reporters are credited
+on request.
+
+## Scope
+
+**In scope:** the platform code (`apps/*`, `infrastructure/*`, `scripts/*`,
+`packages/*`) and the deploy / federation / scoring paths.
+
+**Out of scope — intentional by design:** competition problem templates under
+`problems/` (for example `security-battle-royale`) deliberately ship vulnerable
+applications so competitors can attack and defend them. A vulnerability *inside a
+problem's training scenario is a feature, not a bug*. Please report only issues
+that let a problem escape its isolated competitor account or that affect the
+platform itself.
+
+## Hardening and posture
+
+- [`docs/security/README.md`](./docs/security/README.md) — security baseline for paid events.
+- [`docs/security/HARDENING-CHECKLIST.html`](./docs/security/HARDENING-CHECKLIST.html) — hardening checklist.
+- Cross-account `AssumeRole` into competitor accounts always requires `ExternalId`,
+  and the competitor IAM role is least-privilege. Auth is Cognito JWT throughout
+  (no bypasses). See [CLAUDE.md](./CLAUDE.md) ("Security") for the full list.
+</content>

--- a/docs/architecture/GLOSSARY.html
+++ b/docs/architecture/GLOSSARY.html
@@ -198,7 +198,7 @@
 <hr>
 <h2>Plugin (problem-as-plugin)</h2>
 <p>The architectural pattern from ADR-012: a problem ships <strong>content + UI slot + scoring metadata</strong> to a generic platform host. The platform doesn&#39;t know what <code>microservice-migration-battle</code> <em>is</em>; it only knows how to read its <code>metadata.json</code>, deploy its <code>template.yaml</code>, mount its <code>portal/&lt;slot&gt;.tsx</code> into the participant portal, and poll its endpoints per the metadata.</p>
-<p>Three-asset model (+ optional fourth): <code>metadata.json</code> (required) + <code>template.yaml</code> (required) + <code>README.md</code> / <code>README.en.md</code> (required) + <code>portal/</code> (optional UI) + <code>services/</code> (optional in-stack code).</p>
+<p>Three-asset model (+ optional fourth): <code>metadata.json</code> (required) + <code>template.yaml</code> (required) + <code>README.md</code> (English, primary) / <code>README.ja.md</code> (Japanese mirror) (required) + <code>portal/</code> (optional UI) + <code>services/</code> (optional in-stack code).</p>
 <hr>
 <h2>Pooled vs Silo</h2>
 <p>The two SaaS tenant isolation models, both supported in SaaS mode.</p>

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -163,7 +163,7 @@ The baseline policy must restrict `Resource: "*"` to either a tag-based Conditio
 
 The architectural pattern from ADR-012: a problem ships **content + UI slot + scoring metadata** to a generic platform host. The platform doesn't know what `microservice-migration-battle` *is*; it only knows how to read its `metadata.json`, deploy its `template.yaml`, mount its `portal/<slot>.tsx` into the participant portal, and poll its endpoints per the metadata.
 
-Three-asset model (+ optional fourth): `metadata.json` (required) + `template.yaml` (required) + `README.md` / `README.en.md` (required) + `portal/` (optional UI) + `services/` (optional in-stack code).
+Three-asset model (+ optional fourth): `metadata.json` (required) + `template.yaml` (required) + `README.md` (English, primary) / `README.ja.md` (Japanese mirror) (required) + `portal/` (optional UI) + `services/` (optional in-stack code).
 
 ---
 

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -78,7 +78,7 @@ problem directories; others are deliberately scoped as starter ideas.</p>
 </tr>
 <tr>
 <td><a href="../problems/battles/security-battle-royale/">Security Battle Royale</a></td>
-<td>3</td>
+<td>4</td>
 <td>Battle</td>
 <td><code>uptime-multi</code></td>
 <td>Web security hardening and attacker/defender exercises</td>
@@ -123,7 +123,7 @@ points every minute.</li>
 <h3>Security Battle Royale</h3>
 <ul>
 <li><strong>Concept</strong>: attack and defend a deliberately vulnerable web application.</li>
-<li><strong>Difficulty</strong>: 3 / 5.</li>
+<li><strong>Difficulty</strong>: 4 / 5.</li>
 <li><strong>Category</strong>: Battle.</li>
 <li><strong>Learning goals</strong>: SQL injection, remote code execution, SSRF, IMDS exposure,
 and safe remediation.</li>

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -12,7 +12,7 @@ problem directories; others are deliberately scoped as starter ideas.
 | --- | --- | --- | --- | --- |
 | [Hello World](../problems/challenges/hello-world/) | 1 | Challenge | `flag` | First deploy, scoring sanity check, author onboarding |
 | [Hello World Battle](../problems/battles/hello-world-battle/) | 1 | Battle | uptime | First uptime battle, AWS Systems Manager practice |
-| [Security Battle Royale](../problems/battles/security-battle-royale/) | 3 | Battle | `uptime-multi` | Web security hardening and attacker/defender exercises |
+| [Security Battle Royale](../problems/battles/security-battle-royale/) | 4 | Battle | `uptime-multi` | Web security hardening and attacker/defender exercises |
 | [Microservice Migration Battle](../problems/battles/microservice-migration-battle/) | 4 | Battle | `phased-polling` | Platform modernization and migration planning |
 | [StackStack](../problems/battles/stackstack/) | 4 | Battle | `phased-polling` | Platform-team operations for AI-generated internal apps |
 
@@ -42,7 +42,7 @@ problem directories; others are deliberately scoped as starter ideas.
 ### Security Battle Royale
 
 - **Concept**: attack and defend a deliberately vulnerable web application.
-- **Difficulty**: 3 / 5.
+- **Difficulty**: 4 / 5.
 - **Category**: Battle.
 - **Learning goals**: SQL injection, remote code execution, SSRF, IMDS exposure,
   and safe remediation.

--- a/docs/runbooks/pre-event-checklist.html
+++ b/docs/runbooks/pre-event-checklist.html
@@ -84,7 +84,7 @@
 <li><input disabled="" type="checkbox"> AWS account chosen for the event has at least one IAM admin user available to the operator on call.</li>
 <li><input disabled="" type="checkbox"> <code>infrastructure/environments/&lt;env&gt;/.env</code> exists and <code>make env-check-lite</code> (Lite mode) or <code>make env-check</code> (SaaS mode) returns no error.</li>
 <li><input disabled="" type="checkbox"> Billing alarm is configured for the event AWS account with a threshold appropriate for the planned problem catalog (a single Lite-mode event typically stays under the AWS Free Tier 25 RCU/WCU window enforced by the <code>DynamoDbLowCapacity</code> aspect, but per-team CFn stacks add cost).</li>
-<li><input disabled="" type="checkbox"> Source bundle bucket exists (run <code>make prepare-source-bundle</code> once if not).</li>
+<li><input disabled="" type="checkbox"> Source bundle bucket exists (<code>make deploy</code> creates it automatically; to pre-create it, run <code>bash scripts/prepare-source-bundle.sh</code>).</li>
 </ul>
 <h3>Deploy mode decision</h3>
 <ul>

--- a/docs/runbooks/pre-event-checklist.ja.html
+++ b/docs/runbooks/pre-event-checklist.ja.html
@@ -84,7 +84,7 @@
 <li><input disabled="" type="checkbox"> イベントに使う AWS アカウントに、 オペレータがオンコール中に呼べる IAM Admin ユーザーが少なくとも 1 名いること。</li>
 <li><input disabled="" type="checkbox"> <code>infrastructure/environments/&lt;env&gt;/.env</code> が存在し、 <code>make env-check-lite</code> (Lite mode) または <code>make env-check</code> (SaaS mode) がエラーを返さないこと。</li>
 <li><input disabled="" type="checkbox"> 想定 problem catalog に応じた閾値の billing alarm をイベント AWS アカウントに設定済み。 Lite mode の単発イベントは <code>DynamoDbLowCapacity</code> aspect が強制する AWS Free Tier 25 RCU/WCU 枠に概ね収まるが、 チーム別 CFn スタックは別途コストが発生する。</li>
-<li><input disabled="" type="checkbox"> Source bundle 用 S3 バケットが存在すること (= 未作成なら <code>make prepare-source-bundle</code> を 1 度実行)。</li>
+<li><input disabled="" type="checkbox"> Source bundle 用 S3 バケットが存在すること (= <code>make deploy</code> が自動作成する。 事前作成するなら <code>bash scripts/prepare-source-bundle.sh</code>)。</li>
 </ul>
 <h3>Deploy モードの決定</h3>
 <ul>

--- a/docs/runbooks/pre-event-checklist.ja.md
+++ b/docs/runbooks/pre-event-checklist.ja.md
@@ -20,7 +20,7 @@
 - [ ] イベントに使う AWS アカウントに、 オペレータがオンコール中に呼べる IAM Admin ユーザーが少なくとも 1 名いること。
 - [ ] `infrastructure/environments/<env>/.env` が存在し、 `make env-check-lite` (Lite mode) または `make env-check` (SaaS mode) がエラーを返さないこと。
 - [ ] 想定 problem catalog に応じた閾値の billing alarm をイベント AWS アカウントに設定済み。 Lite mode の単発イベントは `DynamoDbLowCapacity` aspect が強制する AWS Free Tier 25 RCU/WCU 枠に概ね収まるが、 チーム別 CFn スタックは別途コストが発生する。
-- [ ] Source bundle 用 S3 バケットが存在すること (= 未作成なら `make prepare-source-bundle` を 1 度実行)。
+- [ ] Source bundle 用 S3 バケットが存在すること (= `make deploy` が自動作成する。 事前作成するなら `bash scripts/prepare-source-bundle.sh`)。
 
 ### Deploy モードの決定
 

--- a/docs/runbooks/pre-event-checklist.md
+++ b/docs/runbooks/pre-event-checklist.md
@@ -20,7 +20,7 @@ The checklist is split into three sessions because some items (budget alarm prov
 - [ ] AWS account chosen for the event has at least one IAM admin user available to the operator on call.
 - [ ] `infrastructure/environments/<env>/.env` exists and `make env-check-lite` (Lite mode) or `make env-check` (SaaS mode) returns no error.
 - [ ] Billing alarm is configured for the event AWS account with a threshold appropriate for the planned problem catalog (a single Lite-mode event typically stays under the AWS Free Tier 25 RCU/WCU window enforced by the `DynamoDbLowCapacity` aspect, but per-team CFn stacks add cost).
-- [ ] Source bundle bucket exists (run `make prepare-source-bundle` once if not).
+- [ ] Source bundle bucket exists (`make deploy` creates it automatically; to pre-create it, run `bash scripts/prepare-source-bundle.sh`).
 
 ### Deploy mode decision
 

--- a/docs/security/HARDENING-CHECKLIST.html
+++ b/docs/security/HARDENING-CHECKLIST.html
@@ -333,7 +333,7 @@
       <td class="area" rowspan="5">4<br>Data</td>
       <td><span class="item-id">DAT-01</span></td>
       <td>Secrets go to SSM Parameter Store SecureString; Secrets Manager is forbidden</td>
-      <td class="evidence">Harness enforcement rule <code>secrets-manager-forbidden</code> — <code>docs/architecture/harness.md</code>. Implementation in <code>.claude/harness/src/architecture.ts</code>. Rationale: Free Tier alignment + reduces blast radius vs. centralized secret manager.</td>
+      <td class="evidence">Harness enforcement rule <code>secrets-manager-forbidden</code> — <code>docs/architecture/harness.md</code>. Implementation under <code>.claude/harness/src/rules/</code>. Rationale: Free Tier alignment + reduces blast radius vs. centralized secret manager.</td>
       <td>Agent / Reviewer</td>
       <td><span class="badge ok">Implemented</span></td>
     </tr>


### PR DESCRIPTION
## Summary

A full documentation audit (root + architecture + runbooks + operations + problems + marketing/demos — ~68 markdown files plus HTML mirrors, run as five parallel passes) found the usual "locally optimized" drift: docs updated in isolation that no longer agree with each other or the code. This PR fixes the **verified, in-scope** issues; ADR/architecture-owned items are listed at the bottom for you to decide.

### Fixed

| File | Was | Now |
| --- | --- | --- |
| `README.md` | "TenkaCloud has **three** planes" (lists 3) | **four** planes — adds **Participant Portal**, matching the canonical `OVERVIEW.md` / `CONTRIBUTING.md` / `lite-mode-prereqs.md` |
| `CLAUDE.md` (×2) | `` `bin/tenkacloud-lite.ts` `` | `` `infrastructure/bin/tenkacloud-lite.ts` `` (real path; `AGENTS.md` already used it) |
| `CONTRIBUTING.md` | `make start` (no such target) | `make build` + per-app `cd apps/<app> && make dev` (the actual dev-server path) |
| `docs/runbooks/pre-event-checklist.md` (+ `.ja`) | `make prepare-source-bundle` (no such target) | `make deploy` creates the bucket; pre-create with `bash scripts/prepare-source-bundle.sh` |
| `docs/architecture/GLOSSARY.md` | problem asset `README.en.md` | `README.md` (English) / `README.ja.md` (Japanese) — the real convention |
| `docs/gallery.md` | security-battle-royale difficulty **3** | **4** (matches `metadata.json` + `EXAMPLES.md`) |
| `docs/security/HARDENING-CHECKLIST.html` | harness rule in `.claude/harness/src/architecture.ts` | `.claude/harness/src/rules/` (no `src/architecture.ts` exists) |
| `SECURITY.md` | **unmodified GitHub boilerplate** (fake `5.1.x`/`4.0.x` versions, "Use this section to tell people…") | a real policy: private GitHub advisory reporting, supported = latest `main`, and the key caveat that `problems/` templates are **intentionally vulnerable** (out of scope) |

HTML mirrors regenerated via `build-docs`.

### Verified consistent across all docs (no change needed)

Catalog = 6 problems (4 Battle + 2 Challenge + 1 bundle); 5 scoring kinds; SBT 0.3.9 / Bun 1.3.11 / Node 24 / React 19 / Vite 7 / CDK 2; `make deploy`=Lite, `make deploy-saas`=SaaS; stacks `tenkacloud-lite` + `tenkacloud-lite-problem-deploy`; dev ports 5173/5174/5175; i18n ja+en only; harness entry/rule paths; no lingering GameDay/JAM/Unicorn.Rentals.

### Flagged but NOT changed (ADR / architecture — your call)

- **`adr-007-outside-in.html:288`** references the wrong harness path `.claude/harness/src/architecture.ts` (same error fixed elsewhere). Left it because ADRs are self-contained, owner-edited.
- **Missing `adr-008`**: referenced in prose by `OVERVIEW.md:107` and `GLOSSARY.md:39 & :223`, but no `adr-008-*.html` file exists (ADR numbering jumps 007→009). Either write a stub ADR-008 or rephrase the references.
- **Duplicate ADR-029**: two files both titled ADR-029 — `adr-029-attack-resilience-game-always-ends.html` and `adr-029-attack-resilience-liveness.html`. One should be renumbered.

## Test plan

- `markdownlint-cli2` on changed markdown → 0 errors
- `textlint` → exit 0
- `bun run scripts/build-docs.ts --check` → in sync
- `make harness` → no findings

## Regression analysis

Documentation-only. No source, config, template, or build input changes. The only generated artifacts are the regenerated HTML mirrors (`build-docs`), which are in sync with their `.md` sources, so CI's `check-docs` gate stays green. The SECURITY.md rewrite replaces placeholder text with an accurate policy — no behavior change.

## Physical impact

**NO-OP.** Markdown docs and their generated HTML mirrors only. No CloudFormation / Lambda / artifact changes; no AWS resource CREATE/UPDATE/REPLACE/DELETE.
