### PR TITLE
docs: retire Scenario Reviewer role from contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,11 @@ only original or compatibly licensed work.
 
 ## Join the community
 
-TenkaCloud's moat is its problem catalog, and that catalog grows through community contribution. Pick one of six roles and ship one starter task — you do not need to be personally onboarded.
+TenkaCloud's moat is its problem catalog, and that catalog grows through community contribution. Pick one of five roles and ship one starter task — you do not need to be personally onboarded.
 
-- **[docs/community/ONBOARDING.html](./docs/community/ONBOARDING.html)** — role chooser (Tester / Problem Author / Scenario Reviewer / Event Facilitator / Platform Contributor / Sponsor-Requester), with the expected contribution, required skill level, first task, communication channel, time commitment, and recognition path for each role.
+- **[docs/community/ONBOARDING.html](./docs/community/ONBOARDING.html)** — role chooser (Tester / Problem Author / Event Facilitator / Platform Contributor / Sponsor-Requester), with the expected contribution, required skill level, first task, communication channel, time commitment, and recognition path for each role.
 - **[docs/community/PLAYTEST-CHECKLIST.html](./docs/community/PLAYTEST-CHECKLIST.html)** — 30-minute playtest protocol for the Tester role: pick a problem, run `make deploy` in Lite mode, register a team, solve, score, and file a `problem-feedback` issue with a structured template.
