### PR TITLE
fix(event): align teams cap to 99 to match the atomic TransactWrite limit

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/create.ts
@@ -90,14 +90,12 @@ export async function createEvent(
     expiresAt,
   };
 
-  // TransactWrite は 100 items が AWS の上限。teams.max(100) + event 1 = 最大 101 で
-  // 上限を超えるが、検証で teams を <= 99 に絞るより、teams を <= 100 にして event を
-  // 別 PutCommand で先に書く方針は採らない (atomicity を優先)。
-  // → Schema で teams.max(100) としているが、実際は 99 がワーカブル上限。安全側に寄せて
-  //   teams.max(99) にする方針もあるが、Phase 1 はまず TransactWrite 上限ギリギリで動かし、
-  //   Phase 2 (Distributed Map) で chunk 化する。
+  // TransactWrite は 100 items が AWS の上限。event 1 行 + teams を 1 つの atomic write で書くため
+  // teams は最大 99 (= 100 - event 1 行)。 schema (CreateEventRequestSchema) を teams.max(99) に
+  // 揃えたので、 検証を通った request はここに到達した時点で必ず teams <= 99。 100+ teams への対応は
+  // atomicity を犠牲にしないため Phase 2 (Distributed Map で chunk 化) に回す。
+  // 下記は schema を迂回した呼び出しに対する defense-in-depth (validated path では発火しない)。
   if (teams.length + 1 > 100) {
-    // 上限の早期チェック (TransactWrite が ValidationException を返すのを待たず明示的に)
     throw new Error(`TransactWrite items > 100 (teams=${teams.length} + event=1)`);
   }
 

--- a/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/types.ts
@@ -147,7 +147,11 @@ export const CreateEventRequestSchema = z.object({
       }),
     )
     .min(1)
-    .max(100, "1 event あたり 100 teams が DDB TransactWrite 上限"),
+    // create.ts は event 1 行 + teams を 1 つの atomic TransactWrite で書く。 TransactWrite は
+    // 100 item 上限なので teams は最大 99 (= 100 - event 1 行)。 以前 max(100) だったが、 event
+    // 行の +1 を数え落とした off-by-one で、 schema 上は通る 100-team request が runtime で
+    // `TransactWrite items > 100` を投げて 500 になっていた。 schema を実上限に揃える。
+    .max(99, "1 event あたり最大 99 teams (event 1 行 + teams で DDB TransactWrite 100-item 上限)"),
   problems: z.array(EventProblemTargetSchema).min(1).max(50),
 });
 export type CreateEventRequest = z.infer<typeof CreateEventRequestSchema>;

--- a/infrastructure/test/problem-deploy/event-create.test.ts
+++ b/infrastructure/test/problem-deploy/event-create.test.ts
@@ -6,9 +6,34 @@ import {
   DuplicateProblemIdError,
 } from "../../lib/problem-deploy/handlers/event-handler/create";
 import type { EventSharedResources } from "../../lib/problem-deploy/handlers/event-handler/shared";
-import type { CreateEventRequest } from "../../lib/problem-deploy/handlers/event-handler/types";
+import {
+  type CreateEventRequest,
+  CreateEventRequestSchema,
+} from "../../lib/problem-deploy/handlers/event-handler/types";
 
 const NOW_MS = 1_700_000_000_000;
+
+const teamsOf = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    internalSlug: `team-${i}`,
+    awsAccountId: String(100_000_000_000 + i),
+  }));
+
+describe("CreateEventRequestSchema teams cap (event 1 row + teams must fit one 100-item TransactWrite)", () => {
+  const base = { name: "E", problems: [{ problemId: "p", defaultRegion: "ap-northeast-1" }] };
+
+  it("should accept 99 teams (event 1 + 99 = 100 items = the atomic TransactWrite max)", () => {
+    expect(CreateEventRequestSchema.safeParse({ ...base, teams: teamsOf(99) }).success).toBe(true);
+  });
+
+  it("should reject 100 teams (event 1 + 100 = 101 > 100; was a schema/runtime off-by-one -> 500)", () => {
+    // 旧 schema は max(100) で 100-team request を通し、 create.ts が runtime で
+    // `TransactWrite items > 100` を投げて 500 になっていた。 schema を実上限 99 に揃えて 400 で弾く。
+    expect(CreateEventRequestSchema.safeParse({ ...base, teams: teamsOf(100) }).success).toBe(
+      false,
+    );
+  });
+});
 
 function buildShared(): {
   shared: EventSharedResources;


### PR DESCRIPTION
## Summary

`createEvent` writes the event (1 row) + teams (N rows) in a **single atomic
`TransactWrite`**, whose AWS limit is **100 items**. The true max is therefore
**99 teams** (100 − 1 event row), and `create.ts` enforces exactly that:

```ts
if (teams.length + 1 > 100) throw new Error(`TransactWrite items > 100 ...`);
```

But `CreateEventRequestSchema` allowed `teams.max(100)` — it forgot to count the
event row (off-by-one). So a schema-valid **100-team** request passed validation,
then threw at runtime and surfaced as a **500** (the comment already admitted
"Schema で teams.max(100) としているが、実際は 99 がワーカブル上限").

## Fix

Align the schema to `teams.max(99)` so the cap is enforced as a clean **400 at
validation** instead of a 500 mid-handler. This matches the documented
atomicity-first intent — supporting 100+ teams is deferred to the Phase 2
Distributed-Map chunking (which would relax single-write atomicity). The runtime
guard stays as defense-in-depth for any caller that bypasses the schema.

## Test plan

- New `CreateEventRequestSchema` boundary cases: **99 teams accepted**, **100
  rejected** (the previously-passing off-by-one). Existing `createEvent` suite
  green (8 tests). biome + tsc clean.

## Regression analysis

- Only requests with **exactly 100 teams** change behavior: previously a 500
  (runtime throw), now a 400 (validation). 1–99 teams unchanged. No existing test
  used 100 teams.
- `bulk-deploy/persistence.ts` (the other TransactWrite path) already chunks
  correctly (`planPerChunk = floor(TRANSACT_WRITE_BATCH/opsPerEntry)` + slice
  loop) and is unaffected.

## Physical impact

- CFn / AWS: **NO-OP** (validation/handler logic).
- API: a 100-team `POST /events` now returns 400 (clear validation error) instead
  of 500. Organizers needing 100+ teams are gated on Phase 2 chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
