### PR TITLE
feat(landing): remove community section and correct offering claims

### DIFF
--- a/landing/app.js
+++ b/landing/app.js
@@ -4,7 +4,6 @@
       "nav.product": "プロダクト",
       "nav.problems": "問題",
       "nav.extend": "問題を作る",
-      "nav.community": "コミュニティ",
       "nav.docs": "ドキュメント",
       "nav.offerings": "商用プラン",
       "nav.pricing": "料金",
@@ -163,20 +162,6 @@
       "extend.cta1": "問題カタログを見る",
       "extend.cta2": "new-problem skill",
 
-      "community.eyebrow": "コミュニティに参加",
-      "community.h2": "2 つの役割から、ひとつ選んで始める。",
-      "community.lead":
-        "TenkaCloud の堀は、 deploy ランタイムだけでなく <strong>コミュニティ問題カタログ</strong>。 メンテナに個別 onboard してもらわなくても、 役割を 1 つ選んで 30 分の初回 task を済ませれば、 公式コントリビュータになれます。",
-      "community.tester.role": "Tester",
-      "community.tester.h": "問題を遊んで、 papercut を報告する。",
-      "community.tester.p":
-        "30 分の playtest プロトコルに沿って 1 問解き、 構造化テンプレで feedback を出す。 CDK / TypeScript は不要。",
-      "community.tester.cta": "Playtest checklist",
-      "community.author.role": "Problem Author",
-      "community.author.h": "新しい問題を作る。",
-      "community.author.p":
-        "metadata.json + template.yaml の 2 ファイルで 1 問。 Claude Code の <code>/new-problem</code> skill で 30 分 onboarding。",
-      "community.author.cta": "Authoring guide",
       "offerings.eyebrow": "商用プラン",
       "offerings.h2": "プロダクト化された 3 つの提供形態。",
       "offerings.lead":
@@ -292,7 +277,6 @@
       "nav.product": "Product",
       "nav.problems": "Problems",
       "nav.extend": "Author problems",
-      "nav.community": "Community",
       "nav.docs": "Docs",
       "nav.offerings": "Commercial",
       "nav.pricing": "Pricing",
@@ -450,20 +434,6 @@
       "extend.cta1": "Browse the catalog",
       "extend.cta2": "new-problem skill",
 
-      "community.eyebrow": "Join the community",
-      "community.h2": "Pick one of two roles. Ship one starter task.",
-      "community.lead":
-        "TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.",
-      "community.tester.role": "Tester",
-      "community.tester.h": "Play the problems. File the papercuts.",
-      "community.tester.p":
-        "Follow a 30-minute playtest protocol on one problem, then file a structured feedback issue. No CDK / TypeScript needed.",
-      "community.tester.cta": "Playtest checklist",
-      "community.author.role": "Problem Author",
-      "community.author.h": "Ship a new problem.",
-      "community.author.p":
-        "Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.",
-      "community.author.cta": "Authoring guide",
       "offerings.eyebrow": "Commercial offerings",
       "offerings.h2": "Three productized offerings — formally documented.",
       "offerings.lead":

--- a/landing/app.js
+++ b/landing/app.js
@@ -164,7 +164,7 @@
       "extend.cta2": "new-problem skill",
 
       "community.eyebrow": "コミュニティに参加",
-      "community.h2": "5 つの役割から、ひとつ選んで始める。",
+      "community.h2": "2 つの役割から、ひとつ選んで始める。",
       "community.lead":
         "TenkaCloud の堀は、 deploy ランタイムだけでなく <strong>コミュニティ問題カタログ</strong>。 メンテナに個別 onboard してもらわなくても、 役割を 1 つ選んで 30 分の初回 task を済ませれば、 公式コントリビュータになれます。",
       "community.tester.role": "Tester",
@@ -177,8 +177,6 @@
       "community.author.p":
         "metadata.json + template.yaml の 2 ファイルで 1 問。 Claude Code の <code>/new-problem</code> skill で 30 分 onboarding。",
       "community.author.cta": "Authoring guide",
-      "community.more":
-        "全 5 役割を見る (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)",
       "offerings.eyebrow": "商用プラン",
       "offerings.h2": "プロダクト化された 3 つの提供形態。",
       "offerings.lead":
@@ -453,7 +451,7 @@
       "extend.cta2": "new-problem skill",
 
       "community.eyebrow": "Join the community",
-      "community.h2": "Pick one of five roles. Ship one starter task.",
+      "community.h2": "Pick one of two roles. Ship one starter task.",
       "community.lead":
         "TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.",
       "community.tester.role": "Tester",
@@ -466,8 +464,6 @@
       "community.author.p":
         "Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.",
       "community.author.cta": "Authoring guide",
-      "community.more":
-        "See all 5 roles (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)",
       "offerings.eyebrow": "Commercial offerings",
       "offerings.h2": "Three productized offerings — formally documented.",
       "offerings.lead":

--- a/landing/app.js
+++ b/landing/app.js
@@ -169,12 +169,12 @@
       "offerings.a.role": "Hosted Event",
       "offerings.a.h": "単発イベントを、 丸ごと運営代行。",
       "offerings.a.p":
