### PR TITLE
fix(teardown): detect PutEvents partial failure + compensate stuck DELETING rows

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-delete.ts
@@ -14,6 +14,13 @@ export interface BulkTeardownResult {
   readonly eventId: string;
   readonly enqueued: number;
   readonly skipped: number;
+  /**
+   * #1797: status=DELETING には倒せたが DeployDeleteRequested の publish に失敗した件数。
+   * EventBridge PutEvents は HTTP 200 でも `FailedEntryCount > 0` で個別 entry が落ちうるため、
+   * 失敗分は DELETING → FAILED に巻き戻して (= retry 可能にして) この数に計上する。
+   * 0 でない場合、 operator は再度 DELETE を叩けば FAILED 行が再 teardown される。
+   */
+  readonly failed: number;
 }
 
 export type BulkTeardownOutcome =
@@ -22,7 +29,7 @@ export type BulkTeardownOutcome =
 
 const PUT_EVENTS_BATCH = 10;
 
-type UpdateOutcome = { entry: PutEventsRequestEntry } | { skip: true };
+type UpdateOutcome = { entry: PutEventsRequestEntry; jobId: string } | { skip: true };
 
 /**
  * `DELETE /events/{eventId}` の実体。
@@ -35,9 +42,11 @@ type UpdateOutcome = { entry: PutEventsRequestEntry } | { skip: true };
  * 既に DELETING / DELETED な行 / 並行更新 race / 必須フィールド欠損は skipped に計上
  * (= 操作者の再実行に対して idempotent)。
  *
- * 失敗 semantics: publish chunk が失敗すると未 publish 分は status=DELETING のまま
- * orphan 化する。caller が再呼び出ししても DELETING 行は skip されるため、Phase 3 で
- * compensation pattern (FAILED 巻き戻し) を別途検討する。
+ * 失敗 semantics (#1797): EventBridge PutEvents は HTTP 200 でも `FailedEntryCount > 0` で
+ * 個別 entry が落ちうる / chunk 全体が reject しうる。 publish に失敗した行は
+ * DELETING → FAILED に巻き戻して `result.failed` に計上する (= 単一 delete の
+ * `compensateFailedTeardownPublish` と対称)。 FAILED 行は再 DELETE で retry されるため、
+ * DELETING のまま skip され永久に orphan 化する旧挙動を解消する。
  */
 export async function bulkTeardownEvent(
   shared: EventSharedResources,
@@ -56,7 +65,7 @@ export async function bulkTeardownEvent(
 
   const targets = await queryDeploymentsByEvent(shared, tenantId, eventId);
   if (targets.length === 0) {
-    return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0 } };
+    return { kind: "ok", result: { eventId, enqueued: 0, skipped: 0, failed: 0 } };
   }
 
   const updatedAt = new Date(nowMs).toISOString();
@@ -67,18 +76,38 @@ export async function bulkTeardownEvent(
     targets.map((item) => prepareBulkTeardownEntry(shared, tenantId, updatedAt, item)),
   );
 
-  const entries: PutEventsRequestEntry[] = [];
+  const pending: Array<{ entry: PutEventsRequestEntry; jobId: string }> = [];
   let skipped = 0;
   for (const o of outcomes) {
     if ("skip" in o) skipped++;
-    else entries.push(o.entry);
+    else pending.push(o);
   }
 
   // EventBridge PutEvents の chunk を Promise.all で並列発火。
