### PR TITLE
feat(problem-deploy): enforce per-tier concurrent deploy quota

### DIFF
--- a/infrastructure/environments/development/.env.example
+++ b/infrastructure/environments/development/.env.example
@@ -78,3 +78,7 @@ AWS_ACCOUNT_ID=123456789012
 #   CDK_PARAM_S3_BUCKET_NAME=serverless-saas-<account-id>-<region>
 #   CDK_SOURCE_NAME=source.zip
 #   CDK_PARAM_COMMIT_ID=<s3 put-object の version id>
+
+# #1766: tier 別の同時デプロイ上限 (JSON)。未設定ならクォータ無効。
+# 超過した deploy は API が 429 (deploy_quota_exceeded) で弾く。tier 不明 / claim 不在は basic 扱い。
+# CDK_PARAM_DEPLOY_QUOTA_BY_TIER={"basic":3,"advanced":10,"platinum":25}

--- a/infrastructure/environments/production/.env.example
+++ b/infrastructure/environments/production/.env.example
@@ -1,0 +1,4 @@
+
+# #1766: tier 別の同時デプロイ上限 (JSON)。未設定ならクォータ無効。
+# 超過した deploy は API が 429 (deploy_quota_exceeded) で弾く。tier 不明 / claim 不在は basic 扱い。
+# CDK_PARAM_DEPLOY_QUOTA_BY_TIER={"basic":3,"advanced":10,"platinum":25}

--- a/infrastructure/environments/staging/.env.example
+++ b/infrastructure/environments/staging/.env.example
@@ -1,0 +1,4 @@
+
+# #1766: tier 別の同時デプロイ上限 (JSON)。未設定ならクォータ無効。
+# 超過した deploy は API が 429 (deploy_quota_exceeded) で弾く。tier 不明 / claim 不在は basic 扱い。
+# CDK_PARAM_DEPLOY_QUOTA_BY_TIER={"basic":3,"advanced":10,"platinum":25}

--- a/infrastructure/lib/app-config/resolve.ts
+++ b/infrastructure/lib/app-config/resolve.ts
@@ -5,6 +5,7 @@ import * as dotenv from "dotenv";
 import { parseAdminAllowlist } from "../control-plane/saml-admin-allowlist.js";
 import { parseSamlIdpConfig } from "../control-plane/saml-identity-providers.js";
 import { getEnv } from "../helper-functions.js";
+import { parseDeployQuota } from "../problem-deploy/handlers/deploy-handler/deploy-quota.js";
 import type { ParticipantPortalRuntimeConfig } from "../problem-deploy/participant-portal-hosting.js";
 import { parseTenantAdminAllowlist } from "../tenant-template/saml-admin-allowlist.js";
 import { parseTenantSamlIdpConfig } from "../tenant-template/saml-identity-providers.js";
@@ -69,6 +70,7 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
   const challengePayloadBucketName = env.CDK_PARAM_CHALLENGE_PAYLOAD_BUCKET || undefined;
   const challengePayload = resolveChallengePayload(env, config, environment);
   const deployConcurrentBuildLimit = resolveDeployConcurrentBuildLimit(env);
+  const deployQuotaByTier = resolveDeployQuotaByTier(env);
 
   // Issue #1031: 旧 `CDK_PARAM_ADMIN_CONSOLE_ORIGIN` env 直読みは廃止。 admin-console-hosting
   // が先に立ち、 cross-stack ref で control-plane / admin-console-insight に流れる。
@@ -118,6 +120,7 @@ export function resolveAppConfig(input: ResolveAppConfigInput): AppConfig {
     // Issue #1695: config.json の customDomains を AppConfig にそのまま透過 (opt-in TLS 1.2)。
     customDomains: config?.customDomains,
     deployConcurrentBuildLimit,
+    deployQuotaByTier,
     controlPlaneSamlIdps,
     controlPlaneSamlAdminAllowlist,
     tenantSamlIdps,
@@ -326,6 +329,15 @@ function resolveDeployConcurrentBuildLimit(env: NodeJS.ProcessEnv): number | und
     );
   }
   return limit;
+}
+
+/**
+ * #1766: tier 別の同時デプロイ上限。`CDK_PARAM_DEPLOY_QUOTA_BY_TIER` (JSON) を synth 時に
+ * 検証する (= 壊れた値を Lambda runtime まで持ち越さない)。format の正本は handler 側の
+ * `parseDeployQuota` と共有する。未設定はクォータ無効 (undefined)。
+ */
+function resolveDeployQuotaByTier(env: NodeJS.ProcessEnv) {
+  return parseDeployQuota(env.CDK_PARAM_DEPLOY_QUOTA_BY_TIER);
 }
 
 function resolveBudgetConfig(

--- a/infrastructure/lib/app-config/types.ts
+++ b/infrastructure/lib/app-config/types.ts
@@ -101,6 +101,14 @@ export interface AppConfig {
   /** Bulk Deploy の CodeBuild 並列度 (未設定なら AWS account-level quota に任せる)。 */
   readonly deployConcurrentBuildLimit: number | undefined;
 
+  /**
+   * #1766: tier 別の同時デプロイ上限 (`CDK_PARAM_DEPLOY_QUOTA_BY_TIER`、JSON
+   * `{"basic":N,"advanced":N,"platinum":N}`)。未設定ならクォータ無効 (= 在来挙動 / Lite mode)。
+   */
+  readonly deployQuotaByTier:
+    | { readonly basic: number; readonly advanced: number; readonly platinum: number }
+    | undefined;
+
   // Issue #1031: 旧 `adminConsoleOriginForCors` (= `CDK_PARAM_ADMIN_CONSOLE_ORIGIN`) は廃止。
   // admin-console-hosting が先に立ち、 cross-stack ref で control-plane / admin-console-insight
   // に流れる (= Phase 3 env-var dance が不要になる)。

--- a/infrastructure/lib/app-wiring/wire.ts
+++ b/infrastructure/lib/app-wiring/wire.ts
@@ -135,6 +135,8 @@ export function buildTenkaCloudApp(app: cdk.App, config: AppConfig): TenkaCloudA
         | { runtimeConfig: ParticipantPortalRuntimeConfig | "default-dev-mock" }
         | undefined,
       deployConcurrentBuildLimit: config.deployConcurrentBuildLimit,
+      // #1766: tier 別の同時デプロイ上限 (未設定ならクォータ無効)。
+      deployQuotaByTier: config.deployQuotaByTier,
       environmentName: config.environment,
     },
   );

