### PR TITLE
feat(app-admin): first-run setup guide for tenant admins

### DIFF
--- a/apps/application-admin-console/src/components/SetupGuide.tsx
+++ b/apps/application-admin-console/src/components/SetupGuide.tsx
@@ -1,0 +1,90 @@
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import ProgressBar from "@cloudscape-design/components/progress-bar";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import type { EventSummary } from "../api/events-client";
+import { interpolate, useT } from "../i18n";
+import {
+  deriveSetupGuideProgress,
+  readSetupGuideDismissed,
+  resolveSetupStepHref,
+  writeSetupGuideDismissed,
+} from "../lib/setup-guide";
+
+/**
+ * Issue #1773: 初回 Tenant Admin 向けセットアップガイド。
+ * ① イベント作成 → ② 問題選択 → ③ チーム登録 → ④ デプロイ の 4 step checklist を
+ * Event 一覧の上に出す。 完了判定は既存データから導出 (lib/setup-guide.ts)、 新規 backend なし。
+ *
+ *  - 全 step 完了で自動的に消える (= 経験者には出ない)
+ *  - 「非表示にする」 で localStorage に永続化し、 以後表示しない (再表示導線は持たない)
+ */
+export function SetupGuide({ events }: { events: readonly EventSummary[] }) {
+  const t = useT();
+  const navigate = useNavigate();
+  const [dismissed, setDismissed] = useState(readSetupGuideDismissed);
+  const progress = deriveSetupGuideProgress(events);
+  if (dismissed || progress.allComplete) return null;
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={t("setup_guide.description")}
+          actions={
+            <Button
+              onClick={() => {
+                writeSetupGuideDismissed();
+                setDismissed(true);
+              }}
+            >
+              {t("setup_guide.dismiss")}
+            </Button>
+          }
+        >
+          {t("setup_guide.header")}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <ProgressBar
+          value={(progress.completedCount / progress.totalCount) * 100}
+          label={t("setup_guide.progress_label")}
+          additionalInfo={interpolate(t("setup_guide.progress_info"), {
+            completed: String(progress.completedCount),
+            total: String(progress.totalCount),
+          })}
+        />
+        {progress.steps.map((step, idx) => {
+          const href = resolveSetupStepHref(step.id, events);
+          return (
+            <SpaceBetween key={step.id} direction="horizontal" size="s">
+              <StatusIndicator type={step.complete ? "success" : "pending"}>
+                {t(step.complete ? "setup_guide.status_complete" : "setup_guide.status_incomplete")}
+              </StatusIndicator>
+              <Box variant="span" fontWeight="bold">
+                {idx + 1}. {t(`setup_guide.step_${step.id}_title`)}
+              </Box>
+              <Link
+                href={href}
+                onFollow={(e) => {
+                  e.preventDefault();
+                  navigate(href);
+                }}
+              >
+                {t(`setup_guide.step_${step.id}_link`)}
+              </Link>
+            </SpaceBetween>
+          );
+        })}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -719,5 +719,22 @@
     "after_minutes_error": "Enter a whole number between 1 and 1440.",
     "fired_flash": "Fired \"{name}\" at {count} team(s).",
     "scheduled_flash": "Scheduled \"{name}\" to fire in {minutes} minute(s)."
+  },
+  "setup_guide": {
+    "header": "First-run setup guide",
+    "description": "Four steps to run your first event. Completion is derived from your tenant's existing data, and the guide disappears once every step is done.",
+    "dismiss": "Hide this guide",
+    "progress_label": "Setup progress",
+    "progress_info": "{completed} of {total} steps complete",
+    "status_complete": "Done",
+    "status_incomplete": "Not yet",
+    "step_create_event_title": "Create an event",
+    "step_create_event_link": "Create a new event",
+    "step_select_problems_title": "Select problems",
+    "step_select_problems_link": "Browse the problem catalog",
+    "step_register_teams_title": "Register teams",
+    "step_register_teams_link": "Register teams in the event wizard",
+    "step_deploy_title": "Deploy",
+    "step_deploy_link": "Deploy from the event detail page"
   }
 }

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -719,5 +719,22 @@
     "after_minutes_error": "1〜1440 の整数を入力してください。",
     "fired_flash": "「{name}」 を {count} チームに発火しました。",
     "scheduled_flash": "「{name}」 を {minutes} 分後に発火するよう予約しました。"