-  const putChunks: Promise<unknown>[] = [];
-  for (let i = 0; i < entries.length; i += PUT_EVENTS_BATCH) {
-    const chunk = entries.slice(i, i + PUT_EVENTS_BATCH);
-    putChunks.push(shared.events.send(new PutEventsCommand({ Entries: chunk })));
+  // #1797: PutEvents は HTTP 200 でも `FailedEntryCount > 0` で個別 entry が落ちうる
+  // (throttling 等)。 旧コードは送りっぱなしで FailedEntryCount を見ず、 落ちた teardown event を
+  // silent に握り潰して stack を orphan 化させていた (= 他の PutEvents 経路は全て検査済なのに
+  // ここだけ未検査だった)。 各 chunk の結果を検査し、 publish できなかった jobId を集める。
+  const publishChunk = async (
+    chunk: Array<{ entry: PutEventsRequestEntry; jobId: string }>,
+  ): Promise<string[]> => {
+    try {
+      const out = await shared.events.send(
+        new PutEventsCommand({ Entries: chunk.map((c) => c.entry) }),
+      );
+      if ((out.FailedEntryCount ?? 0) === 0) return [];
+      // PutEvents response.Entries は入力 Entries と同順。 ErrorCode 付きが失敗 entry。
+      return (out.Entries ?? [])
+        .map((e, i) => (e.ErrorCode ? chunk[i]?.jobId : undefined))
+        .filter((j): j is string => j !== undefined);
+    } catch {
+      // chunk 全体が reject → その chunk の jobId は全て publish 失敗扱い。
+      return chunk.map((c) => c.jobId);
+    }
+  };
+  const putChunks: Promise<string[]>[] = [];
+  for (let i = 0; i < pending.length; i += PUT_EVENTS_BATCH) {
+    putChunks.push(publishChunk(pending.slice(i, i + PUT_EVENTS_BATCH)));
   }
 
   // #557: Event status を TEARDOWN に倒す。bulk-deploy が DRAFT → DEPLOYING にする
@@ -107,9 +136,61 @@ export async function bulkTeardownEvent(
         throw err;
       }
     });
-  await Promise.all([...putChunks, updateStatus]);
+  const [failedPerChunk] = await Promise.all([Promise.all(putChunks), updateStatus]);
+  const failedJobIds = failedPerChunk.flat();
 
