### PR TITLE
feat(adr-039): production parts + CDK for customer-execution mode

### DIFF
--- a/docs/architecture/adr-039-customer-execution-plane.html
+++ b/docs/architecture/adr-039-customer-execution-plane.html
@@ -62,7 +62,7 @@
   <h1>ADR-039: Customer Execution Plane — keep privileged deploy authority inside the customer boundary</h1>
   <p><em>The hosted control plane sends a signed, digest-bound <code>CloudActionIntent</code>; a customer-controlled execution plane validates it against local policy and deploys with authority the hosted plane can never obtain. A signed signature is authenticity, not authorization.</em></p>
   <div class="meta">
-    <div><b>Status:</b><span class="badge accept">Accepted</span> 2026-06-09 — design + library + PoC shipped; production agent phased</div>
+    <div><b>Status:</b><span class="badge accept">Accepted</span> 2026-06-09 — design + library + production parts (DDB nonce store, local CFn executor, policy/inspector, orchestrator, SQS Lambda CDK) shipped; control-plane integration phased</div>
     <div><b>Extends:</b> <a href="adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a></div>
     <div><b>Builds on:</b> <a href="adr-002-cross-account-federation.html">ADR-002</a>, <a href="adr-009-cross-account-federation.html">ADR-009</a></div>
     <div><b>Issue:</b> #1727</div>
@@ -245,9 +245,10 @@ action.artifact?: {
 <h2>7. Coexistence &amp; migration</h2>
 
 <ol>
-  <li><strong>Now (this ADR):</strong> protocol extension + PoC + library. The central CodeBuild path is unchanged and remains the default.</li>
-  <li><strong>Next:</strong> a registered, authenticated customer execution component (outbound pull / EventBridge API Destinations) reporting results back into <code>Deployments</code>; per-tenant/per-account mode selection.</li>
-  <li><strong>Later:</strong> KMS asymmetric signing keys (per-tenant), DDB-backed nonce store (1/1 PROVISIONED), agent upgrade flow that cannot silently widen policy, and incremental child issues for the production agent.</li>
+  <li><strong>Done — protocol + library + PoC:</strong> the <code>CloudActionIntent</code> extension, the <code>CustomerExecutionPlane</code> validation core, and the offline PoC.</li>
+  <li><strong>Done — production parts (shipped):</strong> a DDB-backed nonce store (<code>DdbNonceStore</code>, conditional <code>PutItem</code> + TTL on a 1/1 PROVISIONED table), a local CloudFormation executor (<code>CloudFormationExecutor</code>, create-or-update / delete via a same-account CFn service role — no AssumeRole back to the control plane), reusable <code>PolicyEvaluator</code> / <code>ArtifactInspector</code> implementations (<code>local-policy.ts</code>), and an end-to-end orchestrator (<code>CustomerExecutionAgent</code>) that audits every decision. A <code>CustomerExecutionPlaneStack</code> CDK construct wires an SQS-driven Lambda in the customer account; its IAM has no <code>sts:AssumeRole</code> into any control-plane role (asserted in the stack test). All library parts hold 100% coverage.</li>
+  <li><strong>Next:</strong> register/authenticate the customer execution component end-to-end, report results back into the <code>Deployments</code> state model, and per-tenant / per-account mode selection from the control plane.</li>
+  <li><strong>Later:</strong> KMS asymmetric signing keys (per-tenant) replacing the HS256 shared secret, a signed plugin/artifact manifest, an artifact store for templates above the inline CFn limit, and an agent upgrade flow that cannot silently widen policy.</li>
 </ol>
 
 <p>Delete operations must remain possible if the hosted control plane is unavailable: the execution plane can run a locally-initiated <code>destroy</code> against its own approved problems, so teardown never depends on the hosted plane being reachable.</p>

--- a/infrastructure/lib/customer-execution/customer-execution-plane-stack.ts
+++ b/infrastructure/lib/customer-execution/customer-execution-plane-stack.ts
@@ -1,0 +1,146 @@
+import * as path from "node:path";
+import { Duration, RemovalPolicy, Stack, type StackProps } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import {
+  Effect,
+  ManagedPolicy,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { Architecture } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import type { Construct } from "constructs";
+import { LAMBDA_NODEJS_RUNTIME } from "../utils/lambda-runtime.js";
+
+/**
+ * Issue #1727 / ADR-039 §7: customer-execution mode の CDK 配線。
+ *
+ * **customer 側のアカウントに** deploy する独立 stack。 hosted control plane が署名した
+ * CloudActionIntent を SQS で受け、 ローカル CFn 権限で deploy/destroy する。
+ *
+ * ADR-039 の核心: ここに作る IAM の中に **control plane を trust する経路は無い**。
+ * deploy 権限は customer 所有の CFn service role に閉じ、 hosted control plane からは
+ * 構造的に到達できない (= control plane を侵害しても、 この権限は奪えない)。
+ */
+export interface CustomerExecutionPlaneStackProps extends StackProps {
+  /** この plane の識別子 (= intent.audience と一致させる)。 */
+  readonly planeAudience: string;
+  /** deploy を許す provider account id (= 通常この dedicated challenge account)。 */
+  readonly allowedAccountIds: readonly string[];
+  /** deploy を許す region。 */
+  readonly allowedRegions: readonly string[];
+  /** ローカルで承認済みの problem id allowlist。 */
+  readonly approvedProblemIds: readonly string[];
+  /** JWS 検証 secret を保持する SSM SecureString パラメータ名。 */
+  readonly verifySecretParameterName: string;
+  /** 見積コスト上限 (USD)。 default 50。 */
+  readonly maxEstimatedCostUsd?: number;
+  /** intent TTL のローカル上限 (秒)。 default 900。 */
+  readonly maxTtlSeconds?: number;
+}
+
+export class CustomerExecutionPlaneStack extends Stack {
+  readonly intentQueue: Queue;
+  readonly nonceTable: Table;
+  readonly cfnServiceRole: Role;
+  readonly executionFunction: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: CustomerExecutionPlaneStackProps) {
+    super(scope, id, props);
+
+    const deadLetterQueue = new Queue(this, "IntentDlq", {
+      retentionPeriod: Duration.days(14),
+    });
+    this.intentQueue = new Queue(this, "IntentQueue", {
+      visibilityTimeout: Duration.minutes(6),
+      deadLetterQueue: { queue: deadLetterQueue, maxReceiveCount: 3 },
+    });
+
+    // replay 防止: nonce を 1 度しか受理しない。 1/1 PROVISIONED + TTL GC (Free Tier 整合)。
+    this.nonceTable = new Table(this, "NonceTable", {
+      partitionKey: { name: "PK", type: AttributeType.STRING },
+      sortKey: { name: "SK", type: AttributeType.STRING },
+      billingMode: BillingMode.PROVISIONED,
+      readCapacity: 1,
+      writeCapacity: 1,
+      timeToLiveAttribute: "expiresAt",
+      removalPolicy: RemovalPolicy.DESTROY,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+    });
+
+    // CloudFormation がチャレンジ stack を配置するときに assume する service role。
+    // broad な権限は **この dedicated challenge account に閉じる** (ADR-039 §3.2)。
+    this.cfnServiceRole = new Role(this, "CfnServiceRole", {
+      assumedBy: new ServicePrincipal("cloudformation.amazonaws.com"),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("AdministratorAccess")],
+      description: "Local CloudFormation execution authority for TenkaCloud challenge deploys.",
+    });
+
+    const fn = new NodejsFunction(this, "Function", {
+      runtime: LAMBDA_NODEJS_RUNTIME,
+      architecture: Architecture.ARM_64,
+      entry: path.resolve(import.meta.dirname, "handler/index.ts"),
+      handler: "handler",
+      timeout: Duration.minutes(5),
+      memorySize: 256,
+      environment: {
+        NONCE_TABLE_NAME: this.nonceTable.tableName,
+        VERIFY_SECRET_PARAM: props.verifySecretParameterName,
+        PLANE_AUDIENCE: props.planeAudience,
+        ALLOWED_ACCOUNT_IDS: props.allowedAccountIds.join(","),
+        ALLOWED_REGIONS: props.allowedRegions.join(","),
+        APPROVED_PROBLEM_IDS: props.approvedProblemIds.join(","),
+        MAX_TTL_SECONDS: String(props.maxTtlSeconds ?? 900),
+        MAX_ESTIMATED_COST_USD: String(props.maxEstimatedCostUsd ?? 50),
+        CFN_SERVICE_ROLE_ARN: this.cfnServiceRole.roleArn,
+        ALLOW_PRIVILEGE_ESCALATION: "false",
+        NODE_OPTIONS: "--enable-source-maps",
+      },
+      bundling: { minify: true, sourceMap: true },
+    });
+    this.executionFunction = fn;
+
+    fn.addEventSource(new SqsEventSource(this.intentQueue, { reportBatchItemFailures: true }));
+    this.nonceTable.grantWriteData(fn);
+
+    // ローカル CFn 操作: tc-* stack のみ。 control plane への AssumeRole は付与しない。
+    fn.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack",
+          "cloudformation:DeleteStack",
+          "cloudformation:DescribeStacks",
+        ],
+        resources: [`arn:aws:cloudformation:*:${this.account}:stack/tc-*/*`],
+      }),
+    );
+    // CFn に service role を渡す権限 (= PassRole)。 PassedToService を CFn に限定。
+    fn.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["iam:PassRole"],
+        resources: [this.cfnServiceRole.roleArn],
+        conditions: { StringEquals: { "iam:PassedToService": "cloudformation.amazonaws.com" } },
+      }),
+    );
+    // 検証 secret (SecureString) の read。
+    fn.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["ssm:GetParameter"],
+        resources: [
+          `arn:aws:ssm:*:${this.account}:parameter${
+            props.verifySecretParameterName.startsWith("/")
+              ? props.verifySecretParameterName
+              : `/${props.verifySecretParameterName}`
+          }`,
+        ],
+      }),
+    );
+  }
+}

