### PR TITLE
feat(app-admin): search and filters for the problem catalog

### DIFF
--- a/apps/application-admin-console/src/data/problems.ts
+++ b/apps/application-admin-console/src/data/problems.ts
@@ -37,6 +37,12 @@ export interface ProblemSummary {
   supportedRegions?: readonly string[];
   /** ADR-026 / ADR-027: 問題が deploy される cloud (provider) と engine。 未宣言は aws/cloudformation。 */
   runtime: { readonly provider: string; readonly engine: string };
+  /**
+   * Issue #1776: `metadata.json` の `scoring.kind` (ADR-012 の 5 builtin kind:
+   * flag / uptime-flat / uptime-multi / phased-polling / attack-detection)。
+   * scoring 未宣言 (= deploy のみで競技要素なし) は undefined。 カタログ絞り込みの facet に使う。
+   */
+  scoringKind?: string;
 }
 
 export interface ProblemDetail extends ProblemSummary {
@@ -70,6 +76,11 @@ export interface ProblemMetadata {
   cfnParameters?: Record<string, string>;
   /** ADR-026 / ADR-027: 問題の実行環境 (provider/engine)。 未宣言は aws/cloudformation 既定。 */
   runtime?: { provider?: string; engine?: string; entry?: string };
+  /**
+   * ADR-012: scoring 宣言。 UI が使うのは `kind` のみ (kind は schema 上 scoring 内で必須)。
+   * 配点詳細 (points / flagOutputKey 等) は backend の責務なので型として持たない。
+   */
+  scoring?: { kind: string };
   /** Issue #1201: 問題作成者宣言の推奨 region。 wizard が初期値に使う。 */
   defaultRegion?: string;
   /** Issue #1201 Phase 2: 動作確認済 region 集合。 wizard が picker の選択肢を絞る。 */
@@ -106,6 +117,8 @@ export function metadataToDetail(metadata: ProblemMetadata): ProblemDetail {
     ...(metadata.supportedRegions && metadata.supportedRegions.length > 0
       ? { supportedRegions: metadata.supportedRegions }
       : {}),
+    // Issue #1776: scoring.kind をカタログ facet 用に投影。 scoring 未宣言は omit。
+    ...(metadata.scoring ? { scoringKind: metadata.scoring.kind } : {}),
   };
 }
 
@@ -129,12 +142,13 @@ export function listProblemSummaries(): readonly ProblemSummary[] {
     estimatedDuration: p.estimatedDuration,
     tags: p.tags,
     runtime: p.runtime,
-    // region 系は ProblemSummary でも optional。 現状 catalog の全 problem が region を宣言
-    // するため omit 分岐 (= region 無し problem) は実データで到達しない (= 将来 problem 用に保持)。
-    // mapping 本体の分岐網羅は metadataToDetail のユニットテストで担保済。
+    // region / scoring 系は ProblemSummary でも optional。 現状 catalog の全 problem が
+    // region と scoring を宣言するため omit 分岐 (= 未宣言 problem) は実データで到達しない
+    // (= 将来 problem 用に保持)。 mapping 本体の分岐網羅は metadataToDetail のユニットテストで担保済。
     /* v8 ignore start */
     ...(p.defaultRegion ? { defaultRegion: p.defaultRegion } : {}),
     ...(p.supportedRegions ? { supportedRegions: p.supportedRegions } : {}),
+    ...(p.scoringKind ? { scoringKind: p.scoringKind } : {}),
     /* v8 ignore stop */
   }));
 }

--- a/apps/application-admin-console/src/i18n/locales/en.json
+++ b/apps/application-admin-console/src/i18n/locales/en.json
@@ -133,6 +133,19 @@
     "empty_filtered": "No problems match the filters.",
     "empty": "No problems registered yet."
   },
+  "problem_search": {
+    "filter_label": "Filter the problem catalog",
+    "filter_description": "Use search and filters to narrow the options in \"Problems to use\" below.",
+    "search_placeholder": "Search by name / ID / description / tags",
+    "all_categories": "All categories",
+    "difficulty_placeholder": "Difficulty",
+    "scoring_kind_placeholder": "Scoring kind",
+    "tag_placeholder": "Tags (match any)",
+    "facet_count": "{count} problems",
+    "match_count": "{filtered} of {total} problems match",
+    "clear_filters": "Clear filters",
+    "empty_filtered": "No problems match the filters."
+  },
   "event_create": {
     "title": "Create new Event",
     "description": "Specify team count and problem set to create an Event. teamLoginKey can be viewed any time on EventDetail.",

--- a/apps/application-admin-console/src/i18n/locales/ja.json
+++ b/apps/application-admin-console/src/i18n/locales/ja.json
@@ -133,6 +133,19 @@
     "empty_filtered": "条件に一致する問題はありません。",
     "empty": "問題がまだ登録されていません。"
   },
+  "problem_search": {
+    "filter_label": "問題カタログを絞り込む",
+    "filter_description": "検索とフィルタで下の「使用する問題」の選択肢を絞り込めます。",
+    "search_placeholder": "問題名 / ID / 説明 / タグから検索",
+    "all_categories": "全カテゴリ",
+    "difficulty_placeholder": "難易度",
+    "scoring_kind_placeholder": "Scoring kind",
+    "tag_placeholder": "タグ (いずれか含む)",
+    "facet_count": "{count} 問",
+    "match_count": "{filtered} / {total} 問が一致",
+    "clear_filters": "絞り込み解除",
+    "empty_filtered": "条件に一致する問題はありません。"
+  },
   "event_create": {
     "title": "新規 Event 作成",
     "description": "チーム数と問題セットを指定して Event を作成します。 teamLoginKey は EventDetail でいつでも確認できます。",

--- a/apps/application-admin-console/src/lib/problem-filter.test.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ProblemSummary } from "../data/problems";
 import {
+  collectScoringKindFacets,
   collectTagFacets,
+  DIFFICULTY_LEVELS,
   EMPTY_FILTER_CRITERIA,
   filterProblems,
   isFilterActive,
@@ -105,6 +107,44 @@ describe("filterProblems (Issue #834)", () => {
     const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "nonexistent" });
     expect(res).toEqual([]);
   });
