### PR TITLE
feat(landing): sharpen hero positioning and trim commercial copy

### DIFF
--- a/landing/app.js
+++ b/landing/app.js
@@ -11,10 +11,10 @@
       "nav.contact": "お問い合わせ",
       "nav.github": "GitHub",
 
-      "hero.h1a": "OSS の問題パックで、",
-      "hero.h1b": "本物のクラウド演習を回す。",
+      "hero.h1a": "クラウドエンジニアの、",
+      "hero.h1b": "天下一武道会。",
       "hero.sub":
-        "TenkaCloud は本物のクラウド演習を回すための OSS プラットフォーム。 チームは <strong>隔離された AWS 環境</strong> でハンズオン問題を解き、 主催者は イベント / 採点 / 再利用可能な問題カタログ を 1 つの管理画面で運営できます。",
+        "本物の AWS で競う、OSS の競技プラットフォーム。 「ローカルでは動く」アプリを本番品質へ ── <strong>認証・公開範囲・監査・可用性</strong>の仕上がりを毎分自動採点し、 順位がリアルタイムに動く。 主催者はイベント・採点・再利用できる問題カタログを 1 画面で運営。",
       "hero.cta1": "Hosted Event の見積もり",
       "hero.cta2": "OSS で試す",
       "hero.demo_link": "5 分のデモを見る",
@@ -164,7 +164,7 @@
       "extend.cta2": "new-problem skill",
 
       "community.eyebrow": "コミュニティに参加",
-      "community.h2": "6 つの役割から、ひとつ選んで始める。",
+      "community.h2": "5 つの役割から、ひとつ選んで始める。",
       "community.lead":
         "TenkaCloud の堀は、 deploy ランタイムだけでなく <strong>コミュニティ問題カタログ</strong>。 メンテナに個別 onboard してもらわなくても、 役割を 1 つ選んで 30 分の初回 task を済ませれば、 公式コントリビュータになれます。",
       "community.tester.role": "Tester",
@@ -177,17 +177,12 @@
       "community.author.p":
         "metadata.json + template.yaml の 2 ファイルで 1 問。 Claude Code の <code>/new-problem</code> skill で 30 分 onboarding。",
       "community.author.cta": "Authoring guide",
-      "community.reviewer.role": "Scenario Reviewer",
-      "community.reviewer.h": "ルーブリックで PR を見る。",
-      "community.reviewer.p":
-        "採点公平性 / hint 段階 / 運否 skip / 推定所要時間 / シナリオ現実性 / template セキュリティの 6 項目。",
-      "community.reviewer.cta": "Review checklist",
       "community.more":
-        "全 6 役割を見る (Tester / Problem Author / Scenario Reviewer / Event Facilitator / Platform Contributor / Sponsor-Requester)",
+        "全 5 役割を見る (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)",
       "offerings.eyebrow": "商用プラン",
-      "offerings.h2": "プロダクト化された 4 つの提供形態。",
+      "offerings.h2": "プロダクト化された 3 つの提供形態。",
       "offerings.lead":
-        'OSS プラットフォーム本体は Apache 2.0 で 無料 のまま。 構築 / 当日運営 / 年間プログラム / 独自問題開発を任せたい組織向けに、 形 (スコープ / 成果物 / 除外 / 提供モデル) を明文化した 4 つのプロダクト化された提供形態 を用意しています。 詳細は <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a> を参照してください。',
+        'OSS プラットフォーム本体は Apache 2.0 で 無料 のまま。 構築 / 当日運営 / 年間プログラム を任せたい組織向けに、 形 (スコープ / 成果物 / 除外 / 提供モデル) を明文化した 3 つのプロダクト化された提供形態 を用意しています。 詳細は <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a> を参照してください。',
       "offerings.a.role": "Hosted Event",
       "offerings.a.h": "単発イベントを、 丸ごと運営代行。",
       "offerings.a.p":
@@ -196,17 +191,12 @@
       "offerings.b.role": "Annual Arena",
       "offerings.b.h": "年間プログラム + KPI ダッシュボード。",
       "offerings.b.p":