+  },
+  "setup_guide": {
+    "header": "初回セットアップガイド",
+    "description": "イベント開催までの 4 ステップ。完了状況はテナント内の既存データから自動判定され、すべて完了するとこのガイドは表示されなくなります。",
+    "dismiss": "非表示にする",
+    "progress_label": "セットアップ進捗",
+    "progress_info": "{completed} / {total} ステップ完了",
+    "status_complete": "完了",
+    "status_incomplete": "未完了",
+    "step_create_event_title": "イベント作成",
+    "step_create_event_link": "新規 Event を作成する",
+    "step_select_problems_title": "問題選択",
+    "step_select_problems_link": "問題カタログから問題を選ぶ",
+    "step_register_teams_title": "チーム登録",
+    "step_register_teams_link": "Event 作成ウィザードでチームを登録する",
+    "step_deploy_title": "デプロイ",
+    "step_deploy_link": "Event 詳細からデプロイを実行する"
   }
 }

--- a/apps/application-admin-console/src/lib/setup-guide.test.ts
+++ b/apps/application-admin-console/src/lib/setup-guide.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { EventStatus, EventSummary } from "../api/events-client";
+import {
+  deriveSetupGuideProgress,
+  readSetupGuideDismissed,
+  resolveSetupStepHref,
+  SETUP_GUIDE_DISMISSED_KEY,
+  writeSetupGuideDismissed,
+} from "./setup-guide";
+
+/**
+ * Issue #1773: Tenant Admin 初回セットアップガイドの完了判定 (純関数) を pin する。
+ * 完了状態は tenant 内の既存データ (EventSummary 一覧) からのみ導出する:
+ *   - create_event: event が 1 件以上
+ *   - select_problems: いずれかの event に problem が 1 件以上
+ *   - register_teams: いずれかの event に team が 1 件以上
+ *   - deploy: いずれかの event が deploy 起動済 status (DEPLOYING/READY/ENDED/TEARDOWN)
+ */
+
+const ev = (over: Partial<EventSummary> = {}): EventSummary => ({
+  eventId: "01HZZZZZZZZZZZZZZZZZZZZZZZ",
+  name: "Ev",
+  status: "DRAFT",
+  teamCount: 0,
+  problemCount: 0,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+  expiresAt: 0,
+  ...over,
+});
+
+const stepById = (events: readonly EventSummary[], id: string) => {
+  const step = deriveSetupGuideProgress(events).steps.find((s) => s.id === id);
+  if (!step) throw new Error(`step not found: ${id}`);
+  return step;
+};
+
+describe("deriveSetupGuideProgress", () => {
+  it("should mark every step incomplete when the tenant has no events", () => {
+    const progress = deriveSetupGuideProgress([]);
+    expect(progress.steps.map((s) => s.id)).toEqual([
+      "create_event",
+      "select_problems",
+      "register_teams",
+      "deploy",
+    ]);
+    expect(progress.steps.every((s) => !s.complete)).toBe(true);
+    expect(progress.completedCount).toBe(0);
+    expect(progress.totalCount).toBe(4);
+    expect(progress.allComplete).toBe(false);
+  });
+
+  it("should complete create_event when at least one event exists while later steps stay incomplete", () => {
+    const progress = deriveSetupGuideProgress([ev()]);
+    expect(stepById([ev()], "create_event").complete).toBe(true);
+    expect(progress.completedCount).toBe(1);
+    expect(progress.allComplete).toBe(false);
+  });
+
+  it("should complete select_problems when any event has at least one problem", () => {
+    expect(stepById([ev({ problemCount: 1 })], "select_problems").complete).toBe(true);
+    expect(stepById([ev({ problemCount: 0 })], "select_problems").complete).toBe(false);
+  });
+
+  it("should complete register_teams when any event has at least one team", () => {
+    expect(stepById([ev({ teamCount: 2 })], "register_teams").complete).toBe(true);
+    expect(stepById([ev({ teamCount: 0 })], "register_teams").complete).toBe(false);
+  });
+
+  it("should complete deploy for every status that implies a deploy was requested", () => {
+    const deployed: EventStatus[] = ["DEPLOYING", "READY", "ENDED", "TEARDOWN"];
+    for (const status of deployed) {
+      expect(stepById([ev({ status })], "deploy").complete).toBe(true);
+    }
+  });
+
+  it("should keep deploy incomplete for DRAFT and ARCHIVED events", () => {
+    const notDeployed: EventStatus[] = ["DRAFT", "ARCHIVED"];
+    for (const status of notDeployed) {
+      expect(stepById([ev({ status })], "deploy").complete).toBe(false);
+    }
+  });
+
+  it("should derive each step independently across multiple events", () => {
+    const events = [ev({ problemCount: 1 }), ev({ eventId: "e2", teamCount: 3 })];
+    expect(stepById(events, "select_problems").complete).toBe(true);
+    expect(stepById(events, "register_teams").complete).toBe(true);
+    expect(stepById(events, "deploy").complete).toBe(false);
+  });
+
+  it("should report allComplete when a deployed event has problems and teams", () => {
+    const progress = deriveSetupGuideProgress([
+      ev({ status: "READY", problemCount: 2, teamCount: 3 }),
+    ]);
+    expect(progress.completedCount).toBe(4);
+    expect(progress.allComplete).toBe(true);
+  });
+});
+
+describe("resolveSetupStepHref", () => {
+  it("should point create_event and register_teams at the event wizard and select_problems at the catalog", () => {
+    expect(resolveSetupStepHref("create_event", [])).toBe("/events/new");
+    expect(resolveSetupStepHref("register_teams", [])).toBe("/events/new");
+    expect(resolveSetupStepHref("select_problems", [])).toBe("/problems");
+  });
+
+  it("should point deploy at the first non-archived event detail", () => {
+    const events = [ev({ eventId: "old", status: "ARCHIVED" }), ev({ eventId: "e1" })];
+    expect(resolveSetupStepHref("deploy", events)).toBe("/events/e1");
+  });
+
+  it("should point deploy at the event wizard when no deployable event exists", () => {
+    expect(resolveSetupStepHref("deploy", [])).toBe("/events/new");
+    expect(resolveSetupStepHref("deploy", [ev({ status: "ARCHIVED" })])).toBe("/events/new");
+  });
+});
+
+describe("setup guide dismissal persistence", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(SETUP_GUIDE_DISMISSED_KEY);
+  });
+
+  it("should read false while the dismissed flag is unset and true after writing it", () => {
+    expect(readSetupGuideDismissed()).toBe(false);
+    writeSetupGuideDismissed();
+    expect(window.localStorage.getItem(SETUP_GUIDE_DISMISSED_KEY)).toBe("true");
+    expect(readSetupGuideDismissed()).toBe(true);
+  });
+
+  it("should fail safe to visible (false) when localStorage is unavailable", () => {
+    const original = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error("denied");
+        },
+        setItem: () => {
+          throw new Error("denied");
+        },
+      },
+    });
+    try {
+      expect(readSetupGuideDismissed()).toBe(false);
+      expect(() => writeSetupGuideDismissed()).not.toThrow();
+    } finally {
+      // original は jsdom が必ず提供する (= undefined 不到達) が、型上 optional なので guard。
+      if (original) Object.defineProperty(window, "localStorage", original);
+    }
+  });
+});