-- **[docs/community/PROBLEM-REVIEW-CHECKLIST.html](./docs/community/PROBLEM-REVIEW-CHECKLIST.html)** — rubric for the Scenario Reviewer role: scoring fairness, hint progression, no-skip-by-luck, time-to-solve estimate, scenario realism, template security (cross-references [#1353](https://github.com/susumutomita/TenkaCloud/issues/1353) for security hardening).
+- **[docs/community/PROBLEM-REVIEW-CHECKLIST.html](./docs/community/PROBLEM-REVIEW-CHECKLIST.html)** — rubric for reviewing a problem PR: scoring fairness, hint progression, no-skip-by-luck, time-to-solve estimate, scenario realism, template security (cross-references [#1353](https://github.com/susumutomita/TenkaCloud/issues/1353) for security hardening).
 
 Coordination model: **GitHub is the durable source of truth**; Discord (when available) is for live coordination only — every decision and bug must end up as a GitHub issue or PR comment. GitHub-only contributors are first-class.
 

--- a/CONTRIBUTOR_MAP.md
+++ b/CONTRIBUTOR_MAP.md
@@ -54,7 +54,7 @@ Both must be green. If something fails, fix the code; do not edit `biome.json` /
 
 **Read**:
 
-- [`docs/community/ONBOARDING.html`](./docs/community/ONBOARDING.html) — Scenario Reviewer role expectations.
+- [`docs/community/ONBOARDING.html`](./docs/community/ONBOARDING.html) — community roles and recognition paths.
 - [`docs/community/PROBLEM-REVIEW-CHECKLIST.html`](./docs/community/PROBLEM-REVIEW-CHECKLIST.html) — 6-section rubric (scoring fairness / hint progression / no-skip-by-luck / time-to-solve / scenario realism / template security).
 - [ADR-012](./docs/architecture/adr-012-problem-plugin-architecture.html) — the plugin contract; useful when you read `metadata.json`.
 

--- a/docs/community/ONBOARDING.html
+++ b/docs/community/ONBOARDING.html
@@ -73,9 +73,9 @@
 <body>
 <header>
   <h1>TenkaCloud Community Onboarding</h1>
-  <p><em>Pick one of six roles. Each role has a 15-30 minute first task and a clear recognition path. You do not need to be personally onboarded by the maintainer.</em></p>
+  <p><em>Pick one of five roles. Each role has a 15-30 minute first task and a clear recognition path. You do not need to be personally onboarded by the maintainer.</em></p>
   <div class="meta">
-    <div><b>For:</b> CCoE practitioners, AWS / JAWS-UG members, cloud security &amp; SRE engineers, training facilitators, problem authors, testers, reviewers</div>
+    <div><b>For:</b> CCoE practitioners, AWS / JAWS-UG members, cloud security &amp; SRE engineers, training facilitators, problem authors, testers</div>
     <div><b>Coordination:</b> <a href="https://github.com/susumutomita/TenkaCloud/discussions">GitHub Discussions</a> (source of truth) + Discord (live coordination, optional)</div>
     <div><b>Related:</b> <a href="../architecture/adr-024-community-voting-and-problem-registry.html">ADR-024</a> (community voting), <a href="../../CONTRIBUTOR_MAP.md">CONTRIBUTOR_MAP.md</a> (task recipes)</div>
   </div>
@@ -85,7 +85,7 @@
 <h2>Contents</h2>
 <ul class="toc">
   <li><a href="#how-this-works">1. How this works</a></li>
-  <li><a href="#role-chooser">2. Role chooser (6 roles)</a></li>
+  <li><a href="#role-chooser">2. Role chooser (5 roles)</a></li>
   <li><a href="#first-pr">3. Role-specific first PR / contribution</a></li>
   <li><a href="#recognition">4. How contribution gets recognized</a></li>
   <li><a href="#communication">5. Where to communicate (GitHub vs Discord)</a></li>
@@ -151,25 +151,8 @@
     </dl>
   </div>
 
-  <div class="role-card reviewer">
-    <div class="role-title">Role 3</div>
-    <h3>Scenario Reviewer <span class="badge warn">judgement</span></h3>
-    <dl>
-      <dt>Expected contribution</dt>
-      <dd>Review whether a problem reflects real cloud practice. Check learning goals, hint progression, scoring fairness, scenario realism.</dd>
-      <dt>Required skill level</dt>
-      <dd>Production AWS experience (cloud security, SRE, platform). You have seen the real version of the incident a problem simulates.</dd>
-      <dt>First task</dt>
-      <dd>Review one open Challenge / Battle PR using <a href="./PROBLEM-REVIEW-CHECKLIST.html">PROBLEM-REVIEW-CHECKLIST.html</a>.</dd>
-      <dt>Where to communicate</dt>
-      <dd>GitHub PR review comments (durable). Discord <code>#reviewer-squad</code> for design discussion before review.</dd>
-      <dt>Time commitment</dt>
-      <dd>30-90 minutes per review. 1-2 reviews per month is enough.</dd>
-    </dl>
-  </div>
-
   <div class="role-card facilitator">
-    <div class="role-title">Role 4</div>
+    <div class="role-title">Role 3</div>
     <h3>Event Facilitator <span class="badge link">operational</span></h3>
     <dl>
       <dt>Expected contribution</dt>
@@ -186,7 +169,7 @@
   </div>
 
   <div class="role-card platform">
-    <div class="role-title">Role 5</div>
+    <div class="role-title">Role 4</div>
     <h3>Platform Contributor <span class="badge muted">deep</span></h3>
     <dl>
       <dt>Expected contribution</dt>
@@ -203,7 +186,7 @@
   </div>
 
   <div class="role-card sponsor">
-    <div class="role-title">Role 6</div>
+    <div class="role-title">Role 5</div>
     <h3>Sponsor / Requester <span class="badge reject">demand</span></h3>
     <dl>
       <dt>Expected contribution</dt>
@@ -246,16 +229,6 @@
   <li>Scaffold: <code>bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;</code> (or use the <code>/new-problem</code> Claude Code skill).</li>
   <li>Fill <code>metadata.json</code> and <code>template.yaml</code>. Validate locally: <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code>.</li>
   <li>Open a PR in the <a href="https://github.com/susumutomita/TenkaCloudChallenge">TenkaCloudChallenge</a> catalog repo.</li>
-</ol>
-</div>
-
-<div class="recipe">
-<h4>Scenario Reviewer — Review one problem PR</h4>
-<ol>
-  <li>Pick an open problem PR in <a href="https://github.com/susumutomita/TenkaCloudChallenge/pulls">TenkaCloudChallenge/pulls</a>.</li>
-  <li>Walk through <a href="./PROBLEM-REVIEW-CHECKLIST.html">PROBLEM-REVIEW-CHECKLIST.html</a> (scoring fairness, hint progression, no-skip-by-luck, time-to-solve estimate, scenario realism, template security).</li>
-  <li>Leave PR review comments referencing checklist items. An "Approve" is fine if every item passes; a "Request changes" review is fine when items fail.</li>
-  <li>For deeper template security concerns, cross-reference the <a href="https://github.com/susumutomita/TenkaCloud/issues/1353">#1353 hardening checklist</a>.</li>
 </ol>
 </div>
 
@@ -308,11 +281,6 @@
     <td>Problem Author</td>
     <td>Your handle is the <code>author</code> field in <code>metadata.json</code>. The catalog UI shows the byline on every problem card.</td>
     <td><code>problems/&lt;id&gt;/metadata.json</code> <code>author</code> field + catalog UI + <code>CONTRIBUTORS.md</code> "Problem authors"</td>
-  </tr>
-  <tr>
-    <td>Scenario Reviewer</td>
-    <td>Your GitHub review approval is preserved in the PR. Active reviewers get the "Reviewer squad" Discord role and a section in <code>CONTRIBUTORS.md</code>.</td>
-    <td>GitHub PR review log + <code>CONTRIBUTORS.md</code> "Reviewers"</td>
   </tr>
   <tr>
     <td>Event Facilitator</td>
@@ -370,11 +338,6 @@
     <td>Final review (use PR)</td>
   </tr>
   <tr>
-    <td>Discord <code>#reviewer-squad</code></td>
-    <td>Discussing review heuristics, rubric calibration</td>
-    <td>Per-PR review (use GitHub PR review)</td>
-  </tr>
-  <tr>
     <td>Discord <code>#facilitators</code></td>
     <td>Scheduling dry-runs, debriefing in real time</td>
     <td>Permanent runbook updates (open a docs PR)</td>
@@ -425,7 +388,7 @@
 
 <details>
 <summary>What if my role does not appear in this list?</summary>
-<p>Open a <a href="https://github.com/susumutomita/TenkaCloud/discussions">Discussion</a>. The 6-role split was designed to cover the typical OSS contributor surface; new roles are welcome if they fill a real gap.</p>
+<p>Open a <a href="https://github.com/susumutomita/TenkaCloud/discussions">Discussion</a>. The 5-role split was designed to cover the typical OSS contributor surface; new roles are welcome if they fill a real gap.</p>
 </details>
 
 </section>

--- a/docs/community/PROBLEM-REVIEW-CHECKLIST.html
+++ b/docs/community/PROBLEM-REVIEW-CHECKLIST.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>TenkaCloud Problem Review Checklist — Rubric for the Scenario Reviewer squad</title>
+<title>TenkaCloud Problem Review Checklist — Rubric for reviewing problem PRs</title>
 <style>
   :root {
     --c-text: #1f2328;
@@ -62,7 +62,7 @@
   <h1>Problem Review Checklist</h1>
   <p><em>Reviewer rubric for Challenge and Battle problem PRs. Use it as PR review comments — one check per rubric item.</em></p>
   <div class="meta">
-    <div><b>For:</b> Scenario Reviewer role (see <a href="./ONBOARDING.html#role-chooser">ONBOARDING.html</a>)</div>
+    <div><b>For:</b> anyone reviewing a Challenge / Battle problem PR — problem authors, maintainers (see <a href="./ONBOARDING.html#role-chooser">community roles</a>)</div>
     <div><b>Goal:</b> Block problems that are unfair, unrealistic, unsafe, or fundamentally broken. Approve problems that meet a credible event bar.</div>
     <div><b>Cross-references:</b> <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> (problem = plugin), <a href="https://github.com/susumutomita/TenkaCloud/issues/1353">#1353</a> (security hardening)</div>
   </div>
@@ -235,7 +235,7 @@
 </div>
 
 <div class="callout ok">
-  After you submit your review, your handle is preserved on the PR. Active reviewers earn the "Reviewer squad" badge — see <a href="./ONBOARDING.html#recognition">Recognition</a>.
+  After you submit your review, your handle is preserved on the PR review history in GitHub — durable credit for the review you gave.
 </div>
 </section>
 


### PR DESCRIPTION
## Summary
LP からコミュニティ章を削除した流れに合わせ、貢献者ドキュメントから「Scenario Reviewer」ロールを撤去し **6 → 5 役割**に整合させた。問題レビュー自体は有用な活動として残し、レビュー用ルーブリックはロール非依存の汎用ドキュメントに改題。

- **`docs/community/ONBOARDING.html`**: Scenario Reviewer のロールカード / 初回タスク recipe / recognition 表の行 / Discord `#reviewer-squad` 行を削除。残るロールを 1〜5 に振り直し、「six/6 roles」「6-role split」を 5 に更新。audience 列の "reviewers" も除去。
- **`CONTRIBUTING.md`**: 「six roles」→「five roles」、ロール列挙から Scenario Reviewer を除去、PROBLEM-REVIEW-CHECKLIST の説明をロール非依存（「reviewing a problem PR」）に。
- **`CONTRIBUTOR_MAP.md`**: 「Scenario Reviewer role expectations」→「community roles and recognition paths」。
- **`docs/community/PROBLEM-REVIEW-CHECKLIST.html`**: タイトルと "For:" を撤去ロール依存から「problem PR を見る人（問題作者 / メンテナ）向けの汎用ルーブリック」に改題。recognition 参照（削除済みの "Reviewer squad" 行）を GitHub レビュー履歴の記述に置換。

問題レビュー用チェックリスト本体は削除せず汎用リソースとして保持（`PLAYTEST-CHECKLIST.html` / `launch-readiness.html` からの参照リンクは有効なまま）。

## Test plan
- リポジトリ全体で `Scenario Reviewer` / `6 roles` / `reviewer-squad` の残存参照が無いことを grep で確認
- ONBOARDING のロール番号が 1〜5 に連番化されていることを確認
- pre-commit hook の markdownlint / textlint / 全 workspace test / audit-deps / cdk synth がパス

## Regression analysis
- 変更はドキュメント（HTML / Markdown）のみ。コード / インフラ / 問題に影響なし。
- 削除した役割のページ内リンク・recognition 行・Discord 行はすべて同時に除去し、デッドリンク無し。
- `PROBLEM-REVIEW-CHECKLIST.html` は保持したため、`PLAYTEST-CHECKLIST.html` / `launch-readiness.html` の参照リンクは有効。

## Physical impact
- **NO-OP**。CFn / インフラ成果物への影響なし。ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
