### PR TITLE
chore(problems): bump submodule pin to latest catalog main

### DIFF
--- a/infrastructure/test/scripts/check-template-cfn-refs.test.ts
+++ b/infrastructure/test/scripts/check-template-cfn-refs.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   collectGetAttResources,
   collectRefs,
+  collectSubMapKeys,
   collectSubRefs,
   parseSections,
 } from "../../../scripts/check-template-cfn-refs";
@@ -197,5 +198,37 @@ Esc: !Sub "literal \${!NotAVariable}"
     expect(out.getAtts).toEqual(["Role"]);
     expect(out.refs).not.toContain("NotAVariable");
     expect(out.getAtts).not.toContain("NotAVariable");
+  });
+
+  it("collectSubRefs: should skip shell expansions that are not valid CFn Sub variable names", () => {
+    // Plain `Fn::Base64: |` UserData ships shell scripts whose ${...} は CFn 参照ではない。
+    // CFn の Sub 変数文法 (英数 logical name / AWS:: pseudo / Dotted.Attr) に合わない式は捨てる。
+    const yaml = `Script: |
+  APP_IP="\${1:-}"
+  NAME="\${EXPECTED_NAME}"
+  WITH_DEFAULT="\${FOO:-bar}"
+  ALL="\${ARR[@]}"
+  CFN: !Sub "\${NamePrefix}"
+`;
+    const out = collectSubRefs(yaml);
+    expect(out.refs).toEqual(["NamePrefix"]);
+    expect(out.getAtts).toEqual([]);
+  });
+
+  it("collectSubMapKeys: should collect list-form Fn::Sub variable-map keys as declared names", () => {
+    // UserData:
+    //   Fn::Base64: !Sub
+    //     - |
+    //       ORIGIN="http://\${NatPublicIp}/"
+    //     - NatPublicIp: !GetAtt NatInstance.PublicIp
+    const yaml = `UserData:
+  Fn::Base64: !Sub
+    - |
+      ORIGIN="http://\${NatPublicIp}/"
+    - NatPublicIp: !GetAtt NatInstance.PublicIp
+`;
+    expect(collectSubMapKeys(yaml)).toEqual(["NatPublicIp"]);
+    const out = collectSubRefs(yaml);
+    expect(out.refs).toContain("NatPublicIp");
   });
 });

--- a/infrastructure/test/scripts/check-template-security.test.ts
+++ b/infrastructure/test/scripts/check-template-security.test.ts
@@ -137,6 +137,22 @@ describe("check-template-security helpers (#869 + #1124)", () => {
       expect(findings).toEqual([]);
     });
 
