### PR TITLE
feat(onboarding): one-click competitor invite links

### DIFF
--- a/apps/application-admin-console/src/components/event-detail/EventTeamsPanel.tsx
+++ b/apps/application-admin-console/src/components/event-detail/EventTeamsPanel.tsx
@@ -4,14 +4,18 @@ import ExpandableSection from "@cloudscape-design/components/expandable-section"
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
 import type { EventDetail } from "../../api/events-client";
+import { buildInviteLink } from "../../lib/invite-link";
 
 type Translate = (key: string, params?: Readonly<Record<string, string | number>>) => string;
 
 export function EventTeamsPanel({
   detail,
+  participantPortalUrl,
   t,
 }: {
   readonly detail: EventDetail;
+  /** 設定されているときだけ各 team 行に招待リンクコピーを出す (#1772)。 */
+  readonly participantPortalUrl?: string;
   readonly t: Translate;
 }) {
   return (
@@ -73,6 +77,22 @@ export function EventTeamsPanel({
                     /* v8 ignore next */
                     onClick={() => void navigator.clipboard?.writeText(tr.teamLoginKey ?? "")}
                   />
+                  {participantPortalUrl && (
+                    <Button
+                      iconName="share"
+                      variant="inline-icon"
+                      ariaLabel={t("event_detail.teams_col_invite_link_aria", {
+                        slug: tr.internalSlug,
+                      })}
+                      onClick={() =>
+                        void navigator.clipboard?.writeText(
+                          // teamLoginKey truthy の row だけ render されるので ?? "" 右辺は不到達。
+                          /* v8 ignore next */
+                          buildInviteLink(participantPortalUrl, tr.teamLoginKey ?? ""),
+                        )
+                      }
+                    />
+                  )}
                 </SpaceBetween>
               ) : (
                 <Box variant="small" color="text-status-inactive">

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -282,6 +282,7 @@
     "teams_col_account_legacy": "(legacy Event: uses problem default)",
     "teams_col_login_key": "teamLoginKey",
     "teams_col_login_key_aria": "Copy teamLoginKey for {slug}",
+    "teams_col_invite_link_aria": "Copy invite link for {slug}",
     "teams_col_login_key_legacy": "(view in detail)",
     "teams_empty": "No teams",
     "loading_spinner": "Loading…",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -282,6 +282,7 @@
     "teams_col_account_legacy": "(旧 Event: problem 既定値を使用)",
     "teams_col_login_key": "teamLoginKey",
     "teams_col_login_key_aria": "{slug} の teamLoginKey をコピー",
+    "teams_col_invite_link_aria": "{slug} の招待リンクをコピー",
     "teams_col_login_key_legacy": "(詳細で再表示可)",
     "teams_empty": "チームがありません",
     "loading_spinner": "読み込み中…",

--- a/apps/application-admin-console/src/lib/invite-link.test.ts
+++ b/apps/application-admin-console/src/lib/invite-link.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildInviteLink } from "./invite-link";
+
+describe("buildInviteLink", () => {
+  it("should build a /login link carrying the key in the URL fragment", () => {
+    expect(buildInviteLink("https://portal.example.com", "KEY-A")).toBe(
+      "https://portal.example.com/login#invite=KEY-A",
+    );
+  });
+
+  it("should strip trailing slashes from the portal URL", () => {
+    expect(buildInviteLink("https://portal.example.com/", "KEY-A")).toBe(
+      "https://portal.example.com/login#invite=KEY-A",
+    );
+  });
+
+  it("should percent-encode keys with URL-unsafe characters", () => {
+    expect(buildInviteLink("https://portal.example.com", "key with spaces&#")).toBe(
+      "https://portal.example.com/login#invite=key%20with%20spaces%26%23",
+    );
+  });
+});

--- a/apps/application-admin-console/src/lib/invite-link.ts
+++ b/apps/application-admin-console/src/lib/invite-link.ts
@@ -1,0 +1,12 @@
+/**
+ * 競技者招待リンク (#1772)。
+ *
+ * participant-portal の /login に teamLoginKey を URL fragment (`#invite=...`) で
+ * 乗せたリンクを組み立てる。 fragment はブラウザがサーバーへ送信しない (= アクセスログ /
+ * Referer に残らない) ので、 login key を経路上に晒さずワンクリック参加を実現できる。
+ * portal 側 (participant-portal の readInviteKeyFromHash) と encode/decode が対になる。
+ */
+export function buildInviteLink(participantPortalUrl: string, teamLoginKey: string): string {
+  const base = participantPortalUrl.replace(/\/+$/, "");
+  return `${base}/login#invite=${encodeURIComponent(teamLoginKey)}`;
+}

--- a/apps/application-admin-console/src/pages/event-detail/tabs.tsx
+++ b/apps/application-admin-console/src/pages/event-detail/tabs.tsx
@@ -89,7 +89,7 @@ export function TeamsTab({ config, detail, t }: EventTabContentProps) {
   return (
     <>
       <EventParticipantsPanel config={config} detail={detail} t={t} />
-      <EventTeamsPanel detail={detail} t={t} />
+      <EventTeamsPanel detail={detail} participantPortalUrl={config.participantPortalUrl} t={t} />
     </>
   );
 }

--- a/apps/application-admin-console/test/components/event-detail/EventTeamsPanel.test.tsx
+++ b/apps/application-admin-console/test/components/event-detail/EventTeamsPanel.test.tsx
@@ -39,6 +39,38 @@ describe("EventTeamsPanel", () => {
     expect(writeText).toHaveBeenCalledWith("KEY-A");
   });
 
+  it("should copy an invite link when participantPortalUrl is configured (#1772)", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    render(
+      <EventTeamsPanel
+        detail={detail([{ internalSlug: "team-a", teamLoginKey: "KEY A" }])}
+        participantPortalUrl="https://portal.example.com/"
+        t={t}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: 'event_detail.teams_col_invite_link_aria|{"slug":"team-a"}',
+      }),
+    );
+    expect(writeText).toHaveBeenCalledWith("https://portal.example.com/login#invite=KEY%20A");
+  });
+
+  it("should not render the invite-link button without participantPortalUrl", () => {
+    render(
+      <EventTeamsPanel
+        detail={detail([{ internalSlug: "team-a", teamLoginKey: "KEY-A" }])}
+        t={t}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: 'event_detail.teams_col_invite_link_aria|{"slug":"team-a"}',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should show the unset / legacy fallbacks for missing fields (collapsed for RUNNING)", () => {
     render(
       <EventTeamsPanel

--- a/apps/participant-portal/src/lib/invite.ts
+++ b/apps/participant-portal/src/lib/invite.ts
@@ -1,0 +1,31 @@
+/**
+ * 競技者招待リンク (#1772) の受け側。
+ *
+ * application-admin-console の buildInviteLink が生成する
+ * `/login#invite=<encodeURIComponent(teamLoginKey)>` の fragment から login key を読む。
+ * fragment はサーバーへ送信されない (= アクセスログ / Referer に残らない) ことが
+ * このリンク形式を選んだ理由。読み取り後は履歴に key を残さないよう
+ * clearInviteHash() で URL から落とす。
+ */
+
+const INVITE_PREFIX = "#invite=";
+
+/** location.hash から招待 key を取り出す。招待リンク以外 / 壊れた encode は null。 */
+export function readInviteKeyFromHash(hash: string): string | null {
+  if (!hash.startsWith(INVITE_PREFIX)) return null;
+  const raw = hash.slice(INVITE_PREFIX.length);
+  if (raw.length === 0) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    // 壊れた percent-encoding (= 招待リンクとして不成立)。 prefill しないだけで、
+    // ユーザーは通常どおり手入力でログインできる。
+    return null;
+  }
+}
+
+/** 招待 fragment を URL / 履歴から除去する (key をアドレスバーに残さない)。 */
+export function clearInviteHash(): void {
+  if (!window.location.hash.startsWith(INVITE_PREFIX)) return;
+  window.history.replaceState(null, "", window.location.pathname + window.location.search);
+}

--- a/apps/participant-portal/src/pages/Login.tsx
+++ b/apps/participant-portal/src/pages/Login.tsx
@@ -7,12 +7,13 @@ import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 import { useAuth } from "../auth/AuthProvider";
 import type { AppConfig } from "../config";
 import { useIsMock } from "../config-context";
 import { useT } from "../i18n";
+import { clearInviteHash, readInviteKeyFromHash } from "../lib/invite";
 
 /**
  * 競技者ログイン画面。チーム単位で発行されたログインキーを入力すると、
@@ -27,9 +28,18 @@ export function LoginPage({ config }: { config: AppConfig }) {
   const auth = useAuth();
   const navigate = useNavigate();
   const t = useT();
-  const [teamLoginKey, setTeamLoginKey] = useState("");
+  // #1772: 招待リンク (`/login#invite=<key>`) で開いたときは key を prefill する。
+  // auto-submit はしない (= #496 の「黙って team が切り替わる」事故防止と同じ思想で、
+  // ログインは必ず competitor の 1 クリックを挟む)。
+  const [teamLoginKey, setTeamLoginKey] = useState(
+    () => readInviteKeyFromHash(window.location.hash) ?? "",
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 読み取り後は fragment を落とし、 login key をアドレスバー / 履歴に残さない。
+  useEffect(() => {
+    clearInviteHash();
+  }, []);
   // LP 「モックで試す」 動線では backend が存在せず login key 文字列 が任意 (= 競技
   // 主催者が発行する短命キーは無い)。 ユーザーに 「何を入れればいいか分からない」 と
   // 思わせないために info banner / placeholder / description を dev-mock 用に出し分ける。

--- a/apps/participant-portal/test/lib/invite.test.ts
+++ b/apps/participant-portal/test/lib/invite.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearInviteHash, readInviteKeyFromHash } from "../../src/lib/invite";
+
+describe("readInviteKeyFromHash", () => {
+  it("should decode the key from an #invite= fragment", () => {
+    expect(readInviteKeyFromHash("#invite=KEY-A")).toBe("KEY-A");
+  });
+
+  it("should percent-decode URL-unsafe characters", () => {
+    expect(readInviteKeyFromHash("#invite=key%20with%20spaces%26%23")).toBe("key with spaces&#");
+  });
+
+  it("should return null for a non-invite hash", () => {
+    expect(readInviteKeyFromHash("")).toBeNull();
+    expect(readInviteKeyFromHash("#other=1")).toBeNull();
+  });
+
+  it("should return null for an empty or malformed invite value", () => {
+    expect(readInviteKeyFromHash("#invite=")).toBeNull();
+    expect(readInviteKeyFromHash("#invite=%E0%A4%A")).toBeNull(); // broken percent-encoding
+  });
+});
+
+describe("clearInviteHash", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("should remove the invite fragment from the URL", () => {
+    window.history.replaceState(null, "", "/login#invite=KEY-A");
+    clearInviteHash();
+    expect(window.location.hash).toBe("");
+    expect(window.location.pathname).toBe("/login");
+  });
+
+  it("should leave non-invite hashes untouched", () => {
+    window.history.replaceState(null, "", "/login#section-1");
+    clearInviteHash();
+    expect(window.location.hash).toBe("#section-1");
+  });
+});

--- a/apps/participant-portal/test/pages/Login.test.tsx
+++ b/apps/participant-portal/test/pages/Login.test.tsx
@@ -87,4 +87,33 @@ describe("LoginPage", () => {
       unmount();
     }
   });
+
+  it("should prefill the key from an invite link fragment and scrub it from the URL (#1772)", async () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ ready: true, session: null, login: mockLogin });
+    window.history.replaceState(null, "", "/login#invite=KEY%20A");
+    try {
+      renderLogin();
+      expect(screen.getByRole("textbox")).toHaveValue("KEY A");
+      // fragment は読み取り後に履歴から除去される (= key をアドレスバーに残さない)。
+      await waitFor(() => expect(window.location.hash).toBe(""));
+      // prefill は auto-submit しない: ログインは competitor のクリック待ち。
+      expect(mockLogin).not.toHaveBeenCalled();
+    } finally {
+      window.history.replaceState(null, "", "/");
+    }
+  });
+
+  it("should start with an empty field when the hash is not an invite link", () => {
+    mockIsMock.mockReturnValue(true);
+    mockAuth.mockReturnValue({ ready: true, session: null, login: mockLogin });
+    window.history.replaceState(null, "", "/login#section");
+    try {
+      renderLogin();
+      expect(screen.getByRole("textbox")).toHaveValue("");
+      expect(window.location.hash).toBe("#section");
+    } finally {
+      window.history.replaceState(null, "", "/");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

競技者参加導線の第一弾改善（インフラ不要・フロント完結）。

- **application-admin-console**: イベント詳細 > Teams パネルの各チーム行に「招待リンクをコピー」ボタンを追加（`participantPortalUrl` が runtime-config に設定されているときのみ表示）。リンクは `buildInviteLink()` で `<portal>/login#invite=<encodeURIComponent(teamLoginKey)>` を生成。
- **participant-portal**: `/login` が `#invite=` fragment から login key を **prefill** し、読み取り直後に `history.replaceState` で fragment を URL から除去（key をアドレスバー・履歴に残さない）。**auto-submit はしない** — #496 の「黙って team が切り替わる」防止と同じ思想で、参加は必ず競技者の 1 クリックを挟む。
- key を fragment に乗せる理由: fragment はブラウザがサーバーへ送信しないため、アクセスログ / Referer に login key が漏れない。

Closes #1772

## Test plan

- [x] `buildInviteLink` 単体（trailing slash / percent-encoding）
- [x] `readInviteKeyFromHash` / `clearInviteHash` 単体（非招待 hash・壊れた encoding・fragment 除去）
- [x] EventTeamsPanel: portalUrl あり→ボタン表示+クリップボード内容、なし→非表示
- [x] LoginPage: prefill + fragment 除去 + auto-submit しないこと
- [x] 両 SPA フルスイート green（admin-console 962 / participant-portal 607）+ `tsc --noEmit` + biome

## Regression analysis

- EventTeamsPanel は新規 optional prop のみ（未設定なら従来描画と同一 — 既存テストで固定済み）。
- LoginPage の prefill は `useState` 初期値と mount 時 effect のみ。非招待 hash では従来挙動（空入力・hash 不変）をテストで固定。既ログイン時の `/login` → `/` リダイレクト（#496）は変更なし。
- i18n は ja/en に同一キーを 1 行ずつ追加（パリティ維持）。

## Physical impact

| 対象 | 種別 |
| --- | --- |
| `apps/application-admin-console/dist` / `apps/participant-portal/dist` | **UPDATE**（静的アセットのみ）|
| CFn リソース | **NO-OP** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team admins can now copy and share invite links directly from the Teams table, enabling faster participant onboarding
  * When participants access via invite links, their team key is automatically prefilled on the login page
  * Invite URL fragments are automatically removed from the browser history after the key is processed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->