### PR TITLE
docs: align tier naming with code (BASIC/ADVANCED pooled, PLATINUM silo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ problems/<category>/<id>/          # metadata.json + template.yaml are the sourc
 ## Cross-plane contracts (do not break)
 
 - **EventBridge bus** is provisioned by `ControlPlaneStack`; `bin/infrastructure.ts` hands the ARN to every other stack. New stacks must use the same bus.
-- **Tenant creation event** (`onboardingRequest`) is picked up by `ServerlessSaaSPipeline`, which deploys the per-tenant stack. BASIC / STANDARD / PREMIUM share the pooled stack; only PLATINUM gets a silo stack.
+- **Tenant creation event** (`onboardingRequest`) is picked up by `ServerlessSaaSPipeline`, which deploys the per-tenant stack. BASIC / ADVANCED share the pooled stack; only PLATINUM gets a silo stack.
 - **DeployRequested event** is picked up by the `ProblemDeployBackendStack` Worker Lambda, which AssumeRoles into the competitor account using the tenant's ExternalId and runs CFn CreateStack. **`ExternalId` is always required** (no omission allowed).
 - **Frontend URLs** are injected through `runtime-config.json` (served under CloudFront). `apps/*/src/config.ts` has a `loadConfig()`. When you add a new URL, update both the hosting stack env and the `config.ts` interface.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ TenkaCloud/
 ### Plane layout
 
 - **Control Plane** (`ControlPlaneStack`) — SBT-bundled Cognito UserPool + System Admin + Tenant CRUD API + EventBridge bus. `admin-console` is the front end.
-- **Application Plane (pooled)** — One `serverless-saas-ref-arch-tenant-template-pooled` instance stands up during Phase 1. BASIC / STANDARD / PREMIUM tenants share a single `application-admin-console` URL behind CloudFront.
+- **Application Plane (pooled)** — One `serverless-saas-ref-arch-tenant-template-pooled` instance stands up during Phase 1. BASIC / ADVANCED tenants share a single `application-admin-console` URL behind CloudFront.
 - **Application Plane (silo)** — On PLATINUM tier tenant creation, `ServerlessSaaSPipeline` kicks off CodeBuild and deploys a dedicated `serverless-saas-ref-arch-tenant-template-<tenantId>` for that tenant.
 - **Problem deploy backend** (`ProblemDeployBackendStack`) — Deployments DDB + Cognito JWT-authenticated HTTP API + Worker Lambda. EventBridge `DeployRequested` is picked up, the worker AssumeRoles into the competitor account using the tenant's ExternalId, then CFn CreateStack runs there.
 - **Participant Portal** — App where each competitor sees their team's problem endpoints and scores. Hosted on S3 + CloudFront from `ProblemDeployBackendStack` (enable via `CDK_PARAM_ENABLE_PARTICIPANT_PORTAL=true`).
@@ -222,7 +222,7 @@ Issue #955 switched the default for `make deploy` to single-tenant Lite mode. It
 
 ### SaaS mode (opt-in, `make deploy-saas`)
 
-For full multi-tenant operation — pooled tiers (BASIC / STANDARD / PREMIUM), silo tier (PLATINUM), and SystemAdmin invitations — use SaaS mode. `make deploy-saas` (`scripts/install.sh`) runs three phases.
+For full multi-tenant operation — pooled tiers (BASIC / ADVANCED), silo tier (PLATINUM), and SystemAdmin invitations — use SaaS mode. `make deploy-saas` (`scripts/install.sh`) runs three phases.
 
 1. **Phase 1**: Deploy `ControlPlaneStack` + `serverless-saas-ref-arch-bootstrap-stack` + `serverless-saas-ref-arch-tenant-template-pooled` + `ServerlessSaaSPipeline`. CORS/callback is localhost only at this point.
 2. **Phase 2**: Feed Phase 1 outputs into runtime-config env, host-build `apps/admin-console`, then deploy `AdminConsoleHostingStack` (S3 + CloudFront).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [`docker-compose.yml`](./docker-compose.yml) and [`docker/Dockerfile`](./doc
 ### D. SaaS mode (optional)
 
 Use SaaS mode only when you need tenant onboarding, pooled tiers
-(BASIC / STANDARD / PREMIUM), silo tenants (PLATINUM), and the SBT control plane.
+(BASIC / ADVANCED), silo tenants (PLATINUM), and the SBT control plane.
 
 ```bash
 cp infrastructure/environments/development/.env.example \

--- a/docs/architecture/GLOSSARY.html
+++ b/docs/architecture/GLOSSARY.html
@@ -55,7 +55,7 @@
 <h2>AppPlane / Application Plane</h2>
 <p>The per-tenant runtime that hosts a tenant&#39;s own Cognito UserPool, API Gateway HTTP API, and <code>application-admin-console</code> SPA. Two tier shapes:</p>
 <ul>
-<li><strong>Pooled</strong> — BASIC / STANDARD / PREMIUM tiers share a single CDK stack (<code>serverless-saas-ref-arch-tenant-template-pooled</code>). One Cognito UserPool, one API, one SPA serve all pooled tenants.</li>
+<li><strong>Pooled</strong> — BASIC / ADVANCED tiers share a single CDK stack (<code>serverless-saas-ref-arch-tenant-template-pooled</code>). One Cognito UserPool, one API, one SPA serve all pooled tenants.</li>
 <li><strong>Silo</strong> — PLATINUM tier gets its own stack (<code>serverless-saas-ref-arch-tenant-template-&lt;tenantId&gt;</code>) deployed via the per-tenant <code>ServerlessSaaSPipeline</code>.</li>
 </ul>
 <p>Distinct from Control Plane (= tenant manager). The Application Plane runs <em>tenant business logic</em>; it doesn&#39;t manage tenants. Defined by invariant <a href="./harness.md"><code>INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME</code></a>.</p>
@@ -203,7 +203,7 @@
 <h2>Pooled vs Silo</h2>
 <p>The two SaaS tenant isolation models, both supported in SaaS mode.</p>
 <ul>
-<li><strong>Pooled</strong> — BASIC / STANDARD / PREMIUM tenants share one CDK stack. Cheaper, faster onboarding.</li>
+<li><strong>Pooled</strong> — BASIC / ADVANCED tenants share one CDK stack. Cheaper, faster onboarding.</li>
 <li><strong>Silo</strong> — PLATINUM tenants each get their own stack via <code>ServerlessSaaSPipeline</code>. Stronger isolation, higher cost.</li>
 </ul>
 <p>Lite mode is implicitly pooled (= one tenant, one stack). See <a href="./adr-018-pooled-userpool-saml-isolation.html">ADR-018</a>.</p>
@@ -232,7 +232,7 @@
 <p>The catalog repo: <a href="https://github.com/susumutomita/TenkaCloudChallenge">https://github.com/susumutomita/TenkaCloudChallenge</a>. Mounted as a Git submodule at <code>problems/</code> in this repo. Holds the actual problem content (battles + challenges) while the platform repo holds the host that deploys/scores them. The split is the physical manifestation of <a href="./adr-012-problem-plugin-architecture.html">ADR-012</a> + <a href="./adr-008-problem-payload-separation.html">ADR-008</a>.</p>
 <hr>
 <h2>Tier</h2>
-<p>The pricing tier a tenant belongs to: BASIC / STANDARD / PREMIUM / PLATINUM. The first three are pooled; PLATINUM is silo. Determined at tenant-create time and stored on <code>TenantDetails</code>. The pipeline decides pooled vs silo based on tier.</p>
+<p>The pricing tier a tenant belongs to: BASIC / ADVANCED / PLATINUM (the old PREMIUM name was renamed to PLATINUM in PR-56). BASIC / ADVANCED are pooled; PLATINUM is silo. Determined at tenant-create time and stored on <code>TenantDetails</code>. The pipeline decides pooled vs silo based on tier. (SBT&#39;s internal per-tier API-key SSM parameters still use SBT&#39;s own basic/standard/premium/platinum names — those are SBT-internal and distinct from the product tiers.)</p>
 <hr>
 <h2>TrustBridge</h2>
 <p>The audit-and-eventually-approval layer for risky cross-account actions. See &quot;CloudActionIntent&quot; above for the implementation handle and <a href="./adr-017-cloud-action-intent-trust-bridge.html">ADR-017</a> for the full design. The name comes from the role it plays: a logged bridge between the platform&#39;s identity and the competitor&#39;s account, where every crossing is recorded and (in future phases) gated.</p>

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -10,7 +10,7 @@ Sorted alphabetically. Acronyms are spelled out on first reference.
 
 The per-tenant runtime that hosts a tenant's own Cognito UserPool, API Gateway HTTP API, and `application-admin-console` SPA. Two tier shapes:
 
-- **Pooled** — BASIC / STANDARD / PREMIUM tiers share a single CDK stack (`serverless-saas-ref-arch-tenant-template-pooled`). One Cognito UserPool, one API, one SPA serve all pooled tenants.
+- **Pooled** — BASIC / ADVANCED tiers share a single CDK stack (`serverless-saas-ref-arch-tenant-template-pooled`). One Cognito UserPool, one API, one SPA serve all pooled tenants.
 - **Silo** — PLATINUM tier gets its own stack (`serverless-saas-ref-arch-tenant-template-<tenantId>`) deployed via the per-tenant `ServerlessSaaSPipeline`.
 
 Distinct from Control Plane (= tenant manager). The Application Plane runs *tenant business logic*; it doesn't manage tenants. Defined by invariant [`INVARIANT_CONTROL_PLANE_DOES_NOT_HOST_TENANT_RUNTIME`](./harness.md).
@@ -171,7 +171,7 @@ Three-asset model (+ optional fourth): `metadata.json` (required) + `template.ya
 
 The two SaaS tenant isolation models, both supported in SaaS mode.
 
-- **Pooled** — BASIC / STANDARD / PREMIUM tenants share one CDK stack. Cheaper, faster onboarding.
+- **Pooled** — BASIC / ADVANCED tenants share one CDK stack. Cheaper, faster onboarding.
 - **Silo** — PLATINUM tenants each get their own stack via `ServerlessSaaSPipeline`. Stronger isolation, higher cost.
 
 Lite mode is implicitly pooled (= one tenant, one stack). See [ADR-018](./adr-018-pooled-userpool-saml-isolation.html).
@@ -226,7 +226,7 @@ The catalog repo: <https://github.com/susumutomita/TenkaCloudChallenge>. Mounted
 
 ## Tier
 
-The pricing tier a tenant belongs to: BASIC / STANDARD / PREMIUM / PLATINUM. The first three are pooled; PLATINUM is silo. Determined at tenant-create time and stored on `TenantDetails`. The pipeline decides pooled vs silo based on tier.
+The pricing tier a tenant belongs to: BASIC / ADVANCED / PLATINUM (the old PREMIUM name was renamed to PLATINUM in PR-56). BASIC / ADVANCED are pooled; PLATINUM is silo. Determined at tenant-create time and stored on `TenantDetails`. The pipeline decides pooled vs silo based on tier. (SBT's internal per-tier API-key SSM parameters still use SBT's own basic/standard/premium/platinum names — those are SBT-internal and distinct from the product tiers.)
 
 ---
 

--- a/docs/architecture/OVERVIEW.html
+++ b/docs/architecture/OVERVIEW.html
@@ -77,8 +77,8 @@
 <pre><code>┌──────────────────────────────────────┐    ┌──────────────────────────────────┐
 │  Control Plane                       │    │  Application Plane               │
 │  • SBT ControlPlane construct        │    │  • per-tenant Cognito + API + UI │
-│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/STANDARD/       │
-│  • Tenant CRUD HTTP API              │    │    PREMIUM tiers) or silo        │
+│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/ADVANCED        │
+│  • Tenant CRUD HTTP API              │    │    tiers) or silo                │
 │  • admin-console UI                  │    │    (PLATINUM tier)               │
 │  • EventBridge bus owner             │    │  • application-admin-console UI  │
 └────────────────┬─────────────────────┘    └────────────────┬─────────────────┘

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -38,8 +38,8 @@ Once the platform is up, runtime traffic flows across four planes that talk thro
 ┌──────────────────────────────────────┐    ┌──────────────────────────────────┐
 │  Control Plane                       │    │  Application Plane               │
 │  • SBT ControlPlane construct        │    │  • per-tenant Cognito + API + UI │
