### PR TITLE
docs: provenance doc + neutralize employer fixture names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`,
 
 See [CLAUDE.md](./CLAUDE.md) for project rules, architecture invariants, and prohibited patterns. The same rules apply whether the change is made by a human or by an AI agent.
 
+## Project provenance
+
+TenkaCloud is an independent open-source project. Before contributing, read
+[`docs/PROJECT_PROVENANCE.md`](./docs/PROJECT_PROVENANCE.md): it records the
+project's development boundaries and the influence-versus-copying distinction.
+Do not contribute an employer's source code, confidential documents, customer
+data, private competition content, or other proprietary assets — contribute
+only original or compatibly licensed work.
+
 ## Join the community
 
 TenkaCloud's moat is its problem catalog, and that catalog grows through community contribution. Pick one of six roles and ship one starter task — you do not need to be personally onboarded.

--- a/apps/application-admin-console/test/config.test.ts
+++ b/apps/application-admin-console/test/config.test.ts
@@ -20,7 +20,7 @@ describe("loadConfig", () => {
                 cognitoDomain: "https://prod-tenant.auth.ap-northeast-1.amazoncognito.com",
                 userClientId: "prod-client-id",
                 tenantId: "tenant-prod-1",
-                tenantName: "DENSO 第一事業部",
+                tenantName: "Acme Manufacturing Division",
                 apiUrl: "https://prod-api.example.com/prod",
               }),
               { status: 200 },
@@ -46,7 +46,7 @@ describe("loadConfig", () => {
     });
 
     it("should take tenantName from runtime-config", async () => {
-      expect((await loadWithFullRuntime()).tenantName).toBe("DENSO 第一事業部");
+      expect((await loadWithFullRuntime()).tenantName).toBe("Acme Manufacturing Division");
     });
 
     it("should take apiBaseUrl from runtime-config.apiUrl (different key)", async () => {

--- a/docs/PROJECT_PROVENANCE.md
+++ b/docs/PROJECT_PROVENANCE.md
@@ -1,0 +1,76 @@
+# Project provenance and independence
+
+This document records the development provenance of TenkaCloud and the
+boundaries that keep it an independent open-source project. It is written in
+factual, neutral language. It is a good-faith attestation by the author about
+how the project was built — not a legal opinion, an audit certificate, or an
+absolute guarantee.
+
+## Independent implementation
+
+- TenkaCloud was implemented independently in this repository. The Git history
+  is incremental and public: it began from an empty project skeleton and grew
+  through publicly documented reference architectures and repeated redesigns.
+- The project is released under the [Apache License 2.0](../LICENSE).
+- It builds on public AWS reference material, which is acknowledged in the
+  codebase and documentation:
+  - the AWS SaaS Builder Toolkit, [`@cdklabs/sbt-aws`](https://github.com/awslabs/sbt-aws);
+  - the AWS [SaaS Factory Serverless SaaS reference architecture](https://github.com/aws-samples/aws-saas-factory-ref-solution-serverless-saas);
+  - general AWS service documentation and public sample patterns.
+
+## Relationship to prior professional experience
+
+The author previously worked in a role where cloud-competition events were run.
+The following boundary applies:
+
+- An early product hypothesis explored compatibility with an existing
+  cloud-competition problem format. After the author left that role and no
+  longer had access to that code or its non-public formats, the compatibility
+  approach was dropped.
+- The current problem model and problem content were rebuilt from scratch.
+- Scenarios such as `Microservice Migration` and `Security Battle Royale`
+  recreate high-level learning themes and general scenario structures (for
+  example, AWS GameDay-style incident response), not any specific proprietary
+  content.
+
+## Influence versus copying
+
+This project distinguishes two categories that are easy to conflate:
+
+- **Influence (used):** ideas, learning goals, general scenario patterns, and
+  the author's own general professional experience and skills. These inform the
+  design and are not owned by any single employer.
+- **Copying (not intentionally included):** verbatim text, source code, design
+  assets, scoring logic, or non-public specifications belonging to a third party
+  or a former employer. No employer source code, confidential documents, private
+  challenge content, customer data, or proprietary assets are intentionally
+  included in this repository.
+
+If anyone identifies material they believe crosses from the first category into
+the second, please open an issue so it can be reviewed and corrected.
+
+## No affiliation or endorsement
+
+- TenkaCloud is not sponsored by, affiliated with, or endorsed by the author's
+  employer (current or former).
+- It is not affiliated with, endorsed by, or officially compatible with any
+  specific cloud-competition event or company. Names of such events or companies,
+  where they appear, are used only to describe general learning themes or for
+  factual comparison.
+- Third-party product names and trademarks (for example, AWS and AWS service
+  names) remain the property of their respective owners and are used only for
+  identification.
+
+## Contributor expectation
+
+Contributors must not add an employer's source code, confidential documents,
+customer data, private competition content, or other proprietary assets.
+Contribute only original work or material under a compatible license, and
+attribute public references where practical. See
+[CONTRIBUTING.md](../CONTRIBUTING.md) for the contribution workflow.
+
+## Scope of this document
+
+- It does not rewrite or squash existing Git history.
+- It does not provide a legal opinion or make an absolute legal conclusion.
+- It does not describe any confidential employment policy or internal project.

--- a/infrastructure/test/application-admin-console-hosting.test.ts
+++ b/infrastructure/test/application-admin-console-hosting.test.ts
@@ -134,7 +134,7 @@ describe("ApplicationAdminConsoleHosting", () => {
         cognitoDomain: "https://example.auth.ap-northeast-1.amazoncognito.com",
         cognitoClientId: "test-client",
         tenantId: "tenant-1",
-        tenantName: "DENSO 第一事業部",
+        tenantName: "Acme Manufacturing Division",
         apiUrl: "https://abc.execute-api.ap-northeast-1.amazonaws.com/prod/",
       });
       return { template: Template.fromStack(stack), stack };


### PR DESCRIPTION
Decouples the public repo's identity from the author's (former) employer: neutralizes the one employer name used as fixture data, and documents the project's independence boundaries.

## #1759 — neutralize employer fixture names
The only employer name in the repo was `tenantName: "DENSO 第一事業部"`, used as fixture data in **3 test files** (nothing in runtime code, docs, or problems). Replaced with the neutral `"Acme Manufacturing Division"` in both the fixture input and its matching expectation, so coverage and intent are unchanged.

## #1760 — `docs/PROJECT_PROVENANCE.md`
A factual, neutral provenance document, framed as the author's **good-faith attestation** (explicitly *not* a legal opinion, audit, or absolute guarantee, per the issue's constraint). It:
- records the independent, incremental Git history and the public reference architectures it builds on (`@cdklabs/sbt-aws`, the AWS Serverless SaaS ref arch), under Apache-2.0;
- captures the owner's stated provenance (per the issue thread): an early compatibility hypothesis was dropped after the author left the role and lost access to that code / non-public formats, and the problem model + content were rebuilt;
- draws the **influence (ideas / learning goals / general scenario patterns / personal experience) vs. copying (text / code / assets / scoring logic / non-public specs — not intentionally included)** distinction;
- disclaims affiliation/endorsement and notes third-party trademarks;
- sets the contributor expectation and links from `CONTRIBUTING.md` (README left unchanged, not made defensive).

Note on framing: I wrote the doc as the author's attestation plus verifiable public facts, with hedged language — I can't and don't certify the absence of proprietary material, which is exactly why the doc avoids absolute claims.

## Test plan
- `apps/application-admin-console` config test → 26 passed; `infrastructure` hosting test → 11 passed.
- Repo-wide grep for the employer name → 0 residual occurrences.
- `make lint` (markdownlint + textlint + biome) → exit 0; `make harness` → no error-level findings.

## Regression analysis
- Fixture rename: the two affected tests assert the round-tripped `tenantName`; input and expectation were changed together, so behavior is identical. No runtime/product code touched.
- Docs: a new Markdown file + a CONTRIBUTING link — no code paths affected.

## Physical impact
- **NO-OP** on CloudFormation/runtime — only test fixture strings, one new doc, and a docs link change. No CDK, IAM, or deployed artifact is affected.

Closes #1759
Closes #1760

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUf19cuyJW9VgBoWNHpF6e)_