-  return { kind: "ok", result: { eventId, enqueued: entries.length, skipped } };
+  // #1797: publish に失敗した行は DELETING のまま放置すると、 次回 DELETE 呼び出しで
+  // 「既に DELETING」 として skip され永久に teardown されない (= silent orphan)。 単一 delete
+  // (delete.ts の compensateFailedTeardownPublish) と対称に DELETING → FAILED へ巻き戻し、
+  // operator の再 DELETE で retry できるようにする。
+  await Promise.all(
+    failedJobIds.map((jobId) => compensateBulkTeardownPublish(shared, tenantId, jobId, updatedAt)),
+  );
+
+  return {
+    kind: "ok",
+    result: {
+      eventId,
+      enqueued: pending.length - failedJobIds.length,
+      skipped,
+      failed: failedJobIds.length,
+    },
+  };
+}
+
+/**
+ * #1797: publish に失敗した teardown 行を DELETING → FAILED に巻き戻す (= retry 可能化)。
+ * ConditionExpression で DELETING の行だけを対象にし、 既に他経路で FAILED/DELETED になった行は
+ * 触らない (CCF は無視 = best-effort、 元の publish 失敗が主シグナル)。
+ */
+async function compensateBulkTeardownPublish(
+  shared: EventSharedResources,
+  tenantId: string,
+  jobId: string,
+  updatedAt: string,
+): Promise<void> {
+  try {
+    await shared.ddb.send(
+      new UpdateCommand({
+        TableName: shared.deploymentsTableName,
+        Key: { PK: `DEPLOYMENT#${jobId}`, SK: "META" },
+        UpdateExpression: "SET #s = :failed, updatedAt = :updatedAt, failureReason = :reason",
+        ConditionExpression: "tenantId = :tenantId AND #s = :deleting",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":failed": "FAILED",
+          ":deleting": "DELETING",
+          ":updatedAt": updatedAt,
+          ":reason": "Failed to publish DeployDeleteRequested event (bulk teardown)",
+          ":tenantId": tenantId,
+        },
+      }),
+    );
+  } catch {
+    // best-effort: CCF (行が既に DELETING でない) も他の DDB error も握る。 巻き戻し失敗が
+    // 元の publish 失敗 (= result.failed に計上済) を覆い隠さないようにする。 delete.ts の
+    // compensateFailedTeardownPublish と同じ best-effort セマンティクス。
+  }
 }
 
 async function prepareBulkTeardownEntry(
@@ -131,6 +212,7 @@ async function prepareBulkTeardownEntry(
   if (!transitioned) return { skip: true };
   const detail = await buildBulkTeardownDetail(shared, tenantId, item, target);
   return {
+    jobId: target.jobId,
     entry: {
       EventBusName: shared.eventBusName,
       Source: EVENT_SOURCE,

--- a/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
+++ b/infrastructure/test/problem-deploy/event-bulk-delete.test.ts
@@ -69,7 +69,7 @@ describe("bulkTeardownEvent", () => {
     const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
     expect(out).toEqual({
       kind: "ok",
-      result: { eventId: "EV1", enqueued: 2, skipped: 0 },
+      result: { eventId: "EV1", enqueued: 2, skipped: 0, failed: 0 },
     });
 
     // Query が FilterExpression で eventId 一致を要求し、cross-event 漏洩を防ぐ
@@ -178,7 +178,10 @@ describe("bulkTeardownEvent", () => {
     ddbSend.mockResolvedValueOnce({ Items: [] });
 
     const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
-    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 0 } });
+    expect(out).toEqual({
+      kind: "ok",
+      result: { eventId: "EV1", enqueued: 0, skipped: 0, failed: 0 },
+    });
     expect(eventsSend).not.toHaveBeenCalled();
   });
 
@@ -199,8 +202,63 @@ describe("bulkTeardownEvent", () => {
     });
 
     const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
-    expect(out).toEqual({ kind: "ok", result: { eventId: "EV1", enqueued: 0, skipped: 1 } });
+    expect(out).toEqual({
+      kind: "ok",
+      result: { eventId: "EV1", enqueued: 0, skipped: 1, failed: 0 },
+    });
     expect(eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("#1797: should compensate (DELETING -> FAILED) and count rows whose PutEvents entry failed (FailedEntryCount > 0)", async () => {
+    // EventBridge PutEvents は HTTP 200 でも個別 entry が落ちる (FailedEntryCount > 0)。 旧コードは
+    // これを無視し teardown event を silent drop → stack orphan。 publish できなかった行は
+    // DELETING のままだと再 DELETE でも skip され永久に消えない。 FAILED に巻き戻して retry 可能化する。
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() }); // Get(Event)
+    ddbSend.mockResolvedValueOnce({ Items: [dep({ jobId: "01A" }), dep({ jobId: "01B" })] }); // Query
+    ddbSend.mockResolvedValue({}); // DELETING transitions + Event TEARDOWN + compensation
+    // 200 だが 2 件目 (01B) の entry が失敗。 response.Entries は入力 Entries と同順。
+    eventsSend.mockResolvedValue({
+      FailedEntryCount: 1,
+      Entries: [{ EventId: "ok" }, { ErrorCode: "ThrottlingException", ErrorMessage: "rate" }],
+    });
+
+    const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({
+      kind: "ok",
+      result: { eventId: "EV1", enqueued: 1, skipped: 0, failed: 1 },
+    });
+
+    const compensations = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is UpdateCommand => c instanceof UpdateCommand)
+      .filter((c) => c.input.ExpressionAttributeValues?.[":failed"] === "FAILED");
+    expect(compensations).toHaveLength(1);
+    expect(compensations[0]?.input.Key?.PK).toBe("DEPLOYMENT#01B");
+    // DELETING の行だけを FAILED に倒す (= 他経路で既に終端化した行は踏まない)。
+    expect(compensations[0]?.input.ConditionExpression).toContain(":deleting");
+  });
+
+  it("#1797: should compensate every row in a chunk that PutEvents rejected entirely", async () => {
+    const { shared, ddbSend, eventsSend } = buildShared();
+    ddbSend.mockResolvedValueOnce({ Item: sampleEvent() });
+    ddbSend.mockResolvedValueOnce({ Items: [dep({ jobId: "01A" }), dep({ jobId: "01B" })] });
+    ddbSend.mockResolvedValue({});
+    eventsSend.mockRejectedValue(new Error("EventBridge unavailable")); // chunk 全体が reject
+
+    const out = await bulkTeardownEvent(shared, "tenant-acme", "EV1", NOW_MS);
+    expect(out).toEqual({
+      kind: "ok",
+      result: { eventId: "EV1", enqueued: 0, skipped: 0, failed: 2 },
+    });
+
+    const compensated = ddbSend.mock.calls
+      .map((c) => c[0])
+      .filter((c): c is UpdateCommand => c instanceof UpdateCommand)
+      .filter((c) => c.input.ExpressionAttributeValues?.[":failed"] === "FAILED")
+      .map((c) => c.input.Key?.PK)
+      .sort();
+    expect(compensated).toEqual(["DEPLOYMENT#01A", "DEPLOYMENT#01B"]);
   });
 
   it("should still complete deployment delete without propagating exceptions even if Event status update hits CCF (e.g. ARCHIVED) (#557)", async () => {


### PR DESCRIPTION
## Summary

`bulk-delete.ts` (the `DELETE /events/{id}` teardown) fired `DeployDeleteRequested`
in `Promise.all` chunks and **never inspected the PutEvents result**. EventBridge
`PutEvents` returns **HTTP 200 even when individual entries fail**
(`FailedEntryCount > 0`, e.g. under throttling), so a partially-failed teardown
**silently dropped those events → the competitor CFn stacks orphan with zero
failure signal** — a strong match for the "event ended but the stack isn't
deleted / CodeBuild idle" symptom (#1797).

It was the **only** `PutEvents` site in the codebase not checking
`FailedEntryCount` — `shared/events.ts`, `bulk-deploy/publish.ts`,
`disruption-fire.ts`, and `condition-disruption-fire.ts` all do.

Worse, the affected rows stay `status=DELETING`, so a retry `DELETE` **skips
them** as "already deleting" → permanently stuck.

## Fix (mirrors two existing patterns)

- **Detect** failures per chunk: inspect `FailedEntryCount` + per-entry
  `ErrorCode` (position-correlated to `jobId`, exactly like
  `bulk-deploy/publish.ts`); a rejected chunk fails all its `jobId`s.
- **Compensate** failed rows `DELETING → FAILED` so a re-issued `DELETE` retries
  them (symmetric with `delete.ts` `compensateFailedTeardownPublish` for single
  delete). This closes the documented "Phase 3" gap using the pattern that
  already exists for single-delete.
- **Report** via the new additive `BulkTeardownResult.failed`; `enqueued` now
  counts only successfully-published rows.

## Test plan

- 2 new cases: `FailedEntryCount > 0` compensates the failed `jobId` (and only
  that one); whole-chunk reject compensates all rows in the chunk.
- Existing bulk-delete suite updated for the additive `failed` field (11 green);
  route / lifecycle / crud consumers green; biome + tsc clean.

## Regression analysis

- All-success path is behavior-identical except the result now carries
  `failed: 0` (additive field; the route returns `result` as JSON, so this is a
  backward-compatible response addition).
- Compensation only touches rows still in `DELETING` (ConditionExpression), and
  swallows CCF/other errors best-effort so it never masks the original publish
  failure (which is already surfaced via `result.failed`).
- `enqueued` semantics tighten from "rows transitioned to DELETING" to "rows
  whose teardown event actually published" — more accurate.

## Physical impact

- CFn / AWS: **NO-OP** (handler logic).
- Runtime: a partially-failed teardown no longer silently orphans stacks; failed
  rows become `FAILED` (retryable) and the count is reported to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