-│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/STANDARD/       │
-│  • Tenant CRUD HTTP API              │    │    PREMIUM tiers) or silo        │
+│  • Cognito UserPool (SystemAdmin)    │    │  • pooled (BASIC/ADVANCED        │
+│  • Tenant CRUD HTTP API              │    │    tiers) or silo                │
 │  • admin-console UI                  │    │    (PLATINUM tier)               │
 │  • EventBridge bus owner             │    │  • application-admin-console UI  │
 └────────────────┬─────────────────────┘    └────────────────┬─────────────────┘


### PR DESCRIPTION
## Summary

ドキュメント 5 ファイル (CLAUDE.md / AGENTS.md / README.md / OVERVIEW.md / GLOSSARY.md + 生成 HTML twin) が pooled tier を「BASIC / STANDARD / PREMIUM」と列挙していたが、製品の正準 tier は **basic / advanced (pooled) + platinum (silo)**:

- admin-console のテナント作成 UI が提供するのは `basic | advanced | platinum` のみ (`apps/admin-console/src/api/tenants.ts` の `Tier` 型)
- 旧 premium は PR-56 で platinum にリネーム済み
- GLOSSARY の Tier 項に「SBT 内部の per-tier API-key SSM パラメータは SBT 固有の basic/standard/premium/platinum 名のままで、製品 tier とは別物」という drift の原因も明記

OVERVIEW の ASCII 図は桁揃えを維持。`make build-docs` で HTML twin を再生成済み。

## 関連して発見した別件 (本 PR には含めない)

`saml-routes.ts` の `POOLED_TIERS = {BASIC, STANDARD, PREMIUM}` deny-list が同じ drift を踏んでおり、**ADVANCED (pooled) テナントが共有 UserPool の SAML mutation ガードをすり抜ける**。fail-closed への反転を別 PR で修正中 (コード変更のため docs PR と分離)。

## Regression analysis

ドキュメントのみの変更。コード・テスト・テンプレートへの影響なし。tier 文字列の実挙動 (provision-tenant.sh の PLATINUM 分岐、tenants.ts の型) は不変。

## Physical impact

- docs 7 ファイル: **UPDATE** (md 5 + 生成 html 2)
- その他: **NO-OP**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
