### PR TITLE
fix(problem-deploy): drain GSI1 pagination in 2 sites #1815 missed

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
+++ b/infrastructure/lib/problem-deploy/handlers/disruption-executor-handler/executor-store.ts
@@ -85,21 +85,30 @@ export async function resolveDeployment(
   resources: ExecutorResources,
   detail: DisruptionFiredDetail,
 ): Promise<DeploymentTarget | undefined> {
-  const out = await resources.ddb.send(
-    new QueryCommand({
-      TableName: resources.deploymentsTableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      FilterExpression: "eventId = :ev AND teamId = :tid AND problemId = :pid",
-      ExpressionAttributeValues: {
-        ":pk": `TENANT#${detail.tenantId}`,
-        ":ev": detail.eventId,
-        ":tid": detail.teamId,
-        ":pid": detail.problemId,
-      },
-    }),
-  );
-  const items = (out.Items ?? []) as Partial<DeploymentItem>[];
+  // #1815 兄弟: GSI1PK=TENANT#<id> パーティションが 1MB を超えると Query は LastEvaluatedKey を
+  // 返す。 FilterExpression は post-read なので目的の行が後続ページに居ると単発 Query では取りこぼし、
+  // resolveDeployment が undefined を返して disruption が silently no-op する。 全ページ drain する。
+  const items: Partial<DeploymentItem>[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await resources.ddb.send(
+      new QueryCommand({
+        TableName: resources.deploymentsTableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        FilterExpression: "eventId = :ev AND teamId = :tid AND problemId = :pid",
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${detail.tenantId}`,
+          ":ev": detail.eventId,
+          ":tid": detail.teamId,
+          ":pid": detail.problemId,
+        },
+        ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
+      }),
+    );
+    items.push(...((out.Items ?? []) as Partial<DeploymentItem>[]));
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
   // #1710: cross-account 情報 (competitorRoleArn / externalIdParameterName) は要求しない。
   // 同一アカウント (Lite) deploy では両者とも欠落するのが正常。
   const ready = items.find(

--- a/infrastructure/lib/problem-deploy/handlers/participant-handler/leaderboard.ts
+++ b/infrastructure/lib/problem-deploy/handlers/participant-handler/leaderboard.ts
@@ -90,19 +90,28 @@ export async function getLeaderboard(
 
   // tenant の全 deployment を引いて event 内のものだけ。FilterExpression は post-read
   // なので RCU は変わらないが network / Lambda 内処理量を節約。
-  const out = await shared.ddb.send(
-    new QueryCommand({
-      TableName: shared.tableName,
-      IndexName: "GSI1",
-      KeyConditionExpression: "GSI1PK = :pk",
-      FilterExpression: "eventId = :ev",
-      ExpressionAttributeValues: {
-        ":pk": `TENANT#${tenantId}`,
-        ":ev": eventId,
-      },
-    }),
-  );
-  const eventDeployments = (out.Items ?? []) as Partial<DeploymentItem>[];
+  // #1815 兄弟: GSI1PK=TENANT#<id> パーティションが 1MB を超えると Query は LastEvaluatedKey を
+  // 返す。 単発 Query だと後続ページの team が leaderboard から落ち「ライバルのスコアが見えない」
+  // (#1793 症状) になるため、 全ページ drain して全 team を集計する。
+  const eventDeployments: Partial<DeploymentItem>[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await shared.ddb.send(
+      new QueryCommand({
+        TableName: shared.tableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :pk",
+        FilterExpression: "eventId = :ev",
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${tenantId}`,
+          ":ev": eventId,
+        },
+        ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
+      }),
+    );
+    eventDeployments.push(...((out.Items ?? []) as Partial<DeploymentItem>[]));
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
 
   // Issue #1038 P1 #9: scoreboard freeze 判定。 event gate を引いて endsAt を取得し、
   // 終了 N 分前から終了時刻までは順位を隠す (= 競技公平性、 終盤の駆け込み防止)。

--- a/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
+++ b/infrastructure/test/problem-deploy/disruption-executor-store.test.ts
@@ -169,4 +169,22 @@ describe("resolveDeployment (ADR-031 #1419)", () => {
     const send = vi.fn().mockResolvedValue({});
     expect(await resolveDeployment(makeResources(send), detail)).toBeUndefined();
   });
+
+  it("#1815-sibling: should drain LastEvaluatedKey so a target paged past 1MB is still found", async () => {
+    // GSI1PK=TENANT#<id> パーティションが 1MB を超えると 1 回の Query は LastEvaluatedKey を
+    // 返し、 FilterExpression にマッチする行が後続ページに居ると単発 Query では取りこぼす。
+    // 旧実装は page 1 だけを見て undefined を返し、 disruption が silently no-op していた。
+    const send = vi
+      .fn()
+      // page 1: filter で全部弾かれた (= 別 event の行で 1MB 埋まった) → Items 空 + 続きあり
+      .mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: "p1" } })
+      // page 2: 目的の COMPLETE 行はここに居る → 続きなし
+      .mockResolvedValueOnce({ Items: [completeRow] });
+    const target = await resolveDeployment(makeResources(send), detail);
+    expect(target?.jobId).toBe("job-1");
+    // page 1 は ExclusiveStartKey 無し、 page 2 は前ページの LastEvaluatedKey を渡す。
+    expect(send.mock.calls[0][0].input.ExclusiveStartKey).toBeUndefined();
+    expect(send.mock.calls[1][0].input.ExclusiveStartKey).toEqual({ PK: "p1" });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
 });

--- a/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
+++ b/infrastructure/test/problem-deploy/participant-leaderboard.test.ts
@@ -194,4 +194,39 @@ describe("getLeaderboard (integration)", () => {
     const out = await getLeaderboard(shared, "KEY1");
     expect(out).toEqual({ kind: "no_event" });
   });
+
+  it("#1815-sibling: should drain GSI1 pages so rivals paged past 1MB still appear", async () => {
+    // GSI1PK=TENANT#<id> パーティションが 1MB を超えると Query は LastEvaluatedKey を返す。
+    // 単発 Query だと後続ページの team が leaderboard から落ち、 「ライバルのスコアが見えない」
+    // (= #1793 症状) になる。 全ページ drain して初めて全 team が集計される。
+    const { shared, ddbSend } = buildShared();
+    // 1st: GSI2 query (自 team)
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ teamId: "T1", eventId: "EV1", tenantId: "tenant-acme" })],
+    });
+    // 2nd: GSI1 page 1 (自 team のみ) + 続きあり
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ teamId: "T1", problemId: "p1", score: 100, status: "COMPLETE" })],
+      LastEvaluatedKey: { PK: "page1" },
+    });
+    // 3rd: GSI1 page 2 (ライバル T2) + 続きなし
+    ddbSend.mockResolvedValueOnce({
+      Items: [sampleRow({ teamId: "T2", problemId: "p1", score: 200, status: "COMPLETE" })],
+    });
+    // 4th 以降 (getEventGate) は未 mock → undefined (= gate 無し、 freeze なし)
+
+    const out = await getLeaderboard(shared, "KEY1");
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      // 単発 Query なら T1 だけ。 drain して初めて T2 (ライバル) が現れる。
+      expect(out.response.entries).toHaveLength(2);
+      expect(out.response.entries.map((e) => e.teamId).sort()).toEqual(["T1", "T2"]);
+    }
+    // GSI1 page 2 は page 1 の LastEvaluatedKey を ExclusiveStartKey として渡す。
+    const page1 = ddbSend.mock.calls[1]?.[0] as QueryCommand;
+    const page2 = ddbSend.mock.calls[2]?.[0] as QueryCommand;
+    expect(page1.input.ExclusiveStartKey).toBeUndefined();
+    expect(page2.input.ExclusiveStartKey).toEqual({ PK: "page1" });
+    expect(page2.input.IndexName).toBe("GSI1");
+  });
 });


### PR DESCRIPTION
## Summary

`#1815` fixed missing DynamoDB pagination in `queryDeploymentsByEvent`
(event-handler), but the **same** `GSI1PK=TENANT#<id>` + post-read
`FilterExpression` query pattern lived **unpaginated** in two more handlers.
A DynamoDB Query returns at most 1 MB per page; once a tenant's deployment
rows exceed that, a single `Query` silently drops everything past page 1.

This PR drains both remaining sites with the same inline
`do { … } while (exclusiveStartKey)` loop `#1815` uses:

| Site | Symptom when the partition exceeds 1 MB |
|---|---|
| `resolveDeployment` (`disruption-executor-handler`) | The target `COMPLETE` row can be paged out → returns `undefined` → the scheduled disruption **silently no-ops** (injection never fires). Undermines disruption fidelity (`#1417`). |
| `getLeaderboard` (`participant-handler`) | Rival teams paged out → leaderboard **silently omits them** ("rivals' scores invisible", the `#1793` symptom). |

The `FilterExpression` is applied post-read, so RCU is unchanged — only the
page reads that were previously skipped are added.

These two were found by auditing every `Query`/`Scan` site in
`problem-deploy/handlers` for a `LastEvaluatedKey` drain. The other unpaginated
sites are safe and intentionally left alone: bounded-partition lookups
(`listCompetitorAccounts`, `queryTeamItems`, endpoint `SLOT#` overrides), an
existence probe (`Select: COUNT, Limit: 1`), and an explicit "latest N"
(`notifications`, `Limit` + `ScanIndexForward`).

## Test plan

- New drain test per site: the target / rival row sits on page 2 behind a
  `LastEvaluatedKey`; the test **fails on the single-Query code** and passes
  after the fix, and asserts `ExclusiveStartKey` is threaded page→page.
- `vitest run test/problem-deploy/` → **1848 passed** (incl. the 2 new tests).
- `biome check` clean, `tsc --noEmit` clean, `make harness` → 0 error findings.

## Regression analysis

- **Behavior on small partitions (the common case): unchanged.** With no
  `LastEvaluatedKey`, the loop runs exactly once — identical to the previous
  single `Query`. Existing tests for both handlers (which return one page with
  no `LastEvaluatedKey`) pass without modification.
- **RCU/cost: unchanged.** `FilterExpression` is server-side post-read; the
  drain only fetches pages that already exist for that partition. No new GSI,
  no capacity change (PROVISIONED 1/1 untouched).
- **Ordering: unchanged.** Items are appended in page order, which is the same
  order a single large `Query` would have returned; downstream `.find()` /
  aggregation are order-independent here.
- **No new infinite-loop risk:** the loop terminates when DynamoDB stops
  returning `LastEvaluatedKey`, the standard drain contract `#1815` relies on.
- Scope is two functions in two handlers; no shared signature, type, or event
  contract changed. `event-handler`'s already-paginated copy (`#1815`) is not
  touched.

## Physical impact

- **Lambda function code (disruption-executor, participant-handler): UPDATE** —
  bundled handler code changes; next deploy ships new code, same function
  identity/ARN.
- **CFn resources: NO-OP** — no resource added/removed/replaced, no env vars,
  no IAM change.
- **DynamoDB: NO-OP** — same table, same GSI1, same key/filter; only client-side
  pagination added.

Relates #1815 #1793 #1417
