### PR TITLE
fix(admin-console): drop internal issue reference from UI copy

### DIFF
--- a/apps/admin-console/src/i18n/locales/en.json
+++ b/apps/admin-console/src/i18n/locales/en.json
@@ -167,7 +167,7 @@
     "tab_provisioning": "Provisioning",
     "tab_deprovisioning": "Deprovisioning",
     "deprovisioning_phase1_header": "Deprovisioning Jobs API is not wired",
-    "deprovisioning_phase1_body": "The admin-insight Lambda has not received the deprovisioning state machine ARN. Run the latest 'make deploy' (= Issue #814 Phase 2).",
+    "deprovisioning_phase1_body": "The admin-insight Lambda has not received the deprovisioning state machine ARN. Run the latest 'make deploy'.",
     "deprovisioning_open_console": "Open Step Functions in AWS Console",
     "deprovisioning_open_console_aria": "Open AWS Step Functions console (state machine list) in a new tab",
     "empty_deprovisioning": "No deprovisioning executions yet. Triggering a tenant deletion will record entries here."

--- a/apps/admin-console/src/i18n/locales/ja.json
+++ b/apps/admin-console/src/i18n/locales/ja.json
@@ -167,7 +167,7 @@
     "tab_provisioning": "Provisioning",
     "tab_deprovisioning": "Deprovisioning",
     "deprovisioning_phase1_header": "Deprovisioning Jobs API が未配線です",
-    "deprovisioning_phase1_body": "本環境では admin-insight Lambda に deprovisioning state machine ARN が渡されていません。最新の 'make deploy' を実行してください (= Issue #814 Phase 2)。",
+    "deprovisioning_phase1_body": "本環境では admin-insight Lambda に deprovisioning state machine ARN が渡されていません。最新の 'make deploy' を実行してください。",
     "deprovisioning_open_console": "AWS Console で Step Functions を開く",
     "deprovisioning_open_console_aria": "AWS Step Functions コンソール (ステートマシン一覧) を新しいタブで開く",
     "empty_deprovisioning": "Deprovisioning の実行履歴はまだありません。 テナント削除を実行すると ここに記録されます。"


### PR DESCRIPTION
## Summary

商用 UI コピー品質方針(開発者ジャーゴン・内部メモを user-visible 文言に出さない)の全 SPA sweep で見つかった唯一の違反を修正。

Jobs ページの deprovisioning 未配線メッセージ(ja/en 両 locale)が「(= Issue #814 Phase 2)」という内部トラッキング参照で終わっていた。内部のトレーサビリティはコードコメントに置くもので、運用者の画面に出すものではない。

**Sweep の範囲と結果**: 3 SPA すべての locale ファイルを `Phase N / DDB / GSI / ULID / Issue 参照` パターンで走査。違反は本件 1 ペアのみ。残り 12 ヒットは Operations ページの AWS 用語(DDB / Lambda / CloudWatch)で、AWS 運用ダッシュボードの利用者には適切な語彙のため現状維持。

## Test plan

- 既存 `Jobs.test.tsx` がページを cover(i18n は key ベース mock で文言リテラルを pin していないため、テスト変更は不要 — 本 PR で追加したテストはゼロ)
- `make before-commit` green(pre-commit hook)

## Regression analysis

- locale の値のみの変更でキー・UI 構造・ロジックは不変
- 当該キーの消費箇所は `Jobs.tsx:277` の 1 箇所のみ(grep 確認済み)

## Physical impact

- `apps/admin-console/dist`(S3 配布物): **UPDATE**(文言のみ)
- その他: **NO-OP**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
