### PR TITLE
fix(teardown): fall back to namePrefix when stackId is empty (#1810)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/delete.ts
@@ -67,7 +67,10 @@ export async function requestTeardown(
   // CFn StackName は namePrefix で十分 (StackId は不要、State Machine 側で region 指定して
   // delete-stack するときも namePrefix で identify できる)。stackId が無い場合 (PENDING で
   // 削除した場合) でも namePrefix は deploy 時に必ず確定している。
-  const stackName = String(item.stackId ?? item.namePrefix ?? "");
+  // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
+  // `??` は空文字を fallback しないので `||` で namePrefix に倒す (= 失敗 deployment の
+  // teardown が missing_required_fields で弾かれて手動削除すら不能になるのを防ぐ)。
+  const stackName = String(item.stackId || item.namePrefix || "");
 
   const missing = missingTeardownFields({ region, awsAccountId, stackName });
   if (missing.length > 0) {

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -149,16 +149,15 @@ function getBulkTeardownTarget(item: Partial<DeploymentItem>):
       readonly stackName: string;
     }
   | undefined {
-  const jobId = String(item.jobId ?? "");
-  const region = String(item.region ?? "");
-  const awsAccountId = String(item.awsAccountId ?? "");
-  // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
-  // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
-  // skip され失敗 stack が orphan 化するのを防ぐ)。delete.ts と同じく各 field を独立 const に
-  // 展開する (object literal 内に値を書くと v8 が literal 先頭行へ statement を集約し、 変更行に
-  // 行単位の DA record が立たず codecov patch が miss 扱いするため)。
-  const stackName = String(item.stackId || item.namePrefix || "");
-  const target = { jobId, region, awsAccountId, stackName };
+  const target = {
+    jobId: String(item.jobId ?? ""),
+    region: String(item.region ?? ""),
+    awsAccountId: String(item.awsAccountId ?? ""),
+    // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
+    // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
+    // skip され失敗 stack が orphan 化するのを防ぐ)。
+    stackName: String(item.stackId || item.namePrefix || ""),
+  };
   return Object.values(target).every(Boolean) ? target : undefined;
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -149,18 +149,16 @@ function getBulkTeardownTarget(item: Partial<DeploymentItem>):
       readonly stackName: string;
     }
   | undefined {
+  const jobId = String(item.jobId ?? "");
+  const region = String(item.region ?? "");
+  const awsAccountId = String(item.awsAccountId ?? "");
   // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
   // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
-  // skip され失敗 stack が orphan 化するのを防ぐ)。delete.ts と同じく独立 statement に置く
-  // (= object literal 内に書くと v8 が先頭行に statement を集約し、 変更行に DA record が
-  // 立たず codecov patch が miss 扱いする。 独立行なら行単位の hit が記録される)。
+  // skip され失敗 stack が orphan 化するのを防ぐ)。delete.ts と同じく各 field を独立 const に
+  // 展開する (object literal 内に値を書くと v8 が literal 先頭行へ statement を集約し、 変更行に
+  // 行単位の DA record が立たず codecov patch が miss 扱いするため)。
   const stackName = String(item.stackId || item.namePrefix || "");
-  const target = {
-    jobId: String(item.jobId ?? ""),
-    region: String(item.region ?? ""),
-    awsAccountId: String(item.awsAccountId ?? ""),
-    stackName,
-  };
+  const target = { jobId, region, awsAccountId, stackName };
   return Object.values(target).every(Boolean) ? target : undefined;
 }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -153,7 +153,10 @@ function getBulkTeardownTarget(item: Partial<DeploymentItem>):
     jobId: String(item.jobId ?? ""),
     region: String(item.region ?? ""),
     awsAccountId: String(item.awsAccountId ?? ""),
-    stackName: String(item.stackId ?? item.namePrefix ?? ""),
+    // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
+    // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
+    // skip され失敗 stack が orphan 化するのを防ぐ)。
+    stackName: String(item.stackId || item.namePrefix || ""),
   };
   return Object.values(target).every(Boolean) ? target : undefined;
 }

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -149,14 +149,17 @@ function getBulkTeardownTarget(item: Partial<DeploymentItem>):
       readonly stackName: string;
     }
   | undefined {
+  // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
+  // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
+  // skip され失敗 stack が orphan 化するのを防ぐ)。delete.ts と同じく独立 statement に置く
+  // (= object literal 内に書くと v8 が先頭行に statement を集約し、 変更行に DA record が
+  // 立たず codecov patch が miss 扱いする。 独立行なら行単位の hit が記録される)。
+  const stackName = String(item.stackId || item.namePrefix || "");
   const target = {
     jobId: String(item.jobId ?? ""),
     region: String(item.region ?? ""),
     awsAccountId: String(item.awsAccountId ?? ""),
-    // #1810: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
-    // `??` は空文字を fallback しないので `||` を使い namePrefix に倒す (空 stackName で
-    // skip され失敗 stack が orphan 化するのを防ぐ)。
-    stackName: String(item.stackId || item.namePrefix || ""),
+    stackName,
   };
   return Object.values(target).every(Boolean) ? target : undefined;
 }