-        "1〜3 日のクラウド演習を、 公開 OSS 問題カタログから選定して 弊社が end-to-end で運営。 設計 / お客様 AWS への deploy / 事前 dry-run / 当日の live 進行 / 事後レポート。 <strong>1 回 fixed price</strong>。",
+        "1 日のクラウド演習を、 公開 OSS 問題カタログから選定して 弊社が end-to-end で運営。 設計 / お客様 AWS への deploy / 事前 dry-run / 当日の live 進行 / 事後レポート。 <strong>1 回 fixed price</strong>。",
       "offerings.a.more": "スコープと成果物を見る",
       "offerings.b.role": "Annual Arena",
-      "offerings.b.h": "年間プログラム + KPI ダッシュボード。",
+      "offerings.b.h": "年間プログラム。",
       "offerings.b.p":
-        "1 組織で <strong>年 4 回</strong> の運営代行イベントを年間契約で。 公開問題カタログから 入門 → 中級 → 上級 の learning path 設計と、 HR / L&amp;D 向け KPI ダッシュボードで定着を可視化。 ※ オリジナル問題の制作は本パックには含みません。",
+        "1 組織で <strong>年 4 回</strong> の運営代行イベントを年間契約で。 公開問題カタログから 入門 → 中級 → 上級 の learning path を設計。 ※ オリジナル問題の制作は本パックには含みません。",
       "offerings.b.more": "スコープと成果物を見る",
       "offerings.d.role": "CCoE Enablement (add-on)",
       "offerings.d.h": "アドバイザリ、 別契約。",
@@ -441,12 +441,12 @@
       "offerings.a.role": "Hosted Event",
       "offerings.a.h": "One operated drill, end to end.",
       "offerings.a.p":
-        "A 1-3 day cloud drill on the public OSS catalog, run by us. Event design, deploy into your AWS account, dry run, live facilitation, post-event report. <strong>Per-event fixed price</strong>.",
+        "A 1-day cloud drill on the public OSS catalog, run by us. Event design, deploy into your AWS account, dry run, live facilitation, post-event report. <strong>Per-event fixed price</strong>.",
       "offerings.a.more": "Scope &amp; deliverables",
       "offerings.b.role": "Annual Arena",
-      "offerings.b.h": "A 12-month program with KPIs.",
+      "offerings.b.h": "A 12-month program.",
       "offerings.b.p":
-        "An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced) and a KPI dashboard for HR / L&amp;D. Original problem development is not included in this package.",
+        "An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced). Original problem development is not included in this package.",
       "offerings.b.more": "Scope &amp; deliverables",
       "offerings.d.role": "CCoE Enablement (add-on)",
       "offerings.d.h": "Advisory, sold separately.",

--- a/landing/index.html
+++ b/landing/index.html
@@ -424,7 +424,7 @@
 <section id="community">
   <div class="wrap audience-intro">
     <div class="eyebrow" data-i18n="community.eyebrow">Join the community</div>
-    <h2 data-i18n="community.h2">Pick one of five roles. Ship one starter task.</h2>
+    <h2 data-i18n="community.h2">Pick one of two roles. Ship one starter task.</h2>
     <p class="lead" data-i18n="community.lead">TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.</p>
   </div>
   <div class="aud">
@@ -440,9 +440,6 @@
       <p data-i18n="community.author.p">Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/problems/AUTHORING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.author.cta">Authoring guide</span> ›</a>
     </div>
-  </div>
-  <div class="wrap" style="margin-top: 1.2rem; text-align: center;">
-    <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/community/ONBOARDING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.more">See all 5 roles (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester)</span> ›</a>
   </div>
 </section>
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -24,7 +24,6 @@
       <a href="#modes" data-i18n="nav.product">プロダクト</a>
       <a href="#onboard" data-i18n="nav.problems">問題</a>
       <a href="#extend" data-i18n="nav.extend">問題を作る</a>
-      <a href="#community" data-i18n="nav.community">コミュニティ</a>
       <a href="https://github.com/susumutomita/TenkaCloud#readme" target="_blank" rel="noopener noreferrer" data-i18n="nav.docs">ドキュメント</a>
       <a href="#offerings" data-i18n="nav.offerings">商用プラン</a>
       <a href="#pricing" data-i18n="nav.pricing">料金</a>
@@ -417,28 +416,6 @@
       <h3 data-i18n="offerings.d.h">Advisory, sold separately.</h3>
       <p data-i18n="offerings.d.p">A monthly retainer for operating-model / training-roadmap work. <strong>Never bundled</strong> into the two offerings above, so events stay productized. If you want both, that is two line items.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#ccoe-enablement" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.d.more">Scope &amp; deliverables</span> ›</a>