--- a/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
+++ b/infrastructure/lib/problem-deploy/deploy-api-lambda.ts
@@ -58,6 +58,15 @@ export interface DeployApiLambdaProps {
    * 未指定なら writeAuditEvent は env 不在で no-op を選ぶ (= 旧 stack 互換、 audit 行 0 件)。
    */
   readonly adminAuditLogTable?: Table;
+  /**
+   * #1766: tier 別の同時デプロイ上限。指定時は `DEPLOY_QUOTA_BY_TIER` env (JSON) を注入し、
+   * handler が deploy 受付時に enforce する (超過 = 429)。未指定はクォータ無効 (空文字 env)。
+   */
+  readonly deployQuotaByTier?: {
+    readonly basic: number;
+    readonly advanced: number;
+    readonly platinum: number;
+  };
 }
 
 /**
@@ -96,6 +105,10 @@ export class DeployApiLambda extends Construct {
         CHALLENGE_PAYLOAD_BUCKET: props.challengePayloadBucketName ?? "",
         // Issue #950: audit log table 名 (未配線なら空文字、 handler の writeAuditEvent が no-op)
         ADMIN_AUDIT_LOG_TABLE_NAME: props.adminAuditLogTable?.tableName ?? "",
+        // #1766: tier 別同時デプロイ上限 (未配線なら空文字 = クォータ無効)
+        DEPLOY_QUOTA_BY_TIER: props.deployQuotaByTier
+          ? JSON.stringify(props.deployQuotaByTier)
+          : "",
         NODE_OPTIONS: "--enable-source-maps",
       },
       bundling: {

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy-quota.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy-quota.ts
@@ -57,6 +57,11 @@ export function parseDeployQuota(raw: string | undefined): DeployQuotaConfig | u
   } catch {
     throw new Error(`DEPLOY_QUOTA_BY_TIER is not valid JSON: ${raw}`);
   }
+  // JSON.parse("null") / 配列 / 文字列等は後続の index アクセスで生 TypeError になり
+  // 意図した設定エラーメッセージを迂回するため、object 以外をここで明示拒否する。
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`DEPLOY_QUOTA_BY_TIER must be a JSON object, got: ${raw}`);
+  }
   const obj = parsed as Partial<Record<QuotaTier, unknown>>;
   for (const tier of ["basic", "advanced", "platinum"] as const) {
     const v = obj[tier];

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy-quota.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy-quota.ts
@@ -1,0 +1,128 @@
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { Context } from "hono";
+import { extractClaims } from "./auth.js";
+
+/**
+ * Issue #1766: tier 別の同時デプロイクォータ。
+ *
+ * tier はこれまで PLATINUM の IdP ガード (tier-guard.ts) と provisioning 分岐にしか効いて
+ * おらず、pooled tenant が無制限に問題デプロイできた。deploy 受付時に tenant tier
+ * (= JWT `custom:tenantTier`、provision 時に server-set + API GW 署名検証済で詐称不能)
+ * を見て、アクティブな deployment 数が上限に達していたら 429 で弾く。
+ *
+ * - 上限値は config (`deployQuotaByTier`) で宣言し、Lambda には `DEPLOY_QUOTA_BY_TIER`
+ *   env (JSON) で渡す。env 未設定 = クォータ無効 (在来 stack / Lite mode の後方互換)。
+ * - tier claim 不在 / 未知値は **最も厳しい basic の上限に倒す** (fail-closed。
+ *   saml-routes の tier deny-list が ADVANCED を取りこぼした regression を踏まえ、
+ *   未知 tier を無制限側に倒さない)。
+ * - count→write の間に並行 request が滑り込む TOCTOU は許容する (= クォータは課金保護の
+ *   近似制御であり、厳密な直列化に DDB TransactWrite を費やすコストに見合わない)。
+ */
+
+export interface DeployQuotaConfig {
+  readonly basic: number;
+  readonly advanced: number;
+  readonly platinum: number;
+}
+
+export type QuotaTier = keyof DeployQuotaConfig;
+
+/** 同時デプロイ数にカウントするアクティブ status。終端 (FAILED/DELETED/EXPIRED 系) は対象外。 */
+const ACTIVE_STATUSES = ["PENDING", "IN_PROGRESS", "COMPLETE", "DELETING"] as const;
+
+export class DeployQuotaExceededError extends Error {
+  constructor(
+    readonly tier: QuotaTier,
+    readonly limit: number,
+    readonly active: number,
+  ) {
+    super(
+      `deploy quota exceeded for tier ${tier}: ${active} active deployment(s) >= limit ${limit}`,
+    );
+    this.name = "DeployQuotaExceededError";
+  }
+}
+
+/**
+ * `DEPLOY_QUOTA_BY_TIER` env (JSON: {"basic":N,"advanced":N,"platinum":N}) を parse する。
+ * 未設定 / 空文字は「クォータ無効」で undefined。設定されているのに壊れている場合は
+ * loud に throw する (= silent に無効化して課金保護が消えるのを防ぐ)。
+ */
+export function parseDeployQuota(raw: string | undefined): DeployQuotaConfig | undefined {
+  if (!raw || raw.trim().length === 0) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`DEPLOY_QUOTA_BY_TIER is not valid JSON: ${raw}`);
+  }
+  const obj = parsed as Partial<Record<QuotaTier, unknown>>;
+  for (const tier of ["basic", "advanced", "platinum"] as const) {
+    const v = obj[tier];
+    if (typeof v !== "number" || !Number.isInteger(v) || v < 0) {
+      throw new Error(
+        `DEPLOY_QUOTA_BY_TIER.${tier} must be a non-negative integer, got: ${String(v)}`,
+      );
+    }
+  }
+  return obj as DeployQuotaConfig;
+}
+
+/**
+ * JWT claims から quota tier を解決する。claim 不在 / 未知値は basic (最も厳しい上限)。
+ */
+export function resolveQuotaTier(c: Context): QuotaTier {
+  const raw = extractClaims(c)?.["custom:tenantTier"];
+  const tier = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (tier === "advanced" || tier === "platinum") return tier;
+  return "basic";
+}
+
+export interface DeployQuotaDeps {
+  readonly ddb: Pick<DynamoDBDocumentClient, "send">;
+  readonly tableName: string;
+  readonly quota: DeployQuotaConfig | undefined;
+}
+
+/**
+ * tenant のアクティブ deployment 数を数え、上限到達なら `DeployQuotaExceededError` を投げる。
+ * quota 未設定 (env 未配線) は no-op。
+ */
+export async function enforceDeployQuota(
+  deps: DeployQuotaDeps,
+  tenantId: string,
+  tier: QuotaTier,
+): Promise<void> {
+  if (!deps.quota) return;
+  const limit = deps.quota[tier];
+  let active = 0;
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  do {
+    const out = await deps.ddb.send(
+      new QueryCommand({
+        TableName: deps.tableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        FilterExpression: "#s IN (:s0, :s1, :s2, :s3)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${tenantId}`,
+          ":s0": ACTIVE_STATUSES[0],
+          ":s1": ACTIVE_STATUSES[1],
+          ":s2": ACTIVE_STATUSES[2],
+          ":s3": ACTIVE_STATUSES[3],
+        },
+        Select: "COUNT",
+        ExclusiveStartKey: lastEvaluatedKey,
+      }),
+    );
+    active += out.Count ?? 0;
+    lastEvaluatedKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+    // 既に超過が確定したら残り page は読まない (RCU 節約)。
+    if (active >= limit) break;
+  } while (lastEvaluatedKey);
+  if (active >= limit) {
+    throw new DeployQuotaExceededError(tier, limit, active);
+  }
+}

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -22,7 +22,12 @@ import {
   resolveChallengePayloadBucket,
 } from "../shared/visibility.js";
 import { type AdapterDependencyConfig, buildAdapterDependencies } from "./adapter-dependencies.js";