--- a/infrastructure/test/problem-deploy/deploy-delete.test.ts
+++ b/infrastructure/test/problem-deploy/deploy-delete.test.ts
@@ -123,6 +123,23 @@ describe("requestTeardown", () => {
     );
   });
 
+  it("#1810: should fall back to namePrefix for stackName when stackId is an empty string (FAILED deploy)", async () => {
+    // 失敗 deployment は stack ARN 記録前に終わると stackId="" (空文字)。旧コードの
+    // `stackId ?? namePrefix` は空文字を fallback できず stackName="" → missing_required_fields
+    // で失敗 deployment の手動削除すら不能だった。namePrefix で teardown できること。
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ status: "FAILED", stackId: "" }) });
+    ddbSend.mockResolvedValueOnce({});
+    eventsSend.mockResolvedValueOnce({});
+
+    const out = await requestTeardown(shared, "tenant-acme", "JOB1", NOW_MS);
+    expect(out.kind).toBe("accepted");
+    const detail = JSON.parse(
+      (eventsSend.mock.calls[0]?.[0] as PutEventsCommand).input.Entries?.[0]?.Detail ?? "{}",
+    );
+    expect(detail.stackName).toBe("tc-p-t"); // = sampleRow namePrefix
+  });
+
   it("should return not_found without calling Update / PutEvents when the row is missing", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: undefined });

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -229,6 +229,25 @@ describe("bulkTeardownEvent", () => {
     expect(out.kind).toBe("ok");
   });
 
+  it("#1810: should tear down a FAILED deployment whose stackId is empty (fallback to namePrefix)", async () => {
+    // 失敗 deployment は stack ARN 記録前に終わると stackId="" (空文字、null ではない)。
+    // 旧コードは `stackId ?? namePrefix` で空文字を fallback できず stackName="" → skip し、
+    // 失敗 stack を orphan 化していた。namePrefix で delete-stack できるよう enqueue されること。
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // Get(Event)
+    ddbSend.mockResolvedValueOnce({
+      Items: [dep({ jobId: "01FAIL", status: "FAILED", stackId: "", namePrefix: "tc-p-team-9" })],
+    });
+    ddbSend.mockResolvedValue({}); // transition + Event status
+    eventsSend.mockResolvedValue({});
+
+    const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 1, skipped: 0 } });
+    const putCmd = eventsSend.mock.calls[0]?.[0] as PutEventsCommand;
+    const detail = JSON.parse(String(putCmd.input.Entries?.[0]?.Detail)) as { stackName?: string };
+    expect(detail.stackName).toBe("tc-p-team-9");
+  });
+
   it("Deployments query should hit GSI1 (TENANT) and filter eventId in-memory", async () => {
     const { shared, ddbSend, eventsSend } = buildShared();
     ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });


### PR DESCRIPTION
## Summary

Closes #1810。失敗 (FAILED) deployment を含むイベントを teardown しても、その失敗 deployment の CFn スタックが削除されず残存していた(実観測: `tc-stackstack-team-sample` が ROLLBACK_COMPLETE で残る)。

### 根本原因

`getBulkTeardownTarget` (`event-handler/bulk-delete.ts`) と `requestTeardown` (`deploy-handler/delete.ts`) が stack 名を `item.stackId ?? item.namePrefix` で解決していた。FAILED deployment は stack ARN 記録前に終わると `stackId=""`(空文字、null ではない)になり、`??` は空文字を fallback しないため `stackName=""` になる:

- **bulk**: `every(Boolean)` が空 stackName で false → 当該 deployment を**無言で skip** → スタック orphan 化(本症状)
- **single**: `missingTeardownFields` が検出 → `missing_required_fields` で失敗 deployment の手動削除すら拒否

実データ (Lite mode) で確認:

| problem | status | stackId | stack |
|---|---|---|---|
| stackstack | FAILED | `""` | ROLLBACK_COMPLETE(残存) |

### 修正

両経路で `??` → `||` にし、空文字 stackId を namePrefix(deploy 要求時に必ず確定)に倒す → name 指定で delete-stack できる。

## Test plan

- RED→GREEN: bulk が FAILED+空stackId 行を skip せず `stackName=namePrefix` で DeployDeleteRequested を publish / single が `accepted` + `stackName=namePrefix` を返す
- 関連 22 tests green

## Regression analysis

- 変更は stackName 解決の `?? → ||` のみ。stackId が非空(正常 deployment)なら従来どおり ARN 優先(`'arn' || namePrefix` → 'arn')。挙動が変わるのは stackId が空/不在のケースだけ(= 本来 namePrefix を使うべきケース)
- 既存テスト(ARN 優先 / missing_required_fields の region・awsAccountId 欠落など)は不変で green

## Physical impact

- handler コード: ソースバンドル経由で次回 deploy 時に配布(**UPDATE**)
- 修正後は FAILED deployment を含むイベントの teardown で失敗 stack も delete-stack 対象になる
- インフラリソース: **NO-OP**

## 関連

- 失敗の発生源だった stackstack UserData 超過: TenkaCloudChallenge PR #76
- teardown 後にスタックが残る同 class: PR #1799(account 検証 + States.Runtime guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
