### PR TITLE
fix(lite-deploy): pin source bucket so edited templates reach CodeBuild (#1789)

### DIFF
--- a/infrastructure/test/scripts/tenkacloud-lite.test.ts
+++ b/infrastructure/test/scripts/tenkacloud-lite.test.ts
@@ -3,6 +3,7 @@ import {
   type CliIO,
   LITE_STACK_NAMES,
   main,
+  parseResolvedBucketName,
   type SpawnCaptureResult,
 } from "../../../scripts/tenkacloud-lite";
 
@@ -141,6 +142,66 @@ describe("tenkacloud-lite CLI (#778 ADR-016 Phase 4)", () => {
     expect(deployCall.args).toContain(LITE_STACK_NAMES.problemDeploy);
     expect(deployCall.args).toContain("--require-approval");
     expect(deployCall.args).toContain("never");
+  });
+
+  // Issue #1789: source bucket 取り違え修正。 cmdUp は prepare-source-bundle.sh の
+  // RESOLVE_ONLY 出力から account-scoped bucket を解決し、 bundle upload + cdk deploy より
+  // 前に CDK_PARAM_S3_BUCKET_NAME へ固定して upload 先 / read 先を一致させる。
+  it("up should pin CDK_PARAM_S3_BUCKET_NAME from RESOLVE_ONLY before cdk deploy (#1789)", async () => {
+    const bucket = "tenkacloud-source-111122223333-ap-northeast-1";
+    const prevBucket = process.env.CDK_PARAM_S3_BUCKET_NAME;
+    const prevToggle = process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+    delete process.env.CDK_PARAM_S3_BUCKET_NAME;
+    delete process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+
+    let toggleDuringResolve: string | undefined;
+    const { io } = buildIO({
+      inheritExitCode: 0,
+      capture: (cmd, args) => {
+        if (cmd === "bash" && args.includes("scripts/prepare-source-bundle.sh")) {
+          // RESOLVE_ONLY toggle はこの capture 実行中だけ立っているはず。
+          toggleDuringResolve = process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+          return {
+            code: 0,
+            stdout:
+              `REGION=ap-northeast-1\nACCOUNT_ID=111122223333\n` +
+              `CDK_PARAM_S3_BUCKET_NAME=${bucket}\nCDK_SOURCE_NAME=source.zip\n`,
+            stderr: "",
+          };
+        }
+        return { code: 0, stdout: "https://example.cloudfront.net", stderr: "" };
+      },
+    });
+
+    try {
+      const code = await main(["up"], io);
+      expect(code).toBe(0);
+      expect(toggleDuringResolve).toBe("1");
+      // 本番 prepare + cdk deploy が読む env が account-scoped bucket に固定される。
+      expect(process.env.CDK_PARAM_S3_BUCKET_NAME).toBe(bucket);
+      // RESOLVE_ONLY toggle は後始末されて漏れない。
+      expect(process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY).toBeUndefined();
+    } finally {
+      if (prevBucket === undefined) delete process.env.CDK_PARAM_S3_BUCKET_NAME;
+      else process.env.CDK_PARAM_S3_BUCKET_NAME = prevBucket;
+      if (prevToggle === undefined) delete process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+      else process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY = prevToggle;
+    }
+  });
+
+  describe("parseResolvedBucketName (#1789)", () => {
+    it("extracts CDK_PARAM_S3_BUCKET_NAME from RESOLVE_ONLY output", () => {
+      const out =
+        "REGION=ap-northeast-1\nACCOUNT_ID=111122223333\n" +
+        "CDK_PARAM_S3_BUCKET_NAME=tenkacloud-source-111122223333-ap-northeast-1\nCDK_SOURCE_NAME=source.zip\n";
+      expect(parseResolvedBucketName(out)).toBe("tenkacloud-source-111122223333-ap-northeast-1");
+    });
+
+    it("returns undefined when the key is absent or empty", () => {
+      expect(parseResolvedBucketName("REGION=ap-northeast-1\nACCOUNT_ID=1\n")).toBeUndefined();
+      expect(parseResolvedBucketName("CDK_PARAM_S3_BUCKET_NAME=\n")).toBeUndefined();
+      expect(parseResolvedBucketName("")).toBeUndefined();
+    });
   });
 
   it("up should early-return without calling cdk deploy when prepare-source-bundle.sh exits non-zero", async () => {

--- a/scripts/tenkacloud-lite.ts
+++ b/scripts/tenkacloud-lite.ts
@@ -127,6 +127,42 @@ function printHelp(io: CliIO): void {
   );
 }
 
+/**
+ * Issue #1789: prepare-source-bundle.sh の RESOLVE_ONLY seam を使い、 source.zip の
+ * upload 先となる account-scoped bucket 名 (= tenkacloud-source-<account>-<region>) を
+ * 解決する。 これは cdk deploy が CodeBuild の source bucket に焼く CDK_PARAM_S3_BUCKET_NAME と
+ * 一致させるための単一 source of truth。 creds 不在等で解決できなければ undefined を返し、
+ * 後段の本番 prepare 実行に通常のエラー表示を委ねる (= ここでは fail-fast しない)。
+ */
+async function resolveSourceBucketName(io: CliIO): Promise<string | undefined> {
+  const previous = process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+  process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY = "1";
+  try {
+    const result = await io.spawnCapture("bash", ["scripts/prepare-source-bundle.sh"]);
+    if (result.code !== 0) return undefined;
+    return parseResolvedBucketName(result.stdout);
+  } finally {
+    // RESOLVE_ONLY toggle は後始末する (= 本番 prepare 実行が resolve-and-exit しないよう)。
+    if (previous === undefined) delete process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY;
+    else process.env.PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY = previous;
+  }
+}
+
+/**
+ * RESOLVE_ONLY 出力 (= `KEY=value` 行の列挙) から CDK_PARAM_S3_BUCKET_NAME を取り出す。
+ * 取れなければ undefined。 unit test から直接 pin するため export している。
+ */
+export function parseResolvedBucketName(stdout: string): string | undefined {
+  for (const line of stdout.split("\n")) {
+    const match = /^CDK_PARAM_S3_BUCKET_NAME=(.*)$/.exec(line.trim());
+    if (match) {
+      const value = match[1].trim();
+      return value.length > 0 ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
 async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
   // Issue #955 follow-up: Lite mode は SBT ControlPlane と provision-tenant.sh を持たないため、
   // tenant admin user を別経路で作る必要がある。 deploy 後に Cognito UserPool ID を
@@ -158,6 +194,23 @@ async function cmdUp(_args: readonly string[], io: CliIO): Promise<number> {
   // Issue #1345: 30-min first-run UX — 各 phase を「[i/N] ...」 で示す。
   const totalSteps = 3;
   io.stdout(`\n[lite] [1/${totalSteps}] preparing source bundle (= S3 bucket + source.zip)...\n`);
+
+  // Issue #1789: source bucket 取り違えで「直したはずの problem template が deploy に
+  // 反映されない」事故の修正。 prepare-source-bundle.sh は account-scoped bucket
+  // (= tenkacloud-source-<account>-<region>) を自前で解決して source.zip を upload するが、
+  // subshell 実行なので resolved bucket 名はこの process に伝わらない。 後段の cdk deploy が
+  // CDK_PARAM_S3_BUCKET_NAME を未設定のまま読むと Makefile 既定値 (= creds 不在時に
+  // serverless-saas-placeholder へフォールバック) が CodeBuild の source bucket に焼かれ、
+  // upload 先と read 先が食い違う。 CodeBuild source は version 無指定の Source.s3 で「最新」を
+  // 引くため、 placeholder bucket の古い source.zip がそのまま deploy され続ける。 同じ
+  // resolution (= 単一 source of truth) を RESOLVE_ONLY で先に解決し process.env に固定して、
+  // bundle upload と cdk deploy を必ず同じ bucket に揃える。
+  const sourceBucket = await resolveSourceBucketName(io);
+  if (sourceBucket) {
+    process.env.CDK_PARAM_S3_BUCKET_NAME = sourceBucket;
+    io.stdout(`[lite]       source bucket = ${sourceBucket}\n`);
+  }
+
   const prepCode = await io.spawnInherit("bash", ["scripts/prepare-source-bundle.sh"]);
   if (prepCode !== 0) {
     io.stderr(`[lite] prepare-source-bundle.sh failed with exit code ${prepCode}\n`);


### PR DESCRIPTION
Fixes #1789.

## Problem

In **Lite mode** (`make deploy` → `scripts/tenkacloud-lite.ts up`), a freshly-edited problem `template.yaml` could silently **never reach the deploy** — CodeBuild kept deploying a *stale* `source.zip` from a different bucket than the one `prepare-source-bundle.sh` uploads to.

Observed live: `battles/stackstack` was migrated Aurora → free-tier RDS, but every per-team deploy kept failing at `AWS::RDS::DBCluster` ("To use Aurora clusters with free plan accounts…") because:
- CodeBuild `source.location` = `serverless-saas-placeholder/source.zip` (2-day-old, Aurora inside)
- the fixed bundle had been uploaded to `tenkacloud-source-<account>-<region>/source.zip` — and was never read.

## Root cause

`cmdUp` runs `prepare-source-bundle.sh` in a **subshell**, so the account-scoped bucket it resolves/uploads to is discarded. The next `cdk deploy` re-derives `CDK_PARAM_S3_BUCKET_NAME` from `Makefile:150`, which falls back to `serverless-saas-placeholder` when `AWS_ACCOUNT_ID` / region aren't in the env. Because the CodeBuild source is `Source.s3({ bucket, path })` with **no version pin**, it always serves the latest object of whatever bucket got baked in — the stale placeholder bundle. The two halves of `make deploy` disagree on the bucket. (The SaaS `install.sh` path is unaffected — it `source`s the script so envs propagate.)

## Fix

Resolve the canonical source bucket in `cmdUp` via `prepare-source-bundle.sh`'s existing `PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY` seam (single source of truth) and pin `process.env.CDK_PARAM_S3_BUCKET_NAME` **before** both the bundle upload and `cdk deploy`. Now the upload target and the CodeBuild read target can never diverge. The `PREPARE_SOURCE_BUNDLE_RESOLVE_ONLY` toggle is set only for the resolve probe and restored afterwards so the real bundle run still uploads (doesn't resolve-and-exit).

## Tests

- New: `cmdUp` pins `CDK_PARAM_S3_BUCKET_NAME` from RESOLVE_ONLY output before `cdk deploy`, and cleans up the toggle.
- New: `parseResolvedBucketName` unit tests (present / absent / empty).
- Green locally: `tsc --noEmit`, `biome lint/format`, `tenkacloud-lite` vitest (28 tests). The repo's full pre-commit suite also passed on the first attempt (it only failed to write the ref due to a concurrent `origin/main` advance; re-committed onto the new tip).

## Notes / follow-up (not in this PR)
A failed deploy leaves the per-team stack in `ROLLBACK_COMPLETE`, which CloudFormation can't update — it must be `delete-stack`ed before redeploy. Worth surfacing in operator docs / the deploy flow (tracked in #1789's acceptance criteria as optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