-        "1 組織で年 4〜6 回の運営代行イベント、 御社固有 問題カタログ (= IP は御社所有) の継続成長、 HR / L&amp;D 向け KPI ダッシュボード。 <strong>年間 base + 1 イベントごとの変動費</strong>。",
+        "1 組織で <strong>年 4 回</strong> の運営代行イベントを年間契約で。 公開問題カタログから 入門 → 中級 → 上級 の learning path 設計と、 HR / L&amp;D 向け KPI ダッシュボードで定着を可視化。 ※ オリジナル問題の制作は本パックには含みません。",
       "offerings.b.more": "スコープと成果物を見る",
-      "offerings.c.role": "Custom Problem",
-      "offerings.c.h": "御社スタックに合わせた、 独自演習を 1 問。",
-      "offerings.c.p":
-        "御社の実スタック / 過去インシデントに合わせて 1 問を新規作成。 シナリオ設計 / 実装 / dry-run / facilitator notes 一式。 <strong>サニタイズされたシナリオのみ — 本番アクセスは行いません。 1 問 fixed price</strong>。",
-      "offerings.c.more": "スコープと成果物を見る",
       "offerings.d.role": "CCoE Enablement (add-on)",
       "offerings.d.h": "アドバイザリ、 別契約。",
       "offerings.d.p":
-        "CCoE 運用モデル / 研修ロードマップ / カタログロードマップ / 内部展開戦略 の月次リテイナー。 上記 3 つの productized 提供には <strong>絶対に bundle しません</strong>。 両方ご希望なら 2 つの契約に分けます。",
+        "CCoE 運用モデル / 研修ロードマップ / カタログロードマップ / 内部展開戦略 の月次リテイナー。 上記 2 つの productized 提供には <strong>絶対に bundle しません</strong>。 両方ご希望なら 2 つの契約に分けます。",
       "offerings.d.more": "スコープと成果物を見る",
 
       "pricing.eyebrow": "料金",
@@ -293,24 +283,12 @@
       "footer.terms": "利用規約",
       "footer.tokushoho": "特定商取引法に基づく表記",
 
-      "makers.eyebrow": "作り手から",
+      "makers.eyebrow": "なぜ作ったのか",
       "makers.h2": "クラウドエンジニアの天下一武道会を、開きたい。",
       "makers.p1":
-        "AWS GameDay は、本当に楽しかった。 もう一度プレーしたいし、 いつかマルチクラウドで「世界一のクラウドエンジニア」を決める競技を見てみたい。",
+        "クラウド競技は、本当に楽しかった。 もう一度挑みたいし、 いつかマルチクラウドで「世界一のクラウドエンジニア」を決める競技を見てみたい。",
       "makers.p2":
