### PR TITLE
fix(problem-deploy): verify target account before delete-stack

### DIFF
--- a/docs/operations/deploy-trace.html
+++ b/docs/operations/deploy-trace.html
@@ -148,7 +148,7 @@
 </tr>
 <tr>
 <td><code>deploy.codebuild.succeeded</code></td>
-<td><code>deploy-battles.sh:234</code> / <code>delete-battles.sh:81</code></td>
+<td><code>deploy-battles.sh:234</code> / <code>delete-battles.sh:103</code></td>
 <td>info</td>
 <td><code>operation</code>, <code>region</code>, <code>problemCount</code></td>
 </tr>
@@ -178,27 +178,33 @@
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.start</code></td>
-<td><code>delete-battles.sh:40</code></td>
+<td><code>delete-battles.sh:54</code></td>
 <td>info</td>
 <td><code>stackName</code>, <code>region</code></td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.succeeded</code></td>
-<td><code>delete-battles.sh:80</code></td>
+<td><code>delete-battles.sh:102</code></td>
 <td>info</td>
 <td>同上</td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.failed</code></td>
-<td><code>delete-battles.sh:56</code> / <code>:74</code></td>
+<td><code>delete-battles.sh:78</code> / <code>:96</code></td>
 <td>info</td>
 <td>同上</td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.already_deleted</code></td>
-<td><code>delete-battles.sh:52</code> / <code>:70</code></td>
+<td><code>delete-battles.sh:74</code> / <code>:92</code></td>
 <td>info</td>
 <td>同上 (= 冪等 no-op、 stuck 復旧時に便利)</td>
