### PR TITLE
fix(harness): implement the two documented-but-missing enforcement rules

### DIFF
--- a/.claude/harness/baselines/handler-must-not-call-fetch.json
+++ b/.claude/harness/baselines/handler-must-not-call-fetch.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "ruleId": "handler-must-not-call-fetch",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/generic-scoring-handler/shared.ts",
+      "line": 212,
+      "match": "fetch("
+    },
+    {
+      "ruleId": "handler-must-not-call-fetch",
+      "filePath": "infrastructure/lib/problem-deploy/handlers/participant-handler/sso.ts",
+      "line": 386,
+      "match": "fetch("
+    }
+  ]
+}

--- a/.claude/harness/bin/regenerate-baselines.ts
+++ b/.claude/harness/bin/regenerate-baselines.ts
@@ -18,6 +18,7 @@ import { resolve } from "node:path";
 import { adrMustBeHtml } from "../src/rules/adr-must-be-html.ts";
 import { adrSelfContained } from "../src/rules/adr-self-contained.ts";
 import { fileTooLarge } from "../src/rules/file-too-large.ts";
+import { handlerMustNotCallFetch } from "../src/rules/handler-must-not-call-fetch.ts";
 import { handlerNoDirectSdkImport } from "../src/rules/handler-no-direct-sdk-import.ts";
 import { iamWildcardNeedsJustify } from "../src/rules/iam-wildcard-needs-justify.ts";
 import { lambdaEnvSize } from "../src/rules/lambda-env-size.ts";