-        "でも、 同じ熱量の場を自由に開催できる仕組みは見つからなかった。 だから自分たちで作って、 OSS にした。 問題を作ってもいいし、 追加しやすい仕組みの上で、 それぞれの人が自分の文脈からオリジナル問題を作れるようにしたい。",
-      "makers.p3":
-        "問題を作れる人はいるかもしれない。 でも、 熱量のある問題を作れる人は、 そうそういない。 だから、 熱量ごと持ち寄れる場にしたかった。",
-      "makers.who": "3 人とも GameDay が大好きで、 ただの素人ではないバックグラウンドがある。",
-      "makers.m1.role": "TenkaCloud / 主催",
-      "makers.m1.name": "冨田 進",
-      "makers.m1.cred": "JAWS DAYS 2024 AWS GameDay 優勝 / 2026 準優勝。",
-      "makers.m2.role": "JAWS-UG 名古屋",
-      "makers.m2.name": "チャーリー",
-      "makers.m2.cred": "JAWS-UG 名古屋 運営メンバー。 地域コミュニティを動かしてきた経験。",
-      "makers.m3.role": "AWS 全冠エンジニア",
-      "makers.m3.name": "きせのん",
-      "makers.m3.cred": "JAWS DAYS 2024 GameDay 優勝 / AWS 全冠 (All Certifications)。",
+        "でも、 同じ熱量の場を自由に開催できる仕組みは見つからなかった。 だから自分たちで作って、 OSS にした。 問題を作ってもいいし、 追加しやすい仕組みの上で、 それぞれの人が自分の文脈からオリジナル問題を作れるようにしました。",
     },
     en: {
       "nav.product": "Product",
@@ -323,10 +301,10 @@
       "nav.contact": "Contact",
       "nav.github": "GitHub",
 
-      "hero.h1a": "Run real cloud drills",
-      "hero.h1b": "with OSS problem packs.",
+      "hero.h1a": "The cloud engineer's",
+      "hero.h1b": "Tenka-Ichi.",
       "hero.sub":
-        "TenkaCloud is an OSS platform for running real cloud drills: teams solve hands-on cloud problems in <strong>isolated AWS environments</strong>, while organizers manage events, scoring, and reusable problem catalogs from a single console.",
+        'An OSS competition platform on real AWS. Take an app that "only works locally" and make it production-grade — <strong>auth, exposure, audit, and availability</strong> are auto-scored every minute, and the leaderboard moves in real time. Organizers run events, scoring, and a reusable problem catalog from one console.',
       "hero.cta1": "Get a Hosted Event quote",
       "hero.cta2": "Try the OSS",
       "hero.demo_link": "Watch the 5-minute demo",
@@ -475,7 +453,7 @@
       "extend.cta2": "new-problem skill",
 
       "community.eyebrow": "Join the community",
-      "community.h2": "Pick one of six roles. Ship one starter task.",
+      "community.h2": "Pick one of five roles. Ship one starter task.",
       "community.lead":
         "TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.",
       "community.tester.role": "Tester",
@@ -488,17 +466,12 @@
       "community.author.p":
         "Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.",
       "community.author.cta": "Authoring guide",
-      "community.reviewer.role": "Scenario Reviewer",
-      "community.reviewer.h": "Score PRs against a rubric.",
-      "community.reviewer.p":
-        "Six checks: scoring fairness, hint progression, no skip-by-luck, time-to-solve estimate, scenario realism, template security.",
-      "community.reviewer.cta": "Review checklist",
       "community.more":
-        "See all 6 roles (Tester / Problem Author / Scenario Reviewer / Event Facilitator / Platform Contributor / Sponsor-Requester)",
+        "See all 5 roles (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)",
       "offerings.eyebrow": "Commercial offerings",
-      "offerings.h2": "Four productized offerings — formally documented.",
+      "offerings.h2": "Three productized offerings — formally documented.",
       "offerings.lead":
-        'The OSS platform stays free under Apache 2.0. For organizations that want setup, live operations, or a program run for them, we offer four productized packages. Each has a fixed shape — scope, deliverables, exclusions, delivery model — written up in <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a>.',
+        'The OSS platform stays free under Apache 2.0. For organizations that want setup, live operations, or a program run for them, we offer three productized packages. Each has a fixed shape — scope, deliverables, exclusions, delivery model — written up in <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a>.',
       "offerings.a.role": "Hosted Event",
       "offerings.a.h": "One operated drill, end to end.",
       "offerings.a.p":
@@ -507,17 +480,12 @@
       "offerings.b.role": "Annual Arena",
       "offerings.b.h": "A 12-month program with KPIs.",
       "offerings.b.p":
-        "4-6 operated events per year for one org, a growing private problem catalog (you own the IP), and a KPI dashboard for HR / L&amp;D. <strong>Annual base + per-event variable</strong>.",
+        "An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced) and a KPI dashboard for HR / L&amp;D. Original problem development is not included in this package.",
       "offerings.b.more": "Scope &amp; deliverables",
-      "offerings.c.role": "Custom Problem",
-      "offerings.c.h": "A drill that matches your stack.",
-      "offerings.c.p":
-        "One problem authored to your scenario — past incident or capability gap. Scenario interview, build, dry-run, facilitator notes. <strong>Sanitized scenario only — never production access. Per-problem fixed price.</strong>",
-      "offerings.c.more": "Scope &amp; deliverables",
       "offerings.d.role": "CCoE Enablement (add-on)",
       "offerings.d.h": "Advisory, sold separately.",
       "offerings.d.p":
-        "A monthly retainer for operating-model / training-roadmap work. <strong>Never bundled</strong> into the three offerings above, so events stay productized. If you want both, that is two line items.",
+        "A monthly retainer for operating-model / training-roadmap work. <strong>Never bundled</strong> into the two offerings above, so events stay productized. If you want both, that is two line items.",
       "offerings.d.more": "Scope &amp; deliverables",
 
       "pricing.eyebrow": "Pricing",
@@ -606,24 +574,12 @@
       "footer.terms": "Terms of Service",
       "footer.tokushoho": "Business identification (Japan TokushoHo)",
 
-      "makers.eyebrow": "From the makers",
+      "makers.eyebrow": "Why we built it",
       "makers.h2": "We want to host a Tenka-Ichi for cloud engineers.",
       "makers.p1":
-        "AWS GameDay was genuinely fun. We want to play it again — and one day watch a multi-cloud competition that crowns the world's best cloud engineer.",
+        "Cloud competitions are genuinely fun. We want to compete again — and one day watch a multi-cloud competition that crowns the world's best cloud engineer.",
       "makers.p2":
         "But we couldn't find a way to freely host events with that same intensity. So we built one, and made it OSS. Anyone can write a problem; on a platform that makes adding them easy, everyone can craft an original problem from their own context.",
-      "makers.p3":
-        "Plenty of people can write a problem. Far fewer can write a problem with real heat behind it. We wanted a place where that heat is what people bring.",
-      "makers.who": "All three of us love GameDay — and none of us are amateurs.",
-      "makers.m1.role": "TenkaCloud / Host",
-      "makers.m1.name": "Susumu Tomita",
-      "makers.m1.cred": "Winner, AWS GameDay @ JAWS DAYS 2024 · Runner-up 2026.",
-      "makers.m2.role": "JAWS-UG Nagoya",
-      "makers.m2.name": "Charlie",
-      "makers.m2.cred": "JAWS-UG Nagoya organizer. Years of moving a regional community.",
-      "makers.m3.role": "AWS All-Certs Engineer",
-      "makers.m3.name": "Kisenon",
-      "makers.m3.cred": "Winner, GameDay @ JAWS DAYS 2024 · AWS All Certifications.",
     },
   };
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -48,9 +48,9 @@
   <div class="wrap hero-grid">
     <div class="hero-copy">
       <h1>
