### PR TITLE
feat(scoring): multi-flag kind — N independent flags per problem

### DIFF
--- a/apps/participant-portal/src/api/portal-client/scoring.ts
+++ b/apps/participant-portal/src/api/portal-client/scoring.ts
@@ -36,17 +36,21 @@ export async function revealHint(
 
 /**
  * Phase 2c: Flag 提出は `problemId` 必須に。`POST /portal/me/submit-flag { problemId, flag }`。
+ *
+ * Issue #1796: multi-flag kind では `flagId` でどの sub-flag への提出かを渡す。 単一 flag kind は
+ * flagId を省略する (= 後方互換、 backend も flagId を無視する)。
  */
 export async function submitFlag(
   apiBaseUrl: string,
   teamLoginKey: string,
   problemId: string,
   flag: string,
+  flagId?: string,
   signal?: AbortSignal,
 ): Promise<SubmitFlagOutcome> {
   return (await portalFetch<SubmitFlagOutcome>(apiBaseUrl, "portal/me/submit-flag", teamLoginKey, {
     method: "POST",
-    body: { problemId, flag },
+    body: flagId === undefined ? { problemId, flag } : { problemId, flag, flagId },
     throwOn400: true,
     // Issue #1006: 409 scoring_not_started / scoring_ended / scoring_locked を
     // PortalScoringGateError として throw (= UI が startsAt 文言を出せる)。

--- a/apps/participant-portal/src/api/portal-client/types.ts
+++ b/apps/participant-portal/src/api/portal-client/types.ts
@@ -30,11 +30,24 @@ export const TERMINAL_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
  */
 export type ScoringKind =
   | "flag"
+  | "multi-flag"
   | "uptime"
   | "uptime-flat"
   | "uptime-multi"
   | "phased-polling"
   | "attack-detection";
+
+/**
+ * Issue #1796: multi-flag の 1 sub-flag の view (= backend `ParticipantScoringInfo.flags[]` と
+ * 同じ shape)。 正解値 (flagOutputKey の値) は含めない (= 答えを漏らさない)。 `solved` は team の
+ * 解済 flag id 集合に含まれるかで判定済み。
+ */
+export interface MultiFlagEntryView {
+  readonly id: string;
+  readonly label: string;
+  readonly points: number;
+  readonly solved: boolean;
+}
 
 /**
  * Issue #742 Phase 4: progressive hint view shape (= backend
@@ -55,6 +68,8 @@ export interface ParticipantScoringInfo {
   readonly pointsPerSuccess?: number;
   readonly hints?: readonly ParticipantHintView[];
   readonly flagSubmitted?: boolean;
+  /** Issue #1796: multi-flag の sub-flag 一覧 (= N 個の提出欄を出すための view)。 */
+  readonly flags?: readonly MultiFlagEntryView[];
 }
 
 /**
@@ -150,7 +165,8 @@ export interface ParticipantTeamView {
 }
 
 export type SubmitFlagOutcome =
-  | { kind: "ok"; scoreDelta: number; totalScore: number }
+  /** Issue #1796: multi-flag のとき、 どの sub-flag が解けたかを示す `flagId` を含む。 */
+  | { kind: "ok"; scoreDelta: number; totalScore: number; flagId?: string }
   | { kind: "already_scored"; totalScore: number }
   /**
    * Issue #817: 不正解。 問題 metadata に `wrongAnswerPenalty` が設定されていれば

--- a/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
+++ b/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppConfigProvider } from "../config-context";
+import { I18nProvider } from "../i18n";
+import { MultiFlagSubmissionPanel } from "./MultiFlagSubmissionPanel";
+
+/**
+ * Issue #1796: MultiFlagSubmissionPanel を実 provider (AppConfigProvider + I18nProvider) で
+ * render し、 N 個の提出欄 / solved 表示 / submit (= client が flagId 付きで呼ばれる) /
+ * wrong alert / dev-mock 経路を pin する。 submitFlag だけ mock し、 evaluateMockFlag・i18n は実物。
+ */
+
+const apiMocks = vi.hoisted(() => ({ submitFlag: vi.fn() }));
+
+vi.mock("../api/portal-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/portal-client")>();
+  return { ...actual, submitFlag: apiMocks.submitFlag };
+});
+
+function withProviders(node: React.ReactNode, mode: "backend" | "dev-mock" = "backend") {
+  return (
+    <AppConfigProvider
+      config={{
+        apiBaseUrl: "https://api.example.com",
+        eventTitle: "Test event",
+        eventRegion: "ap-northeast-1",
+        mode,
+        cloudMode: mode === "backend" ? "real" : "mock",
+      }}
+    >
+      <I18nProvider>{node}</I18nProvider>
+    </AppConfigProvider>
+  );
+}
+
+const FLAGS = [
+  { id: "ep01", label: "Ep01: Reachability", points: 300, solved: false },
+  { id: "ep02", label: "Ep02: TCP/IP", points: 200, solved: false },
+];
+
+const baseProps = {
+  apiBaseUrl: "https://api.example.com",
+  sessionToken: "team-key",
+  problemId: "net-evo",
+  flags: FLAGS,
+  onScored: async () => undefined,
+} as const;
+
+function renderPanel(
+  overrides: Partial<React.ComponentProps<typeof MultiFlagSubmissionPanel>> = {},
+  mode: "backend" | "dev-mock" = "backend",
+) {
+  return render(withProviders(<MultiFlagSubmissionPanel {...baseProps} {...overrides} />, mode));
+}
+
+beforeEach(() => {
+  window.localStorage.setItem("tenkacloud.portal.locale", "en");
+  apiMocks.submitFlag.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("MultiFlagSubmissionPanel", () => {
+  it("should render one input per unsolved flag", () => {
+    renderPanel();
+    expect(screen.getAllByRole("textbox")).toHaveLength(2);
+    expect(screen.getByText("Flags solved: 0 / 2")).toBeInTheDocument();
+  });
+
+  it("should show a solved alert and no input for an already-solved flag", () => {
+    renderPanel({
+      flags: [
+        { ...FLAGS[0], solved: true },
+        FLAGS[1],
+      ],
+    });
+    // solved な ep01 は提出欄を出さず success Alert を表示、 未 solved な ep02 だけ input 1 個。
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
+    expect(screen.getByText("🎉 Ep01: Reachability — solved")).toBeInTheDocument();
+  });
+
+  it("should announce full clear when every flag is solved", () => {
+    renderPanel({
+      flags: FLAGS.map((f) => ({ ...f, solved: true })),
+    });
+    expect(screen.getByText("Flags solved: 2 / 2")).toBeInTheDocument();
+    expect(screen.getByText("All flags solved. This problem is fully cleared!")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("should call submitFlag with the flag id of the row being submitted", async () => {
+    const user = userEvent.setup();
+    const onScored = vi.fn().mockResolvedValue(undefined);
+    apiMocks.submitFlag.mockResolvedValue({
+      kind: "ok",
+      scoreDelta: 200,
+      totalScore: 200,
+      flagId: "ep02",
+    });
+    renderPanel({ onScored });
+    // 2 番目の行 (ep02) に入力して提出する。
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[1], "answer-ep02");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[1]);
+    await waitFor(() =>
+      expect(apiMocks.submitFlag).toHaveBeenCalledWith(
+        "https://api.example.com",
+        "team-key",
+        "net-evo",
+        "answer-ep02",
+        "ep02",
+      ),
+    );
+    expect(onScored).toHaveBeenCalled();
+    expect(await screen.findByText("🎉 Ep02: TCP/IP — solved")).toBeInTheDocument();
+  });
+
+  it("should not submit an empty flag", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(apiMocks.submitFlag).not.toHaveBeenCalled();
+  });
+
+  it("should show a penalty warning on a wrong backend submission", async () => {
+    const user = userEvent.setup();
+    apiMocks.submitFlag.mockResolvedValue({
+      kind: "wrong",
+      scoreDelta: -10,
+      totalScore: 40,
+      wrongCount: 2,
+    });
+    renderPanel();
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[0], "bad");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(await screen.findByText("Wrong (-10 pt) — total 40 pt")).toBeInTheDocument();
+  });
+
+  it("should show the already-scored info when a flag was scored elsewhere", async () => {
+    const user = userEvent.setup();
+    apiMocks.submitFlag.mockResolvedValue({ kind: "already_scored", totalScore: 300 });
+    renderPanel();
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[0], "late");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(await screen.findByText("Already solved (total 300 pt).")).toBeInTheDocument();
+  });
+
+  it("should surface a submit error", async () => {
+    const user = userEvent.setup();
+    apiMocks.submitFlag.mockRejectedValue(new Error("server boom"));
+    renderPanel();
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[0], "x");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(await screen.findByText("server boom")).toBeInTheDocument();
+  });
+
+  it("should evaluate locally in dev-mock mode without calling the backend", async () => {
+    const user = userEvent.setup();
+    renderPanel({}, "dev-mock");
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[0], "tenkacloudsample");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(await screen.findByText("🎉 Ep01: Reachability — solved")).toBeInTheDocument();
+    expect(apiMocks.submitFlag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
+++ b/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
@@ -144,6 +144,23 @@ describe("MultiFlagSubmissionPanel", () => {
     expect(await screen.findByText("Wrong (-10 pt) — total 40 pt")).toBeInTheDocument();
   });
 
+  it("should show a plain wrong warning when the flag carries no penalty", async () => {
+    const user = userEvent.setup();
+    apiMocks.submitFlag.mockResolvedValue({
+      kind: "wrong",
+      scoreDelta: 0,
+      totalScore: 50,
+      wrongCount: 1,
+    });
+    renderPanel();
+    const inputs = screen.getAllByRole("textbox");
+    await user.type(inputs[0], "bad");
+    const buttons = screen.getAllByRole("button", { name: /^Submit/ });
+    await user.click(buttons[0]);
+    expect(await screen.findByText("Wrong")).toBeInTheDocument();
+    expect(screen.getByText("Check the value and try again.")).toBeInTheDocument();
+  });
+
   it("should show the already-scored info when a flag was scored elsewhere", async () => {
     const user = userEvent.setup();
     apiMocks.submitFlag.mockResolvedValue({ kind: "already_scored", totalScore: 300 });

--- a/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
+++ b/apps/participant-portal/src/components/MultiFlagSubmissionPanel.test.tsx
@@ -74,10 +74,7 @@ describe("MultiFlagSubmissionPanel", () => {
 
   it("should show a solved alert and no input for an already-solved flag", () => {
     renderPanel({
-      flags: [
-        { ...FLAGS[0], solved: true },
-        FLAGS[1],
-      ],
+      flags: [{ ...FLAGS[0], solved: true }, FLAGS[1]],
     });
     // solved な ep01 は提出欄を出さず success Alert を表示、 未 solved な ep02 だけ input 1 個。
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
@@ -89,7 +86,9 @@ describe("MultiFlagSubmissionPanel", () => {
       flags: FLAGS.map((f) => ({ ...f, solved: true })),
     });
     expect(screen.getByText("Flags solved: 2 / 2")).toBeInTheDocument();
-    expect(screen.getByText("All flags solved. This problem is fully cleared!")).toBeInTheDocument();
+    expect(
+      screen.getByText("All flags solved. This problem is fully cleared!"),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 

--- a/apps/participant-portal/src/components/MultiFlagSubmissionPanel.tsx
+++ b/apps/participant-portal/src/components/MultiFlagSubmissionPanel.tsx
@@ -1,16 +1,11 @@
 import Alert from "@cloudscape-design/components/alert";
-import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
-import {
-  type MultiFlagEntryView,
-  type SubmitFlagOutcome,
-  submitFlag,
-} from "../api/portal-client";
+import { type MultiFlagEntryView, type SubmitFlagOutcome, submitFlag } from "../api/portal-client";
 import { useIsMock } from "../config-context";
 import { evaluateMockFlag } from "../dev-mock/flag-submit";
 import { useT } from "../i18n";

--- a/apps/participant-portal/src/components/MultiFlagSubmissionPanel.tsx
+++ b/apps/participant-portal/src/components/MultiFlagSubmissionPanel.tsx
@@ -1,0 +1,185 @@
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Input from "@cloudscape-design/components/input";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+import {
+  type MultiFlagEntryView,
+  type SubmitFlagOutcome,
+  submitFlag,
+} from "../api/portal-client";
+import { useIsMock } from "../config-context";
+import { evaluateMockFlag } from "../dev-mock/flag-submit";
+import { useT } from "../i18n";
+import { CelebrationOverlay } from "./CelebrationOverlay";
+import { formatProblemPanelActionError } from "./ProblemPanel.helpers";
+
+/**
+ * Issue #1796: multi-flag kind の提出パネル。 1 問題に N 個の独立 flag を持ち、 競技者が各 flag を
+ * 別々に提出して個別加点される。 `ProblemPanelFlagSubmission` (= 単一 flag kind) を sub-flag ごとに
+ * 並べた構造で、 solved 表示 / 提出欄 / 状態 alert を flag 単位で持つ。
+ *
+ * - solved な flag: 「解答済 (+N pt)」 の success Alert
+ * - 未 solved な flag: label 付き Input + submit Button (= per-flag の submitting state)
+ * - dev-mock mode では backend を叩かず `evaluateMockFlag` で local 評価する
+ * - 正解後は `onScored()` で /portal/me を refetch し、 server truth (= solved 状態) を読み直す
+ *
+ * polling 以外の状態同期 (SSE / WebSocket) は使わない (AGENTS.md)。 refetch は親の polling と
+ * 正解直後の明示 refetch (= onScored) に閉じる。
+ */
+export function MultiFlagSubmissionPanel({
+  apiBaseUrl,
+  sessionToken,
+  problemId,
+  flags,
+  onScored,
+}: {
+  apiBaseUrl: string;
+  sessionToken: string;
+  problemId: string;
+  flags: readonly MultiFlagEntryView[];
+  onScored: () => Promise<void>;
+}) {
+  const t = useT();
+  const solvedCount = flags.filter((f) => f.solved).length;
+  const allSolved = flags.length > 0 && solvedCount === flags.length;
+
+  return (
+    <SpaceBetween size="s">
+      <Alert
+        type={allSolved ? "success" : "info"}
+        header={t("multi_flag.progress_header", { solved: solvedCount, total: flags.length })}
+      >
+        {allSolved ? t("multi_flag.all_solved_body") : t("multi_flag.progress_body")}
+      </Alert>
+      {flags.map((flag) => (
+        <SubFlagRow
+          key={flag.id}
+          apiBaseUrl={apiBaseUrl}
+          sessionToken={sessionToken}
+          problemId={problemId}
+          flag={flag}
+          onScored={onScored}
+        />
+      ))}
+    </SpaceBetween>
+  );
+}
+
+function SubFlagRow({
+  apiBaseUrl,
+  sessionToken,
+  problemId,
+  flag,
+  onScored,
+}: {
+  apiBaseUrl: string;
+  sessionToken: string;
+  problemId: string;
+  flag: MultiFlagEntryView;
+  onScored: () => Promise<void>;
+}) {
+  const t = useT();
+  // dev-mock mode のとき submit を backend に投げず evaluateMockFlag で local 評価する
+  // (= 単一 flag kind の FlagSubmissionPanel と同方針)。
+  const isMock = useIsMock();
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [outcome, setOutcome] = useState<SubmitFlagOutcome | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // 正解直後 (mock / backend 共通): 祝祭 + 獲得スコア。 server 由来の solved 表示も同じ success
+  // Alert に倒すので、 「refetch が空振りして solved に切り替わらない」 mock mode も吸収できる。
+  if (flag.solved || outcome?.kind === "ok") {
+    return (
+      <>
+        {outcome?.kind === "ok" && <CelebrationOverlay visible />}
+        <Alert type="success" header={t("multi_flag.solved_header", { label: flag.label })}>
+          {t("multi_flag.solved_body", { points: flag.points })}
+        </Alert>
+      </>
+    );
+  }
+
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+    if (value.trim().length === 0 || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    setOutcome(null);
+    try {
+      const result = isMock
+        ? evaluateMockFlag(value, flag.points)
+        : await submitFlag(apiBaseUrl, sessionToken, problemId, value, flag.id);
+      setOutcome(result);
+      if (!isMock && result.kind === "ok") await onScored();
+    } catch (err) {
+      setSubmitError(formatProblemPanelActionError(t, err, "problem_panel.submit_error_prefix"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SpaceBetween size="xs">
+      <form onSubmit={handleSubmit}>
+        <Form
+          actions={
+            <Button variant="primary" loading={submitting} formAction="submit">
+              {t("multi_flag.submit_button", { points: flag.points })}
+            </Button>
+          }
+        >
+          <FormField
+            label={t("multi_flag.flag_field_label", { label: flag.label })}
+            description={isMock ? t("problem_panel.flag_mock_hint") : undefined}
+          >
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.detail.value)}
+              placeholder={
+                isMock
+                  ? t("problem_panel.flag_mock_placeholder")
+                  : t("problem_panel.flag_placeholder")
+              }
+              disabled={submitting}
+            />
+          </FormField>
+        </Form>
+      </form>
+      {outcome?.kind === "wrong" && (
+        <Alert
+          type="warning"
+          header={
+            outcome.scoreDelta < 0
+              ? t("problem_panel.wrong_with_penalty_header", {
+                  delta: outcome.scoreDelta,
+                  total: outcome.totalScore,
+                })
+              : t("problem_panel.wrong_header")
+          }
+        >
+          {outcome.scoreDelta < 0
+            ? t("problem_panel.wrong_with_penalty_body", {
+                count: outcome.wrongCount,
+                penalty: -outcome.scoreDelta,
+              })
+            : t("problem_panel.wrong_body")}
+        </Alert>
+      )}
+      {outcome?.kind === "already_scored" && (
+        <Alert type="info" header={t("problem_panel.already_scored_header")}>
+          {t("problem_panel.already_scored_body", { total: outcome.totalScore })}
+        </Alert>
+      )}
+      {submitError && (
+        <Alert type="error" header={t("problem_panel.submit_failed_header")}>
+          {submitError}
+        </Alert>
+      )}
+    </SpaceBetween>
+  );
+}

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -457,6 +457,15 @@ describe("ProblemPanel render branches", () => {
     expect(screen.queryByTestId("flag-panel")).not.toBeInTheDocument();
   });
 
+  it("should render the multi-flag panel even when flags is omitted", () => {
+    // scoring.flags 不在でも panel は出す (= `flags ?? []` の fallback 分岐を pin)。
+    renderPanel({
+      status: "COMPLETE",
+      scoring: { kind: "multi-flag", points: 0 },
+    });
+    expect(screen.getByTestId("multi-flag-panel")).toBeInTheDocument();
+  });
+
   it("should render stack outputs as a link for URLs and plain code otherwise", () => {
     renderPanel({
       status: "COMPLETE",

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -292,7 +292,9 @@ describe("ProblemPanel pure helpers", () => {
   it("should describe each scoring kind", () => {
     expect(describeProblemKind(echoT, undefined)).toBe("problem_panel.kind_unknown");
     expect(describeProblemKind(echoT, { kind: "flag" })).toBe("problem_panel.kind_flag");
-    expect(describeProblemKind(echoT, { kind: "multi-flag" })).toBe("problem_panel.kind_multi_flag");
+    expect(describeProblemKind(echoT, { kind: "multi-flag" })).toBe(
+      "problem_panel.kind_multi_flag",
+    );
     expect(describeProblemKind(echoT, { kind: "uptime-flat" })).toBe("problem_panel.kind_uptime");
     expect(describeProblemKind(echoT, { kind: "phased-polling" })).toBe(
       "problem_panel.kind_phased",

--- a/apps/participant-portal/src/components/ProblemPanel.test.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.test.tsx
@@ -13,6 +13,7 @@ import {
   describeProblemKind,
   formatTerminalTime,
   getCompleteFlagScoring,
+  getCompleteMultiFlagScoring,
   isStaleProblem,
   isUptimeScoring,
   mergeLiveDeployLog,
@@ -36,6 +37,10 @@ vi.mock("../api/portal-client", async (importOriginal) => {
 // FlagSubmissionPanel は #1480 で別途 100% 済。 ここでは ProblemPanel の flag 分岐だけ pin。
 vi.mock("./ProblemPanelFlagSubmission", () => ({
   FlagSubmissionPanel: () => <div data-testid="flag-panel" />,
+}));
+// MultiFlagSubmissionPanel は別 test (#1796) で網羅。 ここでは ProblemPanel の分岐だけ pin。
+vi.mock("./MultiFlagSubmissionPanel", () => ({
+  MultiFlagSubmissionPanel: () => <div data-testid="multi-flag-panel" />,
 }));
 
 function withI18n(node: React.ReactNode) {
@@ -287,6 +292,7 @@ describe("ProblemPanel pure helpers", () => {
   it("should describe each scoring kind", () => {
     expect(describeProblemKind(echoT, undefined)).toBe("problem_panel.kind_unknown");
     expect(describeProblemKind(echoT, { kind: "flag" })).toBe("problem_panel.kind_flag");
+    expect(describeProblemKind(echoT, { kind: "multi-flag" })).toBe("problem_panel.kind_multi_flag");
     expect(describeProblemKind(echoT, { kind: "uptime-flat" })).toBe("problem_panel.kind_uptime");
     expect(describeProblemKind(echoT, { kind: "phased-polling" })).toBe(
       "problem_panel.kind_phased",
@@ -302,6 +308,8 @@ describe("ProblemPanel pure helpers", () => {
   it("should classify uptime vs flag scoring", () => {
     expect(isUptimeScoring(undefined)).toBe(false);
     expect(isUptimeScoring({ kind: "flag" })).toBe(false);
+    // multi-flag も Challenge 軸 (= 提出型) なので uptime とは扱わない。
+    expect(isUptimeScoring({ kind: "multi-flag" })).toBe(false);
     expect(isUptimeScoring({ kind: "uptime" })).toBe(true);
   });
 
@@ -337,6 +345,19 @@ describe("ProblemPanel pure helpers", () => {
     ).toBeUndefined();
     expect(
       getCompleteFlagScoring(p({ status: "COMPLETE", scoring: { kind: "uptime" } })),
+    ).toBeUndefined();
+  });
+
+  it("should resolve a complete multi-flag scoring only when COMPLETE + multi-flag", () => {
+    const p = (over: Partial<ParticipantProblemView>) => ({ ...baseProblem, ...over });
+    expect(
+      getCompleteMultiFlagScoring(p({ status: "COMPLETE", scoring: { kind: "multi-flag" } })),
+    ).toBeDefined();
+    expect(
+      getCompleteMultiFlagScoring(p({ status: "IN_PROGRESS", scoring: { kind: "multi-flag" } })),
+    ).toBeUndefined();
+    expect(
+      getCompleteMultiFlagScoring(p({ status: "COMPLETE", scoring: { kind: "flag" } })),
     ).toBeUndefined();
   });
 
@@ -416,6 +437,22 @@ describe("ProblemPanel render branches", () => {
       scoring: { kind: "flag", flagSubmitted: false, points: 100 },
     });
     expect(screen.getByTestId("flag-panel")).toBeInTheDocument();
+  });
+
+  it("should render the multi-flag submission panel for a COMPLETE multi-flag problem", () => {
+    renderPanel({
+      status: "COMPLETE",
+      scoring: {
+        kind: "multi-flag",
+        points: 500,
+        flags: [
+          { id: "ep01", label: "Ep01", points: 300, solved: false },
+          { id: "ep02", label: "Ep02", points: 200, solved: false },
+        ],
+      },
+    });
+    expect(screen.getByTestId("multi-flag-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("flag-panel")).not.toBeInTheDocument();
   });
 
   it("should render stack outputs as a link for URLs and plain code otherwise", () => {

--- a/apps/participant-portal/src/components/ProblemPanel.tsx
+++ b/apps/participant-portal/src/components/ProblemPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "../api/portal-client";
 import { useT } from "../i18n";
 import { describeAgo } from "../lib/format";
+import { MultiFlagSubmissionPanel } from "./MultiFlagSubmissionPanel";
 import type { ProblemPanelT } from "./ProblemPanel.helpers";
 import { FlagSubmissionPanel } from "./ProblemPanelFlagSubmission";
 
@@ -37,6 +38,7 @@ const STATUS_TYPE: Record<DeploymentStatus, StatusIndicatorProps.Type> = {
 
 const SCORING_KIND_KEY: Record<string, string> = {
   flag: "problem_panel.kind_flag",
+  "multi-flag": "problem_panel.kind_multi_flag",
   uptime: "problem_panel.kind_uptime",
   "uptime-flat": "problem_panel.kind_uptime",
   "uptime-multi": "problem_panel.kind_uptime",
@@ -155,7 +157,9 @@ export function describeProblemKind(
 }
 
 export function isUptimeScoring(scoring: ParticipantProblemView["scoring"]): boolean {
-  return scoring ? scoring.kind !== "flag" : false;
+  // flag / multi-flag は Challenge (= 提出型)。 それ以外 (uptime 系 / phased / attack) は Battle 軸の
+  // 「古い lastScoredAt = stale」 UX を適用する (= polling 採点だから停滞が意味を持つ)。
+  return scoring ? scoring.kind !== "flag" && scoring.kind !== "multi-flag" : false;
 }
 
 export function isStaleProblem(problem: ParticipantProblemView, now: number): boolean {
@@ -173,6 +177,19 @@ export function getCompleteFlagScoring(
 ): FlagScoringInfo | undefined {
   const scoring = problem.scoring;
   if (problem.status !== "COMPLETE" || scoring?.kind !== "flag") return undefined;
+  return scoring;
+}
+
+/**
+ * Issue #1796: deploy COMPLETE かつ multi-flag kind のときだけ MultiFlagSubmissionPanel を出す
+ * (= 単一 flag kind の getCompleteFlagScoring と同方針。 deploy 未完だと flagOutputKey の値が無く
+ * 提出しても no_outputs になるため)。
+ */
+export function getCompleteMultiFlagScoring(
+  problem: ParticipantProblemView,
+): FlagScoringInfo | undefined {
+  const scoring = problem.scoring;
+  if (problem.status !== "COMPLETE" || scoring?.kind !== "multi-flag") return undefined;
   return scoring;
 }
 
@@ -239,6 +256,7 @@ export function ProblemPanel({
   const isStale = isStaleProblem(problem, now);
   const displayedDeployLog = selectDisplayedDeployLog(liveDeployLog, problem.deployLog);
   const flagScoring = getCompleteFlagScoring(problem);
+  const multiFlagScoring = getCompleteMultiFlagScoring(problem);
 
   return (
     <Container
@@ -313,6 +331,15 @@ export function ProblemPanel({
             flagSubmitted={flagScoring.flagSubmitted ?? false}
             points={flagScoring.points ?? 0}
             hints={flagScoring.hints ?? []}
+            onScored={onScored}
+          />
+        )}
+        {multiFlagScoring && (
+          <MultiFlagSubmissionPanel
+            apiBaseUrl={apiBaseUrl}
+            sessionToken={sessionToken}
+            problemId={problem.problemId}
+            flags={multiFlagScoring.flags ?? []}
             onScored={onScored}
           />
         )}

--- a/apps/participant-portal/src/i18n/locales/en.json
+++ b/apps/participant-portal/src/i18n/locales/en.json
@@ -273,6 +273,7 @@
   },
   "problem_panel": {
     "kind_flag": "Challenge (flag submission)",
+    "kind_multi_flag": "Challenge (multiple flags)",
     "kind_uptime": "Battle (uptime points)",
     "kind_phased": "Battle (time-phased scoring)",
     "kind_attack": "Battle (attack detection)",
@@ -330,6 +331,15 @@
     "hint_predecessor_required": "Reveal Hint {index} first.",
     "hint_predecessor_required_aria": "Reveal Hint {index} first before unlocking this one.",
     "hint_out_of_order_error": "Reveal Hint {index} first before this one."
+  },
+  "multi_flag": {
+    "progress_header": "Flags solved: {solved} / {total}",
+    "progress_body": "Submit each flag independently. Every flag scores on its own.",
+    "all_solved_body": "All flags solved. This problem is fully cleared!",
+    "solved_header": "🎉 {label} — solved",
+    "solved_body": "You earned +{points} pt for this flag.",
+    "submit_button": "Submit (+{points} pt)",
+    "flag_field_label": "{label} (Stack Output value)"
   },
   "score_timeline": {
     "header": "Score timeline",

--- a/apps/participant-portal/src/i18n/locales/ja.json
+++ b/apps/participant-portal/src/i18n/locales/ja.json
@@ -273,6 +273,7 @@
   },
   "problem_panel": {
     "kind_flag": "Challenge (flag 提出)",
+    "kind_multi_flag": "Challenge (複数 flag)",
     "kind_uptime": "Battle (uptime 加点)",
     "kind_phased": "Battle (時間経過で加点ルール変動)",
     "kind_attack": "Battle (攻撃 detection)",
@@ -330,6 +331,15 @@
     "hint_predecessor_required": "ヒント {index} を先に公開してください。",
     "hint_predecessor_required_aria": "ヒント {index} を先に公開すると、このヒントが公開できます。",
     "hint_out_of_order_error": "ヒント {index} を先に公開してください。"
+  },
+  "multi_flag": {
+    "progress_header": "解答した flag: {solved} / {total}",
+    "progress_body": "各 flag を個別に提出できます。 flag ごとに独立して加点されます。",
+    "all_solved_body": "全 flag を解答しました。 この問題は完全クリアです！",
+    "solved_header": "🎉 {label} — 解答済",
+    "solved_body": "この flag で +{points} pt を獲得しました。",
+    "submit_button": "提出 (+{points} pt)",
+    "flag_field_label": "{label} (Stack Output 値)"
   },
   "score_timeline": {
     "header": "スコア推移",

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -349,6 +349,33 @@ describe("submitFlag", () => {
       PortalScoringGateError,
     );
   });
+
+  it("should omit flagId from the body for the single flag kind", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ kind: "ok", scoreDelta: 100, totalScore: 100 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await submitFlag("https://x", KEY, "hello-world", "FLAG{demo}");
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body).toEqual({ problemId: "hello-world", flag: "FLAG{demo}" });
+  });
+
+  it("should include flagId in the body for multi-flag submissions (Issue #1796)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await submitFlag("https://x", KEY, "net-evo", "answer", "ep01");
+    expect(out).toEqual({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" });
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body).toEqual({ problemId: "net-evo", flag: "answer", flagId: "ep01" });
+  });
 });
 
 describe("deleteProblemEndpointOverride", () => {

--- a/apps/participant-portal/test/api/portal-client.test.ts
+++ b/apps/participant-portal/test/api/portal-client.test.ts
@@ -364,12 +364,14 @@ describe("submitFlag", () => {
   });
 
   it("should include flagId in the body for multi-flag submissions (Issue #1796)", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
     vi.stubGlobal("fetch", fetchMock);
     const out = await submitFlag("https://x", KEY, "net-evo", "answer", "ep01");
     expect(out).toEqual({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" });

--- a/apps/participant-portal/test/lib/category.test.ts
+++ b/apps/participant-portal/test/lib/category.test.ts
@@ -17,6 +17,11 @@ describe("categoryOf", () => {
     expect(categoryOf(scoring)).toBe("challenge");
   });
 
+  it("should return challenge for kind=multi-flag (Issue #1796 — submission axis)", () => {
+    const scoring: ParticipantScoringInfo = { kind: "multi-flag", points: 500, flags: [] };
+    expect(categoryOf(scoring)).toBe("challenge");
+  });
+
   it("should return battle for kind=phased-polling (#688 regression — phased-polling is on the battle axis)", () => {
     const scoring: ParticipantScoringInfo = { kind: "phased-polling" };
     expect(categoryOf(scoring)).toBe("battle");

--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/types.ts
@@ -140,6 +140,13 @@ export interface DeploymentItem {
    */
   flagSubmitted?: boolean;
   /**
+   * Issue #1796: multi-flag kind で正解済みの sub-flag id の集合。 DynamoDB の String Set (SS)
+   * として保持し、 lib-dynamodb が JS `Set<string>` ↔ SS を marshal する。 旧 row / 手書き行は
+   * 持たない (= 「未解答」 と等価) ので、 単一 `flagSubmitted` boolean を集合へ拡張した形。
+   * flag ごとに 1 回だけ ADD し、 `ConditionExpression` で 2 重加算を防ぐ。
+   */
+  solvedFlagIds?: ReadonlySet<string>;
+  /**
    * Issue #817: Challenge (flag) で不正解 submit を受けた累計回数。 0 default。
    * `wrongAnswerPenalty > 0` の問題で 1 不正解ごとに ADD 1 + score 減算する経路で使う。
    */

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/index.ts
@@ -300,6 +300,7 @@ async function handleSubmitFlag(c: Context, token: string): Promise<Response> {
     token,
     parsed.data.problemId,
     parsed.data.flag,
+    parsed.data.flagId,
   );
   return respondSubmitFlagOutcome(c, outcome);
 }
@@ -330,6 +331,8 @@ function respondSubmitFlagOutcome(
   if (
     outcome.kind === "unauthorized" ||
     outcome.kind === "not_flag_problem" ||
+    // Issue #1796: multi-flag で flagId 不正 / 未指定。 unknown_hint と同じ NOT_FOUND family。
+    outcome.kind === "unknown_flag" ||
     outcome.kind === "no_outputs" ||
     outcome.kind === "scoring_locked"
   ) {

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -176,6 +176,26 @@ export interface ParticipantTeamView {
  * 情報だけ (= flagOutputKey の値は出さない、kind / points / hints のみ) を含める。
  * stackOutputs からも flagOutputKey フィールドは strip し、答えが見えないようにする。
  */
+/**
+ * stackOutputs から「答え」になる flagOutputKey を strip する (= 競技者に出さない)。
+ *   - flag       : 単一 flagOutputKey を削除
+ *   - multi-flag : 全 sub-flag の flagOutputKey を削除 (Issue #1796。 1 つでも露出させない)
+ *   - その他     : 何もしない (= uptime 系等は flagOutputKey を持たない)
+ */
+function stripAnswerOutputs(
+  stackOutputs: Record<string, string>,
+  scoring: ProblemScoringMetadata | undefined,
+): Record<string, string> {
+  if (scoring?.kind === "flag") {
+    delete stackOutputs[scoring.flagOutputKey];
+  } else if (scoring?.kind === "multi-flag") {
+    for (const f of scoring.flags) {
+      delete stackOutputs[f.flagOutputKey];
+    }
+  }
+  return stackOutputs;
+}
+
 export function toProblemView(
   item: Partial<DeploymentItem>,
   scoringMap: Record<string, ProblemScoringMetadata> = {},
@@ -183,17 +203,8 @@ export function toProblemView(
   const status = (item.status ?? "PENDING") as DeploymentStatus;
   if (DELETED_LIKE_STATUSES.has(status)) return undefined;
 
-  const stackOutputs = parseStackOutputs(item.stackOutputs);
   const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
-  if (scoring?.kind === "flag") {
-    delete stackOutputs[scoring.flagOutputKey];
-  } else if (scoring?.kind === "multi-flag") {
-    // Issue #1796: 全 sub-flag の flagOutputKey を strip する (= どれも当てる対象なので
-    // 1 つでも露出させない)。
-    for (const f of scoring.flags) {
-      delete stackOutputs[f.flagOutputKey];
-    }
-  }
+  const stackOutputs = stripAnswerOutputs(parseStackOutputs(item.stackOutputs), scoring);
 
   return {
     jobId: String(item.jobId ?? ""),

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/lookup.ts
@@ -6,6 +6,7 @@ import { parseEndpointsHealth } from "../shared/endpoints-health.js";
 import { parseHintRevealedAttribute } from "../shared/hint-reveal.js";
 import { evaluateGate, type GateBlock, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
+import { getSolvedFlagIds } from "./submit-flag.js";
 
 /**
  * 1 teamLoginKey = 1 team (= N deployments) として view を構成する。
@@ -41,6 +42,7 @@ export interface ParticipantHintView {
 export interface ParticipantScoringInfo {
   readonly kind:
     | "flag"
+    | "multi-flag"
     | "uptime"
     | "uptime-flat"
     | "uptime-multi"
@@ -50,6 +52,17 @@ export interface ParticipantScoringInfo {
   readonly pointsPerSuccess?: number;
   readonly pointsAllOk?: number;
   readonly pointsPerAttack?: number;
+  /**
+   * Issue #1796: multi-flag の sub-flag 一覧 (= portal が N 個の提出欄を出すための view)。
+   * `solved` は team の `solvedFlagIds` に id が入っているかで判定する。 正解値 (flagOutputKey の
+   * 値) は出さない (= 単一 flag kind の flagOutputKey strip と同方針)。
+   */
+  readonly flags?: readonly {
+    readonly id: string;
+    readonly label: string;
+    readonly points: number;
+    readonly solved: boolean;
+  }[];
   /**
    * Issue #742 Phase 4: progressive hint。 revealed=false な hint は content を持たず、
    * frontend は locked 表示 + reveal button を出す。 revealed=true は content を含み
@@ -174,6 +187,12 @@ export function toProblemView(
   const scoring = item.problemId ? scoringMap[item.problemId] : undefined;
   if (scoring?.kind === "flag") {
     delete stackOutputs[scoring.flagOutputKey];
+  } else if (scoring?.kind === "multi-flag") {
+    // Issue #1796: 全 sub-flag の flagOutputKey を strip する (= どれも当てる対象なので
+    // 1 つでも露出させない)。
+    for (const f of scoring.flags) {
+      delete stackOutputs[f.flagOutputKey];
+    }
   }
 
   return {
@@ -315,6 +334,24 @@ function toScoringInfo(
       points: scoring.points,
       ...(hintViews ? { hints: hintViews } : {}),
       flagSubmitted: item.flagSubmitted === true,
+    };
+  }
+  if (scoring.kind === "multi-flag") {
+    // Issue #1796: 各 sub-flag を { id, label, points, solved } で出す。 solved は team の
+    // solvedFlagIds (= String Set) に id が含まれるかで判定。 points は全 sub-flag の合計を
+    // 問題の満点として返す (= 部分点の母数)。
+    // per-flag hints は本 Phase では portal に露出しない (= 後続課題。 reveal-hint も multi-flag を
+    // not_flag_problem として reject し続ける)。
+    const solved = getSolvedFlagIds(item);
+    return {
+      kind: "multi-flag",
+      points: scoring.flags.reduce((sum, f) => sum + f.points, 0),
+      flags: scoring.flags.map((f) => ({
+        id: f.id,
+        label: f.label,
+        points: f.points,
+        solved: solved.has(f.id),
+      })),
     };
   }
   if (scoring.kind === "uptime" || scoring.kind === "uptime-flat") {

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/route-helpers.ts
@@ -28,6 +28,9 @@ const ERROR_STATUS = {
   not_flag_problem: StatusCodes.BAD_REQUEST,
   invalid_hint_id: StatusCodes.BAD_REQUEST,
   unknown_hint: StatusCodes.NOT_FOUND,
+  // Issue #1796: multi-flag で flagId が未指定 / metadata の flags[] に無い id。 unknown_hint と
+  // 同じ NOT_FOUND family (= 指定された sub-flag が存在しない)。
+  unknown_flag: StatusCodes.NOT_FOUND,
   // Issue #1315: progressive hint の順序違反 (= Hint 1 未 reveal で Hint 2 を request)。
   // 409 (= 状態的に受け付けない、 scoring_locked と同じ conflict 系) + body に missingHintId。
   hint_out_of_order: StatusCodes.CONFLICT,

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/schemas.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/schemas.ts
@@ -79,12 +79,16 @@ export const PatchMeBodySchema = z.object({
 export type PatchMeBody = z.infer<typeof PatchMeBodySchema>;
 
 /**
- * POST /portal/me/submit-flag — { problemId, flag }。 旧 index.ts は service に渡す前に
+ * POST /portal/me/submit-flag — { problemId, flag, flagId? }。 旧 index.ts は service に渡す前に
  * regex / length check を index.ts で並べていた。 schema layer に集約。
+ *
+ * Issue #1796: multi-flag kind で「どの sub-flag への提出か」 を表す optional `flagId`。 単一 flag
+ * kind は無視する (= 後方互換)。 cap は hint id と同じ 1-64 文字。
  */
 export const SubmitFlagBodySchema = z.object({
   problemId: ProblemIdSchema,
   flag: z.string().min(1).max(200),
+  flagId: z.string().min(1).max(64).optional(),
 });
 export type SubmitFlagBody = z.infer<typeof SubmitFlagBodySchema>;
 

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/submit-flag.ts
@@ -1,6 +1,7 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import type {
   FlagScoringMetadata,
+  MultiFlagEntry,
   ProblemScoringMetadata,
 } from "../../../utils/scoring-metadata.js";
 import type { DeploymentItem } from "../deploy-handler/types.js";
@@ -11,7 +12,11 @@ import { evaluateGate, getEventGate } from "./event-gate.js";
 import { type ParticipantSharedResources, queryTeamItems } from "./shared.js";
 
 export type SubmitFlagOutcome =
-  | { kind: "ok"; scoreDelta: number; totalScore: number }
+  /**
+   * Issue #1796: multi-flag では `flagId` を含めて返し (= どの sub-flag が解けたか)、
+   * 単一 flag kind では flagId 無し (= 互換)。
+   */
+  | { kind: "ok"; scoreDelta: number; totalScore: number; flagId?: string }
   | { kind: "already_scored"; totalScore: number }
   /**
    * Issue #817: 不正解。 wrongAnswerPenalty が問題 metadata で正の整数で設定されていれば
@@ -20,6 +25,11 @@ export type SubmitFlagOutcome =
    */
   | { kind: "wrong"; scoreDelta: number; totalScore: number; wrongCount: number }
   | { kind: "not_flag_problem" }
+  /**
+   * Issue #1796: multi-flag で flagId が指定されていない / metadata の flags[] に存在しない id。
+   * 単一 flag kind は flagId を無視するのでこの outcome は返さない。
+   */
+  | { kind: "unknown_flag" }
   | { kind: "no_outputs" }
   | { kind: "scoring_locked" }
   /**
@@ -40,9 +50,13 @@ export type SubmitFlagOutcome =
  * - team scope に該当行が無い (key 不正) は `unauthorized`
  * - team に該当 problemId が無い (= 違う event の問題を指定) は `unauthorized`
  *   (= problem の存在を漏らさない)
- * - kind=flag 以外の問題は `not_flag_problem`
+ * - kind=flag / multi-flag 以外の問題は `not_flag_problem`
  * - stackOutputs に flagOutputKey が無い (= deploy 未完了等) は `no_outputs`
  * - 既に flagSubmitted=true なら `already_scored` (= 重複加算しない)
+ *
+ * Issue #1796: multi-flag では `flagId` でどの sub-flag への提出かを受け取り、その flag の
+ * flagOutputKey と照合する (= 単一 flag kind は flagId を無視して従来挙動を保つ)。 解済 flag は
+ * `solvedFlagIds` (String Set) に蓄積し、 flag ごとに 1 回だけ加点する (= 冪等)。
  */
 export async function submitFlag(
   shared: ParticipantSharedResources,
@@ -50,6 +64,7 @@ export async function submitFlag(
   teamLoginKey: string,
   problemId: string,
   submittedFlag: string,
+  flagId?: string,
 ): Promise<SubmitFlagOutcome> {
   const items = await queryTeamItems(shared, teamLoginKey);
   if (items.length === 0) return { kind: "unauthorized" };
@@ -65,6 +80,10 @@ export async function submitFlag(
   if (blocked) return blocked;
 
   const scoring = scoringMap[item.problemId];
+  // Issue #1796: multi-flag は gate を通過した後の照合経路だけが分岐する (= gate / 認可は共通)。
+  if (scoring?.kind === "multi-flag") {
+    return submitMultiFlag(shared, item, scoring.flags, submittedFlag, flagId);
+  }
   if (scoring?.kind !== "flag") return { kind: "not_flag_problem" };
 
   if (item.flagSubmitted === true) {
@@ -80,6 +99,161 @@ export async function submitFlag(
   }
 
   return scoreCorrectFlag(shared, item, scoring);
+}
+
+/**
+ * Issue #1796: solvedFlagIds attribute を寛容に `ReadonlySet<string>` へ正規化する。
+ *
+ * lib-dynamodb は JS `Set<string>` ↔ DynamoDB String Set (SS) を marshal するので通常は Set で
+ * 戻るが、 旧 SDK / 手書き row 由来の string[] や、 未設定 (undefined) も握れるようにする
+ * (= DB row drift / 移行期の防御層、 ADR-008 と整合)。 lookup.ts も同 helper を再利用する。
+ */
+export function getSolvedFlagIds(item: Partial<DeploymentItem>): ReadonlySet<string> {
+  const raw = (item as { solvedFlagIds?: unknown }).solvedFlagIds;
+  if (raw instanceof Set) {
+    return new Set(Array.from(raw, String));
+  }
+  if (Array.isArray(raw)) {
+    return new Set(raw.filter((v): v is string => typeof v === "string"));
+  }
+  return new Set<string>();
+}
+
+/**
+ * Issue #1796: multi-flag の照合 + 加点経路。 flagId で対象 sub-flag を引き、 その flagOutputKey の
+ * stack output 値と `flagMatches` (= 定数時間比較を再利用) で照合する。 解済 flag は
+ * `solvedFlagIds` (String Set) に蓄積し、 flag ごとに 1 回だけ加点する (= 冪等、 ConditionExpression で race を防ぐ)。
+ */
+async function submitMultiFlag(
+  shared: ParticipantSharedResources,
+  item: Partial<DeploymentItem> & { PK: string; problemId: string },
+  flags: readonly MultiFlagEntry[],
+  submittedFlag: string,
+  flagId: string | undefined,
+): Promise<SubmitFlagOutcome> {
+  const entry = flagId ? flags.find((f) => f.id === flagId) : undefined;
+  // flagId 未指定 / metadata の flags[] に無い id は unknown_flag (= 単一 flag kind の挙動とは別)。
+  if (!entry || flagId === undefined) return { kind: "unknown_flag" };
+
+  // 既に解済の flag は重複加算しない (= per-flag 冪等)。 totalScore は header の累計を返す。
+  if (getSolvedFlagIds(item).has(entry.id)) {
+    return { kind: "already_scored", totalScore: Number(item.score ?? 0) };
+  }
+
+  const outputs = parseStackOutputs(item.stackOutputs);
+  const expected = outputs[entry.flagOutputKey];
+  if (typeof expected !== "string") return { kind: "no_outputs" };
+
+  if (!flagMatches(submittedFlag, expected)) {
+    return scoreWrongMultiFlag(shared, item, entry);
+  }
+  return scoreCorrectMultiFlag(shared, item, entry);
+}
+
+async function scoreCorrectMultiFlag(
+  shared: ParticipantSharedResources,
+  item: Partial<DeploymentItem> & { PK: string; problemId: string },
+  entry: MultiFlagEntry,
+): Promise<SubmitFlagOutcome> {
+  // solvedFlagIds に entry.id が未収録のときだけ ADD する (= 2 重加算をレースから守る)。
+  const now = new Date().toISOString();
+  try {
+    const updated = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: item.PK, SK: "META" },
+        UpdateExpression:
+          "ADD score :pts, solvedFlagIds :flagIdSet SET lastScoredAt = :now, updatedAt = :now",
+        ConditionExpression:
+          "attribute_not_exists(solvedFlagIds) OR NOT contains(solvedFlagIds, :flagId)",
+        ExpressionAttributeValues: {
+          ":pts": entry.points,
+          ":flagIdSet": new Set([entry.id]),
+          ":flagId": entry.id,
+          ":now": now,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const totalScore = Number(
+      (updated.Attributes as { score?: unknown })?.score ?? Number(item.score ?? 0) + entry.points,
+    );
+    // 加点成功時のみ score event 行を append (= 単一 flag kind と同じ「flag」source を踏襲)。
+    if (item.jobId) await writeMultiFlagScoreEvent(shared, item, "flag", entry.points, now);
+    return { kind: "ok", scoreDelta: entry.points, totalScore, flagId: entry.id };
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ConditionalCheckFailedException") {
+      return { kind: "already_scored", totalScore: Number(item.score ?? 0) + entry.points };
+    }
+    throw err;
+  }
+}
+
+async function scoreWrongMultiFlag(
+  shared: ParticipantSharedResources,
+  item: Partial<DeploymentItem> & { PK: string; problemId: string },
+  entry: MultiFlagEntry,
+): Promise<SubmitFlagOutcome> {
+  const penalty = entry.wrongAnswerPenalty ?? 0;
+  // penalty 無し (= 0 / 未設定) は単一 flag kind と同じ legacy wrong shape (= 加点経路を打たない)。
+  if (penalty === 0) return legacyWrongFlagOutcome(item);
+  const now = new Date().toISOString();
+  try {
+    // 既に解済の flag は減点しない (= correct 経路と同じ not-already-solved condition)。
+    const updated = await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.tableName,
+        Key: { PK: item.PK, SK: "META" },
+        UpdateExpression: "ADD wrongAnswerCount :one, score :neg SET updatedAt = :now",
+        ConditionExpression:
+          "attribute_not_exists(solvedFlagIds) OR NOT contains(solvedFlagIds, :flagId)",
+        ExpressionAttributeValues: {
+          ":one": 1,
+          ":neg": -penalty,
+          ":flagId": entry.id,
+          ":now": now,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    const attrs = updated.Attributes as { score?: unknown; wrongAnswerCount?: unknown } | undefined;
+    const rawScore = Number(attrs?.score ?? 0);
+    if (item.jobId) await writeMultiFlagScoreEvent(shared, item, "flag-wrong", -penalty, now);
+    return {
+      kind: "wrong",
+      scoreDelta: -penalty,
+      totalScore: rawScore < 0 ? 0 : rawScore,
+      wrongCount: Number(attrs?.wrongAnswerCount ?? 1),
+    };
+  } catch (err) {
+    if ((err as { name?: string })?.name === "ConditionalCheckFailedException") {
+      return { kind: "already_scored", totalScore: Number(item.score ?? 0) };
+    }
+    throw err;
+  }
+}
+
+function writeMultiFlagScoreEvent(
+  shared: ParticipantSharedResources,
+  item: Partial<DeploymentItem> & { problemId: string; jobId?: string },
+  source: "flag" | "flag-wrong",
+  points: number,
+  occurredAt: string,
+): Promise<void> {
+  return writeScoreEvent(
+    shared.ddb,
+    shared.tableName,
+    {
+      jobId: String(item.jobId ?? ""),
+      problemId: item.problemId,
+      teamId: item.teamId,
+      eventId: item.eventId,
+      expiresAt: item.expiresAt ?? 0,
+    },
+    source,
+    points,
+    occurredAt,
+  );
 }
 
 function isSubmitFlagItem(

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -47,6 +47,36 @@ export interface FlagScoringMetadata {
   readonly hints?: readonly ProgressiveHint[];
 }
 
+/**
+ * Issue #1796: multi-flag kind の sub-flag 1 件。 1 問題に N 個の独立 flag を持たせ、
+ * 競技者が各 flag を別々に提出して個別加点される (= ストーリー連作 Challenge を 1 問に統合)。
+ *
+ *   - id: 問題内で unique な stable identifier (= 解済 flag id 集合 `solvedFlagIds` の key、
+ *         submit-flag request の flagId と一致させる。 metadata 順序変更で記録が drift しない)
+ *   - label: portal UI に出す表示名 (= 「Ep01: Reachability」 等)
+ *   - flagOutputKey: 正解値を引く CFn Output key (= 単一 flag kind の flagOutputKey と同義)
+ *   - points: 正解時の加点
+ *   - wrongAnswerPenalty: 不正解 1 回ごとの減点 (= flag ごとに独立、 単一 flag kind と同契約)
+ *   - hints: per-flag progressive hint (= 型は確保するが reveal 経路は本 Phase 未対応)
+ */
+export interface MultiFlagEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly flagOutputKey: string;
+  readonly points: number;
+  readonly wrongAnswerPenalty?: number;
+  readonly hints?: readonly ProgressiveHint[];
+}
+
+/**
+ * Issue #1796: multi-flag kind。 N 個の独立 flag を 1 問題に持たせる。 各 flag の合計が
+ * 問題の満点になる (= 部分点)。 単一 flag kind は不変で温存し、 multi-flag は新規 opt-in。
+ */
+export interface MultiFlagScoringMetadata {
+  readonly kind: "multi-flag";
+  readonly flags: readonly MultiFlagEntry[];
+}
+
 export interface UptimeFlatEndpoint {
   /** metadata.endpoints[].slot を参照する場合の slot 名。 */
   readonly slot?: string;
@@ -172,6 +202,7 @@ export interface AttackDetectionScoringMetadata {
 
 export type ProblemScoringMetadata =
   | FlagScoringMetadata
+  | MultiFlagScoringMetadata
   | UptimeFlatScoringMetadata
   | UptimeMultiScoringMetadata
   | PhasedPollingScoringMetadata
@@ -188,6 +219,7 @@ export function parseScoringMetadata(value: unknown): ProblemScoringMetadata | u
   if (!value || typeof value !== "object") return undefined;
   const v = value as { kind?: unknown };
   if (v.kind === "flag") return parseFlag(value);
+  if (v.kind === "multi-flag") return parseMultiFlag(value);
   if (v.kind === "uptime" || v.kind === "uptime-flat") return parseUptimeFlat(value, v.kind);
   if (v.kind === "uptime-multi") return parseUptimeMulti(value);
   if (v.kind === "phased-polling") return parsePhasedPolling(value);
@@ -204,22 +236,79 @@ function parseFlag(value: unknown): FlagScoringMetadata | undefined {
   };
   if (typeof f.flagOutputKey !== "string") return undefined;
   if (typeof f.points !== "number" || !Number.isFinite(f.points) || f.points <= 0) return undefined;
-  // Issue #817: wrongAnswerPenalty は optional。 不正な値 (= 負 / 非整数 / 非数値) は undefined に
-  // clamp して fallback (= "no penalty" として安全側に倒す、 metadata typo で減点暴走を防ぐ)。
-  const penaltyRaw = f.wrongAnswerPenalty;
-  const wrongAnswerPenalty =
-    typeof penaltyRaw === "number" &&
-    Number.isFinite(penaltyRaw) &&
-    penaltyRaw >= 0 &&
-    Number.isInteger(penaltyRaw)
-      ? penaltyRaw
-      : undefined;
   return {
     kind: "flag",
     flagOutputKey: f.flagOutputKey,
     points: f.points,
-    wrongAnswerPenalty,
+    wrongAnswerPenalty: clampWrongAnswerPenalty(f.wrongAnswerPenalty),
     hints: parseHints(f.hints),
+  };
+}
+
+/**
+ * Issue #817: wrongAnswerPenalty は optional。 不正な値 (= 負 / 非整数 / 非数値) は undefined に
+ * clamp して fallback (= "no penalty" として安全側に倒す、 metadata typo で減点暴走を防ぐ)。
+ * Issue #1796: multi-flag の per-flag penalty も同契約を共有するため helper に切り出す。
+ */
+function clampWrongAnswerPenalty(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    Number.isInteger(value)
+    ? value
+    : undefined;
+}
+
+/**
+ * Issue #1796: multi-flag kind を narrow する。
+ *
+ * **partial-drop しない (= 1 つでも entry が不正なら object 全体を undefined に倒す)**。
+ * hints (parseHints) や uptime-flat の endpoints は不正要素を filter で落としても全体配点は
+ * 変わらないが、 multi-flag の flags[] は 1 件 = 問題の満点の一部 (= 部分点)。 不正 entry を
+ * 黙って drop すると問題の総得点が無言で変わり (= 競技者ごとに満点が違う事故)、 採点の公平性が
+ * 崩れる。 同様に id / flagOutputKey の重複も総得点や採点照合を壊すので reject する (= fail loud)。
+ */
+function parseMultiFlag(value: unknown): MultiFlagScoringMetadata | undefined {
+  const m = value as { flags?: unknown };
+  if (!Array.isArray(m.flags) || m.flags.length === 0) return undefined;
+
+  const flags: MultiFlagEntry[] = [];
+  const seenIds = new Set<string>();
+  const seenOutputKeys = new Set<string>();
+  for (const raw of m.flags) {
+    const entry = parseMultiFlagEntry(raw);
+    if (!entry) return undefined; // 1 件でも不正なら全体 reject (= 部分点が無言で変わるのを防ぐ)
+    if (seenIds.has(entry.id) || seenOutputKeys.has(entry.flagOutputKey)) return undefined;
+    seenIds.add(entry.id);
+    seenOutputKeys.add(entry.flagOutputKey);
+    flags.push(entry);
+  }
+  return { kind: "multi-flag", flags };
+}
+
+function parseMultiFlagEntry(value: unknown): MultiFlagEntry | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const e = value as {
+    id?: unknown;
+    label?: unknown;
+    flagOutputKey?: unknown;
+    points?: unknown;
+    wrongAnswerPenalty?: unknown;
+    hints?: unknown;
+  };
+  const id = optionalNonEmptyString(e.id);
+  const label = optionalNonEmptyString(e.label);
+  const flagOutputKey = optionalNonEmptyString(e.flagOutputKey);
+  if (!id || !label || !flagOutputKey) return undefined;
+  if (typeof e.points !== "number" || !Number.isFinite(e.points) || e.points <= 0) return undefined;
+  const hints = parseHints(e.hints);
+  return {
+    id,
+    label,
+    flagOutputKey,
+    points: e.points,
+    wrongAnswerPenalty: clampWrongAnswerPenalty(e.wrongAnswerPenalty),
+    ...(hints ? { hints } : {}),
   };
 }
 

--- a/infrastructure/test/problem-deploy/participant-lookup.test.ts
+++ b/infrastructure/test/problem-deploy/participant-lookup.test.ts
@@ -255,6 +255,68 @@ describe("lookupTeamByLoginKey (Phase 2c team scope)", () => {
     expect(view?.problems[0]?.scoring?.points).toBe(100);
   });
 
+  describe("multi-flag scoring view (Issue #1796)", () => {
+    const multiScoring = {
+      "security-battle-royale": {
+        kind: "multi-flag" as const,
+        flags: [
+          { id: "ep01", label: "Ep01", flagOutputKey: "AnswerFlagEp01", points: 300 },
+          { id: "ep02", label: "Ep02", flagOutputKey: "AnswerFlagEp02", points: 200 },
+        ],
+      },
+    };
+
+    it("should strip every sub-flag flagOutputKey from stackOutputs (prevent answer leak)", async () => {
+      const { shared, ddbSend } = buildShared(multiScoring);
+      ddbSend.mockResolvedValueOnce({
+        Items: [
+          sampleRow({
+            stackOutputs: JSON.stringify({
+              FrontendUrl: "https://x.example.com",
+              AnswerFlagEp01: "secret-1",
+              AnswerFlagEp02: "secret-2",
+            }),
+          }),
+        ],
+      });
+
+      const view = await lookupTeamByLoginKey(shared, "KEY1");
+      expect(view?.problems[0]?.stackOutputs).toEqual({ FrontendUrl: "https://x.example.com" });
+      const json = JSON.stringify(view);
+      expect(json).not.toContain("secret-1");
+      expect(json).not.toContain("secret-2");
+    });
+
+    it("should report the summed points and per-flag solved state from a String Set", async () => {
+      const { shared, ddbSend } = buildShared(multiScoring);
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ solvedFlagIds: new Set(["ep01"]) })] });
+
+      const scoring = (await lookupTeamByLoginKey(shared, "KEY1"))?.problems[0]?.scoring;
+      expect(scoring?.kind).toBe("multi-flag");
+      expect(scoring?.points).toBe(500); // 300 + 200
+      expect(scoring?.flags).toEqual([
+        { id: "ep01", label: "Ep01", points: 300, solved: true },
+        { id: "ep02", label: "Ep02", points: 200, solved: false },
+      ]);
+    });
+
+    it("should derive solved state from a plain string array too (row drift)", async () => {
+      const { shared, ddbSend } = buildShared(multiScoring);
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow({ solvedFlagIds: ["ep02"] })] });
+
+      const scoring = (await lookupTeamByLoginKey(shared, "KEY1"))?.problems[0]?.scoring;
+      expect(scoring?.flags?.map((f) => f.solved)).toEqual([false, true]);
+    });
+
+    it("should mark all flags unsolved when solvedFlagIds is absent", async () => {
+      const { shared, ddbSend } = buildShared(multiScoring);
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+
+      const scoring = (await lookupTeamByLoginKey(shared, "KEY1"))?.problems[0]?.scoring;
+      expect(scoring?.flags?.every((f) => !f.solved)).toBe(true);
+    });
+  });
+
   it("should include score / lastScoredAt / lastResult / scoring in the problem view", async () => {
     const scoring = {
       "security-battle-royale": { kind: "uptime" as const, pointsPerSuccess: 50 },

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -402,7 +402,9 @@ describe("submitFlag", () => {
       expect(ddbSend).toHaveBeenCalledTimes(3); // Query + UpdateItem + score event Put
       const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
       expect(updateCmd).toBeInstanceOf(UpdateCommand);
-      expect(updateCmd.input.UpdateExpression).toContain("ADD score :pts, solvedFlagIds :flagIdSet");
+      expect(updateCmd.input.UpdateExpression).toContain(
+        "ADD score :pts, solvedFlagIds :flagIdSet",
+      );
       expect(updateCmd.input.ConditionExpression).toContain("NOT contains(solvedFlagIds, :flagId)");
       expect(updateCmd.input.ExpressionAttributeValues?.[":pts"]).toBe(300);
       expect(updateCmd.input.ExpressionAttributeValues?.[":flagId"]).toBe("ep01");
@@ -522,7 +524,10 @@ describe("submitFlag", () => {
 
 describe("getSolvedFlagIds", () => {
   it("should normalize a DynamoDB String Set into a string set", () => {
-    expect([...getSolvedFlagIds({ solvedFlagIds: new Set(["a", "b"]) })].sort()).toEqual(["a", "b"]);
+    expect([...getSolvedFlagIds({ solvedFlagIds: new Set(["a", "b"]) })].sort()).toEqual([
+      "a",
+      "b",
+    ]);
   });
 
   it("should tolerate a plain string array (SDK / row drift)", () => {

--- a/infrastructure/test/problem-deploy/submit-flag.test.ts
+++ b/infrastructure/test/problem-deploy/submit-flag.test.ts
@@ -1,7 +1,10 @@
 import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParticipantSharedResources } from "../../lib/problem-deploy/handlers/participant-handler/shared";
-import { submitFlag } from "../../lib/problem-deploy/handlers/participant-handler/submit-flag";
+import {
+  getSolvedFlagIds,
+  submitFlag,
+} from "../../lib/problem-deploy/handlers/participant-handler/submit-flag";
 import type { ProblemScoringMetadata } from "../../lib/utils/scoring-metadata";
 
 function buildShared(): {
@@ -356,5 +359,177 @@ describe("submitFlag", () => {
       );
       expect(out.kind).toBe("ok");
     });
+  });
+
+  // ---- Issue #1796 / multi-flag kind ----
+  // 1 問題に N 個の独立 flag。 flagId でどの sub-flag への提出かを受け取り、 flag ごとに 1 回だけ
+  // 加点する (= 冪等)。 wrongAnswerPenalty は flag ごとに独立、 0 未満 clamp を維持。
+  describe("multi-flag kind (Issue #1796)", () => {
+    const multiRow = (over: Record<string, unknown> = {}) =>
+      sampleRow({
+        problemId: "net-evo",
+        stackOutputs: JSON.stringify([
+          { OutputKey: "AnswerFlagEp01", OutputValue: "answer-ep01" },
+          { OutputKey: "AnswerFlagEp02", OutputValue: "answer-ep02" },
+        ]),
+        ...over,
+      });
+
+    const multiScoring: Record<string, ProblemScoringMetadata> = {
+      "net-evo": {
+        kind: "multi-flag",
+        flags: [
+          { id: "ep01", label: "Ep01", flagOutputKey: "AnswerFlagEp01", points: 300 },
+          {
+            id: "ep02",
+            label: "Ep02",
+            flagOutputKey: "AnswerFlagEp02",
+            points: 200,
+            wrongAnswerPenalty: 10,
+          },
+        ],
+      },
+    };
+
+    it("should award points and return flagId on a correct sub-flag", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 0 })] });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 300 } });
+      ddbSend.mockResolvedValueOnce({}); // score event PutItem
+
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep01");
+
+      expect(out).toEqual({ kind: "ok", scoreDelta: 300, totalScore: 300, flagId: "ep01" });
+      expect(ddbSend).toHaveBeenCalledTimes(3); // Query + UpdateItem + score event Put
+      const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+      expect(updateCmd).toBeInstanceOf(UpdateCommand);
+      expect(updateCmd.input.UpdateExpression).toContain("ADD score :pts, solvedFlagIds :flagIdSet");
+      expect(updateCmd.input.ConditionExpression).toContain("NOT contains(solvedFlagIds, :flagId)");
+      expect(updateCmd.input.ExpressionAttributeValues?.[":pts"]).toBe(300);
+      expect(updateCmd.input.ExpressionAttributeValues?.[":flagId"]).toBe("ep01");
+      expect(updateCmd.input.ExpressionAttributeValues?.[":flagIdSet"]).toEqual(new Set(["ep01"]));
+    });
+
+    it("should write a score event with source 'flag' and the sub-flag points", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 0, jobId: "JOB1" })] });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 200 } });
+      ddbSend.mockResolvedValueOnce({});
+
+      await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep02", "ep02");
+
+      const putCmd = ddbSend.mock.calls[2]?.[0] as { input: { Item: Record<string, unknown> } };
+      expect(putCmd.input.Item.source).toBe("flag");
+      expect(putCmd.input.Item.points).toBe(200);
+    });
+
+    it("should return already_scored when the sub-flag id is in solvedFlagIds (Set)", async () => {
+      ddbSend.mockResolvedValueOnce({
+        Items: [multiRow({ score: 300, solvedFlagIds: new Set(["ep01"]) })],
+      });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep01");
+      expect(out).toEqual({ kind: "already_scored", totalScore: 300 });
+      expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ、 加点経路を打たない
+    });
+
+    it("should tolerate solvedFlagIds stored as a string array (drift) for already_scored", async () => {
+      ddbSend.mockResolvedValueOnce({
+        Items: [multiRow({ score: 300, solvedFlagIds: ["ep01"] })],
+      });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep01");
+      expect(out).toEqual({ kind: "already_scored", totalScore: 300 });
+    });
+
+    it("should fall to already_scored on a ConditionalCheckFailed race for a correct sub-flag", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 0 })] });
+      ddbSend.mockImplementationOnce(async () => {
+        const err: Error & { name?: string } = new Error("conditional check failed");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep01");
+      expect(out).toEqual({ kind: "already_scored", totalScore: 300 });
+    });
+
+    it("should return unknown_flag when flagId is missing", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow()] });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01");
+      expect(out).toEqual({ kind: "unknown_flag" });
+      expect(ddbSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return unknown_flag when flagId is not among the entries", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow()] });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep99");
+      expect(out).toEqual({ kind: "unknown_flag" });
+    });
+
+    it("should return no_outputs when the sub-flag flagOutputKey is absent from stackOutputs", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ stackOutputs: undefined })] });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "answer-ep01", "ep01");
+      expect(out).toEqual({ kind: "no_outputs" });
+    });
+
+    it("should deduct the per-flag penalty, write a flag-wrong event, and clamp totalScore at 0", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 5, wrongAnswerCount: 0 })] });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: -5, wrongAnswerCount: 1 } });
+      ddbSend.mockResolvedValueOnce({});
+
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "nope", "ep02");
+
+      expect(out).toEqual({ kind: "wrong", scoreDelta: -10, totalScore: 0, wrongCount: 1 });
+      const updateCmd = ddbSend.mock.calls[1]?.[0] as UpdateCommand;
+      expect(updateCmd.input.UpdateExpression).toContain("ADD wrongAnswerCount :one, score :neg");
+      expect(updateCmd.input.ConditionExpression).toContain("NOT contains(solvedFlagIds, :flagId)");
+      const putCmd = ddbSend.mock.calls[2]?.[0] as { input: { Item: Record<string, unknown> } };
+      expect(putCmd.input.Item.source).toBe("flag-wrong");
+      expect(putCmd.input.Item.points).toBe(-10);
+    });
+
+    it("should return the legacy wrong shape (scoreDelta 0, no UpdateItem) when the sub-flag has no penalty", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 25, wrongAnswerCount: 2 })] });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "nope", "ep01");
+      expect(out).toEqual({ kind: "wrong", scoreDelta: 0, totalScore: 25, wrongCount: 2 });
+      expect(ddbSend).toHaveBeenCalledTimes(1); // Query のみ (= penalty 無しは WCU を使わない)
+    });
+
+    it("should fall to already_scored on a ConditionalCheckFailed race for a wrong-with-penalty sub-flag", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [multiRow({ score: 200 })] });
+      ddbSend.mockImplementationOnce(async () => {
+        const err: Error & { name?: string } = new Error("conditional check failed");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      });
+      const out = await submitFlag(shared, multiScoring, "KEY", "net-evo", "nope", "ep02");
+      expect(out).toEqual({ kind: "already_scored", totalScore: 200 });
+    });
+
+    it("should keep the single flag kind byte-identical when a flagId is supplied (flagId ignored)", async () => {
+      ddbSend.mockResolvedValueOnce({ Items: [sampleRow()] });
+      ddbSend.mockResolvedValueOnce({ Attributes: { score: 100 } });
+      ddbSend.mockResolvedValueOnce({});
+      const out = await submitFlag(
+        shared,
+        flagScoring,
+        "KEY",
+        "hello-world",
+        "Hello from tc-hello-world-alpha",
+        "ignored-id",
+      );
+      // 単一 flag kind は flagId を無視し、 従来どおり flagId 無しの ok を返す。
+      expect(out).toEqual({ kind: "ok", scoreDelta: 100, totalScore: 100 });
+    });
+  });
+});
+
+describe("getSolvedFlagIds", () => {
+  it("should normalize a DynamoDB String Set into a string set", () => {
+    expect([...getSolvedFlagIds({ solvedFlagIds: new Set(["a", "b"]) })].sort()).toEqual(["a", "b"]);
+  });
+
+  it("should tolerate a plain string array (SDK / row drift)", () => {
+    expect([...getSolvedFlagIds({ solvedFlagIds: ["x"] })]).toEqual(["x"]);
+  });
+
+  it("should return an empty set when the attribute is absent", () => {
+    expect(getSolvedFlagIds({}).size).toBe(0);
   });
 });