@@ -25,6 +26,7 @@ import { listAllTrackedFiles } from "../src/utils/staged-files.ts";
 
 const RULES = {
   "file-too-large": fileTooLarge,
+  "handler-must-not-call-fetch": handlerMustNotCallFetch,
   "handler-no-direct-sdk-import": handlerNoDirectSdkImport,
   "adr-must-be-html": adrMustBeHtml,
   "adr-self-contained": adrSelfContained,

--- a/.claude/harness/bin/regenerate-baselines.ts
+++ b/.claude/harness/bin/regenerate-baselines.ts
@@ -22,6 +22,7 @@ import { handlerMustNotCallFetch } from "../src/rules/handler-must-not-call-fetc
 import { handlerNoDirectSdkImport } from "../src/rules/handler-no-direct-sdk-import.ts";
 import { iamWildcardNeedsJustify } from "../src/rules/iam-wildcard-needs-justify.ts";
 import { lambdaEnvSize } from "../src/rules/lambda-env-size.ts";
+import { secretsManagerForbidden } from "../src/rules/secrets-manager-forbidden.ts";
 import { listAllTrackedFiles } from "../src/utils/staged-files.ts";
 
 const RULES = {
@@ -32,6 +33,7 @@ const RULES = {
   "adr-self-contained": adrSelfContained,
   "iam-wildcard-needs-justify": iamWildcardNeedsJustify,
   "lambda-env-size": lambdaEnvSize,
+  "secrets-manager-forbidden": secretsManagerForbidden,
 } as const;
 
 const args = process.argv.slice(2);

--- a/.claude/harness/src/cli.ts
+++ b/.claude/harness/src/cli.ts
@@ -1,13 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { type BaselineFile, isBaselined, loadBaseline } from "./baseline.ts";
-import { adrMustBeHtml } from "./rules/adr-must-be-html.ts";
-import { adrSelfContained } from "./rules/adr-self-contained.ts";
-import { fileTooLarge } from "./rules/file-too-large.ts";
-import { handlerNoDirectSdkImport } from "./rules/handler-no-direct-sdk-import.ts";
-import { handlerTenantIsolation } from "./rules/handler-tenant-isolation.ts";
-import { iamWildcardNeedsJustify } from "./rules/iam-wildcard-needs-justify.ts";
-import { lambdaEnvSize } from "./rules/lambda-env-size.ts";
+import { architectureRules } from "./rules/index.ts";
 import type { Finding, Rule, Severity } from "./types.ts";
 import { listAllTrackedFiles, listStagedFiles } from "./utils/staged-files.ts";
 
@@ -22,18 +16,11 @@ export interface RunResult {
   readonly exitCode: number;
 }
 
-const ALL_RULES: readonly Rule[] = [
-  adrMustBeHtml,
-  adrSelfContained,
-  iamWildcardNeedsJustify,
-  // Issue #986 / SOLID 規律強制
-  fileTooLarge,
-  handlerNoDirectSdkImport,
-  // Issue #997 / tenant 分離 audit
-  handlerTenantIsolation,
-  // Issue #1309 / Lambda env 4KB hard limit 再発防止 (= #1308 root cause)
-  lambdaEnvSize,
-];
+// ルールの正本は rules/index.ts の architectureRules のみ (= 単一レジストリ)。
+// 旧実装は cli.ts が独自の ALL_RULES を複製しており、rules/index.ts に登録しただけの
+// ルール (no-conflict-markers / no-aws-trademark-fictions を含む) が CLI で実行されない
+// 「死んだルール」drift を生んでいた。レジストリを 1 つにして構造的に再発を防ぐ。
+const ALL_RULES: readonly Rule[] = architectureRules;
 
 const SEVERITY_RANK: Record<Severity, number> = {
   info: 0,

--- a/.claude/harness/src/rules/handler-must-not-call-fetch.test.ts
+++ b/.claude/harness/src/rules/handler-must-not-call-fetch.test.ts
@@ -40,6 +40,30 @@ describe("handler-must-not-call-fetch", () => {
     expect(findings).toHaveLength(0);
   });
 
+  it("`*` で始まらない block comment 継続行の fetch( 言及も通すべき (レビュー指摘)", () => {
+    const code = [
+      "/*",
+      "  fetch(url) をここで呼んではいけない理由のメモ",
+      "*/",
+      "const x = 1;",
+    ].join("\n");
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("block comment が閉じた後の実コード fetch( は検知すべき", () => {
+    const code = ["/*", "  doc", "*/", "const res = await fetch(url);"].join("\n");
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.line).toBe(4);
+  });
+
   it("テストファイルは対象外にすべき", () => {
     const code = "const res = await fetch(url);";
     const findings = handlerMustNotCallFetch.check({

--- a/.claude/harness/src/rules/handler-must-not-call-fetch.test.ts
+++ b/.claude/harness/src/rules/handler-must-not-call-fetch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { handlerMustNotCallFetch } from "./handler-must-not-call-fetch.ts";
+
+describe("handler-must-not-call-fetch", () => {
+  it("handlers 配下の生 fetch( 呼び出しを error にすべき", () => {
+    const code = 'const res = await fetch(url, { method: "GET" });';
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.ruleId).toBe("handler-must-not-call-fetch");
+    expect(findings[0]?.severity).toBe("error");
+  });
+
+  it("portalFetch( のような別関数名は通すべき (= word boundary)", () => {
+    const code = "const res = await portalFetch(url);";
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("コメント行の fetch( 言及は通すべき", () => {
+    const code = "// この層では fetch( を直接呼ばず client を注入する";
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("handlers 外 (runtime-clients) の fetch は対象外にすべき (= REST client の置き場)", () => {
+    const code = "const res = await fetch(url);";
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/runtime-clients/sakura-apprun-rest-client.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("テストファイルは対象外にすべき", () => {
+    const code = "const res = await fetch(url);";
+    const findings = handlerMustNotCallFetch.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.test.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/.claude/harness/src/rules/handler-must-not-call-fetch.ts
+++ b/.claude/harness/src/rules/handler-must-not-call-fetch.ts
@@ -1,0 +1,72 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+
+/**
+ * CLAUDE.md / harness.md: `lib/handlers/` は `fetch(` を直接呼ばない (= HTTP I/O は
+ * Service / Repository 層、実 REST client は `runtime-clients/` 等の専用 module に置く)。
+ *
+ * Rationale: handler 内の生 fetch は (1) テストで実 HTTP を mock する羽目になる、
+ * (2) timeout / retry / エラー整形の方針が呼び出し箇所ごとに発散する、(3) endpoint が
+ * handler に散らばり監査できない。runtime-clients (sakura/azure/gcp REST client) の
+ * ような注入可能な client interface に閉じ込める。
+ *
+ * CLAUDE.md / harness.md は本ルールを機械チェック対象として記載していたが、実装が
+ * 存在しなかった (= 偽りの安全保証)。ドキュメントの契約に実装を合わせる。
+ * 既存違反は baseline (.claude/harness/baselines/handler-must-not-call-fetch.json) で
+ * 許容し、新規追加のみ block する (= ratchet)。
+ *
+ * Scope: infrastructure/lib/**\/handlers/**\/*.ts (テストは除外)。
+ */
+
+const FETCH_CALL_RE = /\bfetch\s*\(/;
+const LINE_COMMENT_RE = /^\s*(\/\/|\*|\/\*)/;
+
+function shouldInspect(path: string): boolean {
+  if (!path.startsWith("infrastructure/lib/")) return false;
+  if (!path.includes("/handlers/")) return false;
+  if (!path.endsWith(".ts")) return false;
+  if (path.endsWith(".test.ts")) return false;
+  return true;
+}
+
+function scanFile(path: string, content: string): Finding[] {
+  const findings: Finding[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    if (LINE_COMMENT_RE.test(line)) continue;
+    if (!FETCH_CALL_RE.test(line)) continue;
+    findings.push({
+      ruleId: "handler-must-not-call-fetch",
+      severity: "error",
+      filePath: path,
+      line: i + 1,
+      match: "fetch(",
+      message:
+        "Handler code is calling fetch() directly. HTTP I/O belongs in an injectable " +
+        "client module (Service / Repository layer), not in lib/handlers/.",
+      recommendation:
+        "Extract the HTTP call into a dedicated client (see infrastructure/lib/problem-deploy/" +
+        "runtime-clients/ for the established pattern) and inject it, so handlers stay " +
+        "mockable and timeout/retry policy stays centralized.",
+    });
+  }
+  return findings;
+}
+
+export const handlerMustNotCallFetch: Rule = {
+  id: "handler-must-not-call-fetch",
+  severity: "error",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldInspect(path)) continue;
+      try {
+        findings.push(...scanFile(path, ctx.readFile(path)));
+      } catch {
+        // 読めないファイル (削除 / バイナリ) は skip。
+      }
+    }
+    return findings;
+  },
+};

--- a/.claude/harness/src/rules/handler-must-not-call-fetch.ts
+++ b/.claude/harness/src/rules/handler-must-not-call-fetch.ts
@@ -19,6 +19,8 @@ import type { Finding, Rule, RuleContext } from "../types.ts";
 
 const FETCH_CALL_RE = /\bfetch\s*\(/;
 const LINE_COMMENT_RE = /^\s*(\/\/|\*|\/\*)/;
+const BLOCK_COMMENT_OPEN_RE = /\/\*/;
+const BLOCK_COMMENT_CLOSE_RE = /\*\//;
 
 function shouldInspect(path: string): boolean {
   if (!path.startsWith("infrastructure/lib/")) return false;
@@ -31,9 +33,20 @@ function shouldInspect(path: string): boolean {
 function scanFile(path: string, content: string): Finding[] {
   const findings: Finding[] = [];
   const lines = content.split("\n");
+  // `/* ... */` の内側 (継続行が `*` で始まらない自由記述スタイルを含む) を除外する簡易
+  // state machine。文字列リテラル内の `/*` までは追わない (= レビュー指摘の false positive
+  // 解消が目的で、完全な TS パースは過剰)。
+  let inBlockComment = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!line) continue;
+    if (inBlockComment) {
+      if (BLOCK_COMMENT_CLOSE_RE.test(line)) inBlockComment = false;
+      continue;
+    }
+    if (BLOCK_COMMENT_OPEN_RE.test(line) && !BLOCK_COMMENT_CLOSE_RE.test(line)) {
+      inBlockComment = true;
+    }
     if (LINE_COMMENT_RE.test(line)) continue;
     if (!FETCH_CALL_RE.test(line)) continue;
     findings.push({

--- a/.claude/harness/src/rules/handler-tenant-isolation.ts
+++ b/.claude/harness/src/rules/handler-tenant-isolation.ts
@@ -3,7 +3,7 @@ import type { Finding, Rule, RuleContext } from "../types.ts";
 /**
  * Issue #997: tenant 分離 audit。
  *
- * pooled tier (BASIC / STANDARD / PREMIUM) で application-admin-console が共有 stack で動く
+ * pooled tier (BASIC / ADVANCED) で application-admin-console が共有 stack で動く
  * 構成上、 全 handler は **request の tenantId を JWT から取り、 DDB read/write に必ず注入する**
  * 必要がある。 1 handler でも tenantId を見ずに query すれば 「TenantA admin が TenantB のデータを
  * 取得」 という公平性破壊バグになる。

--- a/.claude/harness/src/rules/index.ts
+++ b/.claude/harness/src/rules/index.ts
@@ -1,12 +1,14 @@
 import { adrMustBeHtml } from "./adr-must-be-html.ts";
 import { adrSelfContained } from "./adr-self-contained.ts";
 import { fileTooLarge } from "./file-too-large.ts";
+import { handlerMustNotCallFetch } from "./handler-must-not-call-fetch.ts";
 import { handlerNoDirectSdkImport } from "./handler-no-direct-sdk-import.ts";
 import { handlerTenantIsolation } from "./handler-tenant-isolation.ts";
 import { iamWildcardNeedsJustify } from "./iam-wildcard-needs-justify.ts";
 import { lambdaEnvSize } from "./lambda-env-size.ts";
 import { noAwsTrademarkFictions } from "./no-aws-trademark-fictions.ts";
 import { noConflictMarkers } from "./no-conflict-markers.ts";
+import { secretsManagerForbidden } from "./secrets-manager-forbidden.ts";
 
 export const architectureRules = [
   adrMustBeHtml,
@@ -23,4 +25,8 @@ export const architectureRules = [
   lambdaEnvSize,
   // AWS GameDay branding (= Unicorn.Rentals 等) を OSS / 商用 platform で流用しない // allow-aws-fiction: rule self-description
   noAwsTrademarkFictions,
+  // CLAUDE.md cost-zero principle: Secrets Manager 禁止 (SSM SecureString を使う)
+  secretsManagerForbidden,
+  // CLAUDE.md: lib/handlers/ は fetch( を直接呼ばない (HTTP I/O は注入可能な client へ)
+  handlerMustNotCallFetch,
 ] as const;

--- a/.claude/harness/src/rules/registry-completeness.test.ts
+++ b/.claude/harness/src/rules/registry-completeness.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { architectureRules } from "./index.ts";
+
+/**
+ * レジストリ drift の構造ガード (PR-1806 レビュー指摘の再発防止)。
+ *
+ * 旧実装は cli.ts が独自の ALL_RULES を複製しており、rules/index.ts に登録しただけの
+ * ルール (no-conflict-markers / no-aws-trademark-fictions / 新規 2 ルール) が CLI から
+ * 実行されない「死んだルール」を生んでいた。cli.ts は architectureRules を直接 consume
+ * する構成に変更済みで、本テストは「rules/ 配下に実装した Rule は必ず architectureRules
+ * に登録されている」ことをファイルシステム駆動で固定する (= 登録漏れは即 red)。
+ */
+describe("architecture rules registry completeness", () => {
+  it("should register every rule implemented under rules/ in architectureRules", async () => {
+    const dir = join(import.meta.dirname, ".");
+    const ruleFiles = readdirSync(dir).filter(
+      (f) =>
+        f.endsWith(".ts") &&
+        !f.endsWith(".test.ts") &&
+        f !== "index.ts" &&
+        f !== "registry-completeness.test.ts",
+    );
+    const registeredIds = new Set(architectureRules.map((r) => r.id));
+    const missing: string[] = [];
+    for (const file of ruleFiles) {
+      const mod = (await import(`./${file}`)) as Record<string, unknown>;
+      for (const value of Object.values(mod)) {
+        const maybeRule = value as { id?: unknown; check?: unknown };
+        if (typeof maybeRule?.id === "string" && typeof maybeRule?.check === "function") {
+          if (!registeredIds.has(maybeRule.id)) missing.push(`${file} -> ${maybeRule.id}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/.claude/harness/src/rules/secrets-manager-forbidden.test.ts
+++ b/.claude/harness/src/rules/secrets-manager-forbidden.test.ts
@@ -33,6 +33,24 @@ describe("secrets-manager-forbidden", () => {
     expect(findings).toHaveLength(0);
   });
 
+  it('side-effect import (`import "..."`) もすり抜けさせない (レビュー指摘)', () => {
+    const code = 'import "@aws-sdk/client-secrets-manager";';
+    const findings = secretsManagerForbidden.check({
+      files: ["infrastructure/lib/foo.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("require() 形式もすり抜けさせない", () => {
+    const code = 'const sm = require("@aws-sdk/client-secrets-manager");';
+    const findings = secretsManagerForbidden.check({
+      files: ["scripts/foo.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("harness 自身のファイルは対象外にすべき (= 本ルールの定義が自己検知しない)", () => {
     const code = "const re = /from\\s+[\"']@aws-sdk\\/client-secrets-manager[\"']/;";
     const findings = secretsManagerForbidden.check({

--- a/.claude/harness/src/rules/secrets-manager-forbidden.test.ts
+++ b/.claude/harness/src/rules/secrets-manager-forbidden.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { secretsManagerForbidden } from "./secrets-manager-forbidden.ts";
+
+describe("secrets-manager-forbidden", () => {
+  it("@aws-sdk/client-secrets-manager の import を error にすべき", () => {
+    const code = 'import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";';
+    const findings = secretsManagerForbidden.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.ruleId).toBe("secrets-manager-forbidden");
+    expect(findings[0]?.severity).toBe("error");
+    expect(findings[0]?.match).toBe("@aws-sdk/client-secrets-manager");
+  });
+
+  it("CDK の aws-cdk-lib/aws-secretsmanager construct import も error にすべき", () => {
+    const code = 'import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";';
+    const findings = secretsManagerForbidden.check({
+      files: ["infrastructure/lib/control-plane-stack.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.match).toBe("aws-cdk-lib/aws-secretsmanager");
+  });
+
+  it("SSM (推奨経路) の import は通すべき", () => {
+    const code = 'import { SSMClient } from "@aws-sdk/client-ssm";';
+    const findings = secretsManagerForbidden.check({
+      files: ["infrastructure/lib/problem-deploy/handlers/foo/service.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("harness 自身のファイルは対象外にすべき (= 本ルールの定義が自己検知しない)", () => {
+    const code = "const re = /from\\s+[\"']@aws-sdk\\/client-secrets-manager[\"']/;";
+    const findings = secretsManagerForbidden.check({
+      files: [".claude/harness/src/rules/secrets-manager-forbidden.ts"],
+      readFile: () => code,
+    });
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/.claude/harness/src/rules/secrets-manager-forbidden.ts
+++ b/.claude/harness/src/rules/secrets-manager-forbidden.ts
@@ -12,8 +12,10 @@ import type { Finding, Rule, RuleContext } from "../types.ts";
  * construct import の両方を error にする。
  */
 
+// `import ... from "x"` / side-effect `import "x"` / dynamic `import("x")` / `require("x")`
+// のすべての取り込み形式を捕まえる (= `from` 限定だと side-effect import がすり抜ける)。
 const SECRETS_MANAGER_IMPORT_RE =
-  /from\s+["'](@aws-sdk\/client-secrets-manager|aws-cdk-lib\/aws-secretsmanager)["']/;
+  /(?:from\s+|import\s*\(?\s*|require\s*\(\s*)["'](@aws-sdk\/client-secrets-manager|aws-cdk-lib\/aws-secretsmanager)["']/;
 
 function shouldInspect(path: string): boolean {
   if (!path.endsWith(".ts") && !path.endsWith(".tsx")) return false;

--- a/.claude/harness/src/rules/secrets-manager-forbidden.ts
+++ b/.claude/harness/src/rules/secrets-manager-forbidden.ts
@@ -1,0 +1,63 @@
+import type { Finding, Rule, RuleContext } from "../types.ts";
+
+/**
+ * cost-zero principle (CLAUDE.md): AWS Secrets Manager は per-secret 課金が発生するため
+ * 使用禁止。秘匿値は SSM Parameter Store SecureString (standard tier = 無料) に置く。
+ *
+ * CLAUDE.md / harness.md は本ルールを機械チェック対象として記載していたが、実装が
+ * 存在しなかった (= 偽りの安全保証)。ドキュメントの契約に実装を合わせる。
+ *
+ * Scope: リポジトリ内のすべての .ts (infrastructure / apps / scripts / packages)。
+ * `@aws-sdk/client-secrets-manager` の import と、CDK の `aws-cdk-lib/aws-secretsmanager`
+ * construct import の両方を error にする。
+ */
+
+const SECRETS_MANAGER_IMPORT_RE =
+  /from\s+["'](@aws-sdk\/client-secrets-manager|aws-cdk-lib\/aws-secretsmanager)["']/;
+
+function shouldInspect(path: string): boolean {
+  if (!path.endsWith(".ts") && !path.endsWith(".tsx")) return false;
+  if (path.includes("node_modules/")) return false;
+  // harness 自身 (本ルールの定義 / テスト) は対象外。
+  if (path.startsWith(".claude/harness/")) return false;
+  return true;
+}
+
+export const secretsManagerForbidden: Rule = {
+  id: "secrets-manager-forbidden",
+  severity: "error",
+  check(ctx: RuleContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const path of ctx.files) {
+      if (!shouldInspect(path)) continue;
+      let content: string;
+      try {
+        content = ctx.readFile(path);
+      } catch {
+        continue;
+      }
+      const lines = content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line) continue;
+        const m = line.match(SECRETS_MANAGER_IMPORT_RE);
+        if (!m) continue;
+        findings.push({
+          ruleId: "secrets-manager-forbidden",
+          severity: "error",
+          filePath: path,
+          line: i + 1,
+          match: m[1] ?? "secrets-manager",
+          message:
+            "AWS Secrets Manager is forbidden (per-secret cost). Import of " +
+            (m[1] ?? "secrets-manager") +
+            " detected.",
+          recommendation:
+            "Store the secret in SSM Parameter Store as a SecureString (standard tier is free). " +
+            "See CLAUDE.md cost-zero principle.",
+        });
+      }
+    }
+    return findings;
+  },
+};

--- a/docs/architecture/harness.html
+++ b/docs/architecture/harness.html
@@ -144,7 +144,7 @@ handler の DDB read/write に JWT 由来の tenantId 注入が無い経路を�
 synth 時の Lambda env 合計が AWS の 4KB hard limit に近づくと検出 (Issue #1309、#1308 の CREATE_FAILED 再発防止)。baseline 有り。</p>
 </li>
 <li><p><code>no-aws-trademark-fictions</code>
-AWS 公式競技の fictional branding (Unicorn.Rentals 等) の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。</p>
+AWS 公式競技の fictional branding の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。検出対象の具体名はルール実装 (<code>.claude/harness/src/rules/no-aws-trademark-fictions.ts</code>) を参照。</p>
 </li>
 </ul>
 <h2>Enforcement</h2>

--- a/docs/architecture/harness.html
+++ b/docs/architecture/harness.html
@@ -128,6 +128,24 @@ Git merge / rebase 中に残った conflict marker (<code>&lt;&lt;&lt;&lt;&lt;&l
 <p>これと対をなす Git 層チェックが <code>make check-no-conflicts</code> (= <code>scripts/check-no-conflicts.ts</code>)。 こちらは <code>git merge-tree HEAD origin/main</code> で「現在のブランチが origin/main に clean に merge できるか」を dry-run 検査する。 PR を出す瞬間に DIRTY (= 上流が進んだ) になるのを未然に防ぐ。 <code>make before-commit</code> に組み込まれており、 fail すると pre-commit で止まる。</p>
 <p>両方とも記憶[[feedback_pull_main_before_task]]に紐づく仕掛け。</p>
 </li>
+<li><p><code>file-too-large</code>
+単一ファイルが 500 行超で warning、800 行超で error (Issue #986 / SRP)。既存違反は <code>.claude/harness/baselines/file-too-large.json</code> に baseline 化し、新規だけ捕まえる ratchet。</p>
+</li>
+<li><p><code>handler-no-direct-sdk-import</code>
+Lambda handler の routing 層 (<code>handlers/&lt;name&gt;/index.ts</code>) からの <code>@aws-sdk/client-*</code> / <code>@aws-sdk/lib-*</code> 直接 import を warning (Issue #986 / DIP)。SDK 呼び出しは service / repository module へ。baseline 有り。</p>
+</li>
+<li><p><code>handler-tenant-isolation</code>
+handler の DDB read/write に JWT 由来の tenantId 注入が無い経路を検出 (Issue #997)。pooled 構成で cross-tenant 漏洩を防ぐ第一線。</p>
+</li>
+<li><p><code>iam-wildcard-needs-justify</code>
+<code>infrastructure/lib/**</code> の <code>resources: [&quot;*&quot;]</code> に、直前 5 行以内の <code>justify:</code> comment が無ければ error (Issue #857)。広域権限は理由の明文化を強制する。baseline 有り。</p>
+</li>
+<li><p><code>lambda-env-size</code>
+synth 時の Lambda env 合計が AWS の 4KB hard limit に近づくと検出 (Issue #1309、#1308 の CREATE_FAILED 再発防止)。baseline 有り。</p>
+</li>
+<li><p><code>no-aws-trademark-fictions</code>
+AWS 公式競技の fictional branding (Unicorn.Rentals 等) の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。</p>
+</li>
 </ul>
 <h2>Enforcement</h2>
 <ul>

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -99,7 +99,7 @@ Invariants に加えて、実装レベルの原則を機械検査するルール
   synth 時の Lambda env 合計が AWS の 4KB hard limit に近づくと検出 (Issue #1309、#1308 の CREATE_FAILED 再発防止)。baseline 有り。
 
 - `no-aws-trademark-fictions`
-  AWS 公式競技の fictional branding (Unicorn.Rentals 等) の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。
+  AWS 公式競技の fictional branding の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。検出対象の具体名はルール実装 (`.claude/harness/src/rules/no-aws-trademark-fictions.ts`) を参照。
 
 ## Enforcement
 

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -83,6 +83,24 @@ Invariants に加えて、実装レベルの原則を機械検査するルール
 
   両方とも記憶[[feedback_pull_main_before_task]]に紐づく仕掛け。
 
+- `file-too-large`
+  単一ファイルが 500 行超で warning、800 行超で error (Issue #986 / SRP)。既存違反は `.claude/harness/baselines/file-too-large.json` に baseline 化し、新規だけ捕まえる ratchet。
+
+- `handler-no-direct-sdk-import`
+  Lambda handler の routing 層 (`handlers/<name>/index.ts`) からの `@aws-sdk/client-*` / `@aws-sdk/lib-*` 直接 import を warning (Issue #986 / DIP)。SDK 呼び出しは service / repository module へ。baseline 有り。
+
+- `handler-tenant-isolation`
+  handler の DDB read/write に JWT 由来の tenantId 注入が無い経路を検出 (Issue #997)。pooled 構成で cross-tenant 漏洩を防ぐ第一線。
+
+- `iam-wildcard-needs-justify`
+  `infrastructure/lib/**` の `resources: ["*"]` に、直前 5 行以内の `justify:` comment が無ければ error (Issue #857)。広域権限は理由の明文化を強制する。baseline 有り。
+
+- `lambda-env-size`
+  synth 時の Lambda env 合計が AWS の 4KB hard limit に近づくと検出 (Issue #1309、#1308 の CREATE_FAILED 再発防止)。baseline 有り。
+
+- `no-aws-trademark-fictions`
+  AWS 公式競技の fictional branding (Unicorn.Rentals 等) の流用を検出 (IP リスク)。TenkaCloud 自前のシナリオ名を使う。
+
 ## Enforcement
 
 - `make harness` (= `bun run .claude/harness/bin/architecture.ts --staged --fail-on=error`)


### PR DESCRIPTION
## Summary

PR-1804 の docs 監査で発見した、**ドキュメントと harness 実装の双方向の乖離**を解消する。

CLAUDE.md と `docs/architecture/harness.md` は `secrets-manager-forbidden` / `handler-must-not-call-fetch` を「機械検査済み」と記載していたが、`.claude/harness/src/rules/` に**実装が存在しなかった**(= 偽りの安全保証)。逆に、実装済みの 6 ルールが harness.md の Enforcement Rules 一覧に未記載だった。

### 変更内容

1. **`secrets-manager-forbidden` 実装**(error): `@aws-sdk/client-secrets-manager` と CDK の `aws-cdk-lib/aws-secretsmanager` の import を全 TS/TSX で検出(cost-zero 原則、秘匿値は SSM SecureString)。現状違反 0 のため baseline 不要
2. **`handler-must-not-call-fetch` 実装**(error): `infrastructure/lib/**/handlers/**` の生 `fetch(` 呼び出しを検出(word-boundary、コメント行と `*.test.ts` 除外、`runtime-clients/` は HTTP client の正規の置き場として対象外)。既存 2 箇所(`generic-scoring-handler/shared.ts:212` / `participant-handler/sso.ts:386`)は新 baseline に凍結し新規負債のみ block(`handler-no-direct-sdk-import` と同じ ratchet)
3. 両ルールを `rules/index.ts` と `bin/regenerate-baselines.ts` に登録
4. **harness.md に未記載だった 6 ルールを文書化**: `file-too-large` / `handler-no-direct-sdk-import` / `handler-tenant-isolation` / `iam-wildcard-needs-justify` / `lambda-env-size` / `no-aws-trademark-fictions`
5. `handler-tenant-isolation` のコメント内の stale tier 列挙(STANDARD/PREMIUM → ADVANCED)を修正(PR-1801 の続き)

## Test plan

- 新規テスト 9 件: 検出系(SDK import / CDK construct import / fetch( 呼び出し)と許容系(SSM import / `portalFetch(` の word-boundary / コメント行 / runtime-clients / テストファイル / harness 自己除外)を pin
- `make harness-test` 146 件 green
- `make harness` green(新ルール有効状態で staged 変更に違反なし)
- `make before-commit` green(pre-commit hook)

## Regression analysis

- 新ルールは追加のみで既存ルールのロジック不変。既存コードベースに対する新規 error は 0(secrets-manager は違反なし、fetch の既存 2 箇所は baseline 凍結)— つまり**現在の開発フローを止めずに、ドキュメントが約束していたガードを今後の変更に対して有効化する**
- `regenerate-baselines.ts` への登録は再 baseline 用 CLI の対象追加のみ
- harness.md の追記は既存記載の変更なし(一覧の補完)

## Physical impact

- `.claude/harness/`(ルール 2 + テスト 2 + index/regenerate 登録 + baseline 1): **CREATE/UPDATE**(リポジトリ内ツールのみ)
- `docs/architecture/harness.md`: **UPDATE**
- AWS リソース: **NO-OP**(インフラ変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added architecture enforcement rule prohibiting direct `fetch` calls in handler code. Recommends using injectable runtime client modules for HTTP I/O instead.
  * Added architecture enforcement rule prohibiting AWS Secrets Manager SDK imports. Recommends using SSM Parameter Store SecureString instead.

* **Documentation**
  * Updated documentation to describe new enforcement rules alongside existing architecture checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->