-        <span data-i18n="hero.h1a">OSS の問題パックで、</span><em data-i18n="hero.h1b">本物のクラウド演習を回す。</em>
+        <span data-i18n="hero.h1a">クラウドエンジニアの、</span><em data-i18n="hero.h1b">天下一武道会。</em>
       </h1>
-      <p class="sub" data-i18n="hero.sub">TenkaCloud は本物のクラウド演習を回すための OSS プラットフォーム。 チームは 隔離された AWS 環境 でハンズオン問題を解き、 主催者は イベント / 採点 / 再利用可能な問題カタログ を 1 つの管理画面で運営できます。</p>
+      <p class="sub" data-i18n="hero.sub">本物の AWS で競う、OSS の競技プラットフォーム。 「ローカルでは動く」アプリを本番品質へ ── 認証・公開範囲・監査・可用性の仕上がりを毎分自動採点し、 順位がリアルタイムに動く。 主催者はイベント・採点・再利用できる問題カタログを 1 画面で運営。</p>
       <div class="cta-row">
         <a
           class="cta-primary"
@@ -154,29 +154,10 @@
 
 <section id="makers">
   <div class="wrap audience-intro">
-    <div class="eyebrow" data-i18n="makers.eyebrow">作り手から</div>
+    <div class="eyebrow" data-i18n="makers.eyebrow">なぜ作ったのか</div>
     <h2 data-i18n="makers.h2">クラウドエンジニアの天下一武道会を、開きたい。</h2>