--- a/infrastructure/lib/customer-execution/handler/aws-clients.ts
+++ b/infrastructure/lib/customer-execution/handler/aws-clients.ts
@@ -1,0 +1,61 @@
+import type {
+  CfnDeployClient,
+  CfnStackMutationInput,
+  DdbConditionalPutClient,
+} from "@TenkaCloud/trust-bridge";
+import {
+  type Capability,
+  type CloudFormationClient,
+  CreateStackCommand,
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * trust-bridge の注入 seam に実 AWS SDK client を被せる薄い adapter 群。
+ * ここだけが SDK を知り、 検証/実行/監査のロジックは trust-bridge に閉じる。
+ */
+
+export function buildDdbConditionalPutClient(client: DynamoDBClient): DdbConditionalPutClient {
+  const doc = DynamoDBDocumentClient.from(client);
+  return {
+    async putItem(input) {
+      await doc.send(
+        new PutCommand({
+          TableName: input.TableName,
+          Item: input.Item,
+          ConditionExpression: input.ConditionExpression,
+        }),
+      );
+    },
+  };
+}
+
+export function buildCfnDeployClient(client: CloudFormationClient): CfnDeployClient {
+  const mutation = (input: CfnStackMutationInput) => ({
+    StackName: input.StackName,
+    TemplateBody: input.TemplateBody,
+    Capabilities: [...input.Capabilities] as Capability[],
+    ...(input.RoleARN ? { RoleARN: input.RoleARN } : {}),
+  });
+  return {
+    async createStack(input) {
+      const out = await client.send(new CreateStackCommand(mutation(input)));
+      return out.StackId ? { StackId: out.StackId } : {};
+    },
+    async updateStack(input) {
+      const out = await client.send(new UpdateStackCommand(mutation(input)));
+      return out.StackId ? { StackId: out.StackId } : {};
+    },
+    async deleteStack(input) {
+      await client.send(
+        new DeleteStackCommand({
+          StackName: input.StackName,
+          ...(input.RoleARN ? { RoleARN: input.RoleARN } : {}),
+        }),
+      );
+    },
+  };
+}

--- a/infrastructure/lib/customer-execution/handler/index.ts
+++ b/infrastructure/lib/customer-execution/handler/index.ts
@@ -1,0 +1,150 @@
+import {
+  type AgentRunOutcome,
+  type CloudActionAuditRecord,
+  CloudFormationExecutor,
+  CustomerExecutionAgent,
+  CustomerExecutionPlane,
+  type CustomerExecutionPolicy,
+  combinePolicyEvaluators,
+  createBudgetPolicyEvaluator,
+  createCfnTemplateInspector,
+  DdbNonceStore,
+} from "@TenkaCloud/trust-bridge";
+import { CloudFormationClient } from "@aws-sdk/client-cloudformation";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { buildCfnDeployClient, buildDdbConditionalPutClient } from "./aws-clients.js";
+import { parseIntentMessage } from "./message.js";
+
+/**
+ * Issue #1727 / ADR-039 §7: customer execution plane の Lambda entry (= SQS 駆動)。
+ *
+ * customer 側アカウントで動き、 hosted control plane が署名した CloudActionIntent を
+ * SQS から受け、 **ローカル CFn 権限** で deploy/destroy する。 control plane が trust
+ * する role は一切 AssumeRole しない (ADR-039 の肝)。 trust-bridge の検証・実行・監査
+ * ロジックに、 ここで実 SDK client を注入する。
+ */
+
+interface SqsRecord {
+  readonly messageId: string;
+  readonly body: string;
+}
+interface SqsEvent {
+  readonly Records: readonly SqsRecord[];
+}
+interface SqsBatchResponse {
+  readonly batchItemFailures: { readonly itemIdentifier: string }[];
+}
+
+function env(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`missing required env ${name}`);
+  }
+  return value;
+}
+
+function csv(name: string): string[] {
+  return env(name)
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function buildPolicy(): CustomerExecutionPolicy {
+  return {
+    audience: env("PLANE_AUDIENCE"),
+    allowedProviderAccountRefs: csv("ALLOWED_ACCOUNT_IDS"),
+    allowedRegions: csv("ALLOWED_REGIONS"),
+    approvedProblemIds: csv("APPROVED_PROBLEM_IDS"),
+    allowPrivilegeEscalation: process.env.ALLOW_PRIVILEGE_ESCALATION === "true",
+    maxTtlSeconds: Number(env("MAX_TTL_SECONDS")),
+  };
+}
+
+/** verify 用 secret を SSM SecureString から 1 度だけ取得する (cold start)。 */
+let cachedSecret: Promise<Uint8Array> | undefined;
+function resolveVerifySecret(ssm: SSMClient): Promise<Uint8Array> {
+  cachedSecret ??= (async () => {
+    const out = await ssm.send(
+      new GetParameterCommand({ Name: env("VERIFY_SECRET_PARAM"), WithDecryption: true }),
+    );
+    const value = out.Parameter?.Value;
+    if (!value) {
+      throw new Error("verify secret parameter is empty");
+    }
+    return new TextEncoder().encode(value);
+  })();
+  return cachedSecret;
+}
+
+async function buildAgent(): Promise<CustomerExecutionAgent> {
+  const region = process.env.AWS_REGION;
+  const clientConfig = region ? { region } : {};
+  const secret = await resolveVerifySecret(new SSMClient(clientConfig));
+
+  const nonceStore = new DdbNonceStore({
+    client: buildDdbConditionalPutClient(new DynamoDBClient(clientConfig)),
+    tableName: env("NONCE_TABLE_NAME"),
+  });
+  const plane = new CustomerExecutionPlane({
+    policy: buildPolicy(),
+    verify: { resolveSecret: () => secret, nonceStore },
+    policyEvaluator: combinePolicyEvaluators(
+      createBudgetPolicyEvaluator({
+        maxEstimatedCostUsd: Number(process.env.MAX_ESTIMATED_COST_USD ?? "50"),
+        policyVersion: process.env.POLICY_VERSION ?? "local-1",
+      }),
+    ),
+    artifactInspector: createCfnTemplateInspector(),
+  });
+  const executor = new CloudFormationExecutor({
+    client: buildCfnDeployClient(new CloudFormationClient(clientConfig)),
+    ...(process.env.CFN_SERVICE_ROLE_ARN
+      ? { executionRoleArn: process.env.CFN_SERVICE_ROLE_ARN }
+      : {}),
+  });
+  return new CustomerExecutionAgent({ plane, executor, audit: emitAudit });
+}
+
+/** 監査レコードを構造化ログで出す (= ADR-017 D5 第 1 版: CloudWatch Logs)。 */
+function emitAudit(record: CloudActionAuditRecord): void {
+  console.log(JSON.stringify({ kind: "CloudActionAuditRecord", ...record }));
+}
+
+/**
+ * 再試行すべきか。 deterministic な拒否 (authorization / artifact / policy) は redrive
+ * しない (= 何度やっても同じ)。 authenticity 失敗のうち nonce-replay は「既に処理済み」
+ * の正常系なので再試行不要。 それ以外の一時要因は handler の catch 側で redrive する。
+ */
+function shouldRetry(outcome: AgentRunOutcome): boolean {
+  return (
+    !outcome.ok && outcome.stage === "intent-authenticity" && outcome.reason !== "nonce-replay"
+  );
+}
+
+let agentPromise: Promise<CustomerExecutionAgent> | undefined;
+
+export async function handler(event: SqsEvent): Promise<SqsBatchResponse> {
+  agentPromise ??= buildAgent();
+  const agent = await agentPromise;
+  const failures: { itemIdentifier: string }[] = [];
+
+  for (const record of event.Records) {
+    try {
+      const { token, templateBytes } = parseIntentMessage(record.body);
+      const outcome = await agent.run({ token, artifact: { bytes: templateBytes } });
+      if (shouldRetry(outcome)) {
+        failures.push({ itemIdentifier: record.messageId });
+      }
+    } catch (err) {
+      // 実行時例外 (= CFn API / DDB 一時障害 / parse 不能) は redrive させる。
+      console.error(
+        JSON.stringify({ kind: "ExecutionError", messageId: record.messageId, error: String(err) }),
+      );
+      failures.push({ itemIdentifier: record.messageId });
+    }
+  }
+
+  return { batchItemFailures: failures };
+}

--- a/infrastructure/lib/customer-execution/handler/message.ts
+++ b/infrastructure/lib/customer-execution/handler/message.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+/**
+ * Issue #1727 / ADR-039 §7: customer execution plane の SQS メッセージ契約。
+ *
+ * hosted control plane (または relay) が、 署名済み JWS token と、 その intent が
+ * digest で縛る **承認済みテンプレ本文 (base64)** を 1 メッセージに入れて送る。
+ * agent が token を検証し、 同梱 bytes の digest が signed digest と一致するときだけ
+ * deploy する (= bytes 改ざんは digest 不一致で fail-closed)。
+ *
+ * テンプレは CFn inline 上限 (51,200 bytes) 内を前提 (= 大きいものは S3 参照に拡張する
+ * のが follow-up)。 SQS 本文上限 256KB にも収まる。
+ */
+export const IntentMessageSchema = z
+  .object({
+    token: z.string().min(1),
+    /** 承認済みテンプレ本文の base64。 decode 後の bytes を agent が digest 照合する。 */
+    templateBase64: z.string().min(1),
+  })
+  .strict();
+
+export type IntentMessage = z.infer<typeof IntentMessageSchema>;
+
+export interface ParsedIntentMessage {
+  readonly token: string;
+  readonly templateBytes: Uint8Array;
+}
+
+/**
+ * SQS body 文字列を parse・検証して token + テンプレ bytes を返す。
+ * 不正 JSON / schema 不一致 / base64 不正は throw (= メッセージを処理しない)。
+ */
+export function parseIntentMessage(rawBody: string): ParsedIntentMessage {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawBody);
+  } catch {
+    throw new Error("intent message is not valid JSON");
+  }
+  const parsed = IntentMessageSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(
+      `intent message failed schema validation: ${parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  const templateBytes = decodeBase64(parsed.data.templateBase64);
+  return { token: parsed.data.token, templateBytes };
+}
+
+function decodeBase64(value: string): Uint8Array {
+  // Node の Buffer.from は不正 base64 を黙って切り詰めるので、 round-trip で厳密検証する。
+  const bytes = new Uint8Array(Buffer.from(value, "base64"));
+  if (Buffer.from(bytes).toString("base64") !== normalizeBase64(value)) {
+    throw new Error("templateBase64 is not valid base64");
+  }
+  return bytes;
+}
+
+/** padding 差異を吸収して base64 を比較可能な正規形にする。 */
+function normalizeBase64(value: string): string {
+  const stripped = value.replace(/=+$/, "");
+  const pad = stripped.length % 4 === 0 ? "" : "=".repeat(4 - (stripped.length % 4));
+  return stripped + pad;
+}

--- a/infrastructure/test/customer-execution/customer-execution-plane-stack.test.ts
+++ b/infrastructure/test/customer-execution/customer-execution-plane-stack.test.ts
@@ -1,0 +1,100 @@
+import { App } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { CustomerExecutionPlaneStack } from "../../lib/customer-execution/customer-execution-plane-stack";
+
+function synth(): Template {
+  const app = new App();
+  const stack = new CustomerExecutionPlaneStack(app, "Test", {
+    planeAudience: "plane://acme/challenge-ou",
+    allowedAccountIds: ["111111111111"],
+    allowedRegions: ["us-east-1"],
+    approvedProblemIds: ["net-evo-01-reachability", "stackstack"],
+    verifySecretParameterName: "/tenkacloud/verify-secret",
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+  return Template.fromStack(stack);
+}
+
+describe("CustomerExecutionPlaneStack (#1727 / ADR-039 §7)", () => {
+  it("should provision a 1/1 PROVISIONED nonce table with a TTL attribute", () => {
+    const t = synth();
+    // PROVISIONED is the CFn default so CDK omits BillingMode; the presence of
+    // ProvisionedThroughput (which on-demand tables lack) proves it is PROVISIONED.
+    t.hasResourceProperties("AWS::DynamoDB::Table", {
+      ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+      TimeToLiveSpecification: { AttributeName: "expiresAt", Enabled: true },
+    });
+  });
+
+  it("should create an SQS intent queue with a dead-letter queue", () => {
+    const t = synth();
+    t.resourceCountIs("AWS::SQS::Queue", 2);
+    t.hasResourceProperties("AWS::SQS::Queue", {
+      RedrivePolicy: Match.objectLike({ maxReceiveCount: 3 }),
+    });
+  });
+
+  it("should run an SQS-triggered Lambda with the plane configuration in env", () => {
+    const t = synth();
+    t.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: {
+        Variables: Match.objectLike({
+          PLANE_AUDIENCE: "plane://acme/challenge-ou",
+          ALLOWED_ACCOUNT_IDS: "111111111111",
+          APPROVED_PROBLEM_IDS: "net-evo-01-reachability,stackstack",
+          VERIFY_SECRET_PARAM: "/tenkacloud/verify-secret",
+        }),
+      },
+    });
+    t.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
+      FunctionResponseTypes: ["ReportBatchItemFailures"],
+    });
+  });
+
+  it("should create a CloudFormation service role assumable only by CloudFormation", () => {
+    const t = synth();
+    t.hasResourceProperties("AWS::IAM::Role", {
+      AssumeRolePolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Principal: { Service: "cloudformation.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("should scope CloudFormation deploy permissions to tc-* stacks and gate PassRole to CloudFormation", () => {
+    const t = synth();
+    t.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(["cloudformation:CreateStack", "cloudformation:DeleteStack"]),
+          }),
+          Match.objectLike({
+            Action: "iam:PassRole",
+            Condition: { StringEquals: { "iam:PassedToService": "cloudformation.amazonaws.com" } },
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it("should NOT grant the execution Lambda any sts:AssumeRole into a control-plane role (ADR-039 core property)", () => {
+    // Service roles (CFn / Lambda) legitimately have sts:AssumeRole in their TRUST policy,
+    // but the Lambda's own permission policies must never let it assume an external role.
+    const policies = synth().findResources("AWS::IAM::Policy");
+    for (const policy of Object.values(policies)) {
+      const statements = (
+        policy.Properties as { PolicyDocument: { Statement: { Action?: unknown }[] } }
+      ).PolicyDocument.Statement;
+      for (const stmt of statements) {
+        const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        expect(actions).not.toContain("sts:AssumeRole");
+      }
+    }
+  });
+});

--- a/infrastructure/test/customer-execution/message.test.ts
+++ b/infrastructure/test/customer-execution/message.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseIntentMessage } from "../../lib/customer-execution/handler/message";
+
+function body(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+const TEMPLATE = "AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n";
+const TEMPLATE_B64 = Buffer.from(TEMPLATE, "utf8").toString("base64");
+
+describe("parseIntentMessage", () => {
+  it("should parse a valid message into token + template bytes", () => {
+    const parsed = parseIntentMessage(
+      body({ token: "jws.token.sig", templateBase64: TEMPLATE_B64 }),
+    );
+    expect(parsed.token).toBe("jws.token.sig");
+    expect(new TextDecoder().decode(parsed.templateBytes)).toBe(TEMPLATE);
+  });
+
+  it("should reject non-JSON bodies", () => {
+    expect(() => parseIntentMessage("not json")).toThrow(/not valid JSON/);
+  });
+
+  it("should reject a body missing the token", () => {
+    expect(() => parseIntentMessage(body({ templateBase64: TEMPLATE_B64 }))).toThrow(
+      /schema validation/,
+    );
+  });
+
+  it("should reject unknown extra properties (strict)", () => {
+    expect(() =>
+      parseIntentMessage(body({ token: "t", templateBase64: TEMPLATE_B64, extra: 1 })),
+    ).toThrow(/schema validation/);
+  });
+
+  it("should reject an invalid base64 template", () => {
+    expect(() =>
+      parseIntentMessage(body({ token: "t", templateBase64: "!!!not base64!!!" })),
+    ).toThrow(/not valid base64/);
+  });
+});

--- a/packages/trust-bridge/src/cloudformation-executor.ts
+++ b/packages/trust-bridge/src/cloudformation-executor.ts
@@ -1,0 +1,140 @@
+import type { VerifiedCloudActionIntent } from "./schema.js";
+
+/**
+ * Issue #1727 / ADR-039 D4 (LOCAL execution authority): 検証済み intent と
+ * digest 一致した artifact (= CFn テンプレ本文) を、 **customer-local な
+ * CloudFormation 権限** で実際に deploy / destroy する executor。
+ *
+ * 重要 (ADR-039 の肝): ここで使う権限は customer 側のもの (= 注入された CFn client +
+ * 任意の CFn service role ARN)。 hosted control plane が trust する role を AssumeRole
+ * し直すことは **しない**。 つまり control plane を侵害しても、 この executor が握る
+ * 配置権限には到達できない。
+ *
+ * `@aws-sdk/client-cloudformation` は hard dep にしない (= trust-bridge の方針)。
+ * consumer が `CreateStackCommand` / `UpdateStackCommand` / `DeleteStackCommand` を
+ * wrap した {@link CfnDeployClient} を注入する。 test では fake。
+ */
+
+export interface CfnStackMutationInput {
+  readonly StackName: string;
+  readonly TemplateBody: string;
+  readonly Capabilities: readonly string[];
+  /** CFn service role ARN (= LOCAL authority)。 未指定なら呼び出し元 role で実行。 */
+  readonly RoleARN?: string;
+}
+
+export interface CfnDeployClient {
+  createStack(input: CfnStackMutationInput): Promise<{ readonly StackId?: string }>;
+  updateStack(input: CfnStackMutationInput): Promise<{ readonly StackId?: string }>;
+  deleteStack(input: { readonly StackName: string; readonly RoleARN?: string }): Promise<void>;
+}
+
+export interface CloudFormationExecutorOptions {
+  readonly client: CfnDeployClient;
+  /** stack 名 prefix。 default "tc"。 `tc-*` scoping (ADR-039) と整合。 */
+  readonly stackNamePrefix?: string;
+  /** CFn capabilities。 default `["CAPABILITY_NAMED_IAM"]` (challenge は named IAM を作りうる)。 */
+  readonly capabilities?: readonly string[];
+  /** CFn service role ARN。 渡されれば create/update/delete に転写する。 */
+  readonly executionRoleArn?: string;
+}
+
+export type CfnExecutionAction = "created" | "updated" | "no-op" | "deleted";
+
+export interface CfnExecutionResult {
+  readonly action: CfnExecutionAction;
+  readonly stackName: string;
+  readonly stackId?: string;
+}
+
+const DEFAULT_PREFIX = "tc";
+const DEFAULT_CAPABILITIES = ["CAPABILITY_NAMED_IAM"] as const;
+const STACK_NAME_MAX = 128;
+
+function errName(err: unknown): string | undefined {
+  return (err as { name?: string } | null | undefined)?.name;
+}
+
+function isNoUpdates(err: unknown): boolean {
+  const message = (err as { message?: string } | null | undefined)?.message ?? "";
+  return errName(err) === "ValidationError" && /No updates are to be performed/i.test(message);
+}
+
+/** intent の source から決定的・CFn 命名規則準拠の stack 名を作る。 */
+export function deriveStackName(intent: VerifiedCloudActionIntent, prefix: string): string {
+  const parts = [intent.source.problemId, intent.source.deploymentId].filter(
+    (p): p is string => typeof p === "string" && p.length > 0,
+  );
+  const suffix = parts.length > 0 ? parts.join("-") : intent.requestId;
+  const raw = `${prefix}-${suffix}`;
+  // CFn stack 名: 英数 + ハイフンのみ、 先頭は英字、 最大 128。
+  const cleaned = raw.replace(/[^A-Za-z0-9-]/g, "-").replace(/^[^A-Za-z]+/, "");
+  return (cleaned || prefix).slice(0, STACK_NAME_MAX);
+}
+
+export class CloudFormationExecutor {
+  private readonly options: CloudFormationExecutorOptions;
+
+  constructor(options: CloudFormationExecutorOptions) {
+    this.options = options;
+  }
+
+  /** deploy → create-or-update、 destroy → delete。 他の action は非対応。 */
+  async execute(
+    intent: VerifiedCloudActionIntent,
+    artifactBody: string,
+  ): Promise<CfnExecutionResult> {
+    const stackName = deriveStackName(intent, this.options.stackNamePrefix ?? DEFAULT_PREFIX);
+    if (intent.action.type === "deploy") {
+      return this.deploy(stackName, artifactBody);
+    }
+    if (intent.action.type === "destroy") {
+      await this.options.client.deleteStack({
+        StackName: stackName,
+        ...(this.options.executionRoleArn ? { RoleARN: this.options.executionRoleArn } : {}),
+      });
+      return { action: "deleted", stackName };
+    }
+    throw new Error(
+      `CloudFormationExecutor supports deploy/destroy, got action ${intent.action.type}`,
+    );
+  }
+
+  private mutationInput(stackName: string, body: string): CfnStackMutationInput {
+    return {
+      StackName: stackName,
+      TemplateBody: body,
+      Capabilities: this.options.capabilities ?? [...DEFAULT_CAPABILITIES],
+      ...(this.options.executionRoleArn ? { RoleARN: this.options.executionRoleArn } : {}),
+    };
+  }
+
+  private async deploy(stackName: string, body: string): Promise<CfnExecutionResult> {
+    try {
+      const { StackId } = await this.options.client.createStack(
+        this.mutationInput(stackName, body),
+      );
+      return { action: "created", stackName, ...(StackId ? { stackId: StackId } : {}) };
+    } catch (err) {
+      if (errName(err) === "AlreadyExistsException") {
+        return this.update(stackName, body);
+      }
+      throw err;
+    }
+  }
+
+  private async update(stackName: string, body: string): Promise<CfnExecutionResult> {
+    try {
+      const { StackId } = await this.options.client.updateStack(
+        this.mutationInput(stackName, body),
+      );
+      return { action: "updated", stackName, ...(StackId ? { stackId: StackId } : {}) };
+    } catch (err) {
+      // CFn は「変更なし」を ValidationError で返す。 これは成功扱いの no-op。
+      if (isNoUpdates(err)) {
+        return { action: "no-op", stackName };
+      }
+      throw err;
+    }
+  }
+}

--- a/packages/trust-bridge/src/customer-execution-agent.ts
+++ b/packages/trust-bridge/src/customer-execution-agent.ts
@@ -1,0 +1,111 @@
+import { buildAuditRecord, type CloudActionAuditRecord } from "./audit.js";
+import type { CfnExecutionResult, CloudFormationExecutor } from "./cloudformation-executor.js";
+import type {
+  CustomerExecutionPlane,
+  CustomerExecutionRejected,
+  CustomerExecutionRejectionReason,
+  CustomerExecutionStage,
+} from "./customer-execution-plane.js";
+import type { VerifiedCloudActionIntent } from "./schema.js";
+import type { IntentVerifyFailureReason } from "./verify.js";
+
+/**
+ * Issue #1727 / ADR-039 §7 (Next): customer execution plane の end-to-end orchestrator。
+ *
+ * 1 本の `run()` で「署名 intent を検証 → ローカル authority で CFn 実行 → 監査記録」を回す。
+ *   - authorize (= CustomerExecutionPlane): authenticity / authorization / artifact 検証
+ *   - 成功時のみ CloudFormationExecutor で deploy/destroy (= LOCAL authority)
+ *   - 成否どちらでも CloudActionAuditRecord を audit sink に書く (ADR-017 D5: 全 decision を監査)
+ *
+ * 全部品は注入される (= plane / executor / audit)。 trust-bridge は AWS SDK に依存しない。
+ */
+
+export type AuditWriter = (record: CloudActionAuditRecord) => Promise<void> | void;
+
+export interface CustomerExecutionAgentOptions {
+  readonly plane: CustomerExecutionPlane;
+  readonly executor: CloudFormationExecutor;
+  readonly audit: AuditWriter;
+  readonly now?: () => Date;
+}
+
+export interface AgentRunInput {
+  readonly token: string;
+  readonly artifact: { readonly bytes: Uint8Array };
+}
+
+export interface AgentExecuted {
+  readonly ok: true;
+  readonly intent: VerifiedCloudActionIntent;
+  readonly result: CfnExecutionResult;
+  readonly audit: CloudActionAuditRecord;
+}
+
+export interface AgentRejected {
+  readonly ok: false;
+  readonly stage: CustomerExecutionStage;
+  readonly reason: CustomerExecutionRejectionReason | IntentVerifyFailureReason;
+  readonly details?: readonly string[];
+  readonly audit: CloudActionAuditRecord;
+}
+
+export type AgentRunOutcome = AgentExecuted | AgentRejected;
+
+export class CustomerExecutionAgent {
+  private readonly options: CustomerExecutionAgentOptions;
+  private readonly now: () => Date;
+
+  constructor(options: CustomerExecutionAgentOptions) {
+    this.options = options;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async run(input: AgentRunInput): Promise<AgentRunOutcome> {
+    const outcome = await this.options.plane.authorize({
+      token: input.token,
+      artifact: input.artifact,
+    });
+
+    if (!outcome.ok) {
+      const audit = this.denialAudit(outcome);
+      await this.options.audit(audit);
+      return {
+        ok: false,
+        stage: outcome.stage,
+        reason: outcome.reason,
+        ...(outcome.details ? { details: outcome.details } : {}),
+        audit,
+      };
+    }
+
+    // LOCAL authority で実際に CFn を動かす。 artifact は digest 検証済みの bytes。
+    const body = new TextDecoder().decode(input.artifact.bytes);
+    const result = await this.options.executor.execute(outcome.intent, body);
+    const audit = buildAuditRecord({
+      outcome: { ok: true, intent: outcome.intent },
+      ...(outcome.policyDecision.policyVersion
+        ? { policyVersion: outcome.policyDecision.policyVersion }
+        : {}),
+      now: this.now,
+    });
+    await this.options.audit(audit);
+    return { ok: true, intent: outcome.intent, result, audit };
+  }
+
+  private denialAudit(rejected: CustomerExecutionRejected): CloudActionAuditRecord {
+    if (rejected.intent) {
+      // authentication を通過した拒否: intent の context 付きで deny を記録。
+      return buildAuditRecord({
+        outcome: { ok: true, intent: rejected.intent },
+        overrideDecision: "deny",
+        overrideReason: `${rejected.stage}:${rejected.reason}`,
+        now: this.now,
+      });
+    }
+    // authenticity 失敗: intent 不明。 verify failure として "unknown" deny を記録。
+    return buildAuditRecord({
+      outcome: { ok: false, reason: rejected.reason as IntentVerifyFailureReason },
+      now: this.now,
+    });
+  }
+}

--- a/packages/trust-bridge/src/customer-execution-plane.ts
+++ b/packages/trust-bridge/src/customer-execution-plane.ts
@@ -129,6 +129,13 @@ export interface CustomerExecutionRejected {
   readonly stage: CustomerExecutionStage;
   readonly reason: CustomerExecutionRejectionReason | IntentVerifyFailureReason;
   readonly details?: readonly string[];
+  /**
+   * Issue #1727 / ADR-039: 認証 (signature/schema/TTL/replay) を通過した後の
+   * 拒否 (authorization / artifact) には検証済み intent を添える。 監査ログに
+   * tenant / problem / deployment の文脈を残すため。 authenticity 失敗時は intent が
+   * 無いので undefined。
+   */
+  readonly intent?: VerifiedCloudActionIntent;
 }
 
 export type CustomerExecutionOutcome = CustomerExecutionAuthorized | CustomerExecutionRejected;
@@ -199,13 +206,13 @@ export class CustomerExecutionPlane {
     // Stage 2 — authorization: a valid signature is NOT authorization.
     const authorization = await this.authorizeIntent(intent);
     if (!authorization.ok) {
-      return authorization.rejection;
+      return { ...authorization.rejection, intent };
     }
 
     // Stages 3 + 4 — artifact integrity then safety.
     const artifactRejection = await this.checkArtifact(intent, input);
     if (artifactRejection) {
-      return artifactRejection;
+      return { ...artifactRejection, intent };
     }
 
     return { ok: true, intent, policyDecision: authorization.decision };

--- a/packages/trust-bridge/src/ddb-nonce-store.ts
+++ b/packages/trust-bridge/src/ddb-nonce-store.ts
@@ -1,0 +1,89 @@
+import type { NonceStore } from "./verify.js";
+
+/**
+ * Issue #1727 / ADR-039 §7 (Later): replay 防止を本番化する DDB-backed NonceStore。
+ *
+ * PoC は in-memory Set で nonce を覚えていたが、 Lambda は warm/cold・水平スケールで
+ * memory を共有しないため replay 防止にならない。 本 store は **conditional PutItem**
+ * (`attribute_not_exists(PK)`) で「同 nonce の 2 度目」を DDB レベルで弾く:
+ *   - Put 成功               → "accepted" (= 初回)
+ *   - ConditionalCheckFailed → "replay"   (= 既出 nonce)
+ *   - それ以外のエラー        → rethrow (= fail loud。 silent fallback 禁止)
+ *
+ * TenkaCloud の DDB 1/1 PROVISIONED コスト制約に合わせ、 行は intent の expiresAt +
+ * grace を **TTL 属性** に持たせて DynamoDB TTL に GC を任せる (= sweeper 不要)。
+ * PK は `tenantId#requestId#nonce` で multi-tenant の nonce 衝突を構造的に防ぐ。
+ *
+ * `@aws-sdk/client-dynamodb` は hard dep にしない (= 既存 trust-bridge の方針)。
+ * consumer (= customer-execution Lambda) が `PutItemCommand` を wrap した
+ * {@link DdbConditionalPutClient} を注入する。 test では fake を渡す。
+ */
+
+export interface DdbConditionalPutInput {
+  readonly TableName: string;
+  readonly Item: Record<string, unknown>;
+  /** 通常 `attribute_not_exists(PK)`。 既存なら ConditionalCheckFailed で reject される。 */
+  readonly ConditionExpression: string;
+}
+
+/**
+ * DynamoDB conditional PutItem を呼ぶ最小 seam。 production は
+ * `DynamoDBDocumentClient.send(new PutCommand(input))` を wrap する。
+ * 競合時は `name === "ConditionalCheckFailedException"` の error を reject すること。
+ */
+export interface DdbConditionalPutClient {
+  putItem(input: DdbConditionalPutInput): Promise<void>;
+}
+
+export interface DdbNonceStoreOptions {
+  readonly client: DdbConditionalPutClient;
+  readonly tableName: string;
+  /** intent.expiresAt に足す TTL 余裕 (秒)。 default 300 (= 5 min)。 */
+  readonly ttlGraceSeconds?: number;
+}
+
+const CONDITIONAL_CHECK_FAILED = "ConditionalCheckFailedException";
+const DEFAULT_TTL_GRACE_SECONDS = 300;
+
+/** DynamoDB の条件付き Put で nonce の単一消費を担保する {@link NonceStore}。 */
+export class DdbNonceStore implements NonceStore {
+  private readonly client: DdbConditionalPutClient;
+  private readonly tableName: string;
+  private readonly ttlGraceSeconds: number;
+
+  constructor(options: DdbNonceStoreOptions) {
+    this.client = options.client;
+    this.tableName = options.tableName;
+    this.ttlGraceSeconds = options.ttlGraceSeconds ?? DEFAULT_TTL_GRACE_SECONDS;
+  }
+
+  async recordNonce(
+    intent: Parameters<NonceStore["recordNonce"]>[0],
+  ): Promise<"accepted" | "replay"> {
+    const pk = `${intent.source.tenantId}#${intent.requestId}#${intent.nonce}`;
+    const expiresAtEpoch =
+      Math.floor(Date.parse(intent.constraints.expiresAt) / 1000) + this.ttlGraceSeconds;
+    try {
+      await this.client.putItem({
+        TableName: this.tableName,
+        Item: {
+          PK: pk,
+          SK: "NONCE",
+          requestId: intent.requestId,
+          nonce: intent.nonce,
+          tenantId: intent.source.tenantId,
+          // DynamoDB TTL 属性 (epoch 秒)。 期限切れ行を DDB が自動削除する。
+          expiresAt: expiresAtEpoch,
+        },
+        ConditionExpression: "attribute_not_exists(PK)",
+      });
+      return "accepted";
+    } catch (err) {
+      if ((err as { name?: string } | null)?.name === CONDITIONAL_CHECK_FAILED) {
+        return "replay";
+      }
+      // 想定外エラーは握り潰さず投げる (= AGENTS.md: silent fallback 禁止)。
+      throw err;
+    }
+  }
+}

--- a/packages/trust-bridge/src/index.ts
+++ b/packages/trust-bridge/src/index.ts
@@ -40,6 +40,23 @@ export type {
 } from "./azure-federated-credential.js";
 export { AzureFederatedCredentialExchange } from "./azure-federated-credential.js";
 export type {
+  CfnDeployClient,
+  CfnExecutionAction,
+  CfnExecutionResult,
+  CfnStackMutationInput,
+  CloudFormationExecutorOptions,
+} from "./cloudformation-executor.js";
+export { CloudFormationExecutor, deriveStackName } from "./cloudformation-executor.js";
+export type {
+  AgentExecuted,
+  AgentRejected,
+  AgentRunInput,
+  AgentRunOutcome,
+  AuditWriter,
+  CustomerExecutionAgentOptions,
+} from "./customer-execution-agent.js";
+export { CustomerExecutionAgent } from "./customer-execution-agent.js";
+export type {
   ArtifactInspection,
   ArtifactInspector,
   ClaimInput,
@@ -54,7 +71,12 @@ export type {
   PolicyEvaluator,
 } from "./customer-execution-plane.js";
 export { CustomerExecutionPlane, computeArtifactDigest } from "./customer-execution-plane.js";
-
+export type {
+  DdbConditionalPutClient,
+  DdbConditionalPutInput,
+  DdbNonceStoreOptions,
+} from "./ddb-nonce-store.js";
+export { DdbNonceStore } from "./ddb-nonce-store.js";
 export type {
   GcpAdapterOptions,
   GcpCredential,
@@ -74,6 +96,17 @@ export type {
   VerifyOutcome,
 } from "./jws.js";
 export { signIntent, verifySignature } from "./jws.js";
+export type {
+  BudgetPolicyEvaluatorOptions,
+  CfnTemplateInspectorOptions,
+  ForbiddenTemplatePattern,
+} from "./local-policy.js";
+export {
+  combinePolicyEvaluators,
+  createBudgetPolicyEvaluator,
+  createCfnTemplateInspector,
+  DEFAULT_FORBIDDEN_TEMPLATE_PATTERNS,
+} from "./local-policy.js";
 export type {
   LocalStackCloudAdapterOptions,
   LocalStackCredential,

--- a/packages/trust-bridge/src/local-policy.ts
+++ b/packages/trust-bridge/src/local-policy.ts
@@ -1,0 +1,104 @@
+import type {
+  ArtifactInspector,
+  PolicyDecision,
+  PolicyEvaluator,
+} from "./customer-execution-plane.js";
+
+/**
+ * Issue #1727 / ADR-039 D4: customer-local な PolicyEvaluator / ArtifactInspector の
+ * 再利用可能な実装。 PoC では inline だったものを、 注入できる部品にする。
+ *
+ * CustomerExecutionPlane は既に audience / account / region / problem allowlist /
+ * privilege escalation / TTL を強制するので、 ここでは **その上に重ねる組織ポリシー**
+ * (= 予算上限・テンプレ安全性) を提供する。
+ */
+
+export interface BudgetPolicyEvaluatorOptions {
+  /** intent.constraints.maxEstimatedCostUsd がこの値を超えたら deny。 */
+  readonly maxEstimatedCostUsd: number;
+  readonly policyVersion?: string;
+}
+
+/** 見積コストが local cap を超える intent を deny する PolicyEvaluator。 */
+export function createBudgetPolicyEvaluator(
+  options: BudgetPolicyEvaluatorOptions,
+): PolicyEvaluator {
+  const version = options.policyVersion;
+  return {
+    async evaluate(intent): Promise<PolicyDecision> {
+      const cost = intent.constraints.maxEstimatedCostUsd ?? 0;
+      if (cost > options.maxEstimatedCostUsd) {
+        return {
+          decision: "deny",
+          reason: `estimated cost ${cost} USD exceeds local cap ${options.maxEstimatedCostUsd} USD`,
+          ...(version ? { policyVersion: version } : {}),
+        };
+      }
+      return { decision: "allow", ...(version ? { policyVersion: version } : {}) };
+    },
+  };
+}
+
+/**
+ * 複数の PolicyEvaluator を合成する。 fail-closed の優先順位は deny > needs_approval > allow:
+ * 最初の deny で即停止し、 deny が無ければ needs_approval があればそれを、 無ければ allow を返す。
+ */
+export function combinePolicyEvaluators(
+  ...evaluators: readonly PolicyEvaluator[]
+): PolicyEvaluator {
+  return {
+    async evaluate(intent): Promise<PolicyDecision> {
+      let aggregated: PolicyDecision = { decision: "allow" };
+      for (const evaluator of evaluators) {
+        const decision = await evaluator.evaluate(intent);
+        if (decision.decision === "deny") {
+          return decision;
+        }
+        if (decision.decision === "needs_approval") {
+          aggregated = decision;
+        }
+      }
+      return aggregated;
+    },
+  };
+}
+
+export interface ForbiddenTemplatePattern {
+  readonly id: string;
+  readonly pattern: RegExp;
+}
+
+/**
+ * 既定の禁止パターン: 独立 IAM User / AccessKey の作成、 AdministratorAccess の直付け。
+ * いずれも「隔離 challenge アカウントでも避けたい」 high-risk 構成。 caller は差し替え可能。
+ */
+export const DEFAULT_FORBIDDEN_TEMPLATE_PATTERNS: readonly ForbiddenTemplatePattern[] = [
+  { id: "iam-user", pattern: /AWS::IAM::User\b/ },
+  { id: "iam-access-key", pattern: /AWS::IAM::AccessKey\b/ },
+  { id: "administrator-access", pattern: /AdministratorAccess\b/ },
+];
+
+export interface CfnTemplateInspectorOptions {
+  readonly forbiddenPatterns?: readonly ForbiddenTemplatePattern[];
+}
+
+/**
+ * digest 検証済みのテンプレ bytes を走査し、 禁止パターンに当たれば deny する
+ * {@link ArtifactInspector}。 当たらなければ allow。
+ */
+export function createCfnTemplateInspector(
+  options: CfnTemplateInspectorOptions = {},
+): ArtifactInspector {
+  const patterns = options.forbiddenPatterns ?? DEFAULT_FORBIDDEN_TEMPLATE_PATTERNS;
+  return {
+    async inspect(_intent, bytes) {
+      const text = new TextDecoder().decode(bytes);
+      for (const { id, pattern } of patterns) {
+        if (pattern.test(text)) {
+          return { decision: "deny", reason: `template matches forbidden pattern: ${id}` };
+        }
+      }
+      return { decision: "allow" };
+    },
+  };
+}

--- a/packages/trust-bridge/test/cloudformation-executor.test.ts
+++ b/packages/trust-bridge/test/cloudformation-executor.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CfnDeployClient,
+  type CfnStackMutationInput,
+  CloudFormationExecutor,
+  deriveStackName,
+} from "../src/cloudformation-executor.js";
+import { brandVerified, type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+function intent(overrides: Partial<CloudActionIntent> = {}) {
+  const base: CloudActionIntent = {
+    version: INTENT_VERSION,
+    requestId: "req-1",
+    nonce: "n-1",
+    source: {
+      system: "tenkacloud",
+      tenantId: "t-acme",
+      problemId: "net-evo-01-reachability",
+      deploymentId: "dep-007",
+      workloadId: "w-1",
+    },
+    target: { provider: "aws", providerAccountRef: "111111111111", region: "us-east-1" },
+    action: { type: "deploy", engine: "cloudformation", requestedScopes: ["cfn:CreateStack"] },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+  return brandVerified(base);
+}
+
+class NamedError extends Error {
+  constructor(name: string, message = name) {
+    super(message);
+    this.name = name;
+  }
+}
+
+const TEMPLATE = "AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n";
+
+function client(overrides: Partial<CfnDeployClient> = {}): CfnDeployClient & {
+  created: CfnStackMutationInput[];
+  updated: CfnStackMutationInput[];
+  deleted: { StackName: string; RoleARN?: string }[];
+} {
+  const created: CfnStackMutationInput[] = [];
+  const updated: CfnStackMutationInput[] = [];
+  const deleted: { StackName: string; RoleARN?: string }[] = [];
+  return {
+    created,
+    updated,
+    deleted,
+    createStack: async (i) => {
+      created.push(i);
+      return { StackId: "stack/created" };
+    },
+    updateStack: async (i) => {
+      updated.push(i);
+      return { StackId: "stack/updated" };
+    },
+    deleteStack: async (i) => {
+      deleted.push(i);
+    },
+    ...overrides,
+  };
+}
+
+describe("deriveStackName", () => {
+  it("should compose tc-<problemId>-<deploymentId>", () => {
+    expect(deriveStackName(intent(), "tc")).toBe("tc-net-evo-01-reachability-dep-007");
+  });
+
+  it("should fall back to requestId when problem/deployment ids are absent", () => {
+    const i = intent({ source: { system: "tenkacloud", tenantId: "t", workloadId: "w" } });
+    expect(deriveStackName(i, "tc")).toBe("tc-req-1");
+  });
+
+  it("should sanitize to CFn naming and start with a letter", () => {
+    const i = intent({
+      source: { system: "tenkacloud", tenantId: "t", problemId: "p_!@#x", workloadId: "w" },
+      requestId: "r",
+    });
+    expect(deriveStackName(i, "tc")).toMatch(/^[A-Za-z][A-Za-z0-9-]*$/);
+  });
+
+  it("should yield an empty name when prefix and suffix sanitize away (guard branch)", () => {
+    const i = intent({
+      source: { system: "tenkacloud", tenantId: "t", workloadId: "w" },
+      requestId: "!!!",
+    });
+    expect(deriveStackName(i, "")).toBe("");
+  });
+});
+
+describe("CloudFormationExecutor (#1727 / ADR-039 D4)", () => {
+  it("should create a new stack with default capabilities + service role", async () => {
+    const c = client();
+    const exec = new CloudFormationExecutor({
+      client: c,
+      executionRoleArn: "arn:aws:iam::1:role/cfn",
+    });
+    const res = await exec.execute(intent(), TEMPLATE);
+    expect(res).toEqual({
+      action: "created",
+      stackName: "tc-net-evo-01-reachability-dep-007",
+      stackId: "stack/created",
+    });
+    expect(c.created[0]).toMatchObject({
+      TemplateBody: TEMPLATE,
+      Capabilities: ["CAPABILITY_NAMED_IAM"],
+      RoleARN: "arn:aws:iam::1:role/cfn",
+    });
+  });
+
+  it("should update when the stack already exists", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AlreadyExistsException");
+      },
+    });
+    const res = await exec(c).execute(intent(), TEMPLATE);
+    expect(res).toMatchObject({ action: "updated", stackId: "stack/updated" });
+    expect(c.updated).toHaveLength(1);
+  });
+
+  it("should treat a CFn 'No updates' ValidationError as a no-op success", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AlreadyExistsException");
+      },
+      updateStack: async () => {
+        throw new NamedError("ValidationError", "No updates are to be performed.");
+      },
+    });
+    const res = await exec(c).execute(intent(), TEMPLATE);
+    expect(res).toEqual({ action: "no-op", stackName: "tc-net-evo-01-reachability-dep-007" });
+  });
+
+  it("should delete the stack on a destroy intent", async () => {
+    const c = client();
+    const res = await exec(c).execute(
+      intent({ action: { type: "destroy", engine: "cloudformation", requestedScopes: [] } }),
+      TEMPLATE,
+    );
+    expect(res).toEqual({ action: "deleted", stackName: "tc-net-evo-01-reachability-dep-007" });
+    expect(c.deleted[0]).toMatchObject({
+      StackName: "tc-net-evo-01-reachability-dep-007",
+      RoleARN: "arn:aws:iam::1:role/cfn",
+    });
+  });
+
+  it("should reject unsupported action types", async () => {
+    await expect(
+      exec(client()).execute(
+        intent({ action: { type: "inspect", engine: "cloudformation", requestedScopes: [] } }),
+        TEMPLATE,
+      ),
+    ).rejects.toThrow(/supports deploy\/destroy/);
+  });
+
+  it("should rethrow a createStack error that is not AlreadyExists", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AccessDenied");
+      },
+    });
+    await expect(exec(c).execute(intent(), TEMPLATE)).rejects.toThrow(/AccessDenied/);
+  });
+
+  it("should rethrow an updateStack error that is not 'No updates'", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AlreadyExistsException");
+      },
+      updateStack: async () => {
+        throw new NamedError("ValidationError", "Template format error");
+      },
+    });
+    await expect(exec(c).execute(intent(), TEMPLATE)).rejects.toThrow(/Template format error/);
+  });
+
+  it("should omit capabilities override and role when not configured", async () => {
+    const c = client();
+    const res = await exec(c, {}).execute(intent(), TEMPLATE);
+    expect(res.action).toBe("created");
+    expect(c.created[0].RoleARN).toBeUndefined();
+    expect(c.created[0].Capabilities).toEqual(["CAPABILITY_NAMED_IAM"]);
+  });
+
+  it("should handle a create response without a StackId", async () => {
+    const c = client({ createStack: async () => ({}) });
+    const res = await exec(c).execute(intent(), TEMPLATE);
+    expect(res).toEqual({ action: "created", stackName: "tc-net-evo-01-reachability-dep-007" });
+  });
+
+  it("should handle an update response without a StackId", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AlreadyExistsException");
+      },
+      updateStack: async () => ({}),
+    });
+    const res = await exec(c).execute(intent(), TEMPLATE);
+    expect(res).toEqual({ action: "updated", stackName: "tc-net-evo-01-reachability-dep-007" });
+  });
+
+  it("should delete without a RoleARN when no service role is configured", async () => {
+    const c = client();
+    const res = await exec(c, {}).execute(
+      intent({ action: { type: "destroy", engine: "cloudformation", requestedScopes: [] } }),
+      TEMPLATE,
+    );
+    expect(res.action).toBe("deleted");
+    expect(c.deleted[0].RoleARN).toBeUndefined();
+  });
+
+  it("should rethrow an update error object that carries no message", async () => {
+    const c = client({
+      createStack: async () => {
+        throw new NamedError("AlreadyExistsException");
+      },
+      updateStack: async () => {
+        // message-less error (= not the 'No updates' case) → rethrow.
+        throw { name: "ValidationError" };
+      },
+    });
+    await expect(exec(c).execute(intent(), TEMPLATE)).rejects.toMatchObject({
+      name: "ValidationError",
+    });
+  });
+});
+
+function exec(
+  c: CfnDeployClient,
+  opts: Partial<{ executionRoleArn: string }> = { executionRoleArn: "arn:aws:iam::1:role/cfn" },
+): CloudFormationExecutor {
+  return new CloudFormationExecutor({ client: c, ...opts });
+}