--- a/apps/application-admin-console/src/lib/setup-guide.ts
+++ b/apps/application-admin-console/src/lib/setup-guide.ts
@@ -1,0 +1,94 @@
+import type { EventStatus, EventSummary } from "../api/events-client";
+
+/**
+ * Issue #1773: Tenant Admin 初回セットアップガイド (① イベント作成 → ② 問題選択 →
+ * ③ チーム登録 → ④ デプロイ) の完了判定。 新規 backend は持たず、 tenant 内の既存データ
+ * (EventSummary 一覧) からのみ導出する純関数群。
+ */
+
+export type SetupStepId = "create_event" | "select_problems" | "register_teams" | "deploy";
+
+export interface SetupStepProgress {
+  readonly id: SetupStepId;
+  readonly complete: boolean;
+}
+
+export interface SetupGuideProgress {
+  readonly steps: readonly SetupStepProgress[];
+  readonly completedCount: number;
+  readonly totalCount: number;
+  readonly allComplete: boolean;
+}
+
+/**
+ * 「deploy が一度は起動された」 ことを示す status 集合。 DRAFT は未 deploy。 ARCHIVED は
+ * DRAFT から直接到達し得る (= 一度も deploy していない可能性がある) ため含めない。
+ */
+const DEPLOY_TRIGGERED_STATUSES: ReadonlySet<EventStatus> = new Set([
+  "DEPLOYING",
+  "READY",
+  "ENDED",
+  "TEARDOWN",
+]);
+
+/**
+ * 4 ステップの完了状態を event 一覧から導出する。
+ *   - create_event: event が 1 件以上存在する
+ *   - select_problems: いずれかの event に problem が 1 件以上ある
+ *   - register_teams: いずれかの event に team が 1 件以上ある
+ *   - deploy: いずれかの event が deploy 起動済 status になっている
+ */
+export function deriveSetupGuideProgress(events: readonly EventSummary[]): SetupGuideProgress {
+  const steps: readonly SetupStepProgress[] = [
+    { id: "create_event", complete: events.length > 0 },
+    { id: "select_problems", complete: events.some((e) => e.problemCount > 0) },
+    { id: "register_teams", complete: events.some((e) => e.teamCount > 0) },
+    { id: "deploy", complete: events.some((e) => DEPLOY_TRIGGERED_STATUSES.has(e.status)) },
+  ];
+  const completedCount = steps.filter((s) => s.complete).length;
+  return {
+    steps,
+    completedCount,
+    totalCount: steps.length,
+    allComplete: completedCount === steps.length,
+  };
+}
+
+/**
+ * 各 step を完了させる既存ページへの遷移先。 deploy だけは event 依存:
+ * 最初の non-ARCHIVED event の詳細 (deploy ボタンがある画面) へ、 無ければ作成 wizard へ。
+ */
+export function resolveSetupStepHref(id: SetupStepId, events: readonly EventSummary[]): string {
+  switch (id) {
+    case "create_event":
+    case "register_teams":
+      // problem / team の選択・登録はどちらも Event 作成 wizard 内で行う。
+      return "/events/new";
+    case "select_problems":
+      return "/problems";
+    case "deploy": {
+      const target = events.find((e) => e.status !== "ARCHIVED");
+      return target ? `/events/${encodeURIComponent(target.eventId)}` : "/events/new";
+    }
+  }
+}
+
+/** Home の onboarding dismiss (#542) と同じ命名規約。 値は "true" のみ意味を持つ。 */
+export const SETUP_GUIDE_DISMISSED_KEY = "TenkaCloud.applicationAdmin.setupGuideDismissed";
+
+export function readSetupGuideDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(SETUP_GUIDE_DISMISSED_KEY) === "true";
+  } catch {
+    // localStorage 不可 (= private mode 等) は「未 dismiss = 毎回表示」で安全側。
+    return false;
+  }
+}
+
+export function writeSetupGuideDismissed(): void {
+  try {
+    window.localStorage.setItem(SETUP_GUIDE_DISMISSED_KEY, "true");
+  } catch {
+    // localStorage 不可なら永続化を諦める (= 次回も表示)。 fail loud にする価値がない UI 設定。
+  }
+}

