### PR TITLE
fix(security): const-time flag compare + plugin digest gate + rate-limit docs

### DIFF
--- a/docs/security/HARDENING-CHECKLIST.html
+++ b/docs/security/HARDENING-CHECKLIST.html
@@ -393,9 +393,9 @@
     <tr>
       <td><span class="item-id">PRT-02</span></td>
       <td>Flag submission rate-limited (defends against brute-force / hint anti-skip)</td>
-      <td class="evidence"><code>WRITE_VERY_LOW</code> (3 burst / 6 RPM &asymp; 1 attempt per 10s sustained) on submit-flag route. Token bucket — <code>infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts</code>. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/870">#870</a> brought this from 17,000 attempts/day down to 8,640. Related to i18n hint anti-skip (<a href="https://github.com/susumutomita/TenkaCloud/issues/1108">#1108</a>).</td>
+      <td class="evidence"><code>WRITE_VERY_LOW</code> (3 burst / 6 RPM &asymp; 1 attempt per 10s sustained) on submit-flag route. Token bucket — <code>infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts</code>. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/870">#870</a> brought this from 17,000 attempts/day down to 8,640. <strong>Limitation:</strong> the bucket is <em>per Lambda instance</em> (in-memory) and the participant Function URL pins no <code>reservedConcurrency</code>, so a burst that scales to N warm instances multiplies the effective per-team limit by &asymp;N (best-effort soft wall, not a hard cross-instance guarantee). Real brute-force resistance comes from the 32-char random flag keyspace + the competition gate; a DDB/atomic limiter is the path to a hard distributed cap. Related to i18n hint anti-skip (<a href="https://github.com/susumutomita/TenkaCloud/issues/1108">#1108</a>).</td>
       <td>Agent</td>
-      <td><span class="badge ok">Implemented</span></td>
+      <td><span class="badge gap">Soft</span></td>
     </tr>
     <tr>
       <td><span class="item-id">PRT-03</span></td>
@@ -407,7 +407,7 @@
     <tr>
       <td><span class="item-id">PRT-04</span></td>
       <td>Bearer token has short lifetime + replay defense</td>
-      <td class="evidence">Token issued by <code>participant-handler</code> with a server-side expiry. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/767">#767</a> traces the in-memory rate limiter design that makes warm-instance DoS infeasible.</td>
+      <td class="evidence">Token issued by <code>participant-handler</code> with a server-side expiry. Issue <a href="https://github.com/susumutomita/TenkaCloud/issues/767">#767</a> traces the in-memory rate limiter design. Note: that limiter is per-instance and bypassable under Lambda concurrency (see PRT-02) — it is a soft wall, not a warm-instance DoS guarantee.</td>
       <td>Agent</td>
       <td><span class="badge ok">Implemented</span></td>
     </tr>

--- a/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer.ts
+++ b/infrastructure/lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,10 +21,34 @@ import type { PluginImporter } from "../participant-handler/coordination-plugin-
 export interface S3PluginImporterDeps {
   readonly s3: Pick<S3Client, "send">;
   readonly bucket: string;
+  /**
+   * 整合性 seam (ADR-039 の artifact-digest 方針を plugin load に流用)。 `import()` する前に
+   * download した bundle bytes の digest を期待値と照合する。
+   *   - `sha256:<hex>` を返す → 検証する。 不一致なら throw (= loader が plugin_unavailable に
+   *     fail-closed)。 plugin bucket / publish 経路が改ざんされても任意コード実行を遮断する。
+   *   - `undefined` を返す → 当該 module は未 pin として検証を skip (= resolver が per-module 判断)。
+   *   - hook 自体を渡さない → 検証なし (後方互換: 既存挙動を変えない)。
+   * 期待 digest の供給元 (= 署名付き manifest) の配線は publish パイプライン側の follow-up。
+   */
+  readonly resolveExpectedDigest?: (
+    moduleRef: string,
+  ) => string | undefined | Promise<string | undefined>;
 }
 
 export function coordinationPluginS3Key(moduleRef: string): string {
   return `coordination/${moduleRef}.mjs`;
+}
+
+/** bundle bytes の `sha256:<hex>` digest。 ADR-039 の artifact digest と同形式。 */
+export function pluginBundleDigest(body: string): string {
+  return `sha256:${createHash("sha256").update(body, "utf8").digest("hex")}`;
+}
+
+function digestsEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
 }
 
 /** 本番用 factory: 既定 S3Client を構築して importer を返す (= handler から SDK を直接触らせない seam)。 */