--- a/packages/trust-bridge/test/customer-execution-agent.test.ts
+++ b/packages/trust-bridge/test/customer-execution-agent.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import type { CloudActionAuditRecord } from "../src/audit.js";
+import { type CfnDeployClient, CloudFormationExecutor } from "../src/cloudformation-executor.js";
+import { CustomerExecutionAgent } from "../src/customer-execution-agent.js";
+import {
+  CustomerExecutionPlane,
+  type CustomerExecutionPolicy,
+  computeArtifactDigest,
+  type PolicyEvaluator,
+} from "../src/customer-execution-plane.js";
+import { signIntent } from "../src/jws.js";
+import { type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+const SECRET = new TextEncoder().encode("agent-test-secret-key-hs256-000000");
+const NOW = () => new Date("2026-05-15T19:00:00.000Z");
+const BYTES = new TextEncoder().encode("AWSTemplateFormatVersion: '2010-09-09'\nResources: {}\n");
+const DIGEST = computeArtifactDigest(BYTES);
+
+function intent(overrides: Partial<CloudActionIntent> = {}): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-1",
+    nonce: `n-${Math.random()}`,
+    audience: "plane://acme",
+    source: {
+      system: "tenkacloud",
+      tenantId: "t-acme",
+      problemId: "net-evo-01-reachability",
+      deploymentId: "dep-1",
+      workloadId: "w-1",
+    },
+    target: { provider: "aws", providerAccountRef: "111111111111", region: "us-east-1" },
+    action: {
+      type: "deploy",
+      engine: "cloudformation",
+      requestedScopes: ["cloudformation:CreateStack"],
+      artifact: { digest: DIGEST, sizeBytes: BYTES.byteLength },
+    },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+}
+
+const POLICY: CustomerExecutionPolicy = {
+  audience: "plane://acme",
+  allowedProviderAccountRefs: ["111111111111"],
+  allowedRegions: ["us-east-1"],
+  approvedProblemIds: ["net-evo-01-reachability"],
+  allowPrivilegeEscalation: false,
+  maxTtlSeconds: 900,
+};
+
+function cfnClient(overrides: Partial<CfnDeployClient> = {}): CfnDeployClient {
+  return {
+    createStack: async () => ({ StackId: "stack/abc" }),
+    updateStack: async () => ({}),
+    deleteStack: async () => {},
+    ...overrides,
+  };
+}
+
+function makeAgent(opts: { policyEvaluator: PolicyEvaluator; cfn?: CfnDeployClient }): {
+  agent: CustomerExecutionAgent;
+  audits: CloudActionAuditRecord[];
+} {
+  const audits: CloudActionAuditRecord[] = [];
+  const plane = new CustomerExecutionPlane({
+    policy: POLICY,
+    verify: { resolveSecret: () => SECRET, now: NOW },
+    policyEvaluator: opts.policyEvaluator,
+  });
+  const executor = new CloudFormationExecutor({
+    client: opts.cfn ?? cfnClient(),
+    executionRoleArn: "arn:aws:iam::1:role/cfn",
+  });
+  const agent = new CustomerExecutionAgent({
+    plane,
+    executor,
+    audit: (r) => {
+      audits.push(r);
+    },
+    now: NOW,
+  });
+  return { agent, audits };
+}
+
+const allowEvaluator: PolicyEvaluator = {
+  async evaluate() {
+    return { decision: "allow", policyVersion: "v1" };
+  },
+};
+
+describe("CustomerExecutionAgent (#1727 / ADR-039 §7)", () => {
+  it("should authorize, deploy via local CFn, and audit the allow", async () => {
+    const { agent, audits } = makeAgent({ policyEvaluator: allowEvaluator });
+    const out = await agent.run({
+      token: signIntent(intent(), { secret: SECRET }),
+      artifact: { bytes: BYTES },
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result).toMatchObject({ action: "created", stackId: "stack/abc" });
+      expect(out.intent.source.problemId).toBe("net-evo-01-reachability");
+    }
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      decision: "allow",
+      tenantId: "t-acme",
+      problemId: "net-evo-01-reachability",
+      action: "deploy",
+      policyVersion: "v1",
+      createdAt: "2026-05-15T19:00:00.000Z",
+    });
+  });
+
+  it("should omit policyVersion in the audit when the evaluator gives none", async () => {
+    const noVersion: PolicyEvaluator = {
+      async evaluate() {
+        return { decision: "allow" };
+      },
+    };
+    const { agent, audits } = makeAgent({ policyEvaluator: noVersion });
+    await agent.run({
+      token: signIntent(intent(), { secret: SECRET }),
+      artifact: { bytes: BYTES },
+    });
+    expect(audits[0].policyVersion).toBeUndefined();
+  });
+
+  it("should audit a post-authentication denial with tenant/problem context", async () => {
+    const { agent, audits } = makeAgent({ policyEvaluator: allowEvaluator });
+    // valid signature, but a different (un-approved) account → authorization denial.
+    const wrong = intent({
+      target: { provider: "aws", providerAccountRef: "999999999999", region: "us-east-1" },
+    });
+    const out = await agent.run({
+      token: signIntent(wrong, { secret: SECRET }),
+      artifact: { bytes: BYTES },
+    });
+    expect(out).toMatchObject({
+      ok: false,
+      stage: "intent-authorization",
+      reason: "account-not-allowed",
+    });
+    expect(audits[0]).toMatchObject({
+      decision: "deny",
+      tenantId: "t-acme",
+      problemId: "net-evo-01-reachability",
+      denialReason: "intent-authorization:account-not-allowed",
+    });
+  });
+
+  it("should audit an authenticity denial as an unknown deny (no intent context)", async () => {
+    const { agent, audits } = makeAgent({ policyEvaluator: allowEvaluator });
+    const wrongSecret = new TextEncoder().encode("not-the-signing-secret-at-all-000");
+    const out = await agent.run({
+      token: signIntent(intent(), { secret: wrongSecret }),
+      artifact: { bytes: BYTES },
+    });
+    expect(out).toMatchObject({
+      ok: false,
+      stage: "intent-authenticity",
+      reason: "jws-signature-mismatch",
+    });
+    expect(audits[0]).toMatchObject({
+      decision: "deny",
+      tenantId: "unknown",
+      provider: "unknown",
+      denialReason: "jws-signature-mismatch",
+    });
+  });
+
+  it("should surface rejection details when the plane provides them", async () => {
+    const denyWithReason: PolicyEvaluator = {
+      async evaluate() {
+        return { decision: "deny", reason: "budget exceeded" };
+      },
+    };
+    const { agent } = makeAgent({ policyEvaluator: denyWithReason });
+    const out = await agent.run({
+      token: signIntent(intent(), { secret: SECRET }),
+      artifact: { bytes: BYTES },
+    });
+    expect(out).toMatchObject({
+      ok: false,
+      stage: "intent-authorization",
+      reason: "policy-denied",
+      details: ["budget exceeded"],
+    });
+  });
+
+  it("should default the audit clock to the real time when no clock is injected", async () => {
+    const audits: CloudActionAuditRecord[] = [];
+    const plane = new CustomerExecutionPlane({
+      policy: POLICY,
+      verify: { resolveSecret: () => SECRET, now: NOW },
+      policyEvaluator: allowEvaluator,
+    });
+    const agent = new CustomerExecutionAgent({
+      plane,
+      executor: new CloudFormationExecutor({ client: cfnClient() }),
+      audit: (r) => {
+        audits.push(r);
+      },
+      // no `now` → constructor falls back to () => new Date()
+    });
+    await agent.run({
+      token: signIntent(intent(), { secret: SECRET }),
+      artifact: { bytes: BYTES },
+    });
+    expect(audits[0].createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("should propagate an executor failure", async () => {
+    const { agent } = makeAgent({
+      policyEvaluator: allowEvaluator,
+      cfn: cfnClient({
+        createStack: async () => {
+          throw new Error("CFn AccessDenied");
+        },
+      }),
+    });
+    await expect(
+      agent.run({ token: signIntent(intent(), { secret: SECRET }), artifact: { bytes: BYTES } }),
+    ).rejects.toThrow(/AccessDenied/);
+  });
+});

--- a/packages/trust-bridge/test/ddb-nonce-store.test.ts
+++ b/packages/trust-bridge/test/ddb-nonce-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { type DdbConditionalPutInput, DdbNonceStore } from "../src/ddb-nonce-store.js";
+import { type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+function intent(overrides: Partial<CloudActionIntent> = {}): CloudActionIntent {
+  return {
+    version: INTENT_VERSION,
+    requestId: "req-1",
+    nonce: "nonce-abc",
+    source: { system: "tenkacloud", tenantId: "t-acme", workloadId: "w-1" },
+    target: { provider: "aws", providerAccountRef: "111111111111" },
+    action: { type: "deploy", engine: "cloudformation", requestedScopes: ["cfn:CreateStack"] },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+    },
+    ...overrides,
+  };
+}
+
+class ConditionalCheckFailed extends Error {
+  override readonly name = "ConditionalCheckFailedException";
+}
+
+function recordingClient(behavior: () => Promise<void> = async () => {}) {
+  const calls: DdbConditionalPutInput[] = [];
+  return {
+    calls,
+    putItem: async (input: DdbConditionalPutInput) => {
+      calls.push(input);
+      return behavior();
+    },
+  };
+}
+
+describe("DdbNonceStore (#1727 / ADR-039 §7)", () => {
+  it("should accept a first-seen nonce via a conditional put", async () => {
+    const client = recordingClient();
+    const store = new DdbNonceStore({ client, tableName: "Nonces" });
+    expect(await store.recordNonce(intent())).toBe("accepted");
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]).toMatchObject({
+      TableName: "Nonces",
+      ConditionExpression: "attribute_not_exists(PK)",
+    });
+  });
+
+  it("should scope the PK by tenant + requestId + nonce", async () => {
+    const client = recordingClient();
+    const store = new DdbNonceStore({ client, tableName: "Nonces" });
+    await store.recordNonce(intent({ requestId: "r2", nonce: "n2" }));
+    expect(client.calls[0].Item.PK).toBe("t-acme#r2#n2");
+    expect(client.calls[0].Item).toMatchObject({
+      requestId: "r2",
+      nonce: "n2",
+      tenantId: "t-acme",
+    });
+  });
+
+  it("should set a DynamoDB TTL of expiresAt + grace (epoch seconds)", async () => {
+    const client = recordingClient();
+    const store = new DdbNonceStore({ client, tableName: "Nonces", ttlGraceSeconds: 60 });
+    await store.recordNonce(intent());
+    // 2026-05-15T20:00:00Z = 1778529600 epoch sec; + 60 grace.
+    expect(client.calls[0].Item.expiresAt).toBe(
+      Math.floor(Date.parse("2026-05-15T20:00:00.000Z") / 1000) + 60,
+    );
+  });
+
+  it("should default the TTL grace to 300 seconds", async () => {
+    const client = recordingClient();
+    const store = new DdbNonceStore({ client, tableName: "Nonces" });
+    await store.recordNonce(intent());
+    expect(client.calls[0].Item.expiresAt).toBe(
+      Math.floor(Date.parse("2026-05-15T20:00:00.000Z") / 1000) + 300,
+    );
+  });
+
+  it("should report replay when the conditional put fails (nonce already present)", async () => {
+    const client = recordingClient(async () => {
+      throw new ConditionalCheckFailed("exists");
+    });
+    const store = new DdbNonceStore({ client, tableName: "Nonces" });
+    expect(await store.recordNonce(intent())).toBe("replay");
+  });
+
+  it("should rethrow unexpected errors instead of swallowing them", async () => {
+    const client = recordingClient(async () => {
+      throw new Error("ProvisionedThroughputExceededException");
+    });
+    const store = new DdbNonceStore({ client, tableName: "Nonces" });
+    await expect(store.recordNonce(intent())).rejects.toThrow(/ProvisionedThroughputExceeded/);
+  });
+});