+
+  it("should match the problem id via free-text search (Issue #1776)", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, search: "p2" });
+    expect(res.map((p) => p.id)).toEqual(["p2"]);
+  });
+});
+
+describe("filterProblems scoring kind (Issue #1776)", () => {
+  const problems: readonly ProblemSummary[] = [
+    sample({ id: "p1", scoringKind: "flag" }),
+    sample({ id: "p2", scoringKind: "uptime-flat" }),
+    sample({ id: "p3" }), // scoring 未宣言 (= deploy のみ) の問題
+  ];
+
+  it("should keep only problems whose scoring kind is selected", () => {
+    const res = filterProblems(problems, { ...EMPTY_FILTER_CRITERIA, scoringKinds: ["flag"] });
+    expect(res.map((p) => p.id)).toEqual(["p1"]);
+  });
+
+  it("should OR multiple selected scoring kinds", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      scoringKinds: ["flag", "uptime-flat"],
+    });
+    expect(res.map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
+
+  it("should drop problems without a scoring declaration when the kind filter is active", () => {
+    const res = filterProblems(problems, {
+      ...EMPTY_FILTER_CRITERIA,
+      scoringKinds: ["flag", "uptime-flat", "uptime-multi"],
+    });
+    expect(res.map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
+
+  it("should keep problems without a scoring declaration when no kind filter is active", () => {
+    expect(filterProblems(problems, EMPTY_FILTER_CRITERIA)).toHaveLength(3);
+  });
 });
 
 describe("isFilterActive", () => {
@@ -120,6 +160,7 @@ describe("isFilterActive", () => {
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, categories: ["Battle"] })).toBe(true);
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, tags: ["sample"] })).toBe(true);
     expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, difficulties: [1] })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_FILTER_CRITERIA, scoringKinds: ["flag"] })).toBe(true);
   });
 
   it("should return active=false for whitespace-only search (= trim comparison)", () => {
@@ -144,6 +185,37 @@ describe("collectTagFacets", () => {
 
   it("should return empty facets for an empty array", () => {
     expect(collectTagFacets([])).toEqual([]);
+  });
+});
+
+describe("collectScoringKindFacets (Issue #1776)", () => {
+  it("should count kinds and sort by frequency desc with alphabetical tiebreaker", () => {
+    const problems = [
+      sample({ id: "p1", scoringKind: "flag" }),
+      sample({ id: "p2", scoringKind: "flag" }),
+      sample({ id: "p3", scoringKind: "uptime-flat" }),
+      sample({ id: "p4", scoringKind: "attack-detection" }),
+    ];
+    expect(collectScoringKindFacets(problems)).toEqual([
+      { kind: "flag", count: 2 },
+      { kind: "attack-detection", count: 1 },
+      { kind: "uptime-flat", count: 1 },
+    ]);
+  });
+
+  it("should skip problems without a scoring declaration", () => {
+    const problems = [sample({ id: "p1" }), sample({ id: "p2", scoringKind: "flag" })];
+    expect(collectScoringKindFacets(problems)).toEqual([{ kind: "flag", count: 1 }]);
+  });
+
+  it("should return empty facets for an empty catalog", () => {
+    expect(collectScoringKindFacets([])).toEqual([]);
+  });
+});
+
+describe("DIFFICULTY_LEVELS", () => {
+  it("should enumerate the five catalog difficulty levels in ascending order", () => {
+    expect(DIFFICULTY_LEVELS).toEqual([1, 2, 3, 4, 5]);
   });
 });
 

--- a/apps/application-admin-console/src/lib/problem-filter.ts
+++ b/apps/application-admin-console/src/lib/problem-filter.ts
@@ -2,20 +2,24 @@ import type { ProblemCategory, ProblemStatus, ProblemSummary } from "../data/pro
 
 /**
  * Issue #834 / #835: 問題カタログ page の filter / search を pure logic 化。
+ * Issue #1776: EventCreate の問題選択 UI でも共用 (id 検索 + scoring kind filter を追加)。
  *
  * 設計指針:
  *  - **pure function**: side-effect なし。 React state 側で memoize して使う。
- *  - **union semantic**: 各 filter (search / category / status / difficulty / tag) は **AND**。
- *    tag だけ 「複数 tag 選択時に OR vs AND」 を caller が選べるよう `tagMatchMode` を取る。
- *  - **search**: `name` / `shortDescription` / `tags` (kebab-case の文字列) を **substring** で
- *    case-insensitive に走査。 旧 catalog の 4 問題程度なら正規表現は使わない (= 過剰)。
+ *  - **union semantic**: 各 filter (search / category / status / difficulty / scoring kind /
+ *    tag) は **AND**。 tag だけ 「複数 tag 選択時に OR vs AND」 を caller が選べるよう
+ *    `tagMatchMode` を取る。
+ *  - **search**: `id` / `name` / `shortDescription` / `tags` (kebab-case の文字列) を
+ *    **substring** で case-insensitive に走査。 カタログ規模では正規表現は使わない (= 過剰)。
  */
 
 export type DifficultyLevel = 1 | 2 | 3 | 4 | 5;
+/** カタログの難易度段階 (1=入門 / 5=エキスパート)。 multi-select の選択肢生成に使う。 */
+export const DIFFICULTY_LEVELS: readonly DifficultyLevel[] = [1, 2, 3, 4, 5];
 export type TagMatchMode = "or" | "and";
 
 export interface ProblemFilterCriteria {
-  /** 全文検索 (= name / shortDescription / tags を substring match)。 空文字 = no-op。 */
+  /** 全文検索 (= id / name / shortDescription / tags を substring match)。 空文字 = no-op。 */
   readonly search: string;
   /** カテゴリ filter。 空配列 = 全カテゴリ表示。 */
   readonly categories: readonly ProblemCategory[];
@@ -23,6 +27,11 @@ export interface ProblemFilterCriteria {
   readonly statuses: readonly ProblemStatus[];
   /** 難易度 multi-select。 空配列 = 全難易度表示。 */
   readonly difficulties: readonly DifficultyLevel[];
+  /**
+   * Issue #1776: scoring kind (`metadata.json` の `scoring.kind`) multi-select。
+   * 空配列 = filter なし。 非空のとき scoring 未宣言の問題は除外 (= kind を持たない)。
+   */
+  readonly scoringKinds: readonly string[];
   /** タグ multi-select。 空配列 = タグ filter なし。 */
   readonly tags: readonly string[];
   /** タグが複数選択されたときの結合 (default OR、 "absolutely include" は AND)。 */
@@ -34,6 +43,7 @@ export const EMPTY_FILTER_CRITERIA: ProblemFilterCriteria = {
   categories: [],
   statuses: [],
   difficulties: [],
+  scoringKinds: [],
   tags: [],
   tagMatchMode: "or",
 };
@@ -44,13 +54,14 @@ export function isFilterActive(c: ProblemFilterCriteria): boolean {
     c.categories.length > 0 ||
     c.statuses.length > 0 ||
     c.difficulties.length > 0 ||
+    c.scoringKinds.length > 0 ||
     c.tags.length > 0
   );
 }
 
 function matchesSearch(problem: ProblemSummary, needle: string): boolean {
   if (needle.length === 0) return true;
-  const haystack = [problem.name, problem.shortDescription, ...problem.tags]
+  const haystack = [problem.id, problem.name, problem.shortDescription, ...problem.tags]
     .join(" ")
     .toLowerCase();
   return haystack.includes(needle);
@@ -66,6 +77,15 @@ function matchesTags(
   return selectedTags.some((t) => problemTags.includes(t));
 }
 
+function matchesScoringKind(
+  scoringKind: string | undefined,
+  selectedKinds: readonly string[],
+): boolean {
+  if (selectedKinds.length === 0) return true;
+  // scoring 未宣言 (= kind を持たない) 問題は kind filter が active なら除外。
+  return scoringKind !== undefined && selectedKinds.includes(scoringKind);
+}
+
 export function filterProblems(
   problems: readonly ProblemSummary[],
   criteria: ProblemFilterCriteria,
@@ -78,9 +98,15 @@ export function filterProblems(
     if (criteria.difficulties.length > 0 && !criteria.difficulties.includes(p.difficulty)) {
       return false;
     }
+    if (!matchesScoringKind(p.scoringKind, criteria.scoringKinds)) return false;
     if (!matchesTags(p.tags, criteria.tags, criteria.tagMatchMode)) return false;
     return true;
   });
+}
+
+/** facet 共通の安定 sort: 出現頻度の降順 → タイ時は alphabetical。 */
+function sortFacetEntries(counts: Map<string, number>): readonly [string, number][] {
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 }
 
 /**
@@ -96,9 +122,24 @@ export function collectTagFacets(
       counts.set(tag, (counts.get(tag) ?? 0) + 1);
     }
   }
-  return [...counts.entries()]
-    .map(([tag, count]) => ({ tag, count }))
-    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+  return sortFacetEntries(counts).map(([tag, count]) => ({ tag, count }));
+}
+
+/**
+ * Issue #1776: カタログに実在する scoring kind の一覧を返す (= multi-select 候補)。
+ * kind は固定 enum を持たず実データから収集する (= 新 kind 追加時にコード変更不要)。
+ * scoring 未宣言 (= deploy のみ) の問題は数えない。
+ */
+export function collectScoringKindFacets(
+  problems: readonly ProblemSummary[],
+): readonly { kind: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const p of problems) {
+    if (p.scoringKind !== undefined) {
+      counts.set(p.scoringKind, (counts.get(p.scoringKind) ?? 0) + 1);
+    }
+  }
+  return sortFacetEntries(counts).map(([kind, count]) => ({ kind, count }));
 }
 
 /**

--- a/apps/application-admin-console/src/pages/EventCreate.tsx
+++ b/apps/application-admin-console/src/pages/EventCreate.tsx
@@ -21,7 +21,6 @@ import { EventCreateDeployPromptModal } from "./event-create/EventCreateDeployPr
 import { EventCreateProblemsetSection } from "./event-create/EventCreateProblemsetSection";
 import { EventCreateTeamsSection } from "./event-create/EventCreateTeamsSection";
 import {
-  buildProblemOptions,
   buildVerifiedAccountOption,
   INITIAL_TEAM_COUNT,
   NAME_MAX,
@@ -67,13 +66,9 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
   const navigate = useNavigate();
   const t = useT();
 
+  // 問題 option 化 (#1414 の disabled 出し分け) と検索 / filter (#1776) は
+  // EventCreateProblemsetSection 側の責務。 ここは catalog 全件を渡すだけ。
   const allProblems = useMemo(() => listProblemSummaries(), []);
-  // #1414: 予約済み runtime (sakura/azure/gcp) の問題は deploy 不可なので picker で
-  // disabled + 「近日対応」 にし、 event に組み込めないようにする。
-  const problemOptions: MultiselectProps.Option[] = useMemo(
-    () => buildProblemOptions(allProblems, t("event_create.problem_reserved_tag")),
-    [allProblems, t],
-  );
 
   // Phase 2.2 (Issue #459): verified=true な CompetitorAccounts のみを Select の選択肢にする。
   // fetch + window focus 再取得は hook に切り出し済 (Issue #1241)。
@@ -278,7 +273,7 @@ export function EventCreatePage({ config }: { config: AppConfig }) {
           />
 
           <EventCreateProblemsetSection
-            problemOptions={problemOptions}
+            problems={allProblems}
             selectedProblems={selectedProblems}
             problemRows={problemRows}
             onProblemsChange={onProblemsChange}

--- a/apps/application-admin-console/src/pages/Problems.tsx
+++ b/apps/application-admin-console/src/pages/Problems.tsx
@@ -16,6 +16,7 @@ import { listProblemSummaries, PROVIDER_LABEL, type ProblemSummary } from "../da
 import { interpolate, useT } from "../i18n";
 import {
   collectTagFacets,
+  DIFFICULTY_LEVELS,
   type DifficultyLevel,
   EMPTY_FILTER_CRITERIA,
   filterProblems,
@@ -23,8 +24,6 @@ import {
   type ProblemFilterCriteria,
   toggleTagFilter,
 } from "../lib/problem-filter";
-
-const DIFFICULTY_LEVELS: DifficultyLevel[] = [1, 2, 3, 4, 5];
 
 /**
  * 問題一覧ページ。Cloudscape Cards で 1 件ずつカード表示する。

--- a/apps/application-admin-console/src/pages/event-create/EventCreateProblemsetSection.tsx
+++ b/apps/application-admin-console/src/pages/event-create/EventCreateProblemsetSection.tsx
@@ -1,20 +1,54 @@
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
 import Multiselect, { type MultiselectProps } from "@cloudscape-design/components/multiselect";
-import Select from "@cloudscape-design/components/select";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import { useT } from "../../i18n";
-import { type ProblemRow, REGION_OPTIONS, resolveRegionOptions } from "./helpers";
+import { useMemo, useState } from "react";
+import type { ProblemCategory, ProblemSummary } from "../../data/problems";
+import { interpolate, useT } from "../../i18n";
+import {
+  collectScoringKindFacets,
+  collectTagFacets,
+  DIFFICULTY_LEVELS,
+  type DifficultyLevel,
+  EMPTY_FILTER_CRITERIA,
+  filterProblems,
+  isFilterActive,
+  type ProblemFilterCriteria,
+} from "../../lib/problem-filter";
+import {
+  buildProblemOptions,
+  type ProblemRow,
+  REGION_OPTIONS,
+  resolveRegionOptions,
+} from "./helpers";
+
+/** Select の "全カテゴリ" sentinel。 catalog の category 値 (Battle/Challenge) と衝突しない。 */
+const CATEGORY_ALL = "all";
+
+/** Multiselect 選択値 (string のみ) を取り出す共通 helper。 */
+function optionValues(options: readonly MultiselectProps.Option[]): string[] {
+  return options.map((o) => o.value).filter((v): v is string => typeof v === "string");
+}
 
 /**
- * 「使う問題」 section: 問題 multiselect + 選択された問題ごとの region picker。
+ * 「使う問題」 section: 検索 + filter (Issue #1776) + 問題 multiselect + 選択された問題ごとの
+ * region picker。
+ *
+ * Issue #1776: カタログ増加 (Battle + Challenge 100+) に備え、 multiselect の選択肢を
+ * 検索 (id / name / 説明 / タグ) と category / 難易度 / scoring kind / タグ filter で
+ * 絞り込めるようにする。 filter logic は問題カタログ page と同じ `lib/problem-filter` を共用。
  *
  * region 選択肢は問題 metadata の `supportedRegions` 宣言を尊重 (Issue #1201 Phase 2)。
  */
 export interface EventCreateProblemsetSectionProps {
-  problemOptions: readonly MultiselectProps.Option[];
+  /** カタログ全件 (= filter 前)。 option 化 (#1414 の disabled 出し分け含む) は section 内で行う。 */
+  problems: readonly ProblemSummary[];
   selectedProblems: readonly MultiselectProps.Option[];
   problemRows: readonly ProblemRow[];
   onProblemsChange: (next: readonly MultiselectProps.Option[]) => void;
@@ -22,27 +56,179 @@ export interface EventCreateProblemsetSectionProps {
 }
 
 export function EventCreateProblemsetSection({
-  problemOptions,
+  problems,
   selectedProblems,
   problemRows,
   onProblemsChange,
   onUpdateProblemRow,
 }: EventCreateProblemsetSectionProps) {
   const t = useT();
+  const [criteria, setCriteria] = useState<ProblemFilterCriteria>(EMPTY_FILTER_CRITERIA);
+  const filtered = useMemo(() => filterProblems(problems, criteria), [problems, criteria]);
+  const filterActive = isFilterActive(criteria);
+  // #1414: 予約済み runtime (engine 未実装) の問題は disabled + 「近日対応」 tag。
+  const problemOptions = useMemo(
+    () => buildProblemOptions(filtered, t("event_create.problem_reserved_tag")),
+    [filtered, t],
+  );
+  const tagFacets = useMemo(() => collectTagFacets(problems), [problems]);
+  const scoringKindFacets = useMemo(() => collectScoringKindFacets(problems), [problems]);
+
+  const categoryOptions: SelectProps.Option[] = [
+    { value: CATEGORY_ALL, label: t("problem_search.all_categories") },
+    { value: "Battle", label: "Battle" },
+    { value: "Challenge", label: "Challenge" },
+  ];
+  const selectedCategoryOption: SelectProps.Option =
+    criteria.categories.length === 1
+      ? { value: criteria.categories[0], label: criteria.categories[0] }
+      : categoryOptions[0];
+
+  const difficultyOptions: MultiselectProps.Option[] = DIFFICULTY_LEVELS.map((d) => ({
+    value: String(d),
+    label: `${d} (${t(`problems.difficulty_${d}`)})`,
+  }));
+  const difficultySelected: MultiselectProps.Option[] = criteria.difficulties.map((d) => ({
+    value: String(d),
+    label: String(d),
+  }));
+  const facetCount = (count: number): string =>
+    interpolate(t("problem_search.facet_count"), { count: String(count) });
+  const scoringKindOptions: MultiselectProps.Option[] = scoringKindFacets.map((f) => ({
+    value: f.kind,
+    label: f.kind,
+    description: facetCount(f.count),
+  }));
+  const scoringKindSelected: MultiselectProps.Option[] = criteria.scoringKinds.map((kind) => ({
+    value: kind,
+    label: kind,
+  }));
+  const tagOptions: MultiselectProps.Option[] = tagFacets.map((f) => ({
+    value: f.tag,
+    label: f.tag,
+    description: facetCount(f.count),
+  }));
+  const tagSelected: MultiselectProps.Option[] = criteria.tags.map((tag) => ({
+    value: tag,
+    label: tag,
+  }));
+
+  const clearFilters = () => setCriteria(EMPTY_FILTER_CRITERIA);
+
   return (
     <Container header={<Header variant="h2">{t("event_create.problemset_header")}</Header>}>
       <SpaceBetween size="m">
+        <FormField
+          label={t("problem_search.filter_label")}
+          description={t("problem_search.filter_description")}
+          stretch
+        >
+          <SpaceBetween size="xs">
+            <Input
+              type="search"
+              data-testid="problem-filter-search"
+              value={criteria.search}
+              placeholder={t("problem_search.search_placeholder")}
+              onChange={({ detail }) => setCriteria((prev) => ({ ...prev, search: detail.value }))}
+            />
+            <SpaceBetween direction="horizontal" size="xs">
+              <Select
+                data-testid="problem-filter-category"
+                selectedOption={selectedCategoryOption}
+                options={categoryOptions}
+                onChange={({ detail }) =>
+                  setCriteria((prev) => ({
+                    ...prev,
+                    categories:
+                      detail.selectedOption.value === CATEGORY_ALL
+                        ? []
+                        : [detail.selectedOption.value as ProblemCategory],
+                  }))
+                }
+              />
+              <Multiselect
+                data-testid="problem-filter-difficulty"
+                placeholder={t("problem_search.difficulty_placeholder")}
+                options={difficultyOptions}
+                selectedOptions={difficultySelected}
+                onChange={({ detail }) =>
+                  setCriteria((prev) => ({
+                    ...prev,
+                    difficulties: detail.selectedOptions
+                      .map((o) => Number(o.value))
+                      .filter((n): n is DifficultyLevel =>
+                        DIFFICULTY_LEVELS.includes(n as DifficultyLevel),
+                      ),
+                  }))
+                }
+              />
+              <Multiselect
+                data-testid="problem-filter-scoring-kind"
+                placeholder={t("problem_search.scoring_kind_placeholder")}
+                options={scoringKindOptions}
+                selectedOptions={scoringKindSelected}
+                onChange={({ detail }) =>
+                  setCriteria((prev) => ({
+                    ...prev,
+                    scoringKinds: optionValues(detail.selectedOptions),
+                  }))
+                }
+              />
+              <Multiselect
+                data-testid="problem-filter-tags"
+                placeholder={t("problem_search.tag_placeholder")}
+                options={tagOptions}
+                selectedOptions={tagSelected}
+                filteringType="auto"
+                onChange={({ detail }) =>
+                  setCriteria((prev) => ({ ...prev, tags: optionValues(detail.selectedOptions) }))
+                }
+              />
+            </SpaceBetween>
+            {filterActive && (
+              <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+                <Box variant="small">
+                  {interpolate(t("problem_search.match_count"), {
+                    filtered: String(filtered.length),
+                    total: String(problems.length),
+                  })}
+                </Box>
+                <Button
+                  variant="inline-link"
+                  data-testid="problem-filter-clear"
+                  onClick={clearFilters}
+                >
+                  {t("problem_search.clear_filters")}
+                </Button>
+              </SpaceBetween>
+            )}
+          </SpaceBetween>
+        </FormField>
+
         <FormField
           label={t("event_create.use_problems_label")}
           description={t("event_create.use_problems_description")}
         >
           <Multiselect
+            data-testid="problem-select"
             selectedOptions={[...selectedProblems]}
             options={[...problemOptions]}
             placeholder={t("event_create.problemset_placeholder")}
+            empty={t("problem_search.empty_filtered")}
             onChange={({ detail }) => onProblemsChange(detail.selectedOptions)}
           />
         </FormField>
+
+        {filterActive && filtered.length === 0 && (
+          <Box textAlign="center" color="text-body-secondary">
+            <SpaceBetween size="xs">
+              <Box variant="p">{t("problem_search.empty_filtered")}</Box>
+              <Button data-testid="problem-filter-empty-clear" onClick={clearFilters}>
+                {t("problem_search.clear_filters")}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        )}
 
         {problemRows.length > 0 && (
           <Table

--- a/apps/application-admin-console/test/data/problems.test.ts
+++ b/apps/application-admin-console/test/data/problems.test.ts
@@ -70,6 +70,15 @@ describe("metadataToDetail", () => {
     });
     expect(detail.runtime).toEqual({ provider: "gcp", engine: "infra-manager" });
   });
+
+  it("should project scoring.kind to scoringKind (Issue #1776)", () => {
+    const detail = metadataToDetail({ ...BASE_METADATA, scoring: { kind: "flag" } });
+    expect(detail.scoringKind).toBe("flag");
+  });
+
+  it("should omit scoringKind when scoring is not declared (= deploy-only problem)", () => {
+    expect(metadataToDetail(BASE_METADATA).scoringKind).toBeUndefined();
+  });
 });
 
 describe("isExecutableProblemRuntime (ADR-023 D4)", () => {
@@ -117,5 +126,11 @@ describe("listProblemSummaries", () => {
     const ids = listProblemSummaries().map((s) => s.id);
     const sorted = [...ids].sort((a, b) => a.localeCompare(b));
     expect(ids).toEqual(sorted);
+  });
+
+  it("should carry the catalog entry's scoringKind through to the summary (Issue #1776)", () => {
+    for (const s of listProblemSummaries()) {
+      expect(s.scoringKind).toBe(findProblem(s.id)?.scoringKind);
+    }
   });
 });

--- a/apps/application-admin-console/test/pages/EventCreate.flow.test.tsx
+++ b/apps/application-admin-console/test/pages/EventCreate.flow.test.tsx
@@ -82,13 +82,16 @@ const problem = (over: Partial<ProblemSummary> = {}): ProblemSummary =>
 const config = {} as AppConfig;
 const renderPage = () => render(<EventCreatePage config={config} />);
 const w = (c: HTMLElement) => createWrapper(c);
+// #1776: 問題選択 Multiselect の前に filter 用 Multiselect (difficulty / scoring kind / tags)
+// が並ぶため、 data-testid で特定する。
+const problemSelect = (c: HTMLElement) => w(c).findMultiselect('[data-testid="problem-select"]');
 
 /** name 入力 + teamCount=1 + 問題 p1 選択 + account 選択 を行い、 submit 可能状態にする。 */
 function fillValidForm(container: HTMLElement) {
   // findAllInputs: [name, teamCount, slug...]。 まず teamCount を 1 に。
   w(container).findAllInputs()[1]?.setInputValue("1");
   w(container).findAllInputs()[0]?.setInputValue("My Event");
-  const ms = w(container).findMultiselect();
+  const ms = problemSelect(container);
   ms?.openDropdown();
   ms?.selectOptionByValue("p1");
   const accountSelect = w(container).findAllSelects()[0]; // TeamsSection の account Select
@@ -186,15 +189,16 @@ describe("EventCreatePage flow", () => {
 
   it("should reuse existing rows when adding a problem and update one region among many", () => {
     const { container } = renderPage();
-    w(container).findAllInputs()[1]?.setInputValue("1"); // 1 team → selects: [account, region-p1, region-p2]
-    const ms = w(container).findMultiselect();
+    // 1 team → selects: [account, category-filter, region-p1, region-p2]
+    w(container).findAllInputs()[1]?.setInputValue("1");
+    const ms = problemSelect(container);
     ms?.openDropdown();
     ms?.selectOptionByValue("p1"); // [p1]
     ms?.selectOptionByValue("p2"); // [p1, p2] → onProblemsChange の prev に p1 → existing 再利用経路
     expect(screen.getByText("Problem 1")).toBeInTheDocument();
     expect(screen.getByText("Problem 2")).toBeInTheDocument();
     // p1 の region Select だけ変更 → updateProblemRow の map で p1=match / p2=非match 両分岐。
-    const regionP1 = w(container).findAllSelects()[1];
+    const regionP1 = w(container).findAllSelects()[2];
     regionP1?.openDropdown();
     regionP1?.selectOptionByValue("ap-northeast-1", { expandToViewport: true });
     expect(screen.getByText("Problem 1")).toBeInTheDocument();
@@ -202,7 +206,7 @@ describe("EventCreatePage flow", () => {
 
   it("should fall back to the default region for a problem without metadata region", () => {
     const { container } = renderPage();
-    const ms = w(container).findMultiselect();
+    const ms = problemSelect(container);
     ms?.openDropdown();
     ms?.selectOptionByValue("p2"); // defaultRegion / supportedRegions 未宣言 → fallback 分岐
     expect(screen.getByText("Problem 2")).toBeInTheDocument();
@@ -265,7 +269,7 @@ describe("EventCreatePage flow", () => {
     const { container } = renderPage();
     w(container).findAllInputs()[1]?.setInputValue("1");
     w(container).findAllInputs()[0]?.setInputValue("My Event");
-    const ms = w(container).findMultiselect();
+    const ms = problemSelect(container);
     ms?.openDropdown();
     ms?.selectOptionByValue("p1");
     // account 未選択 → awsAccountId "" → allAccountsValid false → disabled
@@ -284,7 +288,7 @@ describe("EventCreatePage flow", () => {
     const { container } = renderPage();
     w(container).findAllInputs()[1]?.setInputValue("2"); // 2 teams
     w(container).findAllInputs()[0]?.setInputValue("My Event");
-    const ms = w(container).findMultiselect();
+    const ms = problemSelect(container);
     ms?.openDropdown();
     ms?.selectOptionByValue("p1");
     // 両 team に valid account を割り当て (allAccountsValid true にして hasDuplicateSlug まで到達)。

--- a/apps/application-admin-console/test/pages/event-create/EventCreateProblemsetSection.test.tsx
+++ b/apps/application-admin-console/test/pages/event-create/EventCreateProblemsetSection.test.tsx
@@ -1,6 +1,7 @@
 import createWrapper from "@cloudscape-design/components/test-utils/dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProblemSummary } from "../../../src/data/problems";
 import {
   EventCreateProblemsetSection,
   type EventCreateProblemsetSectionProps,
@@ -8,24 +9,57 @@ import {
 import { type ProblemRow, REGION_OPTIONS } from "../../../src/pages/event-create/helpers";
 
 /**
- * 「使う問題」 section: 問題 Multiselect + 選択問題ごとの region Select。 問題選択の
- * onProblemsChange、 region 変更の onUpdateProblemRow、 problemRows 有無の table 表示、
- * defaultRegion が options に無いとき options[0] へ倒す分岐、 supportedRegions による
- * region 絞り込みを pin。 useT echo、 helpers (resolveRegionOptions/REGION_OPTIONS) は実物。
- * Cloudscape は test-utils で駆動。
+ * 「使う問題」 section: 検索 + filter (Issue #1776) + 問題 Multiselect + 選択問題ごとの
+ * region Select。 検索 (id / name / タグ) / category / 難易度 / scoring kind / タグの
+ * 各 filter が multiselect の選択肢を絞ること、 0 件時の empty state + 「絞り込み解除」、
+ * 問題選択の onProblemsChange、 region 変更の onUpdateProblemRow、 problemRows 有無の
+ * table 表示、 defaultRegion fallback、 supportedRegions の絞り込みを pin。
+ * useT は echo mock (interpolate は実物)、 problem-filter / helpers は実物。
+ * Cloudscape は test-utils + data-testid selector で駆動。
  */
-vi.mock("../../../src/i18n", () => ({ useT: () => (k: string) => k }));
+vi.mock("../../../src/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/i18n")>();
+  return { ...actual, useT: () => (k: string) => k };
+});
 
 const r0 = REGION_OPTIONS[0]?.value ?? "ap-northeast-1";
 const r1 = REGION_OPTIONS[1]?.value ?? "us-east-1";
 
+const problem = (over: Partial<ProblemSummary> & { id: string }): ProblemSummary => ({
+  name: `Problem ${over.id}`,
+  category: "Challenge",
+  status: "ready",
+  shortDescription: "short",
+  difficulty: 1,
+  estimatedDuration: "30m",
+  tags: [],
+  runtime: { provider: "aws", engine: "cloudformation" },
+  ...over,
+});
+
+const CATALOG: readonly ProblemSummary[] = [
+  problem({
+    id: "p1",
+    name: "Redis Spike",
+    category: "Battle",
+    difficulty: 4,
+    scoringKind: "uptime-flat",
+    tags: ["redis", "ec2"],
+  }),
+  problem({
+    id: "p2",
+    name: "Hello World",
+    category: "Challenge",
+    difficulty: 1,
+    scoringKind: "flag",
+    tags: ["ssm"],
+  }),
+];
+
 const props = (
   over: Partial<EventCreateProblemsetSectionProps> = {},
 ): EventCreateProblemsetSectionProps => ({
-  problemOptions: [
-    { value: "p1", label: "Problem 1" },
-    { value: "p2", label: "Problem 2" },
-  ],
+  problems: CATALOG,
   selectedProblems: [],
   problemRows: [],
   onProblemsChange: vi.fn(),
@@ -41,18 +75,109 @@ const row = (over: Partial<ProblemRow> = {}): ProblemRow => ({
 
 afterEach(() => vi.clearAllMocks());
 
+const renderSection = (p = props()) => {
+  const utils = render(<EventCreateProblemsetSection {...p} />);
+  const w = createWrapper(utils.container);
+  return {
+    ...utils,
+    p,
+    problemSelect: () => w.findMultiselect('[data-testid="problem-select"]'),
+    searchInput: () => w.findInput('[data-testid="problem-filter-search"]'),
+    categorySelect: () => w.findSelect('[data-testid="problem-filter-category"]'),
+    difficultyFilter: () => w.findMultiselect('[data-testid="problem-filter-difficulty"]'),
+    scoringKindFilter: () => w.findMultiselect('[data-testid="problem-filter-scoring-kind"]'),
+    tagFilter: () => w.findMultiselect('[data-testid="problem-filter-tags"]'),
+  };
+};
+
+/** 開いた problem multiselect dropdown の option label 一覧。 */
+const visibleProblemLabels = (s: ReturnType<typeof renderSection>): string[] => {
+  const ms = s.problemSelect();
+  ms?.openDropdown();
+  return (ms?.findDropdown().findOptions() ?? []).map(
+    (o) => o.findLabel()?.getElement().textContent ?? "",
+  );
+};
+
 describe("EventCreateProblemsetSection", () => {
   it("should emit selected problems from the multiselect", () => {
-    const p = props();
-    const { container } = render(<EventCreateProblemsetSection {...p} />);
-    const ms = createWrapper(container).findMultiselect();
+    const s = renderSection();
+    const ms = s.problemSelect();
     ms?.openDropdown();
     ms?.selectOptionByValue("p1");
-    expect(p.onProblemsChange).toHaveBeenCalled();
+    expect(s.p.onProblemsChange).toHaveBeenCalled();
+  });
+
+  it("should list every catalog problem when no filter is active", () => {
+    const s = renderSection();
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)", "Hello World (p2)"]);
+    // filter 非 active のときは match counter / clear button を出さない。
+    expect(screen.queryByText("problem_search.match_count")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("problem-filter-clear")).not.toBeInTheDocument();
+  });
+
+  it("should narrow the options via free-text search on the problem id", () => {
+    const s = renderSection();
+    s.searchInput()?.setInputValue("p2");
+    expect(visibleProblemLabels(s)).toEqual(["Hello World (p2)"]);
+    // filter active: match counter (interpolate 済) + clear button が出る。
+    expect(screen.getByText("problem_search.match_count")).toBeInTheDocument();
+    expect(screen.getByTestId("problem-filter-clear")).toBeInTheDocument();
+  });
+
+  it("should narrow the options via the category select and restore on 'all'", () => {
+    const s = renderSection();
+    const select = s.categorySelect();
+    select?.openDropdown();
+    select?.selectOptionByValue("Battle");
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)"]);
+    select?.openDropdown();
+    select?.selectOptionByValue("all");
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)", "Hello World (p2)"]);
+  });
+
+  it("should narrow the options via the difficulty multiselect", () => {
+    const s = renderSection();
+    const ms = s.difficultyFilter();
+    ms?.openDropdown();
+    ms?.selectOptionByValue("4");
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)"]);
+  });
+
+  it("should narrow the options via the scoring kind multiselect", () => {
+    const s = renderSection();
+    const ms = s.scoringKindFilter();
+    ms?.openDropdown();
+    ms?.selectOptionByValue("flag");
+    expect(visibleProblemLabels(s)).toEqual(["Hello World (p2)"]);
+  });
+
+  it("should narrow the options via the tag multiselect", () => {
+    const s = renderSection();
+    const ms = s.tagFilter();
+    ms?.openDropdown();
+    ms?.selectOptionByValue("redis");
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)"]);
+  });
+
+  it("should clear every filter via the inline clear button", () => {
+    const s = renderSection();
+    s.searchInput()?.setInputValue("p2");
+    fireEvent.click(screen.getByTestId("problem-filter-clear"));
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)", "Hello World (p2)"]);
+  });
+
+  it("should show the empty state with a clear-filters action when nothing matches", () => {
+    const s = renderSection();
+    s.searchInput()?.setInputValue("no-such-problem");
+    expect(screen.getByText("problem_search.empty_filtered")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("problem-filter-empty-clear"));
+    expect(screen.queryByTestId("problem-filter-empty-clear")).not.toBeInTheDocument();
+    expect(visibleProblemLabels(s)).toEqual(["Redis Spike (p1)", "Hello World (p2)"]);
   });
 
   it("should not render the region table when no problems are selected", () => {
-    render(<EventCreateProblemsetSection {...props({ problemRows: [] })} />);
+    renderSection(props({ problemRows: [] }));
     expect(screen.queryByText("event_create.col_region")).not.toBeInTheDocument();
   });
 
@@ -61,7 +186,8 @@ describe("EventCreateProblemsetSection", () => {
     const p = props({ problemRows: [row()] });
     const { container } = render(<EventCreateProblemsetSection {...p} />);
     expect(screen.getByText("Problem 1")).toBeInTheDocument();
-    const select = createWrapper(container).findSelect();
+    // region Select は table 内 (= category filter Select の後)。 testid 無しなので位置で特定。
+    const select = createWrapper(container).findAllSelects()[1];
     // region Select は expandToViewport なので dropdown は portal に出る → flag が必要。
     select?.openDropdown();
     select?.selectOptionByValue(r1, { expandToViewport: true });
@@ -70,15 +196,13 @@ describe("EventCreateProblemsetSection", () => {
 
   it("should fall back to the first option when defaultRegion is not selectable", () => {
     // defaultRegion が options に無い → find が undefined → options[0] (?? 分岐)。 render で踏む。
-    const p = props({ problemRows: [row({ defaultRegion: "zz-nowhere" })] });
-    render(<EventCreateProblemsetSection {...p} />);
+    renderSection(props({ problemRows: [row({ defaultRegion: "zz-nowhere" })] }));
     expect(screen.getByText("Problem 1")).toBeInTheDocument();
   });
 
   it("should narrow region options to the problem's supportedRegions", () => {
     // resolveRegionOptions の非空 intersection 分岐を踏む。
-    const p = props({ problemRows: [row({ supportedRegions: [r0] })] });
-    render(<EventCreateProblemsetSection {...p} />);
+    renderSection(props({ problemRows: [row({ supportedRegions: [r0] })] }));
     expect(screen.getByText("Problem 1")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

The problem catalog keeps growing (Battle + Challenge 100+), but the problem selection UI in `application-admin-console` (EventCreate problemset section) was a flat `Multiselect`. This PR adds search + filtering on top of the existing `lib/problem-filter` pure logic (Issue #834 / #835), so the Problems catalog page and the selection UI share one filter implementation.

- **Free-text search** over `id` / `name` / `shortDescription` / `tags` (substring, case-insensitive). `id` was added to the shared search haystack, so the catalog page benefits too.
- **Filters**: category (`Select`: All / Battle / Challenge), difficulty (`Multiselect`, 1–5), **scoring kind** (`Multiselect`, faceted from real catalog data — no hardcoded enum), tags (`Multiselect` with inline filtering, OR semantics). All dimensions combine with AND, matching the catalog page.
- **Empty-result state** with a visible match counter (`{filtered} / {total}`) and two "clear filters" actions (inline + empty state).
- **`scoring.kind` surfaced from `metadata.json`**: `ProblemMetadata.scoring?: { kind }` → `ProblemSummary.scoringKind?` (ADR-012's 5 builtin kinds; problems without a scoring declaration stay `undefined` and are excluded only while a kind filter is active).
- **i18n**: new additive `problem_search.*` section in both `ja.json` and `en.json` (no existing keys modified). Difficulty labels reuse the existing `problems.difficulty_*` keys.
- `EventCreateProblemsetSection` now receives the full `ProblemSummary[]` and builds options internally (still via `buildProblemOptions`, so the #1414 "coming soon" disabled handling for reserved runtimes is preserved on the *filtered* set).
- Deduplicated `DIFFICULTY_LEVELS` into `lib/problem-filter` (was a local const in `Problems.tsx`).

Frontend-only; no new dependencies; Cloudscape components already in use elsewhere in the app (Input / Select / Multiselect — `PropertyFilter` is not used anywhere in the repo, so this stays consistent with the existing filter UI on the Problems page).

## Test plan

- `apps/application-admin-console`: **982 tests, 116 files, all passing**; `bun run test:coverage` = **100% lines / functions / branches / statements** (gate #1424).
- New/extended tests (TDD, `should ...` titles):
  - `src/lib/problem-filter.test.ts` — id search, `scoringKinds` AND/OR semantics, exclusion of scoring-less problems, `collectScoringKindFacets` (count/sort/skip/empty), `isFilterActive` with `scoringKinds`, `DIFFICULTY_LEVELS` pin.
  - `test/data/problems.test.ts` — `scoring.kind` → `scoringKind` projection (declared / omitted), summary passthrough against the real catalog.
  - `test/pages/event-create/EventCreateProblemsetSection.test.tsx` — each filter narrows the multiselect options (driven via Cloudscape test-utils + `data-testid`), match counter, inline clear, empty state + clear, plus all pre-existing region-picker behaviors.
  - `test/pages/EventCreate.flow.test.tsx` — updated selectors (`data-testid="problem-select"`) since filter multiselects now precede the problem multiselect in the DOM; all flow assertions unchanged.
- `bunx tsc --noEmit` clean; `bunx biome check` clean (a complexity warning surfaced in `filterProblems` was fixed by extracting `matchesScoringKind`, mirroring `matchesTags`); `make harness` passes (only the pre-existing info about missing `cdk.out`).

## Regression analysis

- **Problems catalog page (`Problems.tsx`)**: shares `filterProblems` — the only behavioral change is that free-text search now also matches problem `id` (strictly additive: previously-matching items still match). `ProblemFilterCriteria` gained `scoringKinds` with `[]` default in `EMPTY_FILTER_CRITERIA`, so existing criteria construction via spread keeps working (both existing filter test suites pass unchanged).
- **EventCreate flow**: `onProblemsChange` / `problemRows` / region-picker contracts are untouched; selections made before applying a filter persist as multiselect tokens even when the options list is narrowed (Cloudscape keeps `selectedOptions` independent of `options`). The #1414 disabled/"coming soon" handling is applied after filtering, so reserved-runtime problems still cannot be selected.
- **`data/problems.ts`**: `scoringKind` is an optional, additive field; `metadataToDetail` keeps dropping deploy internals (`cfnTemplate` / `cfnParameters` / scoring details beyond `kind`). The `listProblemSummaries` omit-branch follows the existing `v8 ignore` idiom for fields that every current catalog entry declares.
- **i18n**: new `problem_search.*` keys only; ja/en kept in lockstep; no existing keys touched, so parallel work on other sections cannot conflict.

## Physical impact

- `apps/application-admin-console/dist/**`: **UPDATE** (SPA bundle changes only).
- CloudFormation / infrastructure: **NO-OP** (no CDK, Lambda, or template changes).
- Dependencies / lockfile: **NO-OP** (no new packages).

Closes #1776

https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_