### PR TITLE
fix(saml): fail-closed tier guard for shared-UserPool SAML mutation

### DIFF
--- a/apps/admin-console/src/pages/TenantDetail.tsx
+++ b/apps/admin-console/src/pages/TenantDetail.tsx
@@ -40,10 +40,11 @@ type TFn = (key: string, params?: Readonly<Record<string, string | number>>) => 
  */
 const POLL_INTERVAL_MS = 60_000;
 
+// 製品の正準 tier (tenants.ts の Tier 型 = basic/advanced/platinum)。小文字で保存された
+// tier も同じ表示に正規化する。未知の値は raw 表示に fallback (下の `?? tenant.tier`)。
 const TIER_LABEL: Record<string, string> = {
   BASIC: "BASIC",
-  STANDARD: "STANDARD",
-  PREMIUM: "PREMIUM",
+  ADVANCED: "ADVANCED",
   PLATINUM: "PLATINUM",
 };
 
@@ -164,7 +165,7 @@ function OverviewTab({
             label: t("tenant_detail.label_tier"),
             value: (
               <Badge color={tierBadgeColor(tenant.tier)}>
-                {TIER_LABEL[tenant.tier] ?? tenant.tier}
+                {TIER_LABEL[tenant.tier.toUpperCase()] ?? tenant.tier}
               </Badge>
             ),
           },

--- a/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
+++ b/infrastructure/lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes.ts
@@ -233,19 +233,24 @@ export function defaultMakeCognitoDeps(
   };
 }
 
-// #1385: pooled tier (BASIC / STANDARD / PREMIUM) は UserPool + UserPoolClient を全 pooled tenant で
-// 共有する (ADR-018)。 そこで SAML config を mutate (= UserPoolClient の SupportedIdentityProviders /
+// #1385: pooled tier は UserPool + UserPoolClient を全 pooled tenant で共有する (ADR-018)。
+// そこで SAML config を mutate (= UserPoolClient の SupportedIdentityProviders /
 // ExplicitAuthFlows 書き換え) すると他 pooled tenant のログインを巻き込む (cross-tenant DoS /
 // 認証ハイジャック)。 専有 UserPool を持つ silo (PLATINUM) / Lite mode のみ mutation を許可する。
 // `custom:tenantTier` は provision 時に server-set され、 API GW JWT authorizer が署名検証するため
 // 詐称不能。 claim 不在 (= silo / Lite / admin 経路) は許可側に倒す (pooled は必ず tier claim を持つ)。