@@ -50,9 +75,31 @@ async function loadFromS3(deps: S3PluginImporterDeps, moduleRef: string): Promis
   );
   const body = await out.Body?.transformToString();
   if (!body) throw new Error(`coordination plugin not found or empty: ${moduleRef}`);
+  // import() する前に整合性を検証する (= 改ざんされた bytes を実行しない fail-closed gate)。
+  await verifyDigestIfConfigured(deps, moduleRef, body);
   // /tmp に書き出して file URL で dynamic import (ESM)。 unique dir で他 ref と衝突させない。
   const dir = await mkdtemp(join(tmpdir(), "coord-plugin-"));
   const file = join(dir, `${moduleRef}.mjs`);
   await writeFile(file, body, "utf8");
   return import(pathToFileURL(file).href);
+}
+
+/**
+ * resolver が設定されていれば、 download した bytes の digest を期待値と照合する。
+ * 不一致は throw (= import 前に止める)。 resolver 未設定 / undefined 返却は検証 skip。
+ */
+async function verifyDigestIfConfigured(
+  deps: S3PluginImporterDeps,
+  moduleRef: string,
+  body: string,
+): Promise<void> {
+  if (!deps.resolveExpectedDigest) return;
+  const expected = await deps.resolveExpectedDigest(moduleRef);
+  if (expected === undefined) return;
+  const actual = pluginBundleDigest(body);
+  if (!digestsEqual(actual, expected)) {
+    throw new Error(
+      `coordination plugin digest mismatch for ${moduleRef}: expected ${expected}, got ${actual}`,
+    );
+  }
 }

--- a/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/kinds/flag.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { KindHandlerInput, KindResult } from "../shared.js";
 import { noopKindResult } from "../shared.js";
 
@@ -13,9 +14,18 @@ import { noopKindResult } from "../shared.js";
  * dedup する。
  */
 