-    </div>
-  </div>
-</section>
-
-<section id="community">
-  <div class="wrap audience-intro">
-    <div class="eyebrow" data-i18n="community.eyebrow">Join the community</div>
-    <h2 data-i18n="community.h2">Pick one of two roles. Ship one starter task.</h2>
-    <p class="lead" data-i18n="community.lead">TenkaCloud's moat is the <strong>community problem catalog</strong>, not only the deploy runtime. You do not need to be personally onboarded by the maintainer — choose a role, follow its 30-minute first task, and you are a recognized contributor.</p>
-  </div>
-  <div class="aud">
-    <div class="col">
-      <div class="role" data-i18n="community.tester.role">Tester</div>
-      <h3 data-i18n="community.tester.h">Play the problems. File the papercuts.</h3>
-      <p data-i18n="community.tester.p">Follow a 30-minute playtest protocol on one problem, then file a structured feedback issue. No CDK / TypeScript needed.</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/community/PLAYTEST-CHECKLIST.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.tester.cta">Playtest checklist</span> ›</a>
-    </div>
-    <div class="col">
-      <div class="role" data-i18n="community.author.role">Problem Author</div>
-      <h3 data-i18n="community.author.h">Ship a new problem.</h3>
-      <p data-i18n="community.author.p">Two files (metadata.json + template.yaml) and you have a problem. The <code>/new-problem</code> Claude Code skill onboards you in 30 minutes.</p>
-      <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/problems/AUTHORING.html" target="_blank" rel="noopener noreferrer"><span data-i18n="community.author.cta">Authoring guide</span> ›</a>
     </div>
   </div>
 </section>

--- a/landing/index.html
+++ b/landing/index.html
@@ -402,13 +402,13 @@
     <div class="col">
       <div class="role" data-i18n="offerings.a.role">Hosted Event</div>
       <h3 data-i18n="offerings.a.h">One operated drill, end to end.</h3>
-      <p data-i18n="offerings.a.p">A 1-3 day cloud drill on the public OSS catalog, run by us. Event design, deploy into your AWS account, dry run, live facilitation, post-event report. <strong>Per-event fixed price</strong>.</p>
+      <p data-i18n="offerings.a.p">A 1-day cloud drill on the public OSS catalog, run by us. Event design, deploy into your AWS account, dry run, live facilitation, post-event report. <strong>Per-event fixed price</strong>.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#hosted-event" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.a.more">Scope &amp; deliverables</span> ›</a>
     </div>
     <div class="col">
       <div class="role" data-i18n="offerings.b.role">Annual Arena</div>
-      <h3 data-i18n="offerings.b.h">A 12-month program with KPIs.</h3>
-      <p data-i18n="offerings.b.p">An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced) and a KPI dashboard for HR / L&amp;D. Original problem development is not included in this package.</p>
+      <h3 data-i18n="offerings.b.h">A 12-month program.</h3>
+      <p data-i18n="offerings.b.p">An annual contract of <strong>4 operated events</strong> per year for one org: learning paths curated from the public problem catalog (beginner → advanced). Original problem development is not included in this package.</p>
       <a class="more" href="https://github.com/susumutomita/TenkaCloud/blob/main/docs/commercial/PACKAGES.html#annual-arena" target="_blank" rel="noopener noreferrer"><span data-i18n="offerings.b.more">Scope &amp; deliverables</span> ›</a>
     </div>
     <div class="col">


### PR DESCRIPTION
## Summary
ランディングのコピーを実態に合わせて整理する 3 つの変更。

1. **「コミュニティに参加」セクション(`#community`)を削除** — 役割カード(Tester / Problem Author)+ lead を丸ごと削除。トップナビの「コミュニティ」リンク(`#community` アンカー)と孤立 i18n キー(`community.*`, `nav.community`)も ja/en 両方から削除。フッターの "Community" カラム(GitHub / Discussions / Issues / Contribute)は独立したフッターナビなので残置。
2. **Annual Arena から未実装の「KPI ダッシュボード」訴求を削除** — 見出し「年間プログラム + KPI ダッシュボード。」→「年間プログラム。」、本文の「HR / L&D 向け KPI ダッシュボードで定着を可視化」を削除(KPI ダッシュボードは未実装のため誇張を排除)。
3. **Hosted Event の期間を修正** — 「1〜3 日のクラウド演習」→「1 日のクラウド演習」(実提供に合わせる)。

ja/en 両ロケール + index.html デフォルトをそろえて編集。

## Test plan
- `biome check landing/app.js` パス / `node --check landing/app.js` パス
- `#community` / `community.*` / `nav.community` / `KPI` / `1〜3` の残存参照が無いことを grep で確認(フッター "Community" カラムは別物として保持)
- pre-commit hook の lint / textlint / 全 workspace test / audit-deps / cdk synth がパス

## Regression analysis
- 変更は `landing/` 配下の静的コピーのみ。アプリ / インフラ / 問題に影響なし。
- 削除したナビ項目のアンカー(`#community`)は対象セクションごと削除済みでデッドリンク無し。
- 削除した i18n キーに対応する DOM 要素はすべて同時削除済み(grep 確認)。
- 未実装機能(KPI ダッシュボード)の訴求を削除し、看板と実態の乖離を解消。

## Physical impact
- **NO-OP**。CFn / インフラ成果物への影響なし。静的 LP コンテンツのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
