### PR TITLE
docs(bulk-deploy): correct TransactWrite limit comment (100, not 25)

### DIFF
--- a/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy/types.ts
+++ b/infrastructure/lib/problem-deploy/handlers/event-handler/bulk-deploy/types.ts
@@ -23,7 +23,11 @@ export interface BulkDeployResult {
 
 export type BulkDeployOutcome = { kind: "ok"; result: BulkDeployResult } | { kind: "not_found" };
 
-/** DDB TransactWrite 1 transaction = 25 items の上限。 retry/forceRedeploy 時は 2 ops/entry。 */
+/**
+ * DDB TransactWriteItems の上限は 1 transaction = 100 actions (2022 以前は 25)。 ここでは
+ * 保守的に 25 で chunk する (= 上限の引き上げに伴う batch size 拡大は別途 capacity 判断)。
+ * retry/forceRedeploy 時は 1 entry = Put + Delete の 2 ops なので、 entry 数はこの半分が上限。
+ */
 export const TRANSACT_WRITE_BATCH = 25;
 /** EventBridge PutEvents 1 call = 10 entries の上限。 */
 export const PUT_EVENTS_BATCH = 10;


### PR DESCRIPTION
## Summary

`TRANSACT_WRITE_BATCH`'s doc comment claimed "DDB TransactWrite 1 transaction
= **25** items の上限". DynamoDB raised the `TransactWriteItems` limit to **100**
actions per transaction in 2022 — the [AWS API reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html)
now documents "up to 100" actions (≤ 4 MB aggregate). The comment encoded the
pre-2022 limit as if current.

This corrects the comment only. The exported constant **stays `25`** — a
conservative chunk well under the real limit; raising the batch size is a
separate capacity decision under the PROVISIONED 1/1 regime, so it is
intentionally out of scope here.

Found during a sweep of DynamoDB item-count limits across `problem-deploy`
handlers (`TransactWrite`/`BatchWrite` 100/25-item limits). Both `TransactWrite`
call sites are correctly bounded (`persistence.ts` chunks by this constant;
`create.ts` has an explicit `teams + 1 > 100` early-throw) — no overflow bug;
only this comment was inaccurate.

## Test plan

- Comment-only change; the exported value is unchanged, so behavior and all
  existing `bulk-deploy` chunking tests are unaffected (no test changes apply
  per `INVARIANT_PR_TESTS_COUPLED_WITH_CHANGE` — existing tests already cover
  the chunking math, which is unchanged).
- `biome check` clean, `tsc --noEmit` clean, `make harness` → 0 error findings.

## Regression analysis

- **None.** `export const TRANSACT_WRITE_BATCH = 25` is byte-for-byte unchanged;
  only the preceding JSDoc comment text changed. No code path, type, or value
  is affected, so chunking behavior in `writeBulkDeployPlan` is identical.

## Physical impact

- **NO-OP.** Comment-only source change. No Lambda code-behavior change, no CFn
  resource diff, no DynamoDB access-pattern change.