+</tr>
+<tr>
+<td><code>deploy.cfn.delete.account_mismatch</code></td>
+<td><code>delete-battles.sh:42</code></td>
+<td>info</td>
+<td><code>stackName</code>, <code>region</code>, <code>expectedAccount</code>, <code>actualAccount</code> (= #1797 credentials が stack の account と不一致。 delete-stack 発行前に loud fail し silent leak を防ぐ)</td>
 </tr>
 </tbody></table>
 <p>Shell 経路の <code>correlationId</code> / <code>jobId</code> field は <code>TENKACLOUD_CORRELATION_ID</code> (現状 <code>PROBLEM_EXTERNAL_ID</code> と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。</p>

--- a/docs/operations/deploy-trace.html
+++ b/docs/operations/deploy-trace.html
@@ -148,7 +148,7 @@
 </tr>
 <tr>
 <td><code>deploy.codebuild.succeeded</code></td>
-<td><code>deploy-battles.sh:234</code> / <code>delete-battles.sh:103</code></td>
+<td><code>deploy-battles.sh:234</code> / <code>delete-battles.sh:109</code></td>
 <td>info</td>
 <td><code>operation</code>, <code>region</code>, <code>problemCount</code></td>
 </tr>
@@ -178,31 +178,31 @@
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.start</code></td>
-<td><code>delete-battles.sh:54</code></td>
+<td><code>delete-battles.sh:60</code></td>
 <td>info</td>
 <td><code>stackName</code>, <code>region</code></td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.succeeded</code></td>
-<td><code>delete-battles.sh:102</code></td>
+<td><code>delete-battles.sh:108</code></td>
 <td>info</td>
 <td>同上</td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.failed</code></td>
-<td><code>delete-battles.sh:78</code> / <code>:96</code></td>
+<td><code>delete-battles.sh:43</code> / <code>:84</code> / <code>:102</code></td>
 <td>info</td>
-<td>同上</td>
+<td>同上 (<code>:43</code> は STS 失敗 = 検証前の credential 異常)</td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.already_deleted</code></td>
-<td><code>delete-battles.sh:74</code> / <code>:92</code></td>
+<td><code>delete-battles.sh:80</code> / <code>:98</code></td>
 <td>info</td>
 <td>同上 (= 冪等 no-op、 stuck 復旧時に便利)</td>
 </tr>
 <tr>
 <td><code>deploy.cfn.delete.account_mismatch</code></td>
-<td><code>delete-battles.sh:42</code></td>
+<td><code>delete-battles.sh:48</code></td>
 <td>info</td>
 <td><code>stackName</code>, <code>region</code>, <code>expectedAccount</code>, <code>actualAccount</code> (= #1797 credentials が stack の account と不一致。 delete-stack 発行前に loud fail し silent leak を防ぐ)</td>
 </tr>

--- a/docs/operations/deploy-trace.md
+++ b/docs/operations/deploy-trace.md
@@ -33,16 +33,16 @@
 | event | 出所 | level | 主な field |
 |---|---|---|---|
 | `deploy.codebuild.start` | `deploy-battles.sh:73` / `delete-battles.sh:33` | info | `operation` (= `create` / `delete`), `region`, `teamSlug` |
-| `deploy.codebuild.succeeded` | `deploy-battles.sh:234` / `delete-battles.sh:103` | info | `operation`, `region`, `problemCount` |
+| `deploy.codebuild.succeeded` | `deploy-battles.sh:234` / `delete-battles.sh:109` | info | `operation`, `region`, `problemCount` |
 | `deploy.codebuild.failed` | `deploy-battles.sh:238` | info | `operation`, `region`, `failureCount` |
 | `deploy.cfn.deploy.start` | `deploy-battles.sh:188` | info | `stackName`, `region`, `teamSlug`, `problemDir` |
 | `deploy.cfn.deploy.succeeded` | `deploy-battles.sh:210` | info | 同上 |
 | `deploy.cfn.deploy.failed` | `deploy-battles.sh:206` | info | 同上 |
-| `deploy.cfn.delete.start` | `delete-battles.sh:54` | info | `stackName`, `region` |
-| `deploy.cfn.delete.succeeded` | `delete-battles.sh:102` | info | 同上 |
-| `deploy.cfn.delete.failed` | `delete-battles.sh:78` / `:96` | info | 同上 |
-| `deploy.cfn.delete.already_deleted` | `delete-battles.sh:74` / `:92` | info | 同上 (= 冪等 no-op、 stuck 復旧時に便利) |
-| `deploy.cfn.delete.account_mismatch` | `delete-battles.sh:42` | info | `stackName`, `region`, `expectedAccount`, `actualAccount` (= #1797 credentials が stack の account と不一致。 delete-stack 発行前に loud fail し silent leak を防ぐ) |
+| `deploy.cfn.delete.start` | `delete-battles.sh:60` | info | `stackName`, `region` |
+| `deploy.cfn.delete.succeeded` | `delete-battles.sh:108` | info | 同上 |
+| `deploy.cfn.delete.failed` | `delete-battles.sh:43` / `:84` / `:102` | info | 同上 (`:43` は STS 失敗 = 検証前の credential 異常) |
+| `deploy.cfn.delete.already_deleted` | `delete-battles.sh:80` / `:98` | info | 同上 (= 冪等 no-op、 stuck 復旧時に便利) |
+| `deploy.cfn.delete.account_mismatch` | `delete-battles.sh:48` | info | `stackName`, `region`, `expectedAccount`, `actualAccount` (= #1797 credentials が stack の account と不一致。 delete-stack 発行前に loud fail し silent leak を防ぐ) |
 
 Shell 経路の `correlationId` / `jobId` field は `TENKACLOUD_CORRELATION_ID` (現状 `PROBLEM_EXTERNAL_ID` と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。
 

--- a/docs/operations/deploy-trace.md
+++ b/docs/operations/deploy-trace.md
@@ -33,15 +33,16 @@
 | event | 出所 | level | 主な field |
 |---|---|---|---|
 | `deploy.codebuild.start` | `deploy-battles.sh:73` / `delete-battles.sh:33` | info | `operation` (= `create` / `delete`), `region`, `teamSlug` |
-| `deploy.codebuild.succeeded` | `deploy-battles.sh:234` / `delete-battles.sh:81` | info | `operation`, `region`, `problemCount` |
+| `deploy.codebuild.succeeded` | `deploy-battles.sh:234` / `delete-battles.sh:103` | info | `operation`, `region`, `problemCount` |
 | `deploy.codebuild.failed` | `deploy-battles.sh:238` | info | `operation`, `region`, `failureCount` |
 | `deploy.cfn.deploy.start` | `deploy-battles.sh:188` | info | `stackName`, `region`, `teamSlug`, `problemDir` |
 | `deploy.cfn.deploy.succeeded` | `deploy-battles.sh:210` | info | 同上 |
 | `deploy.cfn.deploy.failed` | `deploy-battles.sh:206` | info | 同上 |
-| `deploy.cfn.delete.start` | `delete-battles.sh:40` | info | `stackName`, `region` |
-| `deploy.cfn.delete.succeeded` | `delete-battles.sh:80` | info | 同上 |
-| `deploy.cfn.delete.failed` | `delete-battles.sh:56` / `:74` | info | 同上 |
-| `deploy.cfn.delete.already_deleted` | `delete-battles.sh:52` / `:70` | info | 同上 (= 冪等 no-op、 stuck 復旧時に便利) |
+| `deploy.cfn.delete.start` | `delete-battles.sh:54` | info | `stackName`, `region` |
+| `deploy.cfn.delete.succeeded` | `delete-battles.sh:102` | info | 同上 |
+| `deploy.cfn.delete.failed` | `delete-battles.sh:78` / `:96` | info | 同上 |
+| `deploy.cfn.delete.already_deleted` | `delete-battles.sh:74` / `:92` | info | 同上 (= 冪等 no-op、 stuck 復旧時に便利) |
+| `deploy.cfn.delete.account_mismatch` | `delete-battles.sh:42` | info | `stackName`, `region`, `expectedAccount`, `actualAccount` (= #1797 credentials が stack の account と不一致。 delete-stack 発行前に loud fail し silent leak を防ぐ) |
 
 Shell 経路の `correlationId` / `jobId` field は `TENKACLOUD_CORRELATION_ID` (現状 `PROBLEM_EXTERNAL_ID` と同値) を State Machine から伝搬する。 fallback として両 env のどちらか空でない方を採用する。
 

--- a/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
+++ b/infrastructure/lib/problem-deploy/deploy-codebuild-project.ts
@@ -64,6 +64,7 @@ export interface DeployCodeBuildProjectProps {
  *   - `TEAM_SLUG`: 例 `demo-team` (create 時のみ)
  *   - `DELETE_STACK_NAME`: CFn StackName / StackId (delete 時のみ)
  *   - `DELETE_REGION`: delete 対象 region (delete 時のみ)
+ *   - `DELETE_EXPECTED_AWS_ACCOUNT_ID`: stack が実在する account (delete 時のみ、#1797)
  *   - `TENKACLOUD_CORRELATION_ID`: operator trace 用。現状は deploy jobId と同値。
  *
  * 同一 AWS account 内 deploy のみ (MVP-1 制約)。Phase 2 で cross-account になったら
@@ -147,6 +148,12 @@ export class DeployCodeBuildProject extends Construct {
         DELETE_REGION: {
           type: BuildEnvironmentVariableType.PLAINTEXT,
           value: "<unset-overridden-by-step-functions>",
+        },
+        // #1797: delete 時に credentials の account と stack の account の一致を検証する。
+        // 空文字 default = 検証 skip (在来 event との後方互換)。
+        DELETE_EXPECTED_AWS_ACCOUNT_ID: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: "",
         },
         // Phase 2.2 (Issue #459): cross-account AssumeRole metadata。State Machine が
         // event detail から override する。空文字 default = same-account fallback。

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -70,6 +70,9 @@ export class DeployDeleteStateMachine extends Construct {
         OPERATION: { value: "delete" },
         DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
         DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+        // #1797: stack が実在する account を script に渡し、credentials の account と
+        // 突き合わせる。mismatch のまま delete-stack すると no-op 成功で stack が残存する。
+        DELETE_EXPECTED_AWS_ACCOUNT_ID: { value: JsonPath.stringAt("$.detail.awsAccountId") },
         PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
         TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
       },
@@ -86,6 +89,8 @@ export class DeployDeleteStateMachine extends Construct {
           OPERATION: { value: "delete" },
           DELETE_STACK_NAME: { value: JsonPath.stringAt("$.detail.stackName") },
           DELETE_REGION: { value: JsonPath.stringAt("$.detail.region") },
+          // #1797: AssumeRole 先が stack の account と一致するかを script 側で検証する。
+          DELETE_EXPECTED_AWS_ACCOUNT_ID: { value: JsonPath.stringAt("$.detail.awsAccountId") },
           PROBLEM_EXTERNAL_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           TENKACLOUD_CORRELATION_ID: { value: JsonPath.stringAt("$.detail.jobId") },
           COMPETITOR_ROLE_ARN: {

--- a/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
+++ b/infrastructure/lib/problem-deploy/deploy-delete-state-machine.ts
@@ -107,14 +107,20 @@ export class DeployDeleteStateMachine extends Construct {
     const invalidAssumeRoleMetadata = new Pass(this, "InvalidAssumeRoleMetadata", {
       result: Result.fromObject({
         Cause:
-          "competitorRoleArn and externalIdParameterName must be provided together for cross-account delete",
+          "detail must include awsAccountId, and competitorRoleArn / externalIdParameterName must be provided together",
       }),
       resultPath: "$.error",
     });
 
+    // #1797: 両 CodeBuild state が $.detail.awsAccountId を JsonPath 参照するため、
+    // 欠損 event をそのまま流すと States.Runtime (= addCatch で捕捉不能) で execution が
+    // 死に、行が DELETING のまま stuck する。isPresent ガードで markFailed 経路 (捕捉可能な
+    // loud fail) に倒す。Lambda producer は常に詰めるので、ここに来るのは replay / 手動
+    // put-events 等の壊れた event のみ。
     const routeDeleteInput = new Choice(this, "RouteDeleteInput")
       .when(
         Condition.and(
+          Condition.isPresent("$.detail.awsAccountId"),
           Condition.isPresent("$.detail.competitorRoleArn"),
           Condition.isPresent("$.detail.externalIdParameterName"),
         ),
@@ -122,6 +128,7 @@ export class DeployDeleteStateMachine extends Construct {
       )
       .when(
         Condition.and(
+          Condition.isPresent("$.detail.awsAccountId"),
           Condition.not(Condition.isPresent("$.detail.competitorRoleArn")),
           Condition.not(Condition.isPresent("$.detail.externalIdParameterName")),
         ),

--- a/infrastructure/test/problem-deploy/deploy-delete-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete-state-machine.test.ts
@@ -1,0 +1,79 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Project, Source } from "aws-cdk-lib/aws-codebuild";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { describe, expect, it } from "vitest";
+import { DeployDeleteStateMachine } from "../../lib/problem-deploy/deploy-delete-state-machine";
+
+/**
+ * Issue #1797: イベント削除後に競技者 CFn スタックが残存する regression の機械検査。
+ *
+ * delete CodeBuild が「stack の存在しない account」への credentials で走ると、
+ * `delete-stack` は no-op 成功 → `wait` も成功 → DB は DELETED なのに実 stack が残る
+ * silent leak になる。State Machine は deployment 行の `awsAccountId` を
+ * `DELETE_EXPECTED_AWS_ACCOUNT_ID` として CodeBuild に渡し、`delete-battles.sh` が
+ * `sts get-caller-identity` と突き合わせて mismatch を loud fail させる。
+ */
+
+function buildTestStack(): { stack: cdk.Stack; template: Template } {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "Test", {
+    env: { account: "123456789012", region: "ap-northeast-1" },
+  });
+  const deployments = new Table(stack, "Deployments", {
+    partitionKey: { name: "PK", type: AttributeType.STRING },
+    sortKey: { name: "SK", type: AttributeType.STRING },
+  });
+  const codeBuildProject = new Project(stack, "CodeBuild", {
+    source: Source.s3({
+      bucket: cdk.aws_s3.Bucket.fromBucketName(stack, "Src", "test-source-bucket"),
+      path: "source.zip",
+    }),
+  });
+  new DeployDeleteStateMachine(stack, "Sm", {
+    codeBuildProject,
+    deploymentsTable: deployments,
+  });
+  return { stack, template: Template.fromStack(stack) };
+}
+
+/**
+ * DefinitionString は CFn が Fn::Join で組み立てる可能性があるので、join components を
+ * 結合して 1 string にする (ref は ARN placeholder で十分)。
+ */
+function extractDefinition(template: Template): string {
+  const stateMachines = template.findResources("AWS::StepFunctions::StateMachine");
+  const sm = Object.values(stateMachines)[0];
+  expect(sm).toBeDefined();
+  const definitionString = sm?.Properties?.DefinitionString;
+  expect(definitionString).toBeDefined();
+  if (typeof definitionString === "string") return definitionString;
+  const join = definitionString["Fn::Join"];
+  const parts = join[1] as Array<string | Record<string, unknown>>;
+  return parts.map((p) => (typeof p === "string" ? p : "ARN_PLACEHOLDER")).join("");
+}
+
+describe("DeployDeleteStateMachine expected-account wiring (#1797)", () => {
+  it("should forward the deployment row awsAccountId to both delete CodeBuild routes", () => {
+    const { template } = buildTestStack();
+    const asl = extractDefinition(template);
+
+    // same-account / cross-account の両 StartDeleteCodeBuild state が
+    // DELETE_EXPECTED_AWS_ACCOUNT_ID を $.detail.awsAccountId から渡す。
+    const nameCount = asl.split('"Name":"DELETE_EXPECTED_AWS_ACCOUNT_ID"').length - 1;
+    expect(nameCount).toBe(2);
+    const valueCount = asl.split('"Value.$":"$.detail.awsAccountId"').length - 1;
+    expect(valueCount).toBe(2);
+  });
+
+  it("should keep the cross-account route gated on competitorRoleArn + externalIdParameterName both present", () => {
+    const { template } = buildTestStack();
+    const asl = extractDefinition(template);
+
+    // ルーティング条件は #1797 調査の前提 (deploy と delete の routing 対称性)。
+    // 片方だけ存在する壊れた metadata は CodeBuild に到達させず markFailed へ。
+    expect(asl).toContain('"Variable":"$.detail.competitorRoleArn"');
+    expect(asl).toContain('"Variable":"$.detail.externalIdParameterName"');
+    expect(asl).toContain("InvalidAssumeRoleMetadata");
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-delete-state-machine.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete-state-machine.test.ts
@@ -76,4 +76,16 @@ describe("DeployDeleteStateMachine expected-account wiring (#1797)", () => {
     expect(asl).toContain('"Variable":"$.detail.externalIdParameterName"');
     expect(asl).toContain("InvalidAssumeRoleMetadata");
   });
+
+  it("should route events missing awsAccountId to markFailed instead of an uncatchable States.Runtime", () => {
+    const { template } = buildTestStack();
+    const asl = extractDefinition(template);
+
+    // 両 CodeBuild state が $.detail.awsAccountId を JsonPath 参照するため、欠損 event を
+    // CodeBuild state に流すと States.Runtime (= addCatch 捕捉不能) で execution が死に、
+    // 行が DELETING のまま stuck する。両 when 条件の isPresent ガードを pin する。
+    const guardCount = asl.split('"Variable":"$.detail.awsAccountId"').length - 1;
+    expect(guardCount).toBe(2);
+    expect(asl).toContain("detail must include awsAccountId");
+  });
 });

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -234,6 +234,70 @@ describe("requestTeardown", () => {
 });
 
 /**
+ * [#1410-1412 regression guard] #1659 が非 AWS teardown を adapter.destroy に分岐させた際、
+ * **AWS/CFn 行 (= runtimeProvider/Engine/Entry が無い行、 bulk-deploy が永続化する shape)** が
+ * 誤って adapter 経路へ落ちると `AwsCloudFormationRuntimeAdapter.destroy` が
+ * `AdapterMethodNotWiredError` を投げ、 CFn DeleteStack event が publish されず stack が
+ * CREATE_COMPLETE のまま orphan 化する。 Lite mode (same-account, stacks `tc-*-team-N`) の
+ * event teardown はこの行 shape に乗るため、 「runtime field の無い AWS 行は必ず EventBridge CFn 経路」
+ * を invariant として固定する。
+ */
+describe("requestTeardown (AWS/CFn row stays on the DeleteStack EventBridge path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should publish a CFn DeployDeleteRequested (DeleteStack) for an AWS row without runtime fields, not adapter.destroy", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    // bulk-deploy が永続化する AWS 行 shape: runtimeProvider/Engine/Entry は **存在しない**。
+    const item = sampleRow({
+      problemId: "hello-world-battle",
+      namePrefix: "tc-hello-world-battle-team-1",
+      stackId:
+        "arn:aws:cloudformation:ap-northeast-1:999999999999:stack/tc-hello-world-battle-team-1/abc",
+    });
+    expect(item).not.toHaveProperty("runtimeProvider");
+    ddbSend.mockResolvedValueOnce({ Item: item }); // Get
+    ddbSend.mockResolvedValueOnce({}); // transition → DELETING
+    eventsSend.mockResolvedValueOnce({}); // PutEvents (DeployDeleteRequested)
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    // adapter.destroy 経路なら AdapterMethodNotWiredError で reject していたはず。
+    expect(out).toEqual({ kind: "accepted", previousStatus: "COMPLETE" });
+
+    // EventBridge に CFn DeleteStack 要求 (= State Machine → delete-battles.sh) が出る。
+    const putCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    expect(putCmd).toBeInstanceOf(PutEventsCommand);
+    expect(putCmd.input.Entries?.[0]?.DetailType).toBe("DeployDeleteRequested");
+    const detail = JSON.parse(putCmd.input.Entries?.[0]?.Detail ?? "{}");
+    expect(detail.stackName).toBe(
+      "arn:aws:cloudformation:ap-northeast-1:999999999999:stack/tc-hello-world-battle-team-1/abc",
+    );
+  });
+
+  it("should keep an explicit aws/cloudformation row (runtime fields present) on the CFn DeleteStack path", async () => {
+    // 明示 runtime: aws/cloudformation を宣言した問題行も EXECUTABLE_PROVIDER/ENGINE 一致なので
+    // CFn 経路を維持する (= adapter.destroy の AdapterMethodNotWiredError を踏まない)。
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({
+      Item: sampleRow({
+        runtimeProvider: "aws",
+        runtimeEngine: "cloudformation",
+        runtimeEntry: "template.yaml",
+      }),
+    });
+    ddbSend.mockResolvedValueOnce({});
+    eventsSend.mockResolvedValueOnce({});
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out).toEqual({ kind: "accepted", previousStatus: "COMPLETE" });
+    expect(eventsSend).toHaveBeenCalledOnce();
+    const detail = JSON.parse(
+      (eventsSend.mock.calls[0]?.[0] as PutEventsCommand).input.Entries?.[0]?.Detail ?? "{}",
+    );
+    expect(detail.stackName).toBe("tc-p-t");
+  });
+});
+
+/**
  * [ADR-026/027/032 / #1410-1412] 非 AWS runtime (sakura/apprun) の teardown は CFn DeleteStack event を
  * publish せず adapter.destroy (cloud REST) で削除する。 status は DELETING に倒し、 EventBridge は使わない。
  */

--- a/infrastructure/test/scripts/delete-battles-account-check.test.ts
+++ b/infrastructure/test/scripts/delete-battles-account-check.test.ts
@@ -42,12 +42,14 @@ function runDelete(env: Record<string, string>): {
   const fakeAws = `#!/usr/bin/env bash
 echo "$@" >> "$AWS_CALL_LOG"
 if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then
+  if [ -z "$FAKE_CALLER_ACCOUNT" ]; then echo "fake sts failure" >&2; exit 254; fi
   echo "$FAKE_CALLER_ACCOUNT"
   exit 0
 fi
 exit 0
 `;
-  writeFileSync(join(binDir, "aws"), fakeAws, { mode: 0o755 });
+  // writeFileSync の mode は umask で削られ得るので chmodSync で 0o755 を保証する。
+  writeFileSync(join(binDir, "aws"), fakeAws);
   chmodSync(join(binDir, "aws"), 0o755);
 
   const result = spawnSync("bash", [DELETE_SCRIPT, "tc-demo-team", "ap-northeast-1"], {
@@ -75,7 +77,9 @@ afterEach(() => {
   }
 });
 
-describe("delete-battles.sh expected-account verification (#1797)", () => {
+// bash + fake aws を spawn する実 I/O テスト。全 suite 並列時は fork 飽和で default 5s を
+// 超え flake するため、明示 timeout を持つ (test/scripts の spawn 系と同型)。
+describe("delete-battles.sh expected-account verification (#1797)", { timeout: 30_000 }, () => {
   it("should abort before delete-stack when credentials point at a different account", () => {
     const { status, stderr, awsCalls } = runDelete({
       DELETE_EXPECTED_AWS_ACCOUNT_ID: "999999999999",
@@ -98,7 +102,17 @@ describe("delete-battles.sh expected-account verification (#1797)", () => {
     expect(awsCalls).toContain("cloudformation wait stack-delete-complete");
   });
 
-  it("should skip the check for legacy invocations without DELETE_EXPECTED_AWS_ACCOUNT_ID", () => {
+  it("should fail loudly with a clear error when sts get-caller-identity itself fails", () => {
+    const { status, stderr, awsCalls } = runDelete({
+      DELETE_EXPECTED_AWS_ACCOUNT_ID: "999999999999",
+      FAKE_CALLER_ACCOUNT: "",
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain("get-caller-identity failed");
+    expect(awsCalls).not.toContain("cloudformation delete-stack");
+  });
+
+  it("should skip the check for manual invocations without DELETE_EXPECTED_AWS_ACCOUNT_ID", () => {
     const { status, stderr, awsCalls } = runDelete({
       DELETE_EXPECTED_AWS_ACCOUNT_ID: "",
       FAKE_CALLER_ACCOUNT: "111111111111",

--- a/infrastructure/test/scripts/delete-battles-account-check.test.ts
+++ b/infrastructure/test/scripts/delete-battles-account-check.test.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * scripts/delete-battles.sh — expected-account verification (#1797).
+ *
+ * credentials が「stack の実在しない account」を指したまま delete-stack すると、
+ * CFn は no-op 成功 / wait も成功扱いになり、DB は DELETED なのに実 stack が
+ * CREATE_COMPLETE で残存する silent leak になる。`DELETE_EXPECTED_AWS_ACCOUNT_ID`
+ * が渡されたとき `sts get-caller-identity` と突き合わせ、mismatch を delete-stack
+ * 発行前に loud fail させることを pin する。
+ */
+
+const DELETE_SCRIPT = resolve(__dirname, "..", "..", "..", "scripts", "delete-battles.sh");
+const tempDirs: string[] = [];
+
+function runDelete(env: Record<string, string>): {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+  awsCalls: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "tenkacloud-delete-battles-"));
+  tempDirs.push(dir);
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const callLog = join(dir, "aws-calls.log");
+  // Fake aws は CONSTANT script: 可変値は child env 経由でのみ流す (shell injection 回避)。
+  // sts get-caller-identity は FAKE_CALLER_ACCOUNT を返し、それ以外 (delete-stack / wait)
+  // は記録して成功する。
+  const fakeAws = `#!/usr/bin/env bash
+echo "$@" >> "$AWS_CALL_LOG"
+if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then
+  echo "$FAKE_CALLER_ACCOUNT"
+  exit 0
+fi
+exit 0
+`;
+  writeFileSync(join(binDir, "aws"), fakeAws, { mode: 0o755 });
+  chmodSync(join(binDir, "aws"), 0o755);
+
+  const result = spawnSync("bash", [DELETE_SCRIPT, "tc-demo-team", "ap-northeast-1"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      AWS_CALL_LOG: callLog,
+      COMPETITOR_ROLE_ARN: "",
+      CFN_EXEC_ROLE_ARN: "",
+      ...env,
+    },
+  });
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+    awsCalls: existsSync(callLog) ? readFileSync(callLog, "utf8") : "",
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("delete-battles.sh expected-account verification (#1797)", () => {
+  it("should abort before delete-stack when credentials point at a different account", () => {
+    const { status, stderr, awsCalls } = runDelete({
+      DELETE_EXPECTED_AWS_ACCOUNT_ID: "999999999999",
+      FAKE_CALLER_ACCOUNT: "111111111111",
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain("999999999999");
+    expect(stderr).toContain("111111111111");
+    expect(awsCalls).toContain("sts get-caller-identity");
+    expect(awsCalls).not.toContain("cloudformation delete-stack");
+  });
+
+  it("should proceed with delete-stack + wait when the accounts match", () => {
+    const { status, stderr, awsCalls } = runDelete({
+      DELETE_EXPECTED_AWS_ACCOUNT_ID: "999999999999",
+      FAKE_CALLER_ACCOUNT: "999999999999",
+    });
+    expect(status, stderr).toBe(0);
+    expect(awsCalls).toContain("cloudformation delete-stack");
+    expect(awsCalls).toContain("cloudformation wait stack-delete-complete");
+  });
+
+  it("should skip the check for legacy invocations without DELETE_EXPECTED_AWS_ACCOUNT_ID", () => {
+    const { status, stderr, awsCalls } = runDelete({
+      DELETE_EXPECTED_AWS_ACCOUNT_ID: "",
+      FAKE_CALLER_ACCOUNT: "111111111111",
+    });
+    expect(status, stderr).toBe(0);
+    expect(awsCalls).not.toContain("sts get-caller-identity");
+    expect(awsCalls).toContain("cloudformation delete-stack");
+  });
+});

--- a/infrastructure/test/scripts/deploy-stack-recovery.test.ts
+++ b/infrastructure/test/scripts/deploy-stack-recovery.test.ts
@@ -77,7 +77,9 @@ afterEach(() => {
   }
 });
 
-describe("delete_unrecoverable_stack_if_present", () => {
+// bash + fake aws を spawn する実 I/O テスト。全 suite 並列時は fork 飽和で default 5s を
+// 超え flake するため、明示 timeout を持つ (package-source-bundle と同型)。
+describe("delete_unrecoverable_stack_if_present", { timeout: 30_000 }, () => {
   for (const status of [
     "ROLLBACK_COMPLETE",
     "ROLLBACK_FAILED",

--- a/infrastructure/test/scripts/package-source-bundle.test.ts
+++ b/infrastructure/test/scripts/package-source-bundle.test.ts
@@ -65,7 +65,9 @@ afterEach(() => {
 });
 
 describe("scripts/package-source-bundle.sh (#1552)", () => {
-  it("should package allowlisted source roots without AWS credentials", () => {
+  // bash + zip を spawn する実 I/O テスト。単体では ~2s だが全 suite 並列時は
+  // fork 飽和で default 5s を超え flake するため、明示 timeout を持つ。
+  it("should package allowlisted source roots without AWS credentials", { timeout: 30_000 }, () => {
     const { root, workDir } = makeFixture();
 
     const result = packageFixture(root, workDir, {

--- a/infrastructure/test/scripts/prepare-source-bundle.test.ts
+++ b/infrastructure/test/scripts/prepare-source-bundle.test.ts
@@ -66,7 +66,9 @@ afterEach(() => {
   }
 });
 
-describe("scripts/prepare-source-bundle.sh region resolution", () => {
+// bash + aws CLI shim を spawn する実 I/O テスト。全 suite 並列時は fork 飽和で
+// default 5s を超え flake するため、明示 timeout を持つ (package-source-bundle と同型)。
+describe("scripts/prepare-source-bundle.sh region resolution", { timeout: 30_000 }, () => {
   it("should resolve region from AWS_REGION when no aws config profile exists", () => {
     // Reproduces the CodeBuild Lite-deploy failure: AWS_REGION is injected by the
     // build environment but `aws configure get region` has no config file.
@@ -112,7 +114,9 @@ describe("scripts/prepare-source-bundle.sh region resolution", () => {
   });
 });
 
-describe("scripts/prepare-source-bundle.sh bucket resolution (fresh-account #1749)", () => {
+describe("scripts/prepare-source-bundle.sh bucket resolution (fresh-account #1749)", {
+  timeout: 30_000,
+}, () => {
   it("should compute an account-scoped bucket when the name is unset", () => {
     const result = resolveBundleEnv({ AWS_REGION: "ap-northeast-1" });
 

--- a/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
+++ b/infrastructure/test/tenkacloud-lite/tenkacloud-lite-stack.test.ts
@@ -66,7 +66,9 @@ function synth(): Template {
   return Template.fromStack(stack);
 }
 
-describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", () => {
+// synth() は Lambda asset bundling を含む重い実処理。全 suite 並列時は default 5s を
+// 超え flake するため、明示 timeout を持つ。
+describe("TenkaCloudLiteStack (#778 ADR-016 Phase 3)", { timeout: 60_000 }, () => {
   beforeAll(() => {
     ensurePlaceholderDist();
   });

--- a/scripts/delete-battles.sh
+++ b/scripts/delete-battles.sh
@@ -32,6 +32,20 @@ export DEPLOY_REGION="${REGION}"
 assume_competitor_role_if_configured
 trace_log "deploy.codebuild.start" operation "delete" region "${REGION}" stackName "${STACK_NAME}"
 
+# #1797: credentials が「stack の実在する account」を指しているかを delete-stack の前に検証。
+# 別 account を指したまま進むと delete-stack は no-op 成功 / wait も成功扱いになり、
+# DB は DELETED なのに実 stack が CREATE_COMPLETE で残存する silent leak になる。
+# DELETE_EXPECTED_AWS_ACCOUNT_ID 未設定 (在来 event) は従来挙動のまま skip。
+if [[ -n "${DELETE_EXPECTED_AWS_ACCOUNT_ID:-}" ]]; then
+  ACTUAL_AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+  if [[ "${ACTUAL_AWS_ACCOUNT_ID}" != "${DELETE_EXPECTED_AWS_ACCOUNT_ID}" ]]; then
+    trace_log "deploy.cfn.delete.account_mismatch" stackName "${STACK_NAME}" region "${REGION}" \
+      expectedAccount "${DELETE_EXPECTED_AWS_ACCOUNT_ID}" actualAccount "${ACTUAL_AWS_ACCOUNT_ID}"
+    echo "error: credentials are for account ${ACTUAL_AWS_ACCOUNT_ID} but stack ${STACK_NAME} lives in ${DELETE_EXPECTED_AWS_ACCOUNT_ID}; aborting before delete-stack (the stack would silently survive)" >&2
+    exit 1
+  fi
+fi
+
 echo "=========================================="
 echo "Deleting stack"
 echo "  StackName : ${STACK_NAME}"

--- a/scripts/delete-battles.sh
+++ b/scripts/delete-battles.sh
@@ -35,9 +35,15 @@ trace_log "deploy.codebuild.start" operation "delete" region "${REGION}" stackNa
 # #1797: credentials が「stack の実在する account」を指しているかを delete-stack の前に検証。
 # 別 account を指したまま進むと delete-stack は no-op 成功 / wait も成功扱いになり、
 # DB は DELETED なのに実 stack が CREATE_COMPLETE で残存する silent leak になる。
-# DELETE_EXPECTED_AWS_ACCOUNT_ID 未設定 (在来 event) は従来挙動のまま skip。
+# State Machine 経由は常に DELETE_EXPECTED_AWS_ACCOUNT_ID が入る (欠損 event は SFN 側の
+# isPresent ガードで markFailed)。未設定で skip するのは手動実行 (運営 recovery) のみ。
 if [[ -n "${DELETE_EXPECTED_AWS_ACCOUNT_ID:-}" ]]; then
-  ACTUAL_AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+  # set -e 下で command substitution が黙って死なないよう、STS 失敗は明示的に trace する。
+  if ! ACTUAL_AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>&1)"; then
+    trace_log "deploy.cfn.delete.failed" stackName "${STACK_NAME}" region "${REGION}"
+    echo "error: sts get-caller-identity failed (credential / STS availability): ${ACTUAL_AWS_ACCOUNT_ID}" >&2
+    exit 1
+  fi
   if [[ "${ACTUAL_AWS_ACCOUNT_ID}" != "${DELETE_EXPECTED_AWS_ACCOUNT_ID}" ]]; then
     trace_log "deploy.cfn.delete.account_mismatch" stackName "${STACK_NAME}" region "${REGION}" \
       expectedAccount "${DELETE_EXPECTED_AWS_ACCOUNT_ID}" actualAccount "${ACTUAL_AWS_ACCOUNT_ID}"


### PR DESCRIPTION
## Summary

Relates #1797 (イベント削除後に競技者 CFn スタックが残存する)。Issue 調査の root-cause 候補 1 「`delete-battles.sh` の silent-success」を塞ぐ。

delete CodeBuild の credentials が「stack の実在しない account」を指して走ると:

- `aws cloudformation delete-stack` は存在しない stack に対して **no-op 成功**する
- `wait stack-delete-complete` の waiter は missing stack (ValidationError) を**成功扱い**にする
- スクリプトは exit 0 → state machine は DDB 行を `DELETED` に更新

→ 「DB 上は消えたことになっているが実 stack は CREATE_COMPLETE のまま残る」silent leak。失敗シグナルがどこにも出ない。

### 変更内容

1. **`DeployDeleteStateMachine`**: deployment 行の `awsAccountId` を `DELETE_EXPECTED_AWS_ACCOUNT_ID` として same-account / cross-account 両経路の CodeBuild に渡す。さらに両ルーティング条件に `isPresent($.detail.awsAccountId)` ガードを追加 — 欠損 event (replay / 手動 put-events) が `States.Runtime`(`addCatch` で**捕捉不能**、行が DELETING で永久 stuck)で死ぬ代わりに、既存の markFailed 経路へ loud fail する
2. **`scripts/delete-battles.sh`**: (AssumeRole 後の) credentials の account を `sts get-caller-identity` で取得し、期待 account と不一致なら **delete-stack 発行前に loud fail**(exit 1、trace event `deploy.cfn.delete.account_mismatch`)。STS 呼び出し自体の失敗も `set -e` で黙死せず `deploy.cfn.delete.failed` を trace してから exit 1。env 未設定(手動 recovery 実行)は従来挙動のまま skip
3. **`DeployCodeBuildProject`**: 新 env の placeholder 宣言 + doc 追記
4. **guard test (cherry-pick `fd85a74`)**: #1659 の runtime 分岐で AWS/CFn 行が `adapter.destroy` に落ちず CFn `DeployDeleteRequested` 経路に留まることを pin
5. **deflake**: spawn(bash/zip)・synth(asset bundling)系テスト 5 ファイルに describe/it レベルの明示 timeout。全 suite 並列時に fork 飽和で default 5s を超えローカルゲートが flake していた(各ファイルとも分離実行では ~2s で green)
6. **docs**: `deploy-trace.md`/`.html` に `account_mismatch` イベント行を追加、行番号参照を刷新

### レビューゲート

- 7 angle マルチエージェントレビュー実施。適用済み: SFN `isPresent` ガード(States.Runtime 捕捉不能問題)、STS 失敗の明示ハンドリング、新規 spawn テストへの timeout、`writeFileSync mode`+`chmodSync` 冗長除去、コメントの誤った「在来 event」根拠の訂正
- セキュリティレビュー: 新規脆弱性なし(`awsAccountId` は全入口で `^\d{12}$` 制約、shell 内は quoted 比較/エスケープ済みログのみ、IAM 変更なし)

### #1797 を Close しない理由

実症状 (Lite モードで `tc-hello-world-battle-team-1/2` 残存) の root cause は AWS 側ログ (delete state machine 実行履歴 / CodeBuild ログ / DDB 行) での確定が必要で、本 PR は「症状を silent にしていた増幅器」を塞ぐ + 再発時に必ず FAILED として可視化されるようにするもの。確定調査は Issue の「次の調査ステップ」で継続。

### Follow-up 候補(本 PR スコープ外、レビューで検出)

- `bulkTeardownEvent` の `getBulkTeardownTarget` が `awsAccountId` 欠損行を**無音 skip** する(行が COMPLETE のまま Event だけ TEARDOWN になる leak class)
- create 側 (`deploy-battles.sh`) に対称の expected-account 検証が無い(wrong-account create が行を汚染すると delete 側が恒久 loud-fail になる)
- competitor account 登録解除後の teardown は producer 時点で mismatch が計算可能(早期 409 で返せば SFN+CodeBuild を浪費しない)
- テスト基盤の重複: ASL flatten ヘルパー(3 箇所)、fake-aws shim(3 箇所)、timeout 定数の共有化
- `deploy-trace` 表の行番号アンカーが脆い(イベント名アンカー化を検討)

## Test plan

- 新規 `deploy-delete-state-machine.test.ts`(3 tests): 両 CodeBuild 経路の `DELETE_EXPECTED_AWS_ACCOUNT_ID` 配線、cross-account routing 条件、`awsAccountId` 欠損 event の markFailed ルーティングを synth 出力 (ASL) で pin
- 新規 `delete-battles-account-check.test.ts`(4 tests): 実スクリプト × fake `aws` CLI で (a) mismatch → delete-stack 前に exit 1、(b) match → delete-stack + wait 続行、(c) STS 失敗 → 明示エラーで exit 1、(d) env 未設定 → check skip、を pin
- cherry-pick: `deploy-delete.test.ts` に AWS/CFn 行のガード 2 件
- `make harness` green / `make before-commit` green(各コミットの pre-commit hook で全 workspace 2812+ tests 実行済み)

## Regression analysis

- **在来挙動**: Lambda producer (`delete.ts` / `bulk-delete.ts`) は `awsAccountId` を常に必須化済みのため、in-process の event は新ガードを必ず通過し挙動不変。`isPresent` ガードが弾くのは replay / 手動 put-events 等の壊れた event のみで、それらは従来 `States.Runtime` で stuck していた(改善のみ)
- **same-account (Lite) 経路**: detail の `awsAccountId` は deploy 時に persist された値。正常系では caller account と一致するため挙動不変。不一致時は従来「silent に DELETED」→「FAILED + failureReason」になる(これが本修正の目的)
- **cross-account 経路**: AssumeRole 後の account と stack account の一致を検証。verified competitor account の正常系は一致
- **手動実行**: `DELETE_EXPECTED_AWS_ACCOUNT_ID` 未設定なら check skip = 従来挙動
- **STS 依存の追加**: 正常 delete に STS 呼び出しが 1 回増える。transient STS 失敗は FAILED + 明示 trace になる(従来は STS 依存なし)。`sts get-caller-identity` は IAM 権限不要
- **deflake 変更**: timeout 値の引き上げのみでアサーションは不変

## Physical impact

- `AWS::StepFunctions::StateMachine` (DeployDelete): **UPDATE**(DefinitionString に env 1 個 + Choice 条件 2 個追加)
- `AWS::CodeBuild::Project`: **UPDATE**(environmentVariables に placeholder 1 個追加)
- `scripts/delete-battles.sh`: ソースバンドル経由で次回 deploy 時に配布(**UPDATE**、インフラリソース変更なし)。**注意**: CFn diff と source bundle の両方が更新されて初めて保護が有効(片方のみだと env 未設定 skip / env 無視で従来挙動)
- その他リソース: **NO-OP**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