--- a/packages/trust-bridge/test/local-policy.test.ts
+++ b/packages/trust-bridge/test/local-policy.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyEvaluator } from "../src/customer-execution-plane.js";
+import {
+  combinePolicyEvaluators,
+  createBudgetPolicyEvaluator,
+  createCfnTemplateInspector,
+} from "../src/local-policy.js";
+import { brandVerified, type CloudActionIntent, INTENT_VERSION } from "../src/schema.js";
+
+function intent(maxEstimatedCostUsd?: number) {
+  const base: CloudActionIntent = {
+    version: INTENT_VERSION,
+    requestId: "r",
+    nonce: "n",
+    source: { system: "tenkacloud", tenantId: "t", workloadId: "w" },
+    target: { provider: "aws", providerAccountRef: "1" },
+    action: { type: "deploy", engine: "cloudformation", requestedScopes: [] },
+    constraints: {
+      ttlSeconds: 600,
+      expiresAt: "2026-05-15T20:00:00.000Z",
+      allowPrivilegeEscalation: false,
+      ...(maxEstimatedCostUsd === undefined ? {} : { maxEstimatedCostUsd }),
+    },
+  };
+  return brandVerified(base);
+}
+
+const fixed = (decision: "allow" | "deny" | "needs_approval"): PolicyEvaluator => ({
+  async evaluate() {
+    return { decision };
+  },
+});
+
+describe("createBudgetPolicyEvaluator", () => {
+  it("should allow when estimated cost is within the cap", async () => {
+    const e = createBudgetPolicyEvaluator({ maxEstimatedCostUsd: 5, policyVersion: "v1" });
+    expect(await e.evaluate(intent(3))).toEqual({ decision: "allow", policyVersion: "v1" });
+  });
+
+  it("should treat a missing cost as zero (allow)", async () => {
+    const e = createBudgetPolicyEvaluator({ maxEstimatedCostUsd: 5 });
+    expect(await e.evaluate(intent())).toEqual({ decision: "allow" });
+  });
+
+  it("should deny when estimated cost exceeds the cap", async () => {
+    const e = createBudgetPolicyEvaluator({ maxEstimatedCostUsd: 5, policyVersion: "v1" });
+    const d = await e.evaluate(intent(50));
+    expect(d).toMatchObject({ decision: "deny", policyVersion: "v1" });
+    expect(d.reason).toMatch(/exceeds local cap/);
+  });
+
+  it("should deny without a policyVersion when none is configured", async () => {
+    const e = createBudgetPolicyEvaluator({ maxEstimatedCostUsd: 5 });
+    const d = await e.evaluate(intent(50));
+    expect(d.decision).toBe("deny");
+    expect(d.policyVersion).toBeUndefined();
+  });
+});
+
+describe("combinePolicyEvaluators", () => {
+  it("should allow when every evaluator allows", async () => {
+    const e = combinePolicyEvaluators(fixed("allow"), fixed("allow"));
+    expect((await e.evaluate(intent())).decision).toBe("allow");
+  });
+
+  it("should allow when there are no evaluators", async () => {
+    expect((await combinePolicyEvaluators().evaluate(intent())).decision).toBe("allow");
+  });
+
+  it("should short-circuit on the first deny", async () => {
+    let secondCalled = false;
+    const second: PolicyEvaluator = {
+      async evaluate() {
+        secondCalled = true;
+        return { decision: "allow" };
+      },
+    };
+    const e = combinePolicyEvaluators(fixed("deny"), second);
+    expect((await e.evaluate(intent())).decision).toBe("deny");
+    expect(secondCalled).toBe(false);
+  });
+
+  it("should escalate to needs_approval when no deny but an approval gate exists", async () => {
+    const e = combinePolicyEvaluators(fixed("allow"), fixed("needs_approval"), fixed("allow"));
+    expect((await e.evaluate(intent())).decision).toBe("needs_approval");
+  });
+});
+
+describe("createCfnTemplateInspector", () => {
+  const inspect = (text: string) =>
+    createCfnTemplateInspector().inspect(intent(), new TextEncoder().encode(text));
+
+  it("should allow a clean template", async () => {
+    expect(await inspect("Resources:\n  B:\n    Type: AWS::S3::Bucket\n")).toEqual({
+      decision: "allow",
+    });
+  });
+
+  it("should deny a standalone IAM user", async () => {
+    const r = await inspect("Resources:\n  U:\n    Type: AWS::IAM::User\n");
+    expect(r).toMatchObject({ decision: "deny" });
+    expect(r.reason).toMatch(/iam-user/);
+  });
+
+  it("should deny an IAM access key", async () => {
+    expect((await inspect("Type: AWS::IAM::AccessKey")).decision).toBe("deny");
+  });
+
+  it("should deny an AdministratorAccess attachment", async () => {
+    expect(
+      (await inspect("ManagedPolicyArns: [arn:aws:iam::aws:policy/AdministratorAccess]")).decision,
+    ).toBe("deny");
+  });
+
+  it("should honor a custom forbidden pattern list", async () => {
+    const inspector = createCfnTemplateInspector({
+      forbiddenPatterns: [{ id: "no-nat-gw", pattern: /AWS::EC2::NatGateway/ }],
+    });
+    expect(
+      (await inspector.inspect(intent(), new TextEncoder().encode("AWS::IAM::User"))).decision,
+    ).toBe("allow");
+    expect(
+      (await inspector.inspect(intent(), new TextEncoder().encode("Type: AWS::EC2::NatGateway")))
+        .decision,
+    ).toBe("deny");
+  });
+});