-import { type DeployQuotaConfig, parseDeployQuota } from "./deploy-quota.js";
+import {
+  type DeployQuotaConfig,
+  enforceDeployQuota,
+  parseDeployQuota,
+  type QuotaTier,
+} from "./deploy-quota.js";
 import { buildStackPrefix, slugify } from "./naming.js";
 import { generateChallengePayloadUrl } from "./presigned-url.js";
 import { generateTeamLoginKey } from "./team-key.js";
@@ -69,10 +74,14 @@ export interface DeployContext extends AdapterDependencyConfig {
    * `RuntimeNotSupportedError` BEFORE any DDB Put / EventBridge publish runs.
    */
   readonly resolveProblemRuntime?: (problemId: string) => ProblemRuntime | undefined;
+  /** #1766: tier 別同時デプロイ上限。未設定 = クォータ無効 (在来 stack / Lite)。 */
+  readonly deployQuota?: DeployQuotaConfig;
 }
 
 export type DeployInvocation = DeployRequest & {
   readonly problemId: string;
+  /** #1766: JWT claim から解決済みの quota tier。未指定は最も厳しい basic に倒す。 */
+  readonly quotaTier?: QuotaTier;
 };
 
 const DEFAULT_TTL_MS = 8 * 60 * 60 * 1000;
@@ -155,6 +164,15 @@ export async function startDeployment(
     request.awsAccountId,
   );
   if (!verified) throw new UnverifiedCompetitorAccountError(request.awsAccountId);
+
+  // #1766 (+PR-1803 review): クォータはより具体的な検証 (unknown problem / runtime 不一致 /
+  // unverified account) の後、cloud mutation (DDB Put / EventBridge publish) の直前に
+  // enforce する。先頭で弾くと、本来 404/422 を返すべきリクエストまで 429 で隠れる。
+  await enforceDeployQuota(
+    { ddb: ctx.ddb, tableName: ctx.tableName, quota: ctx.deployQuota },
+    ctx.tenantId,
+    request.quotaTier ?? "basic",
+  );
 
   const jobId = ulid();
   const teamLoginKey = generateTeamLoginKey();

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/deploy.ts
@@ -22,6 +22,7 @@ import {
   resolveChallengePayloadBucket,
 } from "../shared/visibility.js";
 import { type AdapterDependencyConfig, buildAdapterDependencies } from "./adapter-dependencies.js";
+import { type DeployQuotaConfig, parseDeployQuota } from "./deploy-quota.js";
 import { buildStackPrefix, slugify } from "./naming.js";
 import { generateChallengePayloadUrl } from "./presigned-url.js";
 import { generateTeamLoginKey } from "./team-key.js";