+    it('should allow ec2 ENI / route-table describes and route53 zone list / GetChange on Resource: "*" (net-evo viewer role)', () => {
+      const findings = findIamResourceWildcardFindings(
+        PATH,
+        "loc",
+        ["*"],
+        [
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeRouteTables",
+          "route53:ListHostedZones",
+          "route53:ListHostedZonesByName",
+          "route53:GetChange",
+        ],
+      );
+      expect(findings).toEqual([]);
+    });
+
     it('should return 0 findings when Resource: "*" is absent (scoped ARNs are OK)', () => {
       expect(
         findIamResourceWildcardFindings(

--- a/scripts/check-template-cfn-refs.ts
+++ b/scripts/check-template-cfn-refs.ts
@@ -163,11 +163,16 @@ function collectSubRefs(yaml: string): { refs: string[]; getAtts: string[] } {
   // しやすいよう、 `${...}` を yaml 全体から拾い、 `!Sub` line context は問わない (= false-positive
   // のリスクはあるが、 problem template の安全側 default として ${...} が出現したら必ず Ref / GetAtt
   // と扱う方が漏れにくい)。
+  // CFn の Sub 変数文法: 英数 logical name / `AWS::Xyz` pseudo / `Resource.Attr` dotted。
+  // これに合わない式 (例: shell の `${1:-}` / `${FOO:-bar}` / `${APP_IP}` / `${ARR[@]}`) は
+  // plain `|` UserData 内の shell script なので reference として扱わない。
+  const CFN_SUB_VAR = /^(AWS::[A-Za-z0-9]+|[A-Za-z][A-Za-z0-9]*(\.[A-Za-z0-9]+)*)$/;
   const re = /\$\{([^}]+)\}/g;
   for (const m of yaml.matchAll(re)) {
     const expr = m[1];
     if (!expr) continue;
     if (expr.startsWith("!")) continue; // ${!Literal} は escape、 reference でない
+    if (!CFN_SUB_VAR.test(expr)) continue;
     if (expr.includes(".")) {
       const head = expr.split(".")[0];
       if (head) getAtts.push(head);
@@ -176,6 +181,30 @@ function collectSubRefs(yaml: string): { refs: string[]; getAtts: string[] } {
     }
   }
   return { refs, getAtts };
+}
+
+/**
+ * `Fn::Sub` リスト形式の変数マップ key を集める。
+ *
+ *   UserData:
+ *     Fn::Base64: !Sub
+ *       - |
+ *         ORIGIN="http://${NatPublicIp}/"
+ *       - NatPublicIp: !GetAtt NatInstance.PublicIp
+ *
+ * `${NatPublicIp}` は Resources / Parameters でなくマップ key で解決されるため、
+ * unresolved 扱いから除外する。 行ベース簡易 parse のため、 値が intrinsic
+ * (!GetAtt / !Ref / !Sub / !ImportValue / !Select / !Join) の list item key のみを拾う
+ * (= Tags の `- Key: Name` のような plain 値は対象外で、 過剰宣言を防ぐ)。
+ */
+function collectSubMapKeys(yaml: string): string[] {
+  const keys: string[] = [];
+  const re = /^\s*-\s+([A-Za-z][A-Za-z0-9]*):\s+!(GetAtt|Ref|Sub|ImportValue|Select|Join)\b/gm;
+  for (const m of yaml.matchAll(re)) {
+    const key = m[1];
+    if (key) keys.push(key);
+  }
+  return keys;
 }
 
 function checkRequiredDeclarations(
@@ -242,17 +271,25 @@ function checkUnresolvedGetAttResources(
 }
 
 export type { Finding };
-export { collectGetAttResources, collectRefs, collectSubRefs, findTemplates, parseSections };
+export {
+  collectGetAttResources,
+  collectRefs,
+  collectSubMapKeys,
+  collectSubRefs,
+  findTemplates,
+  parseSections,
+};
 
 export function checkTemplate(templatePath: string): Finding[] {
   const yaml = readFileSync(templatePath, "utf8");
   const { resources, parameters, outputs } = parseSections(yaml);
   const subRefs = collectSubRefs(yaml);
+  const subMapKeys = new Set(collectSubMapKeys(yaml));
   return [
     ...checkRequiredDeclarations(templatePath, resources, outputs),
     ...checkUnresolvedRefs(
       templatePath,
-      [...collectRefs(yaml), ...subRefs.refs],
+      [...collectRefs(yaml), ...subRefs.refs.filter((r) => !subMapKeys.has(r))],
       resources,
       parameters,
     ),

--- a/scripts/check-template-security.ts
+++ b/scripts/check-template-security.ts
@@ -56,6 +56,13 @@ const RESOURCE_STAR_OK_ACTIONS = new Set([
   "ec2:DescribeAvailabilityZones",
   "ec2:DescribeAccountAttributes",
   "ec2:DescribeNetworkAcls",
+  "ec2:DescribeNetworkInterfaces",
+  "ec2:DescribeRouteTables",
+  // Route 53 read — zone listing has no resource-level permissions, and GetChange
+  // targets ephemeral change IDs that cannot be known when the template is authored.
+  "route53:ListHostedZones",
+  "route53:ListHostedZonesByName",
+  "route53:GetChange",
   // IAM read (= self-reflection)
   "iam:GetRole",
   "iam:GetPolicy",


### PR DESCRIPTION
## Summary

`problems` submodule の pin を `ee82c85` → `52ea38a`(catalog `main` 最新)へ進めて最新化する。取り込む内容:

- **StackStack 完成分**: deploy-from-local step、site-defaced / supply-chain-backdoor disruption(TenkaCloudChallenge#55)、および参加者ポータルが `site_intact` / `no_backdoor` を描画するよう修正(#57)。これで production から転落した参加者が「なぜ落ちたか・どう復帰するか」を UI から読める
- **net-evo Ep02–05**(DNS / egress / TLS / edge)とカタログ/ドキュメント更新(TenkaCloudChallenge#54, #56)

net-evo テンプレートが検証スクリプトの 2 ギャップを露呈したため、テストファーストで再適用:

- `check-template-security`: `ec2:DescribeNetworkInterfaces` / `ec2:DescribeRouteTables` / `route53:ListHostedZones*` / `route53:GetChange` を `RESOURCE_STAR_OK_ACTIONS` に追加(いずれも resource-level permission 非対応の read-only API)
- `check-template-cfn-refs`: ① plain `Fn::Base64: |` 内のシェル展開(`${1:-}` 等、CFn Sub 変数文法に合わない式)を CFn 参照扱いしない ② `Fn::Sub` リスト形式の変数マップキー(`NatPublicIp: !GetAtt ...`)を宣言済みとして解決

## Test plan

- [x] 失敗テスト追加(red)→ 修正(green): security + cfn-refs の 2 ファイル含む 4 test files / 51 tests passed
- [x] `make validate-problems` — 10 問すべて有効
- [x] `bun run scripts/check-template-security.ts` — 危険パターン 0 件
- [x] `bun run scripts/check-template-cfn-refs.ts` — unresolved 0 件
- [x] `make harness` — no findings
- [x] `make before-commit` — 全段通過(synth + IAM Latin-1 ゲート含む)
- [x] StatusPanel の integrity セクションは本体 participant-portal で実レンダリング検証済み(7 posture キー全描画、PR #57 の検証時)

## Regression analysis

- 既存 8 問の検証結果は不変(許可リスト追加と誤検知除去のみ。緩むのは「AWS 仕様上 "*" が必須の read-only API」と「CFn 参照になり得ない式」だけ)
- `collectSubMapKeys` は値が intrinsic の list item キーのみ拾うため、Tags の `- Key: Name` 等で過剰宣言しない(テストで pin)
- StatusPanel 変更は表示のみ。metadata / template / scoring ロジックは不変
- pin と検証スクリプトの変更のみで、プラットフォームのコードパスは未変更

## Physical impact

- CFn / デプロイ済みリソース: **NO-OP**(pin と検証スクリプトのみ。`make deploy` まで実環境は不変)
- 次回 problem deploy 時: stackstack / net-evo スタックは新テンプレートで **CREATE**(参加者アカウント内、競技ごとに使い捨て)
- アーティファクト: `problems` pin **UPDATE**(ee82c85 → 52ea38a)、検証スクリプト 2 本 + テスト 2 本 **UPDATE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