-const POOLED_TIERS: ReadonlySet<string> = new Set(["BASIC", "STANDARD", "PREMIUM"]);
+//
+// fail-closed: 旧実装の pooled deny-list ({BASIC, STANDARD, PREMIUM}) は tier リネーム
+// (#55 premium→platinum、 製品 tier は basic/advanced/platinum) で ADVANCED を取りこぼし、
+// pooled tenant が共有 UserPool を mutate できた。 「claim があり SILO_TIER 以外は全て block」
+// に反転し、 将来の tier 追加 / リネームでもガードが開かないようにする。
+const SILO_TIER = "PLATINUM";
 
 export function pooledTierSamlBlock(c: Context): SamlRouteResult | undefined {
   const claims = extractClaims(c) as JwtClaims | undefined;
   const raw = claims?.["custom:tenantTier"];
   const tier = typeof raw === "string" ? raw.trim().toUpperCase() : undefined;
-  if (tier && POOLED_TIERS.has(tier)) {
+  if (tier && tier !== SILO_TIER) {
     return {
       status: StatusCodes.SERVICE_UNAVAILABLE,
       body: {

--- a/infrastructure/test/problem-deploy/tenant-saml-tier-guard.test.ts
+++ b/infrastructure/test/problem-deploy/tenant-saml-tier-guard.test.ts
@@ -8,9 +8,15 @@ import {
 } from "../../lib/problem-deploy/handlers/competitor-accounts-handler/saml-routes";
 
 /**
- * #1385: pooled tier (BASIC / STANDARD / PREMIUM) は UserPool + UserPoolClient を全 pooled tenant で
- * 共有するため、 SAML config mutation を silo (PLATINUM) / Lite のみに制限する。 tenantTier claim は
+ * #1385: pooled tier は UserPool + UserPoolClient を全 pooled tenant で共有するため、
+ * SAML config mutation を silo (PLATINUM) / Lite のみに制限する。 tenantTier claim は
  * server-set + 署名検証済みなので詐称不能。 claim 不在は許可側 (silo/Lite)。
+ *
+ * Regression guard: 旧実装は pooled tier の deny-list ({BASIC, STANDARD, PREMIUM}) で、
+ * tier リネーム (#55 で premium→platinum、 製品 tier は basic/advanced/platinum) により
+ * ADVANCED (pooled) がガードをすり抜けて共有 UserPool を mutate できた。 現実装は
+ * fail-closed (= claim があり PLATINUM 以外なら全て block) なので、 将来の tier 追加 /
+ * リネームでもガードは開かない。
  */
 function ctxWithTier(tier?: string): Context {
   return {
@@ -31,7 +37,12 @@ describe("pooledTierSamlBlock (#1385)", () => {
     "PREMIUM",
     "basic",
     "Premium",
-  ])("should block SAML config mutation for pooled tier %s (shared UserPool)", (tier) => {
+    // 製品の pooled tier (tenants.ts の Tier 型)。旧 deny-list はこれをすり抜けていた。
+    "ADVANCED",
+    "advanced",
+    // 未知の tier 値も fail-closed で block する (= 将来のリネームでガードが開かない)。
+    "GOLD",
+  ])("should block SAML config mutation for non-silo tier %s (shared UserPool)", (tier) => {
     const block = pooledTierSamlBlock(ctxWithTier(tier));
     expect(block?.status).toBe(StatusCodes.SERVICE_UNAVAILABLE);
     expect((block?.body as { error?: string })?.error).toBe("tenant_tier_not_silo");


### PR DESCRIPTION
## Summary

Relates #1385 / PR-56 / PR-1801(tier 名称 docs 修正で発見した同根の**実バグ**)。

#1385 のガードは pooled tenant による共有 UserPool の SAML config mutation(`SupportedIdentityProviders` / `ExplicitAuthFlows` 書き換え = cross-tenant DoS / ログインハイジャック)を **pooled tier 名の deny-list** `{BASIC, STANDARD, PREMIUM}` でブロックしていた。しかし製品 tier は PR-56 以降 `basic / advanced / platinum` であり、**ADVANCED (pooled) テナントの `custom:tenantTier` claim は deny-list に載っておらず、ガードをすり抜けて共有 UserPool を mutate できた**。失敗するテスト(ADVANCED / advanced / GOLD がすべて旧ガードを通過)で先に実証してから修正。

### 変更内容

1. **fail-closed に反転**: 「claim があり `PLATINUM` 以外なら全てブロック」。将来の tier 追加・リネームでもガードが開かない。claim 不在(silo / Lite / admin 経路)は従来どおり許可側
2. **テスト拡張**: ADVANCED / advanced / 未知 tier (GOLD) のブロックを pin(旧実装ではこの 3 ケースが red)
3. **同根 drift の掃除**: TenantDetail の `TIER_LABEL` を正準 tier に更新 + 大文字正規化 lookup(表示のみの cosmetic)

### 影響評価

- 攻撃には ADVANCED tier の認証済み Tenant Admin が必要(匿名不可)。また SAML SSO は feature flag 既定 OFF(ADR-035)
- 正常系への影響: PLATINUM(silo)と claim 不在経路は挙動不変。BASIC/STANDARD/PREMIUM のブロックも不変。変わるのは「ADVANCED と未知 tier がブロックされるようになる」のみで、それが本来の仕様

## Test plan

- `tenant-saml-tier-guard.test.ts` 12 tests green(新規 3 ケースは修正前に red を確認済み = 両方向検証)
- `TenantDetail.test.tsx` 9 tests green(未知 tier の raw fallback 挙動は既存テストで pin 済みのまま)
- `make harness` / `make before-commit` green

## Regression analysis

- `pooledTierSamlBlock` の呼び出し元(routePut / routeDelete)は不変。GET 経路はガード対象外のまま
- claim 不在 → 許可、PLATINUM → 許可、旧 pooled 3 値 → ブロック、はすべて既存テストで挙動不変を確認
- 行動が変わるのは「ADVANCED / 未知 tier をブロック」のみ。ADVANCED pooled テナントが SAML 設定を保存できていたとすれば、それは共有 UserPool を壊す操作だったので、ブロックが正しい(操作者には既存の `tenant_tier_not_silo` メッセージで PLATINUM へのアップグレード案内が出る)

## Physical impact

- Lambda handler コード(competitor-accounts): ソースバンドル経由で次回 deploy 時に配布(**UPDATE**)
- admin-console dist: **UPDATE**(表示ラベルのみ)
- インフラリソース: **NO-OP**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