@@ -329,6 +330,8 @@ export interface DeploySharedResources {
   readonly ssm: SSMClient;
   /** [ADR-026 / #1412] AppRun REST base URL の override (env)。 未設定なら本番 AppRun 共用型。 */
   readonly sakuraAppRunBaseUrl: string | undefined;
+  /** #1766: tier 別同時デプロイ上限 (env JSON)。 未設定 = クォータ無効 (在来 stack / Lite)。 */
+  readonly deployQuota: DeployQuotaConfig | undefined;
 }
 
 export function buildSharedResources(): DeploySharedResources {
@@ -347,6 +350,7 @@ export function buildSharedResources(): DeploySharedResources {
     s3: new S3Client({}),
     ssm: new SSMClient({}),
     sakuraAppRunBaseUrl: process.env.SAKURA_APPRUN_BASE_URL || undefined,
+    deployQuota: parseDeployQuota(process.env.DEPLOY_QUOTA_BY_TIER),
   };
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -23,6 +23,7 @@ import {
   UnknownProblemError,
   UnverifiedCompetitorAccountError,
 } from "./deploy.js";
+import { DeployQuotaExceededError, enforceDeployQuota, resolveQuotaTier } from "./deploy-quota.js";
 import { getDeployment, listDeployments } from "./list.js";
 import { InvalidRetryRequestError, retryDeployments, validateRetryRequest } from "./retry.js";
 import {
@@ -163,9 +164,28 @@ app.post("/problems/:problemId/deploy", async (c) => {
   const ctx = buildContext(shared, resolveTenantId(c));
 
   try {
+    // #1766: tier 別の同時デプロイクォータ。cloud mutation (DDB Put / EventBridge) の前に弾く。
+    const tier = resolveQuotaTier(c);
+    await enforceDeployQuota(
+      { ddb: shared.ddb, tableName: shared.tableName, quota: shared.deployQuota },
+      ctx.tenantId,
+      tier,
+    );
     const response = await startDeployment(ctx, { ...parsed.data, problemId });
     return c.json(response, StatusCodes.ACCEPTED);
   } catch (err) {
+    if (err instanceof DeployQuotaExceededError) {
+      return c.json(
+        {
+          error: "deploy_quota_exceeded",
+          tier: err.tier,
+          limit: err.limit,
+          active: err.active,
+          message: `同時デプロイ上限 (${err.tier}: ${err.limit}) に達しています。不要な deployment を削除するか、上位 tier を検討してください。`,
+        },
+        StatusCodes.TOO_MANY_REQUESTS,
+      );
+    }
     if (err instanceof UnknownProblemError) {
       return c.json({ error: "unknown_problem", problemId }, StatusCodes.NOT_FOUND);
     }

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/index.ts
@@ -23,7 +23,7 @@ import {
   UnknownProblemError,
   UnverifiedCompetitorAccountError,
 } from "./deploy.js";
-import { DeployQuotaExceededError, enforceDeployQuota, resolveQuotaTier } from "./deploy-quota.js";
+import { DeployQuotaExceededError, resolveQuotaTier } from "./deploy-quota.js";
 import { getDeployment, listDeployments } from "./list.js";
 import { InvalidRetryRequestError, retryDeployments, validateRetryRequest } from "./retry.js";
 import {
@@ -164,14 +164,13 @@ app.post("/problems/:problemId/deploy", async (c) => {
   const ctx = buildContext(shared, resolveTenantId(c));
 
   try {
-    // #1766: tier 別の同時デプロイクォータ。cloud mutation (DDB Put / EventBridge) の前に弾く。
-    const tier = resolveQuotaTier(c);
-    await enforceDeployQuota(
-      { ddb: shared.ddb, tableName: shared.tableName, quota: shared.deployQuota },
-      ctx.tenantId,
-      tier,
-    );
-    const response = await startDeployment(ctx, { ...parsed.data, problemId });
+    // #1766: quota tier は JWT claim から route で解決し、enforcement 自体は
+    // startDeployment 内 (検証通過後・mutation 直前) で行う (PR-1803 review)。
+    const response = await startDeployment(ctx, {
+      ...parsed.data,
+      problemId,
+      quotaTier: resolveQuotaTier(c),
+    });
     return c.json(response, StatusCodes.ACCEPTED);
   } catch (err) {
     if (err instanceof DeployQuotaExceededError) {

--- a/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
+++ b/infrastructure/lib/problem-deploy/problem-deploy-backend-stack.ts
@@ -144,6 +144,16 @@ export interface ProblemDeployBackendStackProps extends cdk.StackProps {
    * 詳細は `DeployCodeBuildProjectProps.concurrentBuildLimit` の docs を参照。
    */
   readonly deployConcurrentBuildLimit?: number;
+
+  /**
+   * #1766: tier 別の同時デプロイ上限。DeployApi Lambda の `DEPLOY_QUOTA_BY_TIER` env (JSON)
+   * に渡す。未設定ならクォータ無効 (= 在来挙動 / Lite mode)。
+   */
+  readonly deployQuotaByTier?: {
+    readonly basic: number;
+    readonly advanced: number;
+    readonly platinum: number;
+  };
   /**
    * SSM SecureString path 構築用の environment 名 (Issue #459 / ADR-002 Phase 2.1)。
    * `/{environmentName}/tenants/{tenantId}/external-id` の prefix として使う。
@@ -310,6 +320,8 @@ export class ProblemDeployBackendStack extends cdk.Stack {
       environmentName: props.environmentName,
       // Issue #950 (ADR-020 Phase D): admin audit log を write
       adminAuditLogTable: adminAuditLog.table,
+      // #1766: tier 別の同時デプロイ上限 (env JSON)。
+      deployQuotaByTier: props.deployQuotaByTier,
     });
     this.deployApiLambda = deployApi.fn;
 

--- a/infrastructure/test/app-config/resolve-branches.test.ts
+++ b/infrastructure/test/app-config/resolve-branches.test.ts
@@ -110,6 +110,23 @@ describe("resolveAppConfig env/fs/input-driven branches", () => {
     ).toBeUndefined();
   });
 
+  it("should parse a valid deploy quota by tier (#1766)", () => {
+    expect(
+      resolve(baseEnv({ CDK_PARAM_DEPLOY_QUOTA_BY_TIER: '{"basic":2,"advanced":5,"platinum":10}' }))
+        .deployQuotaByTier,
+    ).toEqual({ basic: 2, advanced: 5, platinum: 10 });
+  });
+
+  it("should leave the deploy quota undefined when unset (quota disabled, #1766)", () => {
+    expect(resolve(baseEnv()).deployQuotaByTier).toBeUndefined();
+  });
+
+  it("should throw loudly on a broken deploy quota value instead of silently disabling (#1766)", () => {
+    expect(() => resolve(baseEnv({ CDK_PARAM_DEPLOY_QUOTA_BY_TIER: '{"basic":2}' }))).toThrow(
+      /DEPLOY_QUOTA_BY_TIER/,
+    );
+  });
+
   it("should throw on a non-integer concurrent build limit", () => {
     expect(() => resolve(baseEnv({ CDK_PARAM_DEPLOY_CONCURRENT_BUILD_LIMIT: "4.5" }))).toThrow(
       /整数/,

--- a/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
+++ b/infrastructure/test/problem-deploy-backend-stack-lambdas.test.ts
@@ -1,6 +1,9 @@
 import { Match } from "aws-cdk-lib/assertions";
 import { describe, expect, it } from "vitest";
-import { synthDefault } from "./problem-deploy-backend-stack.test-helpers";
+import {
+  synthDefault,
+  synthWithDeployConcurrentBuildLimit,
+} from "./problem-deploy-backend-stack.test-helpers";
 
 describe("ProblemDeployBackendStack (MVP-1) — Deploy API Lambda (invoked from tenant API)", () => {
   const tpl = synthDefault();
@@ -25,6 +28,39 @@ describe("ProblemDeployBackendStack (MVP-1) — Deploy API Lambda (invoked from 
     expect(props.Properties?.Architectures).toEqual(["arm64"]);
     const vars = props.Properties?.Environment?.Variables ?? {};
     expect(vars.BATTLE_PROBLEMS_CATALOG).toBeUndefined();
+  });
+
+  it("DeployApi env DEPLOY_QUOTA_BY_TIER should default to empty (quota disabled, #1766)", () => {
+    const functions = tpl.findResources("AWS::Lambda::Function");
+    const deployApi = Object.entries(functions).find(
+      ([name]) => name.includes("DeployApi") && name.includes("Function"),
+    );
+    const vars =
+      (
+        deployApi?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    expect(vars.DEPLOY_QUOTA_BY_TIER).toBe("");
+  });
+
+  it("DeployApi env DEPLOY_QUOTA_BY_TIER should carry the configured tier limits as JSON (#1766)", () => {
+    const tplWithQuota = synthWithDeployConcurrentBuildLimit();
+    const functions = tplWithQuota.findResources("AWS::Lambda::Function");
+    const deployApi = Object.entries(functions).find(
+      ([name]) => name.includes("DeployApi") && name.includes("Function"),
+    );
+    const vars =
+      (
+        deployApi?.[1] as {
+          Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+        }
+      )?.Properties?.Environment?.Variables ?? {};
+    expect(JSON.parse(String(vars.DEPLOY_QUOTA_BY_TIER))).toEqual({
+      basic: 2,
+      advanced: 5,
+      platinum: 10,
+    });
   });
 
   it("EventApi Lambda env should not include BATTLE_PROBLEMS_CATALOG / BATTLE_PROBLEMS_DISRUPTIONS (#1308)", () => {

--- a/infrastructure/test/problem-deploy-backend-stack.test-helpers.ts
+++ b/infrastructure/test/problem-deploy-backend-stack.test-helpers.ts
@@ -44,6 +44,8 @@ export function synthWithDeployConcurrentBuildLimit(): Template {
     problemsScoring: {},
     problemsEndpoints: {},
     deployConcurrentBuildLimit: 200,
+    // #1766: tier 別同時デプロイ上限の env 配線検証用。
+    deployQuotaByTier: { basic: 2, advanced: 5, platinum: 10 },
     environmentName: "development",
   });
   return Template.fromStack(stack);

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -49,16 +49,6 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
   requestTeardown: mocks.requestTeardown,
 }));
 
-// #1766: enforceDeployQuota だけ差し替え、 error class / resolveQuotaTier は実物を使う
-// (= instanceof 判定の class identity を production と一致させる)。
-const quotaMocks = vi.hoisted(() => ({ enforceDeployQuota: vi.fn() }));
-vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota")
-  >("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota");
-  return { ...actual, enforceDeployQuota: quotaMocks.enforceDeployQuota };
-});
-
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/stack-progress", () => ({
   getStackProgress: mocks.getStackProgress,
   defaultCfnClient: vi.fn(),
@@ -85,13 +75,11 @@ const VALID_DEPLOY_BODY = {
 describe("POST /problems/:problemId/deploy", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("#1766: should return 429 + quota info when the tier deploy quota is exceeded", async () => {
+  it("#1766: should return 429 + quota info when startDeployment hits the tier quota", async () => {
     const { DeployQuotaExceededError } = await import(
       "../../lib/problem-deploy/handlers/deploy-handler/deploy-quota"
     );
-    quotaMocks.enforceDeployQuota.mockRejectedValueOnce(
-      new DeployQuotaExceededError("basic", 2, 2),
-    );
+    mocks.startDeployment.mockRejectedValueOnce(new DeployQuotaExceededError("basic", 2, 2));
     const res = await app.request("/problems/security-battle-royale/deploy", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -101,8 +89,12 @@ describe("POST /problems/:problemId/deploy", () => {
     const body = await res.json();
     expect(body.error).toBe("deploy_quota_exceeded");
     expect(body).toMatchObject({ tier: "basic", limit: 2, active: 2 });
-    // クォータ超過時は cloud mutation (startDeployment) に到達しない。
-    expect(mocks.startDeployment).not.toHaveBeenCalled();
+    // route は JWT claim 由来の quotaTier を invocation に詰めて渡す (enforcement は
+    // startDeployment 内、PR-1803 review)。claim 不在の test 環境では basic に倒れる。
+    expect(mocks.startDeployment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ quotaTier: "basic" }),
+    );
   });
 
   it("Phase 2.2: should return 422 + awsAccountId on UnverifiedCompetitorAccountError", async () => {

--- a/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler-routes.test.ts
@@ -49,6 +49,16 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/delete", () => ({
   requestTeardown: mocks.requestTeardown,
 }));
 
+// #1766: enforceDeployQuota だけ差し替え、 error class / resolveQuotaTier は実物を使う
+// (= instanceof 判定の class identity を production と一致させる)。
+const quotaMocks = vi.hoisted(() => ({ enforceDeployQuota: vi.fn() }));
+vi.mock("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota")
+  >("../../lib/problem-deploy/handlers/deploy-handler/deploy-quota");
+  return { ...actual, enforceDeployQuota: quotaMocks.enforceDeployQuota };
+});
+
 vi.mock("../../lib/problem-deploy/handlers/deploy-handler/stack-progress", () => ({
   getStackProgress: mocks.getStackProgress,
   defaultCfnClient: vi.fn(),
@@ -74,6 +84,26 @@ const VALID_DEPLOY_BODY = {
 
 describe("POST /problems/:problemId/deploy", () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it("#1766: should return 429 + quota info when the tier deploy quota is exceeded", async () => {
+    const { DeployQuotaExceededError } = await import(
+      "../../lib/problem-deploy/handlers/deploy-handler/deploy-quota"
+    );
+    quotaMocks.enforceDeployQuota.mockRejectedValueOnce(
+      new DeployQuotaExceededError("basic", 2, 2),
+    );
+    const res = await app.request("/problems/security-battle-royale/deploy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(VALID_DEPLOY_BODY),
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("deploy_quota_exceeded");
+    expect(body).toMatchObject({ tier: "basic", limit: 2, active: 2 });
+    // クォータ超過時は cloud mutation (startDeployment) に到達しない。
+    expect(mocks.startDeployment).not.toHaveBeenCalled();
+  });
 
   it("Phase 2.2: should return 422 + awsAccountId on UnverifiedCompetitorAccountError", async () => {
     mocks.startDeployment.mockRejectedValueOnce(

--- a/infrastructure/test/problem-deploy/deploy-handler.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-handler.test.ts
@@ -1,10 +1,11 @@
 import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { GetCommand, PutCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type DeployContext,
   type DeployInvocation,
   startDeployment,
+  UnknownProblemError,
   UnverifiedCompetitorAccountError,
 } from "../../lib/problem-deploy/handlers/deploy-handler/deploy";
 
@@ -25,7 +26,7 @@ vi.mock("../../lib/problem-deploy/handlers/deploy-handler/presigned-url", () => 
  */
 function buildContext(
   overrides: Partial<DeployContext> = {},
-  options: { unverified?: boolean } = {},
+  options: { unverified?: boolean; quotaActiveCount?: number } = {},
 ): {
   ctx: DeployContext;
   putSend: ReturnType<typeof vi.fn>;
@@ -37,6 +38,10 @@ function buildContext(
   // それ以外 (PutCommand 等) は putSend に流す。test 側 assertion は putSend の最後の
   // call を見るのが基本。
   const ddbSend = vi.fn(async (cmd: unknown) => {
+    // #1766: quota の active-count Query (Select: COUNT)。
+    if (cmd instanceof QueryCommand && cmd.input.Select === "COUNT") {
+      return { Count: options.quotaActiveCount ?? 0 };
+    }
     if (cmd instanceof GetCommand && cmd.input.TableName === "TestCompetitorAccounts") {
       if (options.unverified) return { Item: undefined };
       const sk = String(cmd.input.Key?.SK ?? "");
@@ -275,6 +280,52 @@ describe("startDeployment", () => {
         s3: undefined,
       });
       await expect(startDeployment(ctx, sampleRequest())).rejects.toThrow(/S3 client/);
+    });
+  });
+});
+
+/**
+ * #1766 + PR-1803 review: クォータは「より具体的な検証の後・mutation の直前」に enforce する。
+ * 上限到達中でも unknown problem / unverified account はそれぞれ本来のエラーで返り、
+ * 429 がそれらを隠さないことを pin する。
+ */
+describe("startDeployment quota ordering (#1766)", () => {
+  const QUOTA = { basic: 1, advanced: 5, platinum: 10 };
+
+  it("should throw UnknownProblemError (not quota) for an unknown problem even at capacity", async () => {
+    const { ctx } = buildContext({ deployQuota: QUOTA }, { quotaActiveCount: 99 });
+    await expect(
+      startDeployment(ctx, sampleRequest({ problemId: "nope", quotaTier: "basic" })),
+    ).rejects.toBeInstanceOf(UnknownProblemError);
+  });
+
+  it("should throw UnverifiedCompetitorAccountError (not quota) even at capacity", async () => {
+    const { ctx } = buildContext(
+      { deployQuota: QUOTA },
+      { unverified: true, quotaActiveCount: 99 },
+    );
+    await expect(
+      startDeployment(ctx, sampleRequest({ quotaTier: "basic" })),
+    ).rejects.toBeInstanceOf(UnverifiedCompetitorAccountError);
+  });
+
+  it("should throw DeployQuotaExceededError before any DDB Put when at capacity", async () => {
+    const { ctx, putSend } = buildContext({ deployQuota: QUOTA }, { quotaActiveCount: 1 });
+    await expect(startDeployment(ctx, sampleRequest({ quotaTier: "basic" }))).rejects.toMatchObject(
+      { name: "DeployQuotaExceededError", tier: "basic", limit: 1 },
+    );
+    // Put / publish (= cloud mutation) に到達しない。
+    expect(putSend).not.toHaveBeenCalled();
+  });
+
+  it("should proceed normally under the limit and when quota is disabled", async () => {
+    const under = buildContext({ deployQuota: QUOTA }, { quotaActiveCount: 0 });
+    await expect(
+      startDeployment(under.ctx, sampleRequest({ quotaTier: "basic" })),
+    ).resolves.toMatchObject({ status: "PENDING" });
+    const disabled = buildContext({}, { quotaActiveCount: 99 });
+    await expect(startDeployment(disabled.ctx, sampleRequest())).resolves.toMatchObject({
+      status: "PENDING",
     });
   });
 });

--- a/infrastructure/test/problem-deploy/deploy-quota.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-quota.test.ts
@@ -1,0 +1,125 @@
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DeployQuotaExceededError,
+  enforceDeployQuota,
+  parseDeployQuota,
+  resolveQuotaTier,
+} from "../../lib/problem-deploy/handlers/deploy-handler/deploy-quota";
+
+/**
+ * Issue #1766: tier 別の同時デプロイクォータ。
+ * 受け入れ条件の 3 ケース (上限内 / 超過 / tier 不明) + env parse の loud-fail を pin する。
+ */
+
+function ctxWithTier(tier?: string): Context {
+  return {
+    env: {
+      event: {
+        requestContext: {
+          authorizer: { jwt: { claims: tier ? { "custom:tenantTier": tier } : {} } },
+        },
+      },
+    },
+  } as unknown as Context;
+}
+
+const QUOTA = { basic: 2, advanced: 5, platinum: 10 };
+
+function depsWithActiveCount(count: number) {
+  const send = vi.fn().mockResolvedValue({ Count: count });
+  return { deps: { ddb: { send }, tableName: "TestDeployments", quota: QUOTA }, send };
+}
+
+describe("parseDeployQuota (#1766)", () => {
+  it("should return undefined (quota disabled) when the env is unset or empty", () => {
+    expect(parseDeployQuota(undefined)).toBeUndefined();
+    expect(parseDeployQuota("")).toBeUndefined();
+    expect(parseDeployQuota("  ")).toBeUndefined();
+  });
+
+  it("should parse a complete tier map", () => {
+    expect(parseDeployQuota('{"basic":2,"advanced":5,"platinum":10}')).toEqual(QUOTA);
+  });
+
+  it.each([
+    ["not json", "{basic:2}"],
+    ["missing tier", '{"basic":2,"advanced":5}'],
+    ["negative", '{"basic":-1,"advanced":5,"platinum":10}'],
+    ["non-integer", '{"basic":1.5,"advanced":5,"platinum":10}'],
+  ])("should throw loudly on a broken value (%s) instead of silently disabling", (_label, raw) => {
+    expect(() => parseDeployQuota(raw)).toThrow(/DEPLOY_QUOTA_BY_TIER/);
+  });
+});
+
+describe("resolveQuotaTier (#1766)", () => {
+  it.each([
+    ["advanced", "advanced"],
+    ["ADVANCED", "advanced"],
+    ["platinum", "platinum"],
+    ["PLATINUM", "platinum"],
+    ["basic", "basic"],
+  ])("should map claim %s to tier %s", (claim, expected) => {
+    expect(resolveQuotaTier(ctxWithTier(claim))).toBe(expected);
+  });
+
+  it("should fall back to basic (most restrictive) for an unknown tier value", () => {
+    expect(resolveQuotaTier(ctxWithTier("GOLD"))).toBe("basic");
+  });
+
+  it("should fall back to basic when the claim is absent", () => {
+    expect(resolveQuotaTier(ctxWithTier(undefined))).toBe("basic");
+  });
+});
+
+describe("enforceDeployQuota (#1766)", () => {
+  it("should accept when active deployments are below the tier limit", async () => {
+    const { deps, send } = depsWithActiveCount(1);
+    await expect(enforceDeployQuota(deps, "tenant-a", "basic")).resolves.toBeUndefined();
+    const cmd = send.mock.calls[0]?.[0] as QueryCommand;
+    expect(cmd).toBeInstanceOf(QueryCommand);
+    expect(cmd.input.ExpressionAttributeValues?.[":pk"]).toBe("TENANT#tenant-a");
+    expect(cmd.input.Select).toBe("COUNT");
+  });
+
+  it("should throw DeployQuotaExceededError when active deployments reach the limit", async () => {
+    const { deps } = depsWithActiveCount(2);
+    await expect(enforceDeployQuota(deps, "tenant-a", "basic")).rejects.toMatchObject({
+      name: "DeployQuotaExceededError",
+      tier: "basic",
+      limit: 2,
+      active: 2,
+    });
+  });
+
+  it("should apply the per-tier limit (advanced allows more than basic)", async () => {
+    const { deps } = depsWithActiveCount(2);
+    await expect(enforceDeployQuota(deps, "tenant-a", "advanced")).resolves.toBeUndefined();
+  });
+
+  it("should be a no-op when quota is undefined (env not wired = legacy stacks / Lite)", async () => {
+    const send = vi.fn();
+    await expect(
+      enforceDeployQuota(
+        { ddb: { send }, tableName: "TestDeployments", quota: undefined },
+        "tenant-a",
+        "basic",
+      ),
+    ).resolves.toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should sum counts across pages and stop early once the limit is reached", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ Count: 1, LastEvaluatedKey: { PK: "x" } })
+      .mockResolvedValueOnce({ Count: 1, LastEvaluatedKey: { PK: "y" } });
+    const deps = { ddb: { send }, tableName: "TestDeployments", quota: QUOTA };
+    await expect(enforceDeployQuota(deps, "tenant-a", "basic")).rejects.toBeInstanceOf(
+      DeployQuotaExceededError,
+    );
+    // 2 page 目で limit=2 に到達 → 3 page 目は読まない (RCU 節約)。
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/infrastructure/test/problem-deploy/deploy-quota.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-quota.test.ts
@@ -44,6 +44,9 @@ describe("parseDeployQuota (#1766)", () => {
   });
 
   it.each([
+    ["null", "null"],
+    ["array", "[1,2,3]"],
+    ["string", '"basic"'],
     ["not json", "{basic:2}"],
     ["missing tier", '{"basic":2,"advanced":5}'],
     ["negative", '{"basic":-1,"advanced":5,"platinum":10}'],


### PR DESCRIPTION
## Summary

Closes #1766。tier はこれまで PLATINUM の IdP ガード(`tier-guard.ts`)とプロビジョニング分岐にしか効いておらず、pooled テナントが無制限に問題デプロイできた。deploy 受付時(cloud mutation = DDB Put / EventBridge publish の前)に tier 別の同時デプロイ上限を enforce する。

### 変更内容

1. **`deploy-quota.ts`(新規 handler モジュール)**
   - `DEPLOY_QUOTA_BY_TIER` env(JSON)の parse。未設定 = クォータ無効(在来 stack / Lite の後方互換)、壊れた値 = **loud throw**(課金保護が silent に消えるのを防ぐ)
   - tier 解決は server-set + API GW 署名検証済みの `custom:tenantTier` claim から。**claim 不在 / 未知値は最も厳しい basic に倒す**(fail-closed — PR-1802 の「tier deny-list が ADVANCED を取りこぼした」リグレッションを踏まえ、未知 tier を無制限側に倒さない)
   - アクティブ数(PENDING / IN_PROGRESS / COMPLETE / DELETING)は既存 GSI1 tenant index の `Select: COUNT` で集計、上限到達でページング打ち切り(RCU 節約)
2. **API**: `POST /problems/:problemId/deploy` が超過時に `StatusCodes.TOO_MANY_REQUESTS` + `{error: "deploy_quota_exceeded", tier, limit, active}` を返す
3. **config 宣言(ハードコードなし)**: `CDK_PARAM_DEPLOY_QUOTA_BY_TIER` を app-config で synth 時に検証(handler と同じ parser を共有 = format の正本は 1 箇所)→ `wire.ts` → `ProblemDeployBackendStack` → `DeployApiLambda` env。3 環境の `.env.example` に記載
4. Lite mode は env 未配線のままクォータ無効(`ONE_PASS_LOCAL` 不変)

### 設計判断

- count→write の TOCTOU(並行 request の滑り込み)は許容。クォータは課金保護の近似制御であり、DDB TransactWrite による厳密直列化のコストに見合わない(コメントに明記)
- bulk-deploy(event 経由)は別エントリポイントのため本 PR の対象外。クォータを bulk にも掛けるかは #1766 の follow-up として要判断

## Test plan

- `deploy-quota.test.ts`(18 cases): parse の loud-fail 4 種 / tier 解決 7 種(未知・不在 → basic を含む)/ **上限内・超過・tier 不明の受け入れ 3 ケース** / ページング打ち切り / quota 無効 no-op
- `deploy-handler-routes.test.ts`: 429 マッピング + 超過時に `startDeployment` 不到達
- `resolve-branches.test.ts`: 有効 JSON / 未設定 / 壊れた値の synth 時 loud-fail
- `problem-deploy-backend-stack-lambdas.test.ts`: CFn env 配線を default("" = 無効)と設定時(JSON)の両方で pin
- `make harness` / `make before-commit` green

## Regression analysis

- **env 未設定(全既存環境)**: `parseDeployQuota(undefined)` → quota 無効 → `enforceDeployQuota` は DDB を一切呼ばず no-op。既存挙動と byte 同一
- **既存テスト**: deploy route の既存テスト(422/404 等)はすべて green のまま。buildSharedResources mock に `deployQuota` が無い場合も undefined = no-op で互換
- **Lite mode**: env 未配線でクォータ無効。`tenkacloud-lite.ts` は未変更
- **claim 不在の SaaS 経路**: quota 有効時のみ basic 上限が掛かる。SaaS の deploy API は Cognito JWT 必須で claim は provision 時に必ず set されるため、実運用で claim 不在になるのは設定異常時のみ(その場合に絞る側へ倒すのが意図)

## Physical impact

- `AWS::Lambda::Function`(DeployApi): **UPDATE**(env 1 個追加。未設定環境では空文字)
- handler コード: ソースバンドル経由で次回 deploy 時に配布(**UPDATE**)
- `.env.example` 3 ファイル: **UPDATE**(コメント行のみ)
- その他リソース: **NO-OP**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tier-based deployment quota limits (basic, advanced, platinum) to prevent excessive concurrent deployments; exceeding limits returns HTTP 429 error.

* **Chores**
  * Configured deployment quota settings across development, staging, and production environments.

* **Tests**
  * Added comprehensive test coverage for quota enforcement and tier resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->