--- a/infrastructure/test/scoring-metadata.test.ts
+++ b/infrastructure/test/scoring-metadata.test.ts
@@ -145,6 +145,138 @@ describe("parseScoringMetadata", () => {
     });
   });
 
+  describe("multi-flag 形式 (Issue #1796)", () => {
+    const validFlags = [
+      { id: "ep01", label: "Ep01: Reachability", flagOutputKey: "AnswerFlagEp01", points: 300 },
+      {
+        id: "ep02",
+        label: "Ep02: TCP/IP",
+        flagOutputKey: "AnswerFlagEp02",
+        points: 200,
+        wrongAnswerPenalty: 10,
+      },
+    ];
+
+    it("should narrow when flags is a non-empty array of valid entries", () => {
+      expect(parseScoringMetadata({ kind: "multi-flag", flags: validFlags })).toEqual({
+        kind: "multi-flag",
+        flags: [
+          {
+            id: "ep01",
+            label: "Ep01: Reachability",
+            flagOutputKey: "AnswerFlagEp01",
+            points: 300,
+            wrongAnswerPenalty: undefined,
+          },
+          {
+            id: "ep02",
+            label: "Ep02: TCP/IP",
+            flagOutputKey: "AnswerFlagEp02",
+            points: 200,
+            wrongAnswerPenalty: 10,
+          },
+        ],
+      });
+    });
+
+    it("should normalize per-flag hints to ProgressiveHint[]", () => {
+      const result = parseScoringMetadata({
+        kind: "multi-flag",
+        flags: [
+          {
+            id: "ep01",
+            label: "Ep01",
+            flagOutputKey: "AnswerFlagEp01",
+            points: 100,
+            hints: ["look at the VPC", { id: "h2", content: "read the SG", penalty: 5 }],
+          },
+        ],
+      });
+      expect(result?.kind).toBe("multi-flag");
+      if (result?.kind !== "multi-flag") return;
+      expect(result.flags[0]?.hints).toEqual([
+        { id: "hint-1", content: "look at the VPC", penalty: 0 },
+        { id: "h2", content: "read the SG", penalty: 5 },
+      ]);
+    });
+
+    it("should clamp an invalid per-flag wrongAnswerPenalty to undefined like the flag kind", () => {
+      const result = parseScoringMetadata({
+        kind: "multi-flag",
+        flags: [
+          { id: "ep01", label: "A", flagOutputKey: "K1", points: 100, wrongAnswerPenalty: -5 },
+          { id: "ep02", label: "B", flagOutputKey: "K2", points: 100, wrongAnswerPenalty: 7.5 },
+          { id: "ep03", label: "C", flagOutputKey: "K3", points: 100, wrongAnswerPenalty: 20 },
+        ],
+      });
+      expect(result?.kind).toBe("multi-flag");
+      if (result?.kind !== "multi-flag") return;
+      expect(result.flags.map((f) => f.wrongAnswerPenalty)).toEqual([undefined, undefined, 20]);
+    });
+
+    it("should return undefined when flags is missing / not an array / empty", () => {
+      expect(parseScoringMetadata({ kind: "multi-flag" })).toBeUndefined();
+      expect(parseScoringMetadata({ kind: "multi-flag", flags: "x" })).toBeUndefined();
+      expect(parseScoringMetadata({ kind: "multi-flag", flags: [] })).toBeUndefined();
+    });
+
+    it("should return undefined for the WHOLE object when any entry is invalid (no partial-drop)", () => {
+      // points 0 以下 → 全体 reject (= 部分点が無言で変わるのを防ぐ)
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [
+            { id: "ep01", label: "A", flagOutputKey: "K1", points: 100 },
+            { id: "ep02", label: "B", flagOutputKey: "K2", points: 0 },
+          ],
+        }),
+      ).toBeUndefined();
+      // id / label / flagOutputKey が空文字 / 非 string → 全体 reject
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [{ id: "", label: "A", flagOutputKey: "K1", points: 100 }],
+        }),
+      ).toBeUndefined();
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [{ id: "ep01", label: 123, flagOutputKey: "K1", points: 100 }],
+        }),
+      ).toBeUndefined();
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [{ id: "ep01", label: "A", points: 100 }],
+        }),
+      ).toBeUndefined();
+    });
+
+    it("should return undefined when two entries share an id", () => {
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [
+            { id: "dup", label: "A", flagOutputKey: "K1", points: 100 },
+            { id: "dup", label: "B", flagOutputKey: "K2", points: 100 },
+          ],
+        }),
+      ).toBeUndefined();
+    });
+
+    it("should return undefined when two entries share a flagOutputKey", () => {
+      expect(
+        parseScoringMetadata({
+          kind: "multi-flag",
+          flags: [
+            { id: "ep01", label: "A", flagOutputKey: "DUP", points: 100 },
+            { id: "ep02", label: "B", flagOutputKey: "DUP", points: 100 },
+          ],
+        }),
+      ).toBeUndefined();
+    });
+  });
+
   describe("[#742 Phase 5] hints は全 5 kind に共通拡張", () => {
     it("uptime-flat kind should accept hints and normalize them to ProgressiveHint[]", () => {
       const result = parseScoringMetadata({


### PR DESCRIPTION
## Summary

Adds a sixth builtin scoring kind, `multi-flag`: one problem carries N independent flags, each submitted and scored separately. This is the platform prerequisite for consolidating multi-episode series (e.g. Internet Evolution Ep01–05) into a single problem (TenkaCloudChallenge#69). The existing `flag` kind is byte-identical and untouched.

- **Types/parser** (`infrastructure/lib/utils/scoring-metadata.ts`): `MultiFlagEntry` + `MultiFlagScoringMetadata` added to the `ProblemScoringMetadata` union. `parseMultiFlag` is **fail-loud** — returns `undefined` for the whole object on missing/empty `flags`, any invalid entry, duplicate `id`s, or duplicate `flagOutputKey`s (silently dropping a flag would change the problem's total score). `wrongAnswerPenalty` clamp shared with `parseFlag`.
- **Submit path** (`participant-handler/submit-flag.ts`): `submitFlag(..., flagId?)`. Per-flag idempotency via a DynamoDB String Set attribute `solvedFlagIds`; correct submit is one atomic `UpdateCommand` (`ADD score, solvedFlagIds … ConditionExpression NOT contains(:flagId)`), race loser → `already_scored`. Per-flag `wrongAnswerPenalty` (0-clamp / legacy shape at 0). New outcome `unknown_flag` → `NOT_FOUND`. `flag` path ignores `flagId` (unchanged).
- **View** (`lookup.ts`): multi-flag strips every entry's `flagOutputKey` from `stackOutputs`; `ParticipantScoringInfo` gains a `multi-flag` kind with a per-flag `{id,label,points,solved}` view (summed points). Per-flag hint reveal is deliberately deferred (`reveal-hint` keeps rejecting multi-flag).
- **Portal** (`apps/participant-portal`): new `MultiFlagSubmissionPanel` (Cloudscape, i18n JA+EN, polling only — no SSE/WebSocket); `ProblemPanel` routes `kind === "multi-flag"` to it and classifies it as a Challenge.

## Test plan

- `make harness` — PASS (no findings).
- `make test` — PASS: infrastructure 2834, participant-portal 624, all workspaces green.
- New tests: parser (valid / empty / bad-entry / dup-id / dup-outputKey → undefined / penalty clamp); submit-flag multi-flag (correct→points+flagId, repeat→already_scored, ConditionalCheckFailed→already_scored, unknown/missing flagId→unknown_flag, missing output→no_outputs, wrong+penalty→event+0-clamp, wrong+no-penalty→legacy, flag-kind regression intact); lookup view (strips all keys, solved from Set and array, points=sum); portal-client flagId body; `MultiFlagSubmissionPanel.test.tsx`.
- `cdk synth` (check-synth) PASS — handler/type wiring builds.

## Regression analysis

- `flag` kind: behavior byte-identical (shared penalty-clamp helper; `flag` path ignores the new `flagId` arg). Existing flag tests pass unchanged.
- Generic scoring dispatcher / other kinds: untouched (multi-flag, like flag, is event-triggered via `submit-flag`, not the polling dispatcher).
- New DDB attribute `solvedFlagIds` is additive (absent on existing items → treated as empty set); no table/schema/capacity change, so the `DynamoDbLowCapacity` aspect is unaffected.
- Route surface: `submit-flag` gains an optional `flagId` body field (backward-compatible) and one new error code (`unknown_flag`).
- No `problems/` submodule change (the diff is infra + apps only).

## Physical impact

| Target | Kind |
| --- | --- |
| `participant-handler` Lambda code (submit-flag, lookup, schemas, routes) | **UPDATE** |
| participant-portal artifact (`apps/*/dist` via runtime build) | **UPDATE** |
| DynamoDB tables / capacity / CFn resources | **NO-OP** (new item attribute only, no resource change) |

Closes #1796

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZSzEehsk5xTtRfpNs4FYF)_