-/** 競技者 input と stack output 値を比較。両端 trim、case-sensitive。 */
+/**
+ * 競技者 input と stack output 値を比較。両端 trim、case-sensitive。
+ *
+ * 比較は定数時間で行う: 両値を SHA-256 で固定長 digest にしてから `timingSafeEqual`
+ * する。 素の `===` は先頭不一致で短絡し、 応答時間に「一致 prefix 長」が漏れる
+ * timing oracle になる (= flag を 1 文字ずつ探れる)。 digest 化で入力長も隠れる。
+ * packages/trust-bridge の digest 照合と同方針。
+ */
 export function flagMatches(submitted: string, expected: string): boolean {
-  return submitted.trim() === expected.trim();
+  const submittedDigest = createHash("sha256").update(submitted.trim(), "utf8").digest();
+  const expectedDigest = createHash("sha256").update(expected.trim(), "utf8").digest();
+  return timingSafeEqual(submittedDigest, expectedDigest);
 }
 
 export function runFlagKind(_input: KindHandlerInput): KindResult {

--- a/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
+++ b/infrastructure/lib/problem-deploy/handlers/shared/rate-limiter.ts
@@ -3,11 +3,17 @@
  *
  * Free Tier 制約 (= DDB 1/1 PROVISIONED) で DDB 経由の sliding window を入れると
  * 1 request あたり 1 RCU + 1 WCU 消費し、 25 RCU/WCU quota を 25 RPS で食い切る。
- * Lambda の reservedConcurrency = 1 を前提に、 **同 Lambda instance 内の in-memory
- * token bucket** で代替する。 同時実行が増えた場合は warm Lambda instance ごとに
- * 別 bucket になるが、 「同 team が同 instance を連打した場合」の DoS を確実に塞ぐ
- * (= shared backend 劣化を防ぐ最低限の壁)。 厳密な distributed limit が必要に
- * なったら DDB token bucket に差し替える設計余地は残す。
+ * その代替として **同 Lambda instance 内の in-memory token bucket** を使う。
+ *
+ * 重要 (security 上の限界): これは **best-effort の per-instance 壁** であり、
+ * **cross-instance のハード保証ではない**。 participant Lambda は公開 Function URL
+ * (`authType: NONE`) で `reservedConcurrentExecutions` を pin していないため、 burst で
+ * warm instance が N 個に scale すると各 instance が満タンの bucket を持ち、 同一
+ * `(team, route)` の実効上限は **約 N 倍** になる (= concurrency で bypass 可能)。
+ * `reservedConcurrency = 1` は本質的な修正ではない (全 team を 1 instance に直列化し
+ * 自滅 DoS になる)。 したがって本 limiter は「単一 instance 連打の DoS を緩める soft wall」
+ * と位置づけ、 brute-force に対する実防御は **巨大な flag 鍵空間 + 競技 gate (start/end/lock)**
+ * に依存する。 ハードな分散制限が要るなら DDB / atomic counter ベースに差し替える。
  */
 
 export interface RateLimitConfig {

--- a/infrastructure/test/problem-deploy/generic-scoring-flag.test.ts
+++ b/infrastructure/test/problem-deploy/generic-scoring-flag.test.ts
@@ -51,4 +51,21 @@ describe("flagMatches (shared helper、 submit-flag と共有)", () => {
   it("should distinguish spaces in the middle", () => {
     expect(flagMatches("hello world", "hello  world")).toBe(false);
   });
+
+  it("should match a realistic per-deploy TC{...} flag exactly", () => {
+    const flag = "TC{a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6}";
+    expect(flagMatches(flag, flag)).toBe(true);
+    expect(flagMatches(`  ${flag}\n`, flag)).toBe(true);
+  });
+
+  it("should reject a near-miss that differs only in the last character (constant-time)", () => {
+    expect(
+      flagMatches("TC{a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6}", "TC{a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P7}"),
+    ).toBe(false);
+  });
+
+  it("should not treat empty input as a match for a non-empty flag", () => {
+    expect(flagMatches("", "TC{secret}")).toBe(false);
+    expect(flagMatches("   ", "TC{secret}")).toBe(false);
+  });
 });

--- a/infrastructure/test/problem-deploy/s3-plugin-importer.test.ts
+++ b/infrastructure/test/problem-deploy/s3-plugin-importer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   coordinationPluginS3Key,
   createS3PluginImporter,
+  pluginBundleDigest,
 } from "../../lib/problem-deploy/handlers/coordination-dispatcher-handler/s3-plugin-importer";
 import { loadCoordinationPlugin } from "../../lib/problem-deploy/handlers/participant-handler/coordination-plugin-loader";
 
@@ -60,5 +61,55 @@ describe("createS3PluginImporter", () => {
     const s3 = mockS3(undefined);
     const importer = createS3PluginImporter({ s3, bucket: "B" });
     await expect(importer("p1")).rejects.toThrow(/not found or empty/);
+  });
+});
+
+describe("createS3PluginImporter digest integrity (ADR-039 流用)", () => {
+  it("should compute a sha256:<hex> digest of the bundle bytes", () => {
+    expect(pluginBundleDigest(PLUGIN_JS)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(pluginBundleDigest(PLUGIN_JS)).toBe(pluginBundleDigest(PLUGIN_JS));
+    expect(pluginBundleDigest(PLUGIN_JS)).not.toBe(pluginBundleDigest(`${PLUGIN_JS}// tampered`));
+  });
+
+  it("should import when the resolved expected digest matches", async () => {
+    const s3 = mockS3(PLUGIN_JS);
+    const importer = createS3PluginImporter({
+      s3,
+      bucket: "B",
+      resolveExpectedDigest: () => pluginBundleDigest(PLUGIN_JS),
+    });
+    const plugin = await loadCoordinationPlugin(importer, "ms-battle");
+    expect(plugin).not.toBeNull();
+  });
+
+  it("should fail closed (throw, no import) when the digest does not match the bytes", async () => {
+    // S3 bucket / publish 経路の改ざんを模す: 期待 digest と download bytes が食い違う。
+    const tamperedBody = `${PLUGIN_JS}globalThis.__pwned = true;\n`;
+    const s3 = mockS3(tamperedBody);
+    const importer = createS3PluginImporter({
+      s3,
+      bucket: "B",
+      resolveExpectedDigest: () => pluginBundleDigest(PLUGIN_JS),
+    });
+    await expect(importer("ms-battle")).rejects.toThrow(/digest mismatch/);
+    // loader 経由なら fail-closed で null (= plugin_unavailable)。
+    const s3b = mockS3(tamperedBody);
+    const importerB = createS3PluginImporter({
+      s3: s3b,
+      bucket: "B",
+      resolveExpectedDigest: () => pluginBundleDigest(PLUGIN_JS),
+    });
+    expect(await loadCoordinationPlugin(importerB, "ms-battle")).toBeNull();
+  });
+
+  it("should skip verification when the resolver returns undefined (module not pinned)", async () => {
+    const s3 = mockS3(PLUGIN_JS);
+    const importer = createS3PluginImporter({
+      s3,
+      bucket: "B",
+      resolveExpectedDigest: () => undefined,
+    });
+    const plugin = await loadCoordinationPlugin(importer, "ms-battle");
+    expect(plugin).not.toBeNull();
   });
 });


### PR DESCRIPTION
An authorized security audit of our own code surfaced three issues. This PR fixes the two application-layer ones and corrects an overstated security claim for the third (the fix for which is infra — left to the owner per the role split).

## 1 — Flag comparison timing oracle *(Low → fixed)*
`flagMatches` compared with `submitted.trim() === expected.trim()`. String `===` short-circuits at the first differing byte, so response time leaks the matching-prefix length (a per-character oracle), and the secret's length leaks too. Replaced with **SHA-256 → `timingSafeEqual`** over fixed-length digests — the same constant-time approach used in `packages/trust-bridge`. Trim + case-sensitive semantics are unchanged.

## 2 — Plugin loader imported bytes without integrity verification *(Medium / supply-chain → fixed, opt-in)*
`s3-plugin-importer.ts` downloads `coordination/<id>.mjs` and `import()`s it — **ESM top-level code runs immediately**, before the structural check, with no sandbox and **no digest check**. ADR-030 limits the blast radius (minimal IAM + reviewed bundle), so this is not a remote competitor RCE, but a compromise of the plugin bucket or publish path would run arbitrary code in the dispatcher Lambda. Added an opt-in `resolveExpectedDigest` seam (ADR-039's `sha256:<hex>` artifact-digest format) that verifies the bytes **before** `import()` and **fails closed** on mismatch (loader → `plugin_unavailable`). No hook = unchanged behavior, so this is backward compatible; wiring the signed manifest that supplies the expected digest is a publish-pipeline follow-up.

## 3 — Rate limiter overstated as a hard guarantee *(Medium / availability → doc correction; infra fix deferred)*
The participant token-bucket limiter is **in-memory per Lambda instance**, and the public Function URL (`authType: NONE`) pins **no `reservedConcurrency`**. Under a burst that scales to N warm instances, each gets a fresh bucket, so the per-`(team, route)` limit multiplies by ~N.

PoC against the repo's actual limiter:
```
Single warm instance:    3 allowed (cap = 3)
50 concurrent instances: 150 allowed for the SAME team|route   → 50x bypass
```
Corrected the `rate-limiter.ts` docstring and `HARDENING-CHECKLIST` PRT-02/PRT-04 to label it a **best-effort soft wall**, not a cross-instance guarantee (real brute-force resistance comes from the 32-char flag keyspace + competition gate). The actual remedy — a DDB/atomic distributed limiter, or accepting the soft wall — is a CDK/infra decision left to the owner (`reservedConcurrency=1` is not viable: it self-DoSes all teams through one instance).

## What I checked and found already solid (no change)
`auth.ts` (format-gates the token before any DDB read), `submit-flag.ts` (team scope resolved from the key, no IDOR; atomic anti-double-score; competition gate), `event-report/exporters/html.ts` (every interpolated field escaped — no stored XSS). No `eval`/`new Function`; no `child_process` in request handlers.

## Test plan
- `bunx vitest run` on flag / s3-plugin-importer / rate-limiter / submit-flag / coordination-plugin-loader → **61 passed**. New cases: near-miss/empty-input flag compares; digest match/mismatch (fail-closed)/unpinned-skip for the importer.
- `tsc --noEmit` clean; Biome clean; `make harness` clean (no error-level findings).

## Regression analysis
- `flagMatches`: identical truth table to `===` (SHA-256 is collision-resistant; equal trimmed inputs → equal digests). All existing flag/submit-flag tests still pass.
- Plugin importer: the digest path only runs when a caller passes `resolveExpectedDigest`; the production `defaultS3PluginImporter` passes none, so live coordination loading is unchanged.
- Rate limiter: **doc/comment only**, zero behavior change.

## Physical impact
- All changes are application code + docs — **NO-OP** on CloudFormation. No CDK stack, IAM, Lambda config, or DynamoDB capacity is touched; `cdk synth` output is unchanged. (`flag.ts` and `s3-plugin-importer.ts` are bundled into existing Lambdas, but their deployed behavior is unchanged absent the new opt-in hook.)

Relates #1353

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUf19cuyJW9VgBoWNHpF6e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bundle integrity verification for coordination plugins with SHA-256 digest validation.

* **Security Enhancements**
  * Implemented timing-attack resistant flag comparison.
  * Enhanced security documentation clarifying rate limiting controls and their per-instance soft wall limitations.

* **Tests**
  * Expanded test coverage for flag matching and plugin bundle digest verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->