### PR DESCRIPTION
Builds out the **ADR-039 customer-execution mode** from "design + PoC" to production-grade parts + CDK wiring, so a customer can actually run signed-intent deploys with authority the hosted control plane can never reach. Extends #1727 (PR-1752 shipped the design/PoC).

## What's new

### trust-bridge library (AWS-SDK-free, 100% coverage)
Every part takes an injected client seam (same pattern as `AwsAssumeRoleExchange`), so the library stays SDK-independent and fully unit-tested:
- **`DdbNonceStore`** — real replay protection via conditional `PutItem` (`attribute_not_exists(PK)`) on a 1/1 PROVISIONED table with a TTL attribute for GC. (PoC used an in-memory `Set`, which a scaled Lambda can't share.)
- **`CloudFormationExecutor`** — the LOCAL execution authority: real `create-or-update` / `delete` (handles `AlreadyExists` → update, "No updates" → no-op) through a same-account CFn **service role**. It never AssumeRoles a control-plane-trusted role.
- **`local-policy.ts`** — reusable `createBudgetPolicyEvaluator`, `combinePolicyEvaluators` (fail-closed deny > needs_approval > allow), and `createCfnTemplateInspector` (denies standalone IAM User / AccessKey / AdministratorAccess; custom patterns supported).
- **`CustomerExecutionAgent`** — end-to-end orchestrator: `authorize` → execute → audit. Emits a `CloudActionAuditRecord` for **every** decision (ADR-017 D5), with tenant/problem context on post-authentication denials.
- **`CustomerExecutionPlane`** — now attaches the verified intent to post-authentication rejections (backward-compatible optional field) so denials can be audited with context.

### CDK + Lambda (customer-account stack)
- **`CustomerExecutionPlaneStack`** — an SQS intent queue (+ DLQ), a 1/1 PROVISIONED nonce table (TTL GC), a CloudFormation service role, and an SQS-driven Lambda. The Lambda's IAM scopes CloudFormation to `tc-*` stacks, gates `iam:PassRole` to `cloudformation.amazonaws.com`, and reads the JWS verify secret from SSM — **with no `sts:AssumeRole` into any control-plane role** (the ADR-039 core property, asserted in the stack test).
- **handler** — thin SDK adapters (`aws-clients.ts`) over the trust-bridge seams + SQS partial-batch (`ReportBatchItemFailures`) + structured audit logging; `message.ts` parses the `{token, templateBase64}` contract with strict base64 validation.

ADR-039 §7 updated to mark these as shipped; control-plane integration / KMS asymmetric keys / signed manifest remain phased.

## Test plan
- `packages/trust-bridge`: `vitest` 143 passed; coverage gate **100%** lines/functions/branches; `tsc` clean.
- `infrastructure`: customer-execution `vitest` 11 passed (CDK stack synth+bundle, the no-`sts:AssumeRole` property, message parsing); `tsc --noEmit` clean.
- `make harness` clean (no error-level findings); `make lint` exit 0.

## Regression analysis
- All trust-bridge additions are new modules; the one change to an existing file (`customer-execution-plane.ts`) adds an **optional** `intent` field to rejections and threads it through `authorize` — `toMatchObject` assertions and existing behavior are unaffected (full suite still 100%).
- The `CustomerExecutionPlaneStack` is a **standalone** stack, not wired into `bin/infrastructure.ts`, so it does not alter any existing deployed stack. It is instantiated only by its own test today and by a customer separately (like `competitor-bootstrap.yaml`).

## Physical impact
- `packages/trust-bridge/**`, `infrastructure/lib/customer-execution/**`, ADR: **NO-OP** on existing CloudFormation — nothing in `bin/infrastructure.ts`/the dev app changes; `cdk synth` of the current app is unchanged.
- `CustomerExecutionPlaneStack` itself, when a customer deploys it, is a **CREATE** of a new stack (SQS + DynamoDB + IAM roles + Lambda) in the customer account — not deployed by this repo's pipelines.

Relates #1727

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUf19cuyJW9VgBoWNHpF6e)_