-    <p class="lead" data-i18n="makers.p1">AWS GameDay は、本当に楽しかった。 もう一度プレーしたいし、 いつかマルチクラウドで「世界一のクラウドエンジニア」を決める競技を見てみたい。</p>
-    <p class="lead" data-i18n="makers.p2">でも、 同じ熱量の場を自由に開催できる仕組みは見つからなかった。 だから自分たちで作って、 OSS にした。 問題を作ってもいいし、 追加しやすい仕組みの上で、 それぞれの人が自分の文脈からオリジナル問題を作れるようにしたい。</p>
-    <p class="lead" data-i18n="makers.p3">問題を作れる人はいるかもしれない。 でも、 熱量のある問題を作れる人は、 そうそういない。 だから、 熱量ごと持ち寄れる場にしたかった。</p>
-    <p class="lead" data-i18n="makers.who">3 人とも GameDay が大好きで、 ただの素人ではないバックグラウンドがある。</p>
-  </div>
-  <div class="aud">
-    <div class="col">
-      <div class="role" data-i18n="makers.m1.role">TenkaCloud / 主催</div>
-      <h3 data-i18n="makers.m1.name">冨田 進</h3>
-      <p data-i18n="makers.m1.cred">JAWS DAYS 2024 AWS GameDay 優勝 / 2026 準優勝。</p>
-    </div>
-    <div class="col">
-      <div class="role" data-i18n="makers.m2.role">JAWS-UG 名古屋</div>
-      <h3 data-i18n="makers.m2.name">チャーリー</h3>
-      <p data-i18n="makers.m2.cred">JAWS-UG 名古屋 運営メンバー。 地域コミュニティを動かしてきた経験。</p>
-    </div>
-    <div class="col">
-      <div class="role" data-i18n="makers.m3.role">AWS 全冠エンジニア</div>
-      <h3 data-i18n="makers.m3.name">きせのん</h3>
-      <p data-i18n="makers.m3.cred">JAWS DAYS 2024 GameDay 優勝 / AWS 全冠 (All Certifications)。</p>
-    </div>
+    <p class="lead" data-i18n="makers.p1">クラウド競技は、本当に楽しかった。 もう一度挑みたいし、 いつかマルチクラウドで「世界一のクラウドエンジニア」を決める競技を見てみたい。</p>
+    <p class="lead" data-i18n="makers.p2">でも、 同じ熱量の場を自由に開催できる仕組みは見つからなかった。 だから自分たちで作って、 OSS にした。 問題を作ってもいいし、 追加しやすい仕組みの上で、 それぞれの人が自分の文脈からオリジナル問題を作れるようにしました。</p>
   </div>
 </section>
 
@@ -404,7 +385,7 @@
     <div class="eyebrow" data-i18n="extend.eyebrow">問題は、増やせる</div>
     <h2 data-i18n="extend.h2">足りない問題は、自分で作ればいい。</h2>
     <p class="lead" data-i18n="extend.lead">問題カタログは <a href="https://github.com/susumutomita/TenkaCloudChallenge" target="_blank" rel="noopener noreferrer">TenkaCloudChallenge</a> リポジトリで完全に開かれていて、 metadata.json + template.yaml の 2 ファイルを書けば 1 問追加できます。 Claude Code 等のコーディングエージェント向けに 問題作成 skill (<code>new-problem</code>) も同梱されているので、 「こういう問題を作りたい」 とアイデアを話すだけで、 初めてでも 1 問が形になります。</p>
