### PR TITLE
feat(problems): semantic validation rules for metadata.json

### DIFF
--- a/infrastructure/test/scripts/validate-problems-runtime.test.ts
+++ b/infrastructure/test/scripts/validate-problems-runtime.test.ts
@@ -64,7 +64,8 @@ describe("checkCrossRefs runtime awareness", () => {
       "azure-problem",
       {
         runtime: { provider: "azure", engine: "bicep", entry: "main.bicep" },
-        scoring: { kind: "flag", flagOutputKey: "FlagValue" },
+        // points は SCHEMA 必須 field。 #1777 semantic check (flag) も正値を要求する。
+        scoring: { kind: "flag", flagOutputKey: "FlagValue", points: 100 },
         endpoints: [{ slot: "web", default: { from: "cfn-output", key: "ServiceUrl" } }],
       },
       { name: "main.bicep", body: "// bicep template, no CFn Outputs here\n" },
@@ -77,7 +78,7 @@ describe("checkCrossRefs runtime awareness", () => {
       "aws-problem",
       {
         runtime: { provider: "aws", engine: "cloudformation", entry: "template.yaml" },
-        scoring: { kind: "flag", flagOutputKey: "FlagValue" },
+        scoring: { kind: "flag", flagOutputKey: "FlagValue", points: 100 },
       },
       { name: "template.yaml", body: "Outputs:\n  SomethingElse:\n    Value: x\n" },
     );
@@ -119,7 +120,7 @@ describe("checkCrossRefs runtime awareness", () => {
   it("should default to template.yaml for a legacy problem with no runtime declared", () => {
     const { metaPath, meta } = writeProblem(
       "legacy-problem",
-      { scoring: { kind: "flag", flagOutputKey: "FlagValue" } },
+      { scoring: { kind: "flag", flagOutputKey: "FlagValue", points: 100 } },
       { name: "template.yaml", body: "Outputs:\n  FlagValue:\n    Value: x\n" },
     );
     // legacy = aws/cloudformation 既定 → CFn check が走り、 FlagValue は Outputs にあるので OK。

--- a/infrastructure/test/scripts/validate-problems-semantic.test.ts
+++ b/infrastructure/test/scripts/validate-problems-semantic.test.ts
@@ -1,0 +1,282 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkDisruptionTriggerRefs,
+  checkFlagSemantics,
+  checkPhaseTimeline,
+  checkUptimeMultiSemantics,
+} from "../../../scripts/lib/semantic-check";
+import { checkCrossRefs } from "../../../scripts/validate-problems";
+
+/**
+ * Issue #1777: JSON Schema が構造を保証した後の field 間整合性 (= semantic rules) を
+ * validate-problems が enforce することを保証する。 fixture はすべて inline (実カタログ非依存)。
+ *
+ *   - uptime-multi: probedSlots[].slot の一意性 / endpoints[].slot への参照解決 / weight の正値
+ *   - phased-polling: phases[] の昇順 (= time-ordered, non-overlapping) と name の一意性
+ *   - disruptions: triggers[].phase-entered の phaseName が phases[].name に実在
+ *   - flag: flagOutputKey 非空 / points 正値 / wrongAnswerPenalty 整合 / hints penalty 合計 < points
+ */
+
+describe("checkUptimeMultiSemantics (#1777)", () => {
+  const wellFormed = () => ({
+    endpoints: [
+      { slot: "frontend", default: { from: "cfn-output", key: "FrontendUrl" } },
+      { slot: "api", default: { from: "cfn-output", key: "ApiUrl" } },
+    ],
+    scoring: {
+      kind: "uptime-multi",
+      probedSlots: [
+        { slot: "frontend", path: "/", expectStatus: [200] },
+        { slot: "api", path: "/api/v1/apistatus", expectStatus: [200] },
+      ],
+      pointsAllOk: 100,
+      failurePenalty: 0,
+      attackBlocked: { slot: "api", path: "/api/v1/blocked", pointsPerBlock: 10 },
+      attackProbes: [
+        { slot: "api", path: "/api/v1/auth", method: "POST", vulnerableStatus: [200], penalty: 50 },
+      ],
+    },
+  });
+
+  it("should pass a well-formed uptime-multi scoring with unique probed slots", () => {
+    expect(checkUptimeMultiSemantics(wellFormed())).toEqual([]);
+  });
+
+  it("should be a no-op for non-uptime-multi kinds", () => {
+    expect(
+      checkUptimeMultiSemantics({
+        scoring: { kind: "flag", flagOutputKey: "AnswerFlag", points: 100 },
+      }),
+    ).toEqual([]);
+    expect(checkUptimeMultiSemantics({})).toEqual([]);
+  });
+
+  it("should reject duplicate probedSlots slot names", () => {
+    const meta = wellFormed();
+    meta.scoring.probedSlots.push({ slot: "api", path: "/other", expectStatus: [200] });
+    const errs = checkUptimeMultiSemantics(meta);
+    expect(errs.some((e) => e.includes('slot="api"') && e.includes("duplicated"))).toBe(true);
+  });
+
+  it("should reject a probedSlot referencing an undeclared endpoint slot", () => {
+    const meta = wellFormed();
+    meta.scoring.probedSlots[1].slot = "database";
+    const errs = checkUptimeMultiSemantics(meta);
+    expect(
+      errs.some((e) => e.includes('slot="database"') && e.includes("not declared in endpoints[]")),
+    ).toBe(true);
+  });
+
+  it("should reject attackBlocked / attackProbes referencing undeclared slots", () => {
+    const meta = wellFormed();
+    meta.scoring.attackBlocked.slot = "ghost-blocked";
+    meta.scoring.attackProbes[0].slot = "ghost-probe";
+    const errs = checkUptimeMultiSemantics(meta);
+    expect(errs.some((e) => e.includes("attackBlocked") && e.includes("ghost-blocked"))).toBe(true);
+    expect(errs.some((e) => e.includes("attackProbes") && e.includes("ghost-probe"))).toBe(true);
+  });
+
+  it("should reject probed slots when the problem declares no endpoints at all", () => {
+    const meta = wellFormed() as Record<string, unknown>;
+    delete meta.endpoints;
+    const errs = checkUptimeMultiSemantics(meta);
+    expect(errs.some((e) => e.includes("not declared in endpoints[]"))).toBe(true);
+  });
+
+  it("should reject non-positive weights (pointsAllOk / pointsPerBlock / penalty)", () => {
+    const meta = wellFormed();
+    meta.scoring.pointsAllOk = 0;
+    meta.scoring.attackBlocked.pointsPerBlock = -5;
+    meta.scoring.attackProbes[0].penalty = Number.NaN;
+    const errs = checkUptimeMultiSemantics(meta);
+    expect(errs.some((e) => e.includes("pointsAllOk") && e.includes("positive"))).toBe(true);
+    expect(errs.some((e) => e.includes("pointsPerBlock") && e.includes("positive"))).toBe(true);
+    expect(errs.some((e) => e.includes("attackProbes[0].penalty") && e.includes("positive"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("checkPhaseTimeline (#1777)", () => {
+  const phases = () => [
+    { name: "degraded", afterMinutes: 60, effect: { switchPlatformToDegraded: ["ec2"] } },
+    { name: "legacy", afterMinutes: 90, effect: { scorePathOverride: "/score?legacy=true" } },
+  ];
+
+  it("should pass phases declared in strictly ascending afterMinutes order with unique names", () => {
+    expect(checkPhaseTimeline({ phases: phases() })).toEqual([]);
+  });
+
+  it("should be a no-op when no phases are declared", () => {
+    expect(checkPhaseTimeline({})).toEqual([]);
+    expect(checkPhaseTimeline({ phases: [] })).toEqual([]);
+  });
+
+  it("should reject duplicate phase names", () => {
+    const p = phases();
+    p[1].name = "degraded";
+    const errs = checkPhaseTimeline({ phases: p });
+    expect(errs.some((e) => e.includes('name="degraded"') && e.includes("duplicated"))).toBe(true);
+  });
+
+  it("should reject phases that are not time-ordered (descending afterMinutes)", () => {
+    const p = phases();
+    p[0].afterMinutes = 90;
+    p[1].afterMinutes = 60;
+    const errs = checkPhaseTimeline({ phases: p });
+    expect(errs.some((e) => e.includes("ascending") && e.includes("afterMinutes"))).toBe(true);
+  });
+
+  it("should reject overlapping phases (equal afterMinutes)", () => {
+    const p = phases();
+    p[1].afterMinutes = p[0].afterMinutes;
+    const errs = checkPhaseTimeline({ phases: p });
+    expect(errs.some((e) => e.includes("ascending") && e.includes("afterMinutes"))).toBe(true);
+  });
+});
+
+describe("checkDisruptionTriggerRefs (#1777)", () => {
+  const meta = (phaseName: string) => ({
+    phases: [
+      { name: "degraded", afterMinutes: 60, effect: {} },
+      { name: "legacy", afterMinutes: 90, effect: {} },
+    ],
+    disruptions: [
+      {
+        id: "latency-injection",
+        name: "Latency",
+        eventDetailType: "DisruptionFired",
+        triggers: [
+          { kind: "after-deploy", afterMinutes: 30 },
+          { kind: "phase-entered", phaseName },
+        ],
+      },
+    ],
+  });
+
+  it("should pass when a phase-entered trigger references a declared phase", () => {
+    expect(checkDisruptionTriggerRefs(meta("degraded"))).toEqual([]);
+  });
+
+  it("should be a no-op when disruptions declare no triggers", () => {
+    expect(
+      checkDisruptionTriggerRefs({
+        disruptions: [{ id: "x", name: "X", eventDetailType: "X" }],
+      }),
+    ).toEqual([]);
+    expect(checkDisruptionTriggerRefs({})).toEqual([]);
+  });
+
+  it("should reject a phase-entered trigger referencing an unknown phase and name the disruption", () => {
+    const errs = checkDisruptionTriggerRefs(meta("ghost-phase"));
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("disruptions[id=latency-injection]");
+    expect(errs[0]).toContain('phaseName="ghost-phase"');
+  });
+});
+
+describe("checkFlagSemantics (#1777)", () => {
+  const wellFormed = () => ({
+    scoring: {
+      kind: "flag",
+      flagOutputKey: "AnswerFlag",
+      points: 300,
+      wrongAnswerPenalty: 15,
+      hints: [
+        { id: "hint-1", content: "look at the route table", penalty: 20 },
+        { id: "hint-2", content: "check the SG", penalty: 50 },
+        { id: "hint-3", content: "the answer is in SSM", penalty: 100 },
+      ],
+    },
+  });
+
+  it("should pass a well-formed flag scoring", () => {
+    expect(checkFlagSemantics(wellFormed())).toEqual([]);
+  });
+
+  it("should be a no-op for non-flag kinds", () => {
+    expect(
+      checkFlagSemantics({
+        scoring: { kind: "uptime-flat", endpoints: [], pointsPerSuccess: 1 },
+      }),
+    ).toEqual([]);
+    expect(checkFlagSemantics({})).toEqual([]);
+  });
+
+  it("should reject an empty flagOutputKey (it would degenerately pass the Outputs cross-ref)", () => {
+    const meta = wellFormed();
+    meta.scoring.flagOutputKey = "";
+    const errs = checkFlagSemantics(meta);
+    expect(errs.some((e) => e.includes("flagOutputKey") && e.includes("non-empty"))).toBe(true);
+  });
+
+  it("should reject non-positive points", () => {
+    const meta = wellFormed();
+    meta.scoring.points = 0;
+    expect(
+      checkFlagSemantics(meta).some((e) => e.includes("points") && e.includes("positive")),
+    ).toBe(true);
+  });
+
+  it("should loudly reject a wrongAnswerPenalty the platform would silently drop", () => {
+    // parseFlag (scoring-metadata.ts) は負値 / 非整数 / 非数値を黙って undefined に倒す。
+    // 出題時に validator が止めることで silent fallback を踏ませない。
+    for (const bad of [-1, 1.5, Number.NaN]) {
+      const meta = wellFormed();
+      meta.scoring.wrongAnswerPenalty = bad;
+      expect(
+        checkFlagSemantics(meta).some((e) => e.includes("wrongAnswerPenalty")),
+        `wrongAnswerPenalty=${bad} should be rejected`,
+      ).toBe(true);
+    }
+  });
+
+  it("should reject hint penalties whose total reaches the flag points", () => {
+    const meta = wellFormed();
+    meta.scoring.hints[2].penalty = 230; // 20 + 50 + 230 = 300 = points
+    const errs = checkFlagSemantics(meta);
+    expect(errs.some((e) => e.includes("hints") && e.includes("points"))).toBe(true);
+  });
+
+  it("should accept legacy v1 string hints (penalty 0)", () => {
+    const meta = wellFormed() as { scoring: Record<string, unknown> };
+    meta.scoring.hints = ["plain text hint", "another one"];
+    expect(checkFlagSemantics(meta as Record<string, unknown>)).toEqual([]);
+  });
+});
+
+describe("checkCrossRefs wiring of semantic rules (#1777)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "semantic-check-"));
+    writeFileSync(
+      join(dir, "template.yaml"),
+      "Resources:\n  Noop:\n    Type: AWS::CloudFormation::WaitConditionHandle\nOutputs:\n  FrontendUrl:\n    Value: x\n  ApiUrl:\n    Value: y\n",
+    );
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("should surface semantic errors through checkCrossRefs", () => {
+    const meta = {
+      id: "fixture-problem",
+      cfnTemplate: "template.yaml",
+      endpoints: [
+        { slot: "frontend", default: { from: "cfn-output", key: "FrontendUrl" } },
+        { slot: "api", default: { from: "cfn-output", key: "ApiUrl" } },
+      ],
+      scoring: {
+        kind: "uptime-multi",
+        probedSlots: [
+          { slot: "frontend", path: "/", expectStatus: [200] },
+          { slot: "frontend", path: "/", expectStatus: [200] },
+        ],
+        pointsAllOk: 100,
+      },
+    };
+    const errs = checkCrossRefs(join(dir, "metadata.json"), meta);
+    expect(errs.some((e) => e.includes('slot="frontend"') && e.includes("duplicated"))).toBe(true);
+  });
+});

--- a/scripts/lib/semantic-check.ts
+++ b/scripts/lib/semantic-check.ts
@@ -1,0 +1,233 @@
+/**
+ * [Issue #1777] metadata.json の semantic validation rules。
+ *
+ * problems/SCHEMA.json (JSON Schema) は個々の field の構造までしか保証しないので、
+ * field 間の整合性はここで enforce する (= 実 deploy / 採点 tick まで気付けない
+ * 宣言ミスを出題時に止める)。
+ *
+ *   - uptime-multi: probedSlots[].slot の一意性、 slot 参照が endpoints[].slot に解決できる、
+ *     weight (pointsAllOk / attackBlocked.pointsPerBlock / attackProbes[].penalty) の正値
+ *   - phased-polling: phases[] が afterMinutes 厳密昇順 (= time-ordered, non-overlapping、
+ *     SCHEMA description の「昇順で並べる規約」を機械化)、 name の一意性
+ *   - disruptions: triggers[].kind=phase-entered の phaseName が phases[].name に実在
+ *     (action.targetRef / functionRef の CFn Outputs 解決は disruption-action-check が担当)
+ *   - flag: flagOutputKey 非空 (空文字は Outputs cross-ref の string-include を素通りする) /
+ *     points 正値 / wrongAnswerPenalty は非負整数 (platform の parseFlag が silent drop する値を
+ *     出題時に loud に reject) / hints penalty 合計 < points (全 hint 開示で報酬が消える宣言を禁止)
+ *
+ * validate-problems.ts から切り出した独立 module (= SRP / disruption-action-check.ts と同方針)。
+ */
+
+type Metadata = Record<string, unknown>;
+type ValidationError = string;
+
+function isPositiveNumber(v: unknown): boolean {
+  return typeof v === "number" && Number.isFinite(v) && v > 0;
+}
+
+function declaredEndpointSlots(meta: Metadata): Set<string> {
+  const slots = new Set<string>();
+  const endpoints = Array.isArray(meta.endpoints) ? meta.endpoints : [];
+  for (const ep of endpoints as Array<Record<string, unknown>>) {
+    if (ep && typeof ep.slot === "string") slots.add(ep.slot);
+  }
+  return slots;
+}
+
+function describeDeclaredSlots(slots: Set<string>): string {
+  return slots.size > 0 ? [...slots].join(", ") : "(none)";
+}
+
+function checkSlotRef(field: string, slot: unknown, declared: Set<string>): ValidationError[] {
+  if (typeof slot !== "string" || declared.has(slot)) return [];
+  return [
+    `${field}.slot="${slot}" not declared in endpoints[] (declared slots: ${describeDeclaredSlots(declared)})`,
+  ];
+}
+
+function checkProbedSlots(
+  probedSlots: readonly unknown[],
+  declared: Set<string>,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const seen = new Set<string>();
+  probedSlots.forEach((raw, i) => {
+    const slot = (raw as Record<string, unknown> | null)?.slot;
+    if (typeof slot !== "string") return;
+    if (seen.has(slot)) {
+      errors.push(
+        `scoring.probedSlots[${i}].slot="${slot}" is duplicated (uptime-multi probed slots must be unique)`,
+      );
+    }
+    seen.add(slot);
+    errors.push(...checkSlotRef(`scoring.probedSlots[${i}]`, slot, declared));
+  });
+  return errors;
+}
+
+function checkAttackBlocked(attackBlocked: unknown, declared: Set<string>): ValidationError[] {
+  if (!attackBlocked || typeof attackBlocked !== "object" || Array.isArray(attackBlocked)) {
+    return [];
+  }
+  const b = attackBlocked as Record<string, unknown>;
+  const errors = checkSlotRef("scoring.attackBlocked", b.slot, declared);
+  if (b.pointsPerBlock !== undefined && !isPositiveNumber(b.pointsPerBlock)) {
+    errors.push("scoring.attackBlocked.pointsPerBlock must be a positive number");
+  }
+  return errors;
+}
+
+function checkAttackProbes(attackProbes: unknown, declared: Set<string>): ValidationError[] {
+  if (!Array.isArray(attackProbes)) return [];
+  const errors: ValidationError[] = [];
+  attackProbes.forEach((raw, i) => {
+    const p = raw as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") return;
+    errors.push(...checkSlotRef(`scoring.attackProbes[${i}]`, p.slot, declared));
+    if (p.penalty !== undefined && !isPositiveNumber(p.penalty)) {
+      errors.push(`scoring.attackProbes[${i}].penalty must be a positive number`);
+    }
+  });
+  return errors;
+}
+
+/**
+ * kind=uptime-multi の semantic check。 probedSlots[].slot は一意 (= 同一 endpoint の二重 probe
+ * は AND 条件の宣言ミス) かつ endpoints[].slot に解決できること。 weight 系 field は正値。
+ */
+export function checkUptimeMultiSemantics(meta: Metadata): ValidationError[] {
+  const scoring = meta.scoring as Record<string, unknown> | undefined;
+  if (scoring?.kind !== "uptime-multi") return [];
+
+  const declared = declaredEndpointSlots(meta);
+  const errors: ValidationError[] = [];
+  if (Array.isArray(scoring.probedSlots)) {
+    errors.push(...checkProbedSlots(scoring.probedSlots, declared));
+  }
+  if (scoring.pointsAllOk !== undefined && !isPositiveNumber(scoring.pointsAllOk)) {
+    errors.push("scoring.pointsAllOk must be a positive number");
+  }
+  errors.push(...checkAttackBlocked(scoring.attackBlocked, declared));
+  errors.push(...checkAttackProbes(scoring.attackProbes, declared));
+  return errors;
+}
+
+/**
+ * phases[] の timeline check。 SCHEMA description の「phases[] は afterMinutes 昇順で並べる規約」
+ * を機械化する: 厳密昇順 (= time-ordered かつ同時刻の重複なし)、 name は一意。
+ * 主に kind=phased-polling が使うが、 phases[] を宣言したどの問題にも適用する。
+ */
+export function checkPhaseTimeline(meta: Metadata): ValidationError[] {
+  const phases = Array.isArray(meta.phases) ? meta.phases : [];
+  const errors: ValidationError[] = [];
+  const seenNames = new Set<string>();
+  let prev: { afterMinutes: number; name: string } | undefined;
+  phases.forEach((raw, i) => {
+    const p = raw as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") return;
+    const name = typeof p.name === "string" ? p.name : `#${i}`;
+    if (seenNames.has(name)) {
+      errors.push(`phases[${i}].name="${name}" is duplicated (phase names must be unique)`);
+    }
+    seenNames.add(name);
+    const afterMinutes = p.afterMinutes;
+    if (typeof afterMinutes !== "number" || !Number.isFinite(afterMinutes)) return;
+    if (prev && afterMinutes <= prev.afterMinutes) {
+      errors.push(
+        `phases[${i}] (name="${name}", afterMinutes=${afterMinutes}) must come strictly after ` +
+          `phases preceding it (name="${prev.name}", afterMinutes=${prev.afterMinutes}) — ` +
+          "declare phases in strictly ascending afterMinutes order (time-ordered, non-overlapping)",
+      );
+    }
+    prev = { afterMinutes, name };
+  });
+  return errors;
+}
+
+/**
+ * disruptions[].triggers[] の参照整合性。 kind=phase-entered の phaseName は phases[].name に
+ * 実在しなければならない (= 存在しない phase を待ち続けて永遠に発火しない宣言を出題時に止める)。
+ * CFn Outputs への参照 (action.targetRef / functionRef) は disruption-action-check.ts が担当。
+ */
+export function checkDisruptionTriggerRefs(meta: Metadata): ValidationError[] {
+  const disruptions = Array.isArray(meta.disruptions) ? meta.disruptions : [];
+  const phases = Array.isArray(meta.phases) ? meta.phases : [];
+  const phaseNames = new Set<string>();
+  for (const p of phases as Array<Record<string, unknown>>) {
+    if (p && typeof p.name === "string") phaseNames.add(p.name);
+  }
+
+  const errors: ValidationError[] = [];
+  for (const raw of disruptions as Array<Record<string, unknown>>) {
+    if (!raw || typeof raw !== "object" || !Array.isArray(raw.triggers)) continue;
+    const id = typeof raw.id === "string" ? raw.id : "?";
+    raw.triggers.forEach((trigger, i) => {
+      const t = trigger as Record<string, unknown> | null;
+      if (!t || t.kind !== "phase-entered" || typeof t.phaseName !== "string") return;
+      if (!phaseNames.has(t.phaseName)) {
+        errors.push(
+          `disruptions[id=${id}].triggers[${i}] phase-entered references unknown phaseName="${t.phaseName}" ` +
+            `(declared phases: ${describeDeclaredSlots(phaseNames)})`,
+        );
+      }
+    });
+  }
+  return errors;
+}
+
+function totalHintPenalty(hints: unknown): number {
+  if (!Array.isArray(hints)) return 0;
+  let total = 0;
+  for (const hint of hints) {
+    const penalty = (hint as Record<string, unknown> | null)?.penalty;
+    if (typeof penalty === "number" && Number.isFinite(penalty) && penalty > 0) total += penalty;
+  }
+  return total;
+}
+
+function checkWrongAnswerPenalty(penalty: unknown): ValidationError[] {
+  if (penalty === undefined) return [];
+  if (
+    typeof penalty === "number" &&
+    Number.isFinite(penalty) &&
+    Number.isInteger(penalty) &&
+    penalty >= 0
+  ) {
+    return [];
+  }
+  return [
+    `scoring.wrongAnswerPenalty=${String(penalty)} must be a non-negative integer ` +
+      "(the platform parseFlag silently drops invalid values — fail loudly at authoring time instead)",
+  ];
+}
+
+/**
+ * kind=flag の semantic check。 flagOutputKey は非空 (空文字は `yaml.includes(":")` の
+ * Outputs cross-ref を素通りして採点が壊れる)、 points は正値、 wrongAnswerPenalty は
+ * platform parser (scoring-metadata.ts parseFlag) が受理する非負整数、 hints の penalty 合計は
+ * points 未満 (= 全 hint を開示しても報酬が残る宣言だけを許す)。
+ */
+export function checkFlagSemantics(meta: Metadata): ValidationError[] {
+  const scoring = meta.scoring as Record<string, unknown> | undefined;
+  if (scoring?.kind !== "flag") return [];
+
+  const errors: ValidationError[] = [];
+  if (typeof scoring.flagOutputKey !== "string" || scoring.flagOutputKey.trim() === "") {
+    errors.push(
+      "scoring.flagOutputKey must be a non-empty string (an empty key degenerately passes the template Outputs cross-ref)",
+    );
+  }
+  if (!isPositiveNumber(scoring.points)) {
+    errors.push("scoring.points must be a positive number");
+  }
+  errors.push(...checkWrongAnswerPenalty(scoring.wrongAnswerPenalty));
+
+  const penaltyTotal = totalHintPenalty(scoring.hints);
+  if (isPositiveNumber(scoring.points) && penaltyTotal >= (scoring.points as number)) {
+    errors.push(
+      `scoring.hints total penalty (${penaltyTotal}) must be less than scoring.points (${String(scoring.points)}) ` +
+        "— revealing every hint must not zero out the flag reward",
+    );
+  }
+  return errors;
+}

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -28,6 +28,12 @@ import {
   checkDisruptionActions,
   checkDisruptionEffects,
 } from "./lib/disruption-action-check";
+import {
+  checkDisruptionTriggerRefs,
+  checkFlagSemantics,
+  checkPhaseTimeline,
+  checkUptimeMultiSemantics,
+} from "./lib/semantic-check";
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const PROBLEMS_DIR = join(REPO_ROOT, "problems");
@@ -113,6 +119,11 @@ export function checkCrossRefs(metaPath: string, meta: Metadata): ValidationErro
     ...checkDisruptionActions(meta),
     ...checkDisruptionEffects(meta),
     ...checkRegionConsistency(meta),
+    // [Issue #1777] schema 通過後の field 間整合性 (semantic rules)。
+    ...checkUptimeMultiSemantics(meta),
+    ...checkPhaseTimeline(meta),
+    ...checkDisruptionTriggerRefs(meta),
+    ...checkFlagSemantics(meta),
   ];
 
   // CFn Outputs 構文 (`Key:`) を前提にした cross-ref は executable な aws/cloudformation


### PR DESCRIPTION
## Summary

`make validate-problems` previously stopped at JSON Schema conformance plus CFn-output cross-refs. This PR adds **semantic rules** — field-to-field consistency checks that the schema cannot express — in a new module `scripts/lib/semantic-check.ts` (same SRP split as `disruption-action-check.ts`), wired into `checkCrossRefs` in `scripts/validate-problems.ts`. All field names are derived from `problems/SCHEMA.json` and the real catalog (no invented fields).

- **uptime-multi** (`checkUptimeMultiSemantics`): `scoring.probedSlots[].slot` must be unique and must resolve to a declared `endpoints[].slot` (same for `attackBlocked.slot` / `attackProbes[].slot`); weight fields (`pointsAllOk`, `attackBlocked.pointsPerBlock`, `attackProbes[].penalty`) must be positive finite numbers.
- **phased-polling** (`checkPhaseTimeline`): `phases[]` must be declared in strictly ascending `afterMinutes` order (time-ordered, non-overlapping — mechanizes the SCHEMA description's "declare in ascending order" convention) and `phases[].name` must be unique.
- **disruptions** (`checkDisruptionTriggerRefs`): `triggers[].kind === "phase-entered"` must reference an existing `phases[].name`. Note: in the current SCHEMA, disruptions reference no endpoint slots; their other references (`action.targetRef` / `functionRef` → CFn Outputs) were already enforced by `disruption-action-check.ts`, so `phaseName` was the remaining unchecked reference.
- **flag** (`checkFlagSemantics`): `flagOutputKey` must be a non-empty string (an empty string degenerately passes the `yaml.includes(":")` Outputs cross-ref); `points` must be positive; `wrongAnswerPenalty`, if declared, must be a non-negative integer (the platform's `parseFlag` in `infrastructure/lib/utils/scoring-metadata.ts` silently drops invalid values at runtime — the validator now rejects them loudly at authoring time); the total of v2 hint `penalty` values must stay below `points` (revealing every hint must not zero out the reward — consistent with the entire catalog: 30 < 100, 170 < 300).

Violations fail `make validate-problems` with exit 1 and print the offending metadata.json path plus a per-rule message (existing `NG <path> (cross-ref)` reporting path).

**Catalog status**: all 10 problems in the pinned `problems/` submodule pass every new rule — no baseline or rule-weakening was needed.

## Test plan

- New `infrastructure/test/scripts/validate-problems-semantic.test.ts` (23 tests, inline fixtures only): at least one passing and one failing fixture per rule, plus a wiring test proving `checkCrossRefs` surfaces semantic errors.
- Updated 3 fixtures in `validate-problems-runtime.test.ts` that declared `kind: "flag"` without the SCHEMA-required `points` (they test runtime awareness, not flag semantics; making them schema-valid preserves their intent).
- `cd infrastructure && bunx vitest run test/scripts/validate-problems-*.test.ts test/problems-schema-hints.test.ts` — 86/86 pass.
- `make validate-problems` — all 10 catalog problems OK (the existing E2E pin in `validate-problems-cross-ref.test.ts` also re-runs the real script).
- `make harness` — no errors (one pre-existing info about missing `cdk.out`).
- `bunx biome check` clean on all changed files; `infrastructure` workspace `tsc --noEmit` clean.

## Regression analysis

- **Catalog CI / submodule bump flow**: `make validate-problems` now enforces stricter rules; a future catalog commit that violates them will fail the platform-side gate. This is the intended behavior (fail loudly). Current pinned catalog passes 100%.
- **`checkCrossRefs` consumers**: the new checks are pure functions appended to the existing error array — schema-valid metadata that previously passed still passes (verified against the full catalog). Problems already failing keep failing with the same messages plus any new ones.
- **`scripts/tenkacloud-problem.ts validate` / scaffolds**: scaffolding templates produce metadata with unique slots, ordered phases, and consistent flag fields, so `/create-problem` output is unaffected (scaffold tests still green in `scaffolds-validate.test.ts` path via the full suite).
- **Runtime behavior**: nothing in `infrastructure/lib` changes; the platform's silent-fallback paths (`parseFlag`) are untouched — the validator now just prevents authors from ever hitting them.

## Physical impact

- **CFn**: NO-OP — no CDK stack, template, or Lambda artifact changes; this is a validator/scripts + tests-only change.
- **Artifacts**: `scripts/lib/semantic-check.ts` (new), `scripts/validate-problems.ts` (wiring), two test files. No `apps/*/dist`, no deployable output diffs.

Closes #1777

https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_