--- a/apps/application-admin-console/src/pages/EventList.tsx
+++ b/apps/application-admin-console/src/pages/EventList.tsx
@@ -20,6 +20,7 @@ import {
   type EventSummary,
   listEvents,
 } from "../api/events-client";
+import { SetupGuide } from "../components/SetupGuide";
 import type { AppConfig } from "../config";
 import { usePollingList } from "../hooks/usePollingList";
 import { interpolate, useT } from "../i18n";
@@ -222,6 +223,10 @@ export function EventListPage({ config }: { config: AppConfig }) {
           {error}
         </Alert>
       )}
+
+      {/* Issue #1773: 初回セットアップガイド。 items 取得済のときだけ出す (= fetch 失敗時に
+          全 step を誤って「未完了」 表示しない)。 全 step 完了 / dismiss 済なら自動で消える。 */}
+      {items && <SetupGuide events={items} />}
 
       {archivedCount > 0 && (
         <Checkbox checked={showArchived} onChange={({ detail }) => setShowArchived(detail.checked)}>

--- a/apps/application-admin-console/test/components/SetupGuide.test.tsx
+++ b/apps/application-admin-console/test/components/SetupGuide.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventSummary } from "../../src/api/events-client";
+import { SETUP_GUIDE_DISMISSED_KEY } from "../../src/lib/setup-guide";
+
+/**
+ * SetupGuide (Issue #1773): 初回 Tenant Admin 向け 4 ステップ checklist の render を pin する。
+ * 完了 derive は lib/setup-guide.test.ts で個別に固定済なので、 ここは
+ *   - 4 ステップ + 進捗表示の描画
+ *   - 完了 / 未完了 StatusIndicator の出し分け
+ *   - step link の navigate 先
+ *   - 全完了 / dismiss 済での非表示と「非表示にする」の localStorage 永続化
+ * を component 境界で検証する。 useNavigate / useT を mock、 interpolate は実物。
+ */
+const { mockNav } = vi.hoisted(() => ({ mockNav: vi.fn() }));
+vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
+
+// 補間されるキーだけテンプレートを返し、他は key を echo する t。
+const T: Record<string, string> = {
+  "setup_guide.progress_info": "{completed} / {total} steps done",
+};
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return { ...actual, useT: () => (k: string) => T[k] ?? k };
+});
+
+const { SetupGuide } = await import("../../src/components/SetupGuide");
+
+const ev = (over: Partial<EventSummary> = {}): EventSummary => ({
+  eventId: "e1",
+  name: "Ev",
+  status: "DRAFT",
+  teamCount: 0,
+  problemCount: 0,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+  expiresAt: 0,
+  ...over,
+});
+
+beforeEach(() => {
+  window.localStorage.removeItem(SETUP_GUIDE_DISMISSED_KEY);
+  mockNav.mockClear();
+});
+afterEach(() => {
+  window.localStorage.removeItem(SETUP_GUIDE_DISMISSED_KEY);
+});
+
+describe("SetupGuide", () => {
+  it("should render all four steps as pending with 0/4 progress when the tenant has no events", () => {
+    render(<SetupGuide events={[]} />);
+    expect(screen.getByText("setup_guide.header")).toBeInTheDocument();
+    expect(screen.getByText("0 / 4 steps done")).toBeInTheDocument();
+    expect(screen.getAllByText("setup_guide.status_incomplete")).toHaveLength(4);
+    // title は連番付き ("1. <title>") で render されるので連番込みの全文で確認する。
+    for (const [idx, id] of [
+      "create_event",
+      "select_problems",
+      "register_teams",
+      "deploy",
+    ].entries()) {
+      expect(screen.getByText(`${idx + 1}. setup_guide.step_${id}_title`)).toBeInTheDocument();
+      expect(screen.getByText(`setup_guide.step_${id}_link`)).toBeInTheDocument();
+    }
+  });
+
+  it("should mark derived-complete steps with a success indicator and update the progress count", () => {
+    render(<SetupGuide events={[ev({ problemCount: 2, teamCount: 3 })]} />);
+    expect(screen.getByText("3 / 4 steps done")).toBeInTheDocument();
+    expect(screen.getAllByText("setup_guide.status_complete")).toHaveLength(3);
+    expect(screen.getAllByText("setup_guide.status_incomplete")).toHaveLength(1);
+  });
+
+  it("should navigate to the wizard from the create step and to the event detail from the deploy step", () => {
+    render(<SetupGuide events={[ev({ eventId: "e1" })]} />);
+    fireEvent.click(screen.getByText("setup_guide.step_create_event_link"));
+    expect(mockNav).toHaveBeenCalledWith("/events/new");
+    fireEvent.click(screen.getByText("setup_guide.step_deploy_link"));
+    expect(mockNav).toHaveBeenCalledWith("/events/e1");
+  });
+
+  it("should point the deploy step at the event wizard when every event is archived", () => {
+    render(<SetupGuide events={[ev({ status: "ARCHIVED" })]} />);
+    fireEvent.click(screen.getByText("setup_guide.step_deploy_link"));
+    expect(mockNav).toHaveBeenCalledWith("/events/new");
+  });
+
+  it("should render nothing when every step is complete", () => {
+    render(<SetupGuide events={[ev({ status: "READY", problemCount: 1, teamCount: 1 })]} />);
+    expect(screen.queryByText("setup_guide.header")).not.toBeInTheDocument();
+  });
+
+  it("should render nothing when the guide was previously dismissed", () => {
+    window.localStorage.setItem(SETUP_GUIDE_DISMISSED_KEY, "true");
+    render(<SetupGuide events={[]} />);
+    expect(screen.queryByText("setup_guide.header")).not.toBeInTheDocument();
+  });
+
+  it("should hide the guide and persist the dismissal when the dismiss button is clicked", () => {
+    render(<SetupGuide events={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: "setup_guide.dismiss" }));
+    expect(screen.queryByText("setup_guide.header")).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(SETUP_GUIDE_DISMISSED_KEY)).toBe("true");
+  });
+});

