### PR TITLE
fix(event): paginate queryDeploymentsByEvent so teardown/schedule miss no deployment

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/shared.ts
@@ -102,25 +102,38 @@ export async function queryDeploymentsByEvent(
   // / UpdateExpression 全てで alias 必須。 caller が `#s` を含む projection を渡すケース
   // (= bulk-deploy.ts が `jobId, teamId, problemId, #s` で呼ぶ) を黙ってサポートするため、
   // alias を本 helper 側で定義する。 caller が `#s` を使わなくても extra alias は ignored。
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.deploymentsTableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      FilterExpression: "eventId = :ev",
-      ExpressionAttributeValues: {
-        ":pk": `TENANT#${tenantId}`,
-        ":ev": eventId,
-      },
-      ...(projectionExpression
-        ? {
-            ProjectionExpression: projectionExpression,
-            ...(projectionExpression.includes("#s")
-              ? { ExpressionAttributeNames: { "#s": "status" } }
-              : {}),
-          }
-        : {}),
-    }),
-  );
-  return (out.Items ?? []) as Partial<DeploymentItem>[];
+  //
+  // #1797: GSI1PK=TENANT#<id> パーティションが 1MB を超えると Query は LastEvaluatedKey を
+  // 返してページ分割する。1 ページ目だけ読むと後続ページの deployment を取りこぼし、teardown
+  // (bulk-delete) / end-event / schedule 伝播 / bulk-deploy の既存検知が黙って漏れる
+  // (= 対象 stack が enqueue されず orphan 化)。FilterExpression(eventId) は各ページ内で
+  // 適用されるので、目的 event の行が後続ページに居ると完全に missed。全ページを drain する。
+  const items: Partial<DeploymentItem>[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        FilterExpression: "eventId = :ev",
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${tenantId}`,
+          ":ev": eventId,
+        },
+        ...(projectionExpression
+          ? {
+              ProjectionExpression: projectionExpression,
+              ...(projectionExpression.includes("#s")
+                ? { ExpressionAttributeNames: { "#s": "status" } }
+                : {}),
+            }
+          : {}),
+        ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
+      }),
+    );
+    items.push(...((out.Items ?? []) as Partial<DeploymentItem>[]));
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+  return items;
 }

--- a/infrastructure/test/problem-deploy/event-handler-shared.test.ts
+++ b/infrastructure/test/problem-deploy/event-handler-shared.test.ts
@@ -56,4 +56,26 @@ describe("queryDeploymentsByEvent (Issue #670)", () => {
     expect(cmd.input.ProjectionExpression).toBeUndefined();
     expect(cmd.input.ExpressionAttributeNames).toBeUndefined();
   });
+
+  it("#1797: should drain every page (DynamoDB 1MB limit) so no deployment is missed", async () => {
+    // GSI1PK=TENANT#<id> パーティションが 1MB を超えると Query は LastEvaluatedKey を返して
+    // ページ分割する。旧コードは 1 ページ目しか読まず、後続ページの deployment を取りこぼした
+    // → teardown で対象 stack が enqueue されず orphan 化 / end-event / schedule 伝播も漏れる。
+    // FilterExpression(eventId) は各ページ内で適用されるので、目的 event の行が後続ページに
+    // 居ると完全に missed。全ページを drain する。
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ Items: [{ jobId: "a" }], LastEvaluatedKey: { PK: "p1" } })
+      .mockResolvedValueOnce({ Items: [{ jobId: "b" }], LastEvaluatedKey: { PK: "p2" } })
+      .mockResolvedValueOnce({ Items: [{ jobId: "c" }] });
+
+    const result = await queryDeploymentsByEvent(buildShared(send), "tenant-acme", "evt-1");
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(result.map((r) => r.jobId)).toEqual(["a", "b", "c"]);
+    // 1 ページ目は ExclusiveStartKey 無し、2 ページ目以降は前ページの LastEvaluatedKey を渡す。
+    expect((send.mock.calls[0]?.[0] as QueryCommand).input.ExclusiveStartKey).toBeUndefined();
+    expect((send.mock.calls[1]?.[0] as QueryCommand).input.ExclusiveStartKey).toEqual({ PK: "p1" });
+    expect((send.mock.calls[2]?.[0] as QueryCommand).input.ExclusiveStartKey).toEqual({ PK: "p2" });
+  });
 });


### PR DESCRIPTION
## Summary

`queryDeploymentsByEvent` issued a **single** `QueryCommand` against GSI1
(`GSI1PK = TENANT#<id>`) with a `FilterExpression` on `eventId`, returning
`out.Items ?? []` with **no `LastEvaluatedKey` loop**. DynamoDB caps a Query
page at 1MB and applies the filter *within* each scanned page, so once a
tenant's deployment rows on that partition exceed ~1MB, the target event's
deployments on later pages are **silently dropped**.

This is a strong candidate for the **"event ended but the stack isn't deleted /
CodeBuild does nothing"** symptom (#1797): a dropped row is never enqueued for
teardown, so no `DeployDeleteRequested` is published and the CFn stack orphans.

## Affected callers (all fixed by this one change)

| Caller | Effect of the miss |
|---|---|
| `bulk-delete.ts` (teardown) | missed stacks never deleted, no CodeBuild — **#1797 symptom** |
| `end-event.ts` | event-end status not propagated to missed deployments |
| `schedule.ts` | startsAt/endsAt not denormalized to missed deployments |
| `bulk-deploy/orchestrator.ts` | existing-deployment detection misses rows → possible duplicate deploys |

## Fix

Drain all pages via an `ExclusiveStartKey`/`LastEvaluatedKey` loop. First page is
unchanged (no `ExclusiveStartKey`); later pages pass the prior page's key.
Single-page responses behave identically (loop runs once), so existing behavior
for all four callers is preserved.

## Test plan

- New pagination case in `event-handler-shared.test.ts`: 3-page mock — RED
  (called 1×, returns only page 1) → GREEN (called 3×, returns all items,
  `ExclusiveStartKey` correctly threaded).
- Caller suites stay green: `event-bulk-delete` / `event-schedule` /
  `end-event-internals` (43 tests total). biome + tsc clean.

## Regression analysis

- Behavior is identical for the common single-page case (loop runs once; the
  3 existing #670 projection tests still pass unchanged).
- Only adds previously-missing later pages. No signature/type/API change.
- Note: this is independent of the `stackId`/`namePrefix` teardown fixes
  (#1811/#1813) — it addresses *whether the row is found at all*, which precedes
  the stackName resolution.

## Physical impact

- CFn / AWS: **NO-OP** (handler data-access logic).
- DynamoDB read: for large tenants, now issues N Query pages instead of 1
  (correctness over a single capped read). RCU within Free-Tier budget; reads are
  the rare teardown/schedule path, not a hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