-    <p class="lead" data-i18n="extend.starter">スターターカタログは <strong>ready 5 問 + draft 2 問 + 1 イベント bundle</strong> (= 1 Challenge + 2 Battles を 60〜90 分で回す <a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/bundles/starter-event.json" target="_blank" rel="noopener noreferrer"><code>starter-event</code></a>)。 CCoE / JAWS-UG meetup で 「今日これ流せばいい」 が即決できる credible なラインナップです。</p>
+    <p class="lead" data-i18n="extend.starter">スターターカタログは <strong>ready 5 問 + draft 2 問 + 1 イベント bundle</strong> (= 1 Challenge + 2 Battles を 60〜90 分で回す <a href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/bundles/starter-event.json" target="_blank" rel="noopener noreferrer"><code>starter-event</code></a>)。 CCoE / 社内勉強会で 「今日これ流せばいい」 が即決できる credible なラインナップです。</p>
     <div class="extend-cta">
       <a class="more" href="https://github.com/susumutomita/TenkaCloudChallenge#readme" target="_blank" rel="noopener noreferrer"><span data-i18n="extend.cta1">問題カタログを見る</span> ›</a>
       <a class="more" href="https://github.com/susumutomita/TenkaCloudChallenge/blob/main/.claude/skills/new-problem/SKILL.md#new-problem--scaffold-a-tenkacloudchallenge-problem" target="_blank" rel="noopener noreferrer"><span data-i18n="extend.cta2">new-problem skill</span> ›</a>
@@ -415,8 +396,8 @@
 <section id="offerings" class="alt">
   <div class="wrap audience-intro">
     <div class="eyebrow" data-i18n="offerings.eyebrow">Commercial offerings</div>
-    <h2 data-i18n="offerings.h2">Four productized offerings — formally documented.</h2>
-    <p class="lead" data-i18n="offerings.lead">The OSS platform stays free under Apache 2.0. For organizations that want setup, live operations, or a program run for them, we offer four productized packages. Each has a fixed shape — scope, deliverables, exclusions, delivery model — written up in <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a>.</p>
+    <h2 data-i18n="offerings.h2">Three productized offerings — formally documented.</h2>
+    <p class="lead" data-i18n="offerings.lead">The OSS platform stays free under Apache 2.0. For organizations that want setup, live operations, or a program run for them, we offer three productized packages. Each has a fixed shape — scope, deliverables, exclusions, delivery model — written up in <a href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html" target="_blank" rel="noopener noreferrer">PACKAGES.html</a>.</p>
   </div>
   <div class="aud">
     <div class="col">
@@ -428,19 +409,13 @@
     <div class="col">
       <div class="role" data-i18n="offerings.b.role">Annual Arena</div>
       <h3 data-i18n="offerings.b.h">A 12-month program with KPIs.</h3>
-      <p data-i18n="offerings.b.p">4-6 operated events per year for one org, a growing private problem catalog (you own the IP), and a KPI dashboard for HR / L&amp;D. <strong>Annual base + per-event variable</strong>.</p>
+      <p data-i18n="offerings.b.p">An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced) and a KPI dashboard for HR / L&amp;D. Original problem development is not included in this package.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#annual-arena" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.b.more">Scope &amp; deliverables</span> ›</a>
-    </div>
-    <div class="col">
-      <div class="role" data-i18n="offerings.c.role">Custom Problem</div>
-      <h3 data-i18n="offerings.c.h">A drill that matches your stack.</h3>
-      <p data-i18n="offerings.c.p">One problem authored to your scenario — past incident or capability gap. Scenario interview, build, dry-run, facilitator notes. <strong>Sanitized scenario only — never production access. Per-problem fixed price.</strong></p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#custom-problem" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.c.more">Scope &amp; deliverables</span> ›</a>
     </div>
     <div class="col">
       <div class="role" data-i18n="offerings.d.role">CCoE Enablement (add-on)</div>
       <h3 data-i18n="offerings.d.h">Advisory, sold separately.</h3>
-      <p data-i18n="offerings.d.p">A monthly retainer for operating-model / training-roadmap work. <strong>Never bundled</strong> into the three offerings above, so events stay productized. If you want both, that is two line items.</p>
+      <p data-i18n="offerings.d.p">A monthly retainer for operating-model / training-roadmap work. <strong>Never bundled</strong> into the two offerings above, so events stay productized. If you want both, that is two line items.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#ccoe-enablement" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.d.more">Scope &amp; deliverables</span> ›</a>
     </div>
   </div>
@@ -449,7 +424,7 @@
 <section id="community">
   <div class="wrap audience-intro">
     <div class="eyebrow" data-i18n="community.eyebrow">Join the community</div>
-    <h2 data-i18n="community.h2">Pick one of six roles. Ship one starter task.</h2>
+    <h2 data-i18n="community.h2">Pick one of five roles. Ship one starter task.</h2>
     <p class="lead" data-i18n="community.lead">TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.</p>
   </div>
   <div class="aud">
@@ -465,15 +440,9 @@
       <p data-i18n="community.author.p">Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/problems/AUTHORING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.author.cta">Authoring guide</span> ›</a>
     </div>
-    <div class="col">
-      <div class="role" data-i18n="community.reviewer.role">Scenario Reviewer</div>
-      <h3 data-i18n="community.reviewer.h">Score PRs against a rubric.</h3>
-      <p data-i18n="community.reviewer.p">Six checks: scoring fairness, hint progression, no skip-by-luck, time-to-solve estimate, scenario realism, template security.</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/community/PROBLEM-REVIEW-CHECKLIST.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.reviewer.cta">Review checklist</span> ›</a>
-    </div>
   </div>
   <div class="wrap" style="margin-top: 1.2rem; text-align: center;">
-    <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/community/ONBOARDING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.more">See all 6 roles (Tester / Problem Author / Scenario Reviewer / Event Facilitator / Platform Contributor / Sponsor-Requester)</span> ›</a>
+    <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/community/ONBOARDING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.more">See all 5 roles (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)</span> ›</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
ランディングページのポジショニングとコピーを整理し、ピッチデッキの強い訴求に合わせて「何のプロダクトか」が一目で伝わるようにした。固有名詞・個人名を落とし、提供形態も実態に合わせた。

- **ヒーロー**: 「OSS の問題パックで本物のクラウド演習を回す」→ **「クラウドエンジニアの、天下一武道会。」**。サブで製品カテゴリ（本物の AWS で競う OSS 競技プラットフォーム）と中身（"動く"アプリを本番品質へ、認証/公開範囲/監査/可用性を毎分自動採点・リアルタイム順位）を明示。
- **「なぜ作ったのか」セクション**（旧 makers、eyebrow も `作り手から`→`なぜ作ったのか`）: 個人名プロフィール 3 枚と固有名詞（AWS GameDay / JAWS-UG）を削除し、collective な origin story に。
- **Annual Arena**: 年 4 回固定に統一。bespoke 問題カタログ(IP)・変動費の記述を削除し、「オリジナル問題の制作は本パックに含まない」を明記。
- **Custom Problem オファリングを削除**（bespoke で重く productized でないため）。商用オファリングを 4→3 に。
- **コミュニティ**: Scenario Reviewer ロールをカードから削除し、6→5 役割に。
- ja/en 両ロケールをそろえて編集。biome format 済み。

## Test plan
- `biome check landing/app.js` パス（pre-commit hook の `biome check` も 1190 files green）
- `node --check landing/app.js` パス
- 固有名詞 / 個人名 / 孤立 i18n キーが残っていないことを grep で確認
- pre-commit hook の lint / textlint / 全 workspace test がパス

## Regression analysis
- 変更は `landing/` 配下の静的コピー（index.html + app.js の i18n 文字列）のみ。アプリ / インフラ / 問題には影響なし。
- 削除した i18n キー（`makers.who`/`m1-3`, `community.reviewer.*`, `offerings.c.*`）は対応する DOM 要素も同時に削除済みで参照先なし（grep 確認済み）。
- 連動カウント（6→5 役割 / 4→3 オファリング / 上記 3 つ→2 つ）を ja / en・index.html の全箇所で整合。

## Physical impact
- **NO-OP**。CFn / インフラ成果物への影響なし。静的 LP コンテンツのみ。

## Follow-up（このPRの範囲外・別途判断）
- `docs/community/`（ONBOARDING.html / PROBLEM-REVIEW-CHECKLIST.html）と `CONTRIBUTING.md` はまだ「6 役割 / Scenario Reviewer」記載。LP と揃えるか要判断。
- お問い合わせフォームの「独自問題の追加開発」選択肢 + 料金注記は、bespoke 相談窓口として意図的に残置。
- `pitch/index.html` Team スライドの個人名 / 「Game Day」、`legal.*` の代表者名（特商法で必須）は本PR対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