--- a/apps/application-admin-console/test/pages/EventList.setup-guide.test.tsx
+++ b/apps/application-admin-console/test/pages/EventList.setup-guide.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventSummary } from "../../src/api/events-client";
+import type { AppConfig } from "../../src/config";
+
+/**
+ * EventListPage × SetupGuide の wiring (Issue #1773) を pin する。
+ * guide 本体の挙動は test/components/SetupGuide.test.tsx、 完了 derive は
+ * src/lib/setup-guide.test.ts で固定済。 ここでは
+ *   - 未完了 step が残る間は一覧の上に guide が出る
+ *   - 全 step 完了で guide が消える
+ *   - 一覧 fetch 失敗 (= items 未取得) では guide を出さない (誤った「未完了」表示の防止)
+ * の 3 経路だけを見る。
+ */
+const { mockApiClient, mockNav, mockList } = vi.hoisted(() => ({
+  mockApiClient: vi.fn(),
+  mockNav: vi.fn(),
+  mockList: vi.fn(),
+}));
+
+vi.mock("../../src/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/client")>();
+  return { ...actual, useApiClient: mockApiClient };
+});
+vi.mock("../../src/api/events-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/api/events-client")>();
+  return { ...actual, listEvents: mockList };
+});
+vi.mock("react-router", () => ({ useNavigate: () => mockNav }));
+vi.mock("../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/i18n")>();
+  return { ...actual, useT: () => (k: string) => k };
+});
+
+const { EventListPage } = await import("../../src/pages/EventList");
+
+const config = {} as AppConfig;
+const ev = (over: Partial<EventSummary> = {}): EventSummary =>
+  ({
+    eventId: "e1",
+    name: "Event One",
+    status: "DRAFT",
+    teamCount: 2,
+    problemCount: 3,
+    createdAt: "2026-05-01T00:00:00Z",
+    updatedAt: "2026-05-01T00:00:00Z",
+    expiresAt: 0,
+    ...over,
+  }) as EventSummary;
+
+beforeEach(() => {
+  mockApiClient.mockReturnValue({ post: vi.fn() });
+  mockList.mockReset().mockResolvedValue({ items: [] });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("EventListPage setup guide wiring", () => {
+  it("should render the setup guide above the list while onboarding steps remain incomplete", async () => {
+    mockList.mockResolvedValue({ items: [ev()] }); // DRAFT = deploy step 未完
+    render(<EventListPage config={config} />);
+    expect(await screen.findByText("Event One")).toBeInTheDocument();
+    expect(screen.getByText("setup_guide.header")).toBeInTheDocument();
+  });
+
+  it("should not render the setup guide once every onboarding step is complete", async () => {
+    mockList.mockResolvedValue({ items: [ev({ status: "READY" })] });
+    render(<EventListPage config={config} />);
+    expect(await screen.findByText("Event One")).toBeInTheDocument();
+    expect(screen.queryByText("setup_guide.header")).not.toBeInTheDocument();
+  });
+
+  it("should not render the setup guide when the event list fails to load", async () => {
+    mockList.mockRejectedValue(new Error("list boom"));
+    render(<EventListPage config={config} />);
+    expect(await screen.findByText("list boom")).toBeInTheDocument();
+    expect(screen.queryByText("setup_guide.header")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1773

初回ログインした Tenant Admin が「① イベント作成 → ② 問題選択 → ③ チーム登録 → ④ デプロイ」の順路を迷わないよう、Events 一覧ページ (`/events`) の Header 直下にチェックリスト型のセットアップガイドを追加した。フロント完結 (新規バックエンドなし・新規依存なし)。

- **完了判定は tenant 内の既存データからのみ導出** (`src/lib/setup-guide.ts`, 純関数):
  - ① イベント作成 = event が 1 件以上
  - ② 問題選択 = いずれかの event に `problemCount > 0`
  - ③ チーム登録 = いずれかの event に `teamCount > 0`
  - ④ デプロイ = いずれかの event が deploy 起動済 status (`DEPLOYING` / `READY` / `ENDED` / `TEARDOWN`。`ARCHIVED` は DRAFT から直接到達し得るため含めない)
- **UI** (`src/components/SetupGuide.tsx`): Cloudscape `Container` + `ProgressBar` (N/4 ステップ完了) + step ごとの `StatusIndicator` (success/pending) + 既存ページへの `Link` (① ③ → `/events/new`、② → `/problems`、④ → 最初の non-archived event 詳細、無ければ `/events/new`)
- **自動非表示**: 全 step 完了で render しない (= 経験者には出ない)
- **「非表示にする」**: localStorage (`TenkaCloud.applicationAdmin.setupGuideDismissed`、Home #542 と同じ命名規約) に永続化。再表示導線はスコープ外 (issue どおり)
- **fetch 失敗時はガイドを出さない** (`items` 取得済のときだけ render し、誤った「未完了」表示を防ぐ。エラーは既存の Alert で loud に表示)
- **i18n**: `setup_guide.*` セクションを `ja.json` / `en.json` 両方に追加 (additive、既存キーは未変更 = 並行作業との conflict 回避)

EventList の polling 結果 (`EventSummary[]`) をそのまま使うため、追加の API リクエストはゼロ。

## Test plan

TDD (tests first, `should ...` titles)。新規 23 tests:

- `src/lib/setup-guide.test.ts` (13) — 4 step の完了判定 (空 tenant / 各 step 単独 / 全 status 網羅 / 複数 event 横断 / allComplete)、step ごとの遷移先 (deploy の non-archived fallback 含む)、localStorage read/write + 不可環境 (private mode) の fail-safe
- `test/components/SetupGuide.test.tsx` (7) — 4 step + 進捗の render、success/pending の出し分け、link navigate、全完了/dismiss 済での非表示、「非表示にする」の永続化
- `test/pages/EventList.setup-guide.test.tsx` (3) — EventList との wiring (未完了で表示 / 全完了で非表示 / fetch 失敗で非表示)

実行結果:

- `bun run test` — 119 files / 985 tests passed
- `bun run test:coverage` — **100% statements (2547/2547) / branches (1590/1590) / functions (824/824) / lines (2276/2276)** (#1424 gate 維持、`/* v8 ignore */` の追加なし)
- `bunx tsc --noEmit` — clean
- `bunx biome check` — clean (changed files)
- `make harness` — error 0 件 (info: cdk.out 未 synth の skip のみ)

## Regression analysis

- **EventList ページ**: 変更は import 1 行 + `{items && <SetupGuide events={items} />}` の 1 ブロックのみ。既存の polling / archive / filter ロジックは未変更で、既存 18 tests + 全 suite green を確認済み。ガイドの追加 render により既存 E2E/test の DOM クエリが衝突する可能性を確認したが、既存 tests は固有キー (`event_list.*`) / role で選択しており衝突なし。
- **i18n**: 追加キーのみ (既存キー未変更)。ja/en のキー parity をスクリプトで検証済み。
- **既存 tenant への見え方**: 既にイベント運用済みの tenant では全 step が完了扱いになりガイドは render されない (= 経験者の画面は変わらない)。途中状態 (例: DRAFT event のみ) の tenant にはガイドが出るが、「非表示にする」で恒久 dismiss できる。
- **localStorage 不可環境** (private mode 等): read/write とも try/catch で fail-safe (毎回表示side)。クラッシュ経路なし。
- **判定の限界 (許容)**: deploy 後に全 event を ARCHIVED にした tenant では ④ が未完了表示に戻る (summary からは deploy 履歴を判別できないため)。dismiss で回避可能であり、新規 API 追加より優先しない。

## Physical impact

- `apps/application-admin-console/dist/` — **UPDATE** (SPA bundle に SetupGuide component + i18n キーが追加される)
- CloudFormation — **NO-OP** (インフラ変更なし。backend / CDK / IAM / DDB に一切手を入れていない)
- 新規依存 — **NO-OP** (`package.json` / lockfile 未変更)

https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_