### PR TITLE
fix(problem-deploy): namePrefix fallback in getStackProgress for empty stackId

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
+++ b/infrastructure/lib/problem-deploy/handlers/deploy-handler/stack-progress.ts
@@ -218,7 +218,10 @@ export async function getStackProgress(
   const consoleUrl = buildCfnConsoleUrl(region, stackName, item.stackId);
   // CFn は StackName / StackId のどちらでも引ける。stackId が確定済ならそれを使う
   // (= 万一 stack を delete → 同名再作成した場合に旧 stack の events に混入しない)。
-  const stackRef = item.stackId ?? stackName;
+  // #1810 sibling: FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字) になる。
+  // `??` は空文字を fallback しないので `||` で namePrefix (= stackName) に倒す (空 StackName で
+  // CFn を引くと DescribeStackEvents が失敗し、失敗 deploy の進捗が一切引けなくなるのを防ぐ)。
+  const stackRef = item.stackId || stackName;
   // Phase 2.2 (Issue #459): verified=true 行が CompetitorAccounts table にあれば
   // AssumeRole 経由で cross-account client を組む。無ければ同 account 経路 (= dev /
   // 旧 deployment 行 / 未 verify) で従来通り。

--- a/infrastructure/test/problem-deploy/stack-progress.test.ts
+++ b/infrastructure/test/problem-deploy/stack-progress.test.ts
@@ -191,6 +191,36 @@ describe("getStackProgress", () => {
     expect(out.progress.consoleUrl).toContain("#/stacks/stackinfo");
   });
 
+  it("#1810 sibling: should query CFn with namePrefix when stackId is an empty string (FAILED deploy)", async () => {
+    // FAILED deployment は stack ARN 記録前に終わると stackId="" (空文字、null ではない)。
+    // `item.stackId ?? namePrefix` は空文字を fallback しないので StackName="" で CFn を引き、
+    // DescribeStackEvents が失敗する → 失敗 deploy の進捗を一切引けなくなる。`||` で namePrefix
+    // に倒し、stackId が空でも実 stack 名で events/resources を引けることを固定する。
+    const { shared, ddbSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleRow({ status: "FAILED", stackId: "" }) });
+
+    const seenStackNames: Array<string | undefined> = [];
+    const cfn = {
+      send: vi.fn(
+        async (cmd: { constructor: { name: string }; input?: { StackName?: string } }) => {
+          seenStackNames.push(cmd.input?.StackName);
+          const name = cmd.constructor.name;
+          if (name === "DescribeStackEventsCommand") return { StackEvents: [] };
+          if (name === "DescribeStackResourcesCommand") return { StackResources: [] };
+          throw new Error(`unexpected CFn command: ${name}`);
+        },
+      ),
+    };
+
+    const out = await getStackProgress(shared, { cfnClient: () => cfn as never }, TENANT, JOB_ID);
+
+    expect(out.kind).toBe("ok");
+    // 空文字 stackId は namePrefix に倒れ、CFn は実 stack 名で引かれる ("" では引かない)。
+    expect(seenStackNames.length).toBeGreaterThan(0);
+    expect(seenStackNames).not.toContain("");
+    expect(seenStackNames.every((n) => n === STACK_NAME)).toBe(true);
+  });
+
   it("should return stuck cause and recovery hint when IN_PROGRESS is frozen past the threshold", async () => {
     const { shared, ddbSend } = buildShared();
     ddbSend.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

`#1810` sibling sweep. The empty-`stackId` teardown bug fixed in PR-1811
(`delete.ts` / `bulk-delete.ts`) had an unfixed twin in `getStackProgress`.

A FAILED deployment that ends before its CloudFormation stack ARN is recorded
stores `stackId=""` (empty string, **not** null/undefined). In
`stack-progress.ts`:

```ts
const stackRef = item.stackId ?? stackName;   // "" ?? namePrefix  ->  ""
```

`??` only falls through on null/undefined, so `stackRef` becomes `""` and CFn is
queried with `StackName: ""`. `DescribeStackEventsCommand` / `DescribeStackResourcesCommand`
then fail, and the **progress view of a failed deployment can't be loaded at
all** — precisely the rows an operator most needs to inspect.

Fix: `??` -> `||` so an empty `stackId` falls back to `namePrefix` (line 216
already guards `namePrefix` non-empty before this point). Same one-character
root-cause class as `#1810`.

How this was found: ran a same-root-cause sibling grep (`X ?? Y` chains on
fields that can legitimately be `""`) across `infrastructure/lib`. This is the
only **proven** sibling — `stackId=""` is an established data state (FAILED
deployments). Other `??` sites (`disruption-fire`, `plan-builder`,
`team-score-events`, etc.) operate on operands with no proven empty-string
state, where `??` is intentional (distinguishing `""` from `undefined`), so they
are deliberately left unchanged.

## Test plan

- New test `#1810 sibling: should query CFn with namePrefix when stackId is an
  empty string (FAILED deploy)` — RED on the old code
  (`expected [ '', '' ] to not include ''`), GREEN after the fix.
- Full `stack-progress.test.ts`: 14/14 pass. biome + tsc clean.

## Regression analysis

- Behavior change is limited to the `stackId===""` case, which previously
  produced a broken CFn query (empty `StackName`); after the fix it queries the
  real stack name. Non-empty `stackId` is unaffected (`"arn..." || x` === the
  arn). `null`/`undefined` `stackId` also unchanged (`undefined || x` === x,
  same result the old `??` produced).
- `buildCfnConsoleUrl` already treats `stackId===""` as "no stackId" via its
  `if (stackId)` truthy check, so the console deep link is unaffected.
- No API/type/signature change; no caller impact.

## Physical impact

- CFn / AWS resources: **NO-OP** (handler logic only; no CDK/template change).
- Runtime behavior: failed-deployment progress polling now succeeds instead of
  erroring on an empty `StackName`.
