### PR TITLE
feat(problems): add multi-flag kind to authoring CLI, scaffolds, docs

### DIFF
--- a/.claude/skills/create-problem/SKILL.md
+++ b/.claude/skills/create-problem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-problem
-description: TenkaCloud の問題ディレクトリ (problems/<category>/<id>/) を ADR-012 thick metadata DSL (5 scoring kinds + endpoints + phases + disruptions + dashboard.slots) で生成する。Battle (リアルタイム対戦) または Challenge (個別演習) の雛形を作る。
+description: TenkaCloud の問題ディレクトリ (problems/<category>/<id>/) を ADR-012 thick metadata DSL (6 scoring kinds + endpoints + phases + disruptions + dashboard.slots) で生成する。Battle (リアルタイム対戦) または Challenge (個別演習) の雛形を作る。
 allowed-tools: Bash(make validate-problems:*), Bash(bun run scripts/tenkacloud-problem.ts:*), Read, Write, Edit, Glob
 ---
 
@@ -15,12 +15,13 @@ scaffold 生成の前に次を順番に聞き出す (= 答えが揃わないま�
 1. **問題タイトル + 1 行 description** — UI に出る name と shortDescription の素材。
 2. **学習目標 (= learning goals)** — 「ユーザーが何を理解する?」 を bullet で 2〜3 つ。
 3. **想定 difficulty + duration** — difficulty 1〜5、 duration は free string (`60〜90 分` 等)。
-4. **scoring kind** — 下の決定木 / Step 0 を見て 5 種から 1 つに絞る。 迷っているうちは scaffold しない。
+4. **scoring kind** — 下の決定木 / Step 0 を見て 6 種から 1 つに絞る。 迷っているうちは scaffold しない。
 5. **scaffold + 編集ガイド** — `bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>` で雛形を生成し、 残った `__PLACEHOLDER__` を上の回答で埋める。
 
 決定木 (= scoring kind):
 
 - 1 つの値 (= flag) を提出して終わる → `flag` (Challenge)
+- 1 問で複数の独立 flag を個別提出して部分点採点する → `multi-flag` (Challenge)
 - endpoint が 1 つ、 常時 200 で加点 → `uptime-flat` (Battle)
 - 複数 endpoint、 全部同時 200 で加点 → `uptime-multi` (Battle)
 - 時間経過で rule が変わる (= 移行 deadline 等) → `phased-polling` (Battle)
@@ -46,17 +47,18 @@ problems/<category>/<id>/
 
 ## Step 0 — kind を決める (= ADR-012 Phase 3 の核)
 
-scoring engine は **問題の `metadata.scoring.kind` で 5 種** の評価ロジックを切り替える。 1 問題 1 kind。 最初に「この問題はどう採点するか」 を決める。
+scoring engine は **問題の `metadata.scoring.kind` で 6 種** の評価ロジックを切り替える。 1 問題 1 kind。 最初に「この問題はどう採点するか」 を決める。
 
 | kind                | カテゴリ        | 用途 / 採点ルール                                                                                                                                       |
 | ------------------- | ---------------| ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `flag`              | Challenge      | 1 deploy で 1 回 flag 提出。 `CFn Outputs.flagOutputKey` の値と submitted flag を一致比較して `points` 加算。                                              |
+| `multi-flag`        | Challenge      | 1 問題に N 個の独立 flag を持ち、 各 flag を個別提出して部分点を与える。 `flags[].points` の合計が満点。 単一 flag で足りるなら `flag` を使う。              |
 | `uptime-flat`       | Battle (旧 `uptime`) | endpoint 群を 1 分毎に probe。 全 ok で `pointsPerSuccess` 加算、 fail で no-op or penalty。                                                              |
 | `uptime-multi`      | Battle         | N slot probe。 **全 slot 同時 ok** で `pointsAllOk` 加算、 1 つでも fail で `failurePenalty`。 復旧優先度を持たせるゲーム性。                                |
 | `phased-polling`    | Battle         | 時間経過 (`phases[].afterMinutes`) で score rule が変わる。 platform 自己申告 (`/meta`) を読んで EC2 / Lambda / ECS / App Runner 等に分類。 microservice 移行系。 |
 | `attack-detection`  | Battle         | CFn Output 内 attack counter の差分で加点 (= `current - prev` × `pointsPerAttack`)。 SOC 想定。                                                            |
 
-迷ったら次の質問: 「1 回提出で終わるか?」 → `flag`。 「endpoint が常に生きていることをスコアにするか?」 → `uptime-flat` or `uptime-multi`。 「途中で rule が変わるか?」 → `phased-polling`。 「攻撃検知数で勝敗が決まるか?」 → `attack-detection`。
+迷ったら次の質問: 「1 回提出で終わるか?」 → `flag`。 「1 問で複数の独立 flag を部分点採点するか?」 → `multi-flag`。 「endpoint が常に生きていることをスコアにするか?」 → `uptime-flat` or `uptime-multi`。 「途中で rule が変わるか?」 → `phased-polling`。 「攻撃検知数で勝敗が決まるか?」 → `attack-detection`。
 
 ## Step 1 — CLI で雛形生成 (推奨)
 
@@ -100,7 +102,7 @@ CLI を使わず手書きする場合は `.claude/templates/problems/<kind>/` �
 
 `problems/SCHEMA.json` に従う。 IDE 補完のため `$schema` を相対 path で先頭に置く。
 
-各 kind の具体例は `.claude/templates/problems/<kind>/metadata.json` を直接参照。 5 kind 分すべて揃えてある。
+各 kind の具体例は `.claude/templates/problems/<kind>/metadata.json` を直接参照。 6 kind 分すべて揃えてある。
 
 ### endpoints[] (= ADR-012 Phase 2 thick DSL)
 
@@ -230,7 +232,7 @@ aws cloudformation deploy \
 
 - [ ] `metadata.json` の `id` が dir 名と完全一致
 - [ ] `category` が `Battle` / `Challenge` (大文字始まり)
-- [ ] `scoring.kind` が 5 種のいずれか
+- [ ] `scoring.kind` が 6 種のいずれか
 - [ ] `cfnTemplate` で参照する `template.yaml` が同 dir にある
 - [ ] template.yaml の Parameters に `NamePrefix` を含む
 - [ ] 全リソース名 / タグに `${NamePrefix}` が冠されている
@@ -242,7 +244,7 @@ aws cloudformation deploy \
 
 ## 参考
 
-- 雛形 templates: [`.claude/templates/problems/<kind>/`](../../templates/problems/) — 5 kind 分の skeleton
+- 雛形 templates: [`.claude/templates/problems/<kind>/`](../../templates/problems/) — 6 kind 分の skeleton
 - 外部 contributor quickstart: [`docs/problems/CONTRIBUTING.md`](../../../docs/problems/CONTRIBUTING.md) — 30 分 quickstart + decision tree + lifecycle + validation error 表
 - 30 分 onboarding (= field reference): [`docs/problems/AUTHORING.html`](../../../docs/problems/AUTHORING.html)
 - 既存 5 問題の design 振り返り: [`docs/problems/EXAMPLES.md`](../../../docs/problems/EXAMPLES.md)

--- a/.claude/templates/problems/multi-flag/metadata.json
+++ b/.claude/templates/problems/multi-flag/metadata.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../SCHEMA.json",
+  "id": "__PROBLEM_ID__",
+  "name": "__PROBLEM_NAME__",
+  "category": "Challenge",
+  "status": "draft",
+  "visibility": "public",
+  "difficulty": 3,
+  "estimatedDuration": "60〜90 分",
+  "shortDescription": "1 問題に N 個の独立 flag を持つ多段 Challenge。 各 flag を個別に発見して portal に提出し、 flag ごとに部分点を得る (multi-flag 採点)。",
+  "description": "本問題は 1 つの deploy に複数の独立した正解 flag を仕込んだ多段 Challenge です。 競技者は各 flag を別々に発見し、 portal の提出フォームに flag ごとに submit します。 flag は互いに独立しており、 任意の順序で解けます (= ストーリー連作 Challenge を 1 問に統合)。\\n\\n採点ロジック: scoring engine が `cfnTemplate` の Outputs から各 `scoring.flags[].flagOutputKey` で正解値を読み取り、 提出値と照合します。 一致した flag の `points` を個別に加算します (= 部分点)。 問題の満点は `flags[].points` の合計です。 flag ごとに `wrongAnswerPenalty` を設定すると、 その flag の不正解 1 回ごとに減点されます (team score は 0 未満に clamp)。 hint は flag ごとに段階開示でき、 開示した hint の `penalty` だけ差し引かれます。\\n\\n単一 flag で十分な場合は `flag` kind を使ってください。 multi-flag は「1 問で複数の独立課題を出し、 部分点を与えたい」場合の opt-in です。\\n\\n想定経路: (1) deploy 後に payload を取得 → (2) 各 episode の flag を Console / CLI で発見 → (3) portal で flag ごとに提出。",
+  "tags": ["sample", "challenge", "multi-flag"],
+  "exposedPorts": [
+    { "port": 1, "name": "(no public endpoint — 各 flag は SSM Parameter 等から取り出す)" }
+  ],
+  "learningGoals": [
+    "1 つの環境から複数の独立した正解値を順不同で発見する",
+    "IAM の最小権限下で必要な情報だけを段階的に引き出す",
+    "問題文と CFn Outputs を突き合わせて 「どの flag がどの Output に対応するか」 を特定する"
+  ],
+  "cfnTemplate": "template.yaml",
+  "runtime": {
+    "provider": "aws",
+    "engine": "cloudformation",
+    "entry": "template.yaml"
+  },
+  "scoring": {
+    "kind": "multi-flag",
+    "flags": [
+      {
+        "id": "ep01",
+        "label": "Ep01: 最初の発見",
+        "flagOutputKey": "Flag1Value",
+        "points": 30,
+        "hints": [
+          {
+            "id": "ep01-hint-1",
+            "content": "competitor IAM role には `ssm:GetParameter` が付与されています。 `aws ssm get-parameter --name /<NamePrefix>/flags/ep01` を試してください。",
+            "penalty": 5
+          }
+        ]
+      },
+      {
+        "id": "ep02",
+        "label": "Ep02: 二段目",
+        "flagOutputKey": "Flag2Value",
+        "points": 30,
+        "wrongAnswerPenalty": 5,
+        "hints": [
+          {
+            "id": "ep02-hint-1",
+            "content": "flag は `TC{...}` 形式です。 `/<NamePrefix>/flags/ep02` の Value をそのまま提出してください。 この flag は不正解ごとに 5 点減点されます。",
+            "penalty": 5
+          }
+        ]
+      },
+      {
+        "id": "ep03",
+        "label": "Ep03: 最終",
+        "flagOutputKey": "Flag3Value",
+        "points": 40,
+        "hints": [
+          {
+            "id": "ep03-hint-1",
+            "content": "最終 flag は配点が最大です。 `/<NamePrefix>/flags/ep03` を読み取ってください。",
+            "penalty": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/templates/problems/multi-flag/template.yaml
+++ b/.claude/templates/problems/multi-flag/template.yaml
@@ -1,0 +1,58 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  TenkaCloud problem — __PROBLEM_ID__ (multi-flag Challenge).
+  1 つの deploy に N 個の独立 flag を仕込み、 競技者が各 flag を個別に発見して portal に
+  提出する多段 Challenge の skeleton。 本 skeleton は flag ごとに 1 つの SSM Parameter を
+  置く最小構成 (3 flag = 3 Parameter / 3 Output)。 実問題では Secrets Manager / S3 /
+  Lambda Env 等に置き換え、 IAM scope を最小化してください。
+  flag を追加・削除するときは Resources の FlagNParameter と Outputs の FlagNValue を
+  metadata.scoring.flags[] と 1:1 で増減させること (= flagOutputKey と Output 名を一致させる)。
+
+Parameters:
+  NamePrefix:
+    Type: String
+    MinLength: 5
+    MaxLength: 80
+    AllowedPattern: "^tc-[a-z0-9]+(-[a-z0-9]+)+$"
+    Description: "tc-{problemSlug}-{teamSlug} 形式の共通リソース prefix。"
+
+Resources:
+  # 各 flag を独立した SSM Parameter として置く。 metadata.scoring.flags[].flagOutputKey が
+  # 下の Outputs の論理名を指す (= scoring engine の比較対象)。
+  Flag1Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${NamePrefix}/flags/ep01"
+      Type: String
+      Value: "TC{__REPLACE_WITH_REAL_FLAG_1__}"
+      Description: "Ep01 の正解 flag (= metadata.scoring.flags[0].flagOutputKey が指す Output の元)。"
+
+  Flag2Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${NamePrefix}/flags/ep02"
+      Type: String
+      Value: "TC{__REPLACE_WITH_REAL_FLAG_2__}"
+      Description: "Ep02 の正解 flag。"
+
+  Flag3Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${NamePrefix}/flags/ep03"
+      Type: String
+      Value: "TC{__REPLACE_WITH_REAL_FLAG_3__}"
+      Description: "Ep03 の正解 flag。"
+
+Outputs:
+  Flag1Value:
+    Description: "Ep01 の正解値 (= metadata.scoring.flags[].flagOutputKey で参照)。"
+    Value: !GetAtt Flag1Parameter.Value
+  Flag2Value:
+    Description: "Ep02 の正解値。"
+    Value: !GetAtt Flag2Parameter.Value
+  Flag3Value:
+    Description: "Ep03 の正解値。"
+    Value: !GetAtt Flag3Parameter.Value
+  NamePrefix:
+    Description: "Deploy 時に渡された prefix (echo)。"
+    Value: !Ref NamePrefix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ problems/<category>/<id>/
 └── portal/          # Optional (.tsx files declared in dashboard.slots)
 ```
 
-Scoring uses one of five built-in kinds (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) — one per problem. The platform's generic scoring Lambda (ADR-012 Phase 3) dispatches them. Don't put problem-specific scoring code into the platform.
+Scoring uses one of six built-in kinds (`flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) — one per problem. The platform's generic scoring Lambda (ADR-012 Phase 3) dispatches them. Don't put problem-specific scoring code into the platform.
 
 A scaffolding CLI is available:
 
@@ -206,7 +206,7 @@ bun run scripts/tenkacloud-problem.ts validate <id>
 bun run scripts/tenkacloud-problem.ts list-kinds
 ```
 
-Scaffold templates live under `.claude/templates/problems/<kind>/` — one per kind (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`).
+Scaffold templates live under `.claude/templates/problems/<kind>/` — one per kind (`flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`).
 
 ## References
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export JSII_DEPRECATED := quiet
         lint lint-md lint-text lint-format lint_md lint_text format_check \
         fix fix-md fix-text fix-format format \
         harness harness-test tech-debt \
-        check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-cli-access \
+        check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-cli-access check-template-name-limits \
         env-check env-check-lite env-init env-init-test synth check-synth diff bootstrap \
         deploy deploy-saas deploy-control-plane deploy-bootstrap destroy destroy-saas \
         deploy-docker destroy-docker docker-shell docker-build \
@@ -70,6 +70,10 @@ check-template-cfn-refs: ; bun run scripts/check-template-cfn-refs.ts
 # 現状は既存 5 テンプレが未対応なので standalone target のみ。 TenkaCloudChallenge 側で
 # templates を更新してから before-commit / check に組み込む (follow-up PR で wire)。
 check-template-cli-access: ; bun run scripts/check-template-cli-access.ts
+# Issue #1812: IAM RoleName / Lambda FunctionName を ${NamePrefix} 込みで明示宣言すると
+# NamePrefix (最大 84 文字) が 64 文字上限を超え deploy が CREATE_FAILED する。 synth / lint は
+# 通るので merge 前にここで弾く (= em-dash #664 / UserData #76 と同じ deploy-only 制約 class)。
+check-template-name-limits: ; bun run scripts/check-template-name-limits.ts
 # feedback_pull_main_before_task: 現在のブランチが origin/main と clean に merge 可能かを
 # git merge-tree (= read-only dry-run) で検査。 conflict 発生時は exit 1 で fail。
 # CI / pre-push hook ともに、 「PR を出した瞬間に DIRTY になる」 のを未然に防ぐ。
@@ -79,8 +83,8 @@ audit-deps:    ; bun run audit:dependencies
 # ため、 本体 before-commit / check からは外す。 platform 側 build:problems-index を走らせると
 # catalog repo の biome JSON formatter (= 別 lock 版) と微妙な drift が出てしまうため、
 # index.json の正本性は catalog 側で担保する設計。
-check:         install lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-no-conflicts audit-deps check-synth
-before-commit: lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-no-conflicts audit-deps check-synth
+check:         install lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-name-limits check-no-conflicts audit-deps check-synth
+before-commit: lint test validate-problems check-docs check-http-status check-template-ascii check-template-security check-template-cfn-refs check-template-name-limits check-no-conflicts audit-deps check-synth
 
 # `cdk synth` が通ることを保証 (= ts-node / tsx の module resolution、 stack 構築の type error
 # 等を本番 deploy 前にキャッチ)。 Makefile placeholder env で全 stack を synth するので AWS 認証は不要。

--- a/docs/architecture/adr-012-problem-plugin-architecture.html
+++ b/docs/architecture/adr-012-problem-plugin-architecture.html
@@ -138,6 +138,8 @@
 
 <p>5 種で表現できない問題が出た時は本 ADR の拡張で kind を増やす。 「問題ごとに Lambda を立てる」 ことはしない。</p>
 
+<p><strong>拡張: <code>multi-flag</code> (6 種目、 #1796)</strong> — 上記 5 種に加え、 1 問題に N 個の独立 flag を持たせ、 競技者が各 flag を個別に提出して部分点を得る <code>multi-flag</code> kind を本 ADR の拡張として追加した。 採点は <code>flag</code> と同じく提出時 (participant-handler の <code>submit-flag</code>) に走るため、 1 分間隔の generic scoring Lambda の polling dispatch (= 上記 5 種) には乗らない。 したがって scoring kind は author が選べる 6 種 (うち提出採点 = <code>flag</code> / <code>multi-flag</code>、 polling 採点 = <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>) となる。</p>
+
 <h3>Endpoint model: default + override の slot</h3>
 
 <p>各 endpoint は <code>metadata.endpoints[]</code> で slot として宣言する。</p>

--- a/docs/community/ONBOARDING.html
+++ b/docs/community/ONBOARDING.html
@@ -225,7 +225,7 @@
 <h4>Problem Author — Ship a small Challenge</h4>
 <ol>
   <li>Read <a href="../problems/AUTHORING.html">docs/problems/AUTHORING.html</a> (30 min onboarding).</li>
-  <li>Decide which of the 5 scoring kinds your problem uses (<code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>).</li>
+  <li>Decide which of the 6 scoring kinds your problem uses (<code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>).</li>
   <li>Scaffold: <code>bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;</code> (or use the <code>/new-problem</code> Claude Code skill).</li>
   <li>Fill <code>metadata.json</code> and <code>template.yaml</code>. Validate locally: <code>bun run scripts/tenkacloud-problem.ts validate &lt;id&gt;</code>.</li>
   <li>Open a PR in the <a href="https://github.com/susumutomita/TenkaCloudChallenge">TenkaCloudChallenge</a> catalog repo.</li>

--- a/docs/demos/architecture-tour-30min.html
+++ b/docs/demos/architecture-tour-30min.html
@@ -101,7 +101,7 @@
 <p><strong>Talking points.</strong></p>
 <ul>
 <li>The Worker Lambda subscribes to <code>DeployCreateRequested</code> events on the EventBridge bus. When one fires, it AssumeRoles into the competitor account using the tenant&#39;s <code>ExternalId</code> (always required — there is no opt-out) and runs CFn <code>CreateStack</code> with the problem&#39;s <code>template.yaml</code>.</li>
-<li>Scoring is centralized in one Lambda that dispatches by <code>kind</code>. The five kinds are <code>flag</code>, <code>uptime-flat</code>, <code>uptime-multi</code>, <code>phased-polling</code>, <code>attack-detection</code>. <strong>No problem-specific code lives in the platform</strong> — that is <code>ADR-012</code>.</li>
+<li>Scoring is centralized in one Lambda that dispatches by <code>kind</code>. The six kinds are <code>flag</code>, <code>multi-flag</code>, <code>uptime-flat</code>, <code>uptime-multi</code>, <code>phased-polling</code>, <code>attack-detection</code>. <strong>No problem-specific code lives in the platform</strong> — that is <code>ADR-012</code>.</li>
 <li>Reconciliation is EventBridge-driven (<code>ADR-014</code>). The frontend polls (no SSE — see <code>AGENTS.md</code>) and EventBridge supplements the polling so we do not need long-lived sockets.</li>
 <li>The Worker Lambda is fronted by Step Functions for retry / delete orchestration. Idempotency is preserved by keying state on <code>(tenantId, eventId, teamId, problemId)</code>.</li>
 </ul>

--- a/docs/demos/architecture-tour-30min.ja.html
+++ b/docs/demos/architecture-tour-30min.ja.html
@@ -101,7 +101,7 @@
 <p><strong>トークポイント</strong>。</p>
 <ul>
 <li>Worker Lambda は EventBridge bus の <code>DeployCreateRequested</code> イベントを subscribe。 発火するとテナントの <code>ExternalId</code> (必須 / opt out 不可) で competitor アカウントへ AssumeRole し、 問題の <code>template.yaml</code> で CFn <code>CreateStack</code> を実行。</li>
-<li>採点は 1 本の Lambda に集約し、 <code>kind</code> で dispatch。 5 種は <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>。 <strong>プラットフォーム側に問題固有コードは置かない</strong> — <code>ADR-012</code>。</li>
+<li>採点は 1 本の Lambda に集約し、 <code>kind</code> で dispatch。 6 種は <code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>。 <strong>プラットフォーム側に問題固有コードは置かない</strong> — <code>ADR-012</code>。</li>
 <li>Reconciliation は EventBridge 駆動 (<code>ADR-014</code>)。 フロントエンドは polling (SSE は使わない — <code>AGENTS.md</code>)、 EventBridge は polling を補強するので long-lived socket は不要。</li>
 <li>Worker Lambda は Step Functions が前段に立ち、 retry / delete のオーケストレーションを担う。 idempotency は state を <code>(tenantId, eventId, teamId, problemId)</code> で key 化して保つ。</li>
 </ul>

--- a/docs/demos/architecture-tour-30min.ja.md
+++ b/docs/demos/architecture-tour-30min.ja.md
@@ -61,7 +61,7 @@
 **トークポイント**。
 
 - Worker Lambda は EventBridge bus の `DeployCreateRequested` イベントを subscribe。 発火するとテナントの `ExternalId` (必須 / opt out 不可) で competitor アカウントへ AssumeRole し、 問題の `template.yaml` で CFn `CreateStack` を実行。
-- 採点は 1 本の Lambda に集約し、 `kind` で dispatch。 5 種は `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`。 **プラットフォーム側に問題固有コードは置かない** — `ADR-012`。
+- 採点は 1 本の Lambda に集約し、 `kind` で dispatch。 6 種は `flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`。 **プラットフォーム側に問題固有コードは置かない** — `ADR-012`。
 - Reconciliation は EventBridge 駆動 (`ADR-014`)。 フロントエンドは polling (SSE は使わない — `AGENTS.md`)、 EventBridge は polling を補強するので long-lived socket は不要。
 - Worker Lambda は Step Functions が前段に立ち、 retry / delete のオーケストレーションを担う。 idempotency は state を `(tenantId, eventId, teamId, problemId)` で key 化して保つ。
 

--- a/docs/demos/architecture-tour-30min.md
+++ b/docs/demos/architecture-tour-30min.md
@@ -61,7 +61,7 @@ Set the frame: TenkaCloud is built on `@cdklabs/sbt-aws` 0.3.9 and obeys four pl
 **Talking points.**
 
 - The Worker Lambda subscribes to `DeployCreateRequested` events on the EventBridge bus. When one fires, it AssumeRoles into the competitor account using the tenant's `ExternalId` (always required — there is no opt-out) and runs CFn `CreateStack` with the problem's `template.yaml`.
-- Scoring is centralized in one Lambda that dispatches by `kind`. The five kinds are `flag`, `uptime-flat`, `uptime-multi`, `phased-polling`, `attack-detection`. **No problem-specific code lives in the platform** — that is `ADR-012`.
+- Scoring is centralized in one Lambda that dispatches by `kind`. The six kinds are `flag`, `multi-flag`, `uptime-flat`, `uptime-multi`, `phased-polling`, `attack-detection`. **No problem-specific code lives in the platform** — that is `ADR-012`.
 - Reconciliation is EventBridge-driven (`ADR-014`). The frontend polls (no SSE — see `AGENTS.md`) and EventBridge supplements the polling so we do not need long-lived sockets.
 - The Worker Lambda is fronted by Step Functions for retry / delete orchestration. Idempotency is preserved by keying state on `(tenantId, eventId, teamId, problemId)`.
 

--- a/docs/demos/sales-pitch-15min.html
+++ b/docs/demos/sales-pitch-15min.html
@@ -84,12 +84,12 @@
 <p><strong>Pricing hint.</strong> Cross-account <code>AssumeRole</code> is included at every tier. The one-time competitor-side bootstrap is <code>infrastructure/templates/competitor-bootstrap.yaml</code>, a single CFn that creates the role with <code>ExternalId</code>.</p>
 <h2>Step 6 — Solve and score (≈ 3 min)</h2>
 <p><strong>Action.</strong> Same as quickstart Step 6. After the score increments, switch back to the admin console scoreboard.</p>
-<p><strong>Talking point.</strong> &quot;Scoring is one of five built-in kinds — <code>flag</code>, <code>uptime-flat</code>, <code>uptime-multi</code>, <code>phased-polling</code>, <code>attack-detection</code>. Each problem picks one. The platform has a single generic scoring Lambda that dispatches to the right kind — no problem-specific code in the platform. That keeps the operational surface small.&quot;</p>
+<p><strong>Talking point.</strong> &quot;Scoring is one of six built-in kinds — <code>flag</code>, <code>multi-flag</code>, <code>uptime-flat</code>, <code>uptime-multi</code>, <code>phased-polling</code>, <code>attack-detection</code>. Each problem picks one. The platform has a single generic scoring Lambda that dispatches to the right kind — no problem-specific code in the platform. That keeps the operational surface small.&quot;</p>
 <p><strong>Pricing hint.</strong> Real-time scoreboard refresh, multi-team dashboards, and disruption-phase visibility ship at Hosted Event tier and above. Starter has the same scoring path with simpler dashboards.</p>
 <h2>Closing (≈ 2 min)</h2>
 <p>Cover three points:</p>
 <ol>
-<li><strong>Reality check.</strong> What we ship today: cross-account isolated deploy, five scoring kinds, EventBridge state reconciliation (<code>ADR-014</code>), polling-based UI (no SSE — see <code>AGENTS.md</code>). What we are working toward: voting-based community catalog (<code>ADR-024</code>), provider-specific runtimes for non-AWS (<code>ADR-023</code>). We do not claim &quot;production-grade multi-cloud&quot; or &quot;full SOC2&quot; today.</li>
+<li><strong>Reality check.</strong> What we ship today: cross-account isolated deploy, six scoring kinds, EventBridge state reconciliation (<code>ADR-014</code>), polling-based UI (no SSE — see <code>AGENTS.md</code>). What we are working toward: voting-based community catalog (<code>ADR-024</code>), provider-specific runtimes for non-AWS (<code>ADR-023</code>). We do not claim &quot;production-grade multi-cloud&quot; or &quot;full SOC2&quot; today.</li>
 <li><strong>Operating model.</strong> Lite mode = <code>make deploy</code>, 1 organizer / 1 event, 10-minute setup. SaaS mode = <code>make deploy-saas</code>, multi-tenant, pooled + silo tier mix, 15 to 20 minutes to bring up the control plane.</li>
 <li><strong>CTA.</strong> Pick a starter problem (<code>hello-world</code>, <code>s3-public-bucket</code>, <code>lambda-cold-start</code>). Run one dry-run with your own SRE team. The longest commitment is one <code>make deploy</code> run.</li>
 </ol>
@@ -111,7 +111,7 @@
 </tr>
 <tr>
 <td>&quot;Each event needs custom scoring.&quot;</td>
-<td>Five scoring kinds (<code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>).</td>
+<td>Six scoring kinds (<code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>).</td>
 </tr>
 <tr>
 <td>&quot;We need event-day operations to be calm.&quot;</td>

--- a/docs/demos/sales-pitch-15min.ja.html
+++ b/docs/demos/sales-pitch-15min.ja.html
@@ -84,12 +84,12 @@
 <p><strong>料金ヒント</strong>。 クロスアカウント <code>AssumeRole</code> は全 tier に含まれます。 競技者側の 1 回きりブートストラップは <code>infrastructure/templates/competitor-bootstrap.yaml</code>、 <code>ExternalId</code> 付きで role を作る 1 ファイルの CFn です。</p>
 <h2>ステップ 6 — 解いてスコア反映 (約 3 分)</h2>
 <p><strong>操作</strong>。 quickstart ステップ 6 と同じ。 スコアが加算されたら admin console のスコアボードに戻ります。</p>
-<p><strong>トークポイント</strong>。「採点はビルトインの 5 種 — <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code> のいずれか。 各問題が 1 つを選びます。 プラットフォームには共通の generic 採点 Lambda が 1 本あり、 問題種別に応じて dispatch します — プラットフォーム側に問題固有コードはゼロ。 これで運用面の表面積を小さく保てます」</p>
+<p><strong>トークポイント</strong>。「採点はビルトインの 6 種 — <code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code> のいずれか。 各問題が 1 つを選びます。 プラットフォームには共通の generic 採点 Lambda が 1 本あり、 問題種別に応じて dispatch します — プラットフォーム側に問題固有コードはゼロ。 これで運用面の表面積を小さく保てます」</p>
 <p><strong>料金ヒント</strong>。 リアルタイムスコアボードリフレッシュ / マルチチームダッシュボード / disruption phase 可視化は Hosted Event tier 以上に含まれます。 Starter tier も同じ採点経路ですが、 ダッシュボードはシンプル版です。</p>
 <h2>クロージング (約 2 分)</h2>
 <p>3 点を伝えます。</p>
 <ol>
-<li><strong>現実の話</strong>。 今日出荷しているもの : クロスアカウント分離 deploy、 5 種の採点、 EventBridge 駆動 state 再同期 (<code>ADR-014</code>)、 polling UI (SSE は使わない — <code>AGENTS.md</code> 参照)。 取り組み中 : 投票方式のコミュニティカタログ (<code>ADR-024</code>)、 AWS 以外向け provider-specific runtime (<code>ADR-023</code>)。「production-grade なマルチクラウド」や「フル SOC2」は今日は名乗らない。</li>
+<li><strong>現実の話</strong>。 今日出荷しているもの : クロスアカウント分離 deploy、 6 種の採点、 EventBridge 駆動 state 再同期 (<code>ADR-014</code>)、 polling UI (SSE は使わない — <code>AGENTS.md</code> 参照)。 取り組み中 : 投票方式のコミュニティカタログ (<code>ADR-024</code>)、 AWS 以外向け provider-specific runtime (<code>ADR-023</code>)。「production-grade なマルチクラウド」や「フル SOC2」は今日は名乗らない。</li>
 <li><strong>運用モデル</strong>。 Lite mode = <code>make deploy</code>、 1 主催者 / 1 イベント、 10 分でセットアップ。 SaaS mode = <code>make deploy-saas</code>、 マルチテナント、 pooled + silo の組み合わせ、 control plane 起動に 15 〜 20 分。</li>
 <li><strong>CTA</strong>。 starter 問題 (<code>hello-world</code>、 <code>s3-public-bucket</code>、 <code>lambda-cold-start</code>) を選んで御社の SRE チームでドライランを 1 回。 最も長いコミットメントは <code>make deploy</code> 1 回分。</li>
 </ol>
@@ -111,7 +111,7 @@
 </tr>
 <tr>
 <td>「イベントごとに採点ロジックが必要」</td>
-<td>5 種の採点 (<code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>)</td>
+<td>6 種の採点 (<code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>)</td>
 </tr>
 <tr>
 <td>「イベント当日の運用を穏やかにしたい」</td>

--- a/docs/demos/sales-pitch-15min.ja.md
+++ b/docs/demos/sales-pitch-15min.ja.md
@@ -61,7 +61,7 @@
 
 **操作**。 quickstart ステップ 6 と同じ。 スコアが加算されたら admin console のスコアボードに戻ります。
 
-**トークポイント**。「採点はビルトインの 5 種 — `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection` のいずれか。 各問題が 1 つを選びます。 プラットフォームには共通の generic 採点 Lambda が 1 本あり、 問題種別に応じて dispatch します — プラットフォーム側に問題固有コードはゼロ。 これで運用面の表面積を小さく保てます」
+**トークポイント**。「採点はビルトインの 6 種 — `flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection` のいずれか。 各問題が 1 つを選びます。 プラットフォームには共通の generic 採点 Lambda が 1 本あり、 問題種別に応じて dispatch します — プラットフォーム側に問題固有コードはゼロ。 これで運用面の表面積を小さく保てます」
 
 **料金ヒント**。 リアルタイムスコアボードリフレッシュ / マルチチームダッシュボード / disruption phase 可視化は Hosted Event tier 以上に含まれます。 Starter tier も同じ採点経路ですが、 ダッシュボードはシンプル版です。
 
@@ -69,7 +69,7 @@
 
 3 点を伝えます。
 
-1. **現実の話**。 今日出荷しているもの : クロスアカウント分離 deploy、 5 種の採点、 EventBridge 駆動 state 再同期 (`ADR-014`)、 polling UI (SSE は使わない — `AGENTS.md` 参照)。 取り組み中 : 投票方式のコミュニティカタログ (`ADR-024`)、 AWS 以外向け provider-specific runtime (`ADR-023`)。「production-grade なマルチクラウド」や「フル SOC2」は今日は名乗らない。
+1. **現実の話**。 今日出荷しているもの : クロスアカウント分離 deploy、 6 種の採点、 EventBridge 駆動 state 再同期 (`ADR-014`)、 polling UI (SSE は使わない — `AGENTS.md` 参照)。 取り組み中 : 投票方式のコミュニティカタログ (`ADR-024`)、 AWS 以外向け provider-specific runtime (`ADR-023`)。「production-grade なマルチクラウド」や「フル SOC2」は今日は名乗らない。
 2. **運用モデル**。 Lite mode = `make deploy`、 1 主催者 / 1 イベント、 10 分でセットアップ。 SaaS mode = `make deploy-saas`、 マルチテナント、 pooled + silo の組み合わせ、 control plane 起動に 15 〜 20 分。
 3. **CTA**。 starter 問題 (`hello-world`、 `s3-public-bucket`、 `lambda-cold-start`) を選んで御社の SRE チームでドライランを 1 回。 最も長いコミットメントは `make deploy` 1 回分。
 
@@ -79,7 +79,7 @@
 | --------------------------------------------- | --------------------------------------------------------------------------------------- |
 | 「研修がスライドのみで身につかない」          | 実 AWS のハンズオン問題、 決定論的な採点経路                                            |
 | 「サンドボックスアカウントの爆発半径が広い」  | チーム別の隔離アカウント + `ExternalId` 付き AssumeRole + scope 制限 `ParticipantViewerRole` |
-| 「イベントごとに採点ロジックが必要」          | 5 種の採点 (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) |
+| 「イベントごとに採点ロジックが必要」          | 6 種の採点 (`flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`) |
 | 「イベント当日の運用を穏やかにしたい」        | EventBridge 駆動の reconciliation (ADR-014)、 polling UI、 冪等な teardown              |
 | 「自社 SRE が問題を書きたい」                 | 1 問 3 ファイル、 `ADR-012` 問題プラグインアーキテクチャ、 プラットフォーム fork 不要   |
 | 「将来 AWS から離れる可能性がある」           | `ADR-023` provider-specific runtime ロードマップ。 今日は AWS のみ、 範囲は正直に伝える |

--- a/docs/demos/sales-pitch-15min.md
+++ b/docs/demos/sales-pitch-15min.md
@@ -61,7 +61,7 @@ This is the 15-minute version of the quickstart, intended for facilitators runni
 
 **Action.** Same as quickstart Step 6. After the score increments, switch back to the admin console scoreboard.
 
-**Talking point.** "Scoring is one of five built-in kinds — `flag`, `uptime-flat`, `uptime-multi`, `phased-polling`, `attack-detection`. Each problem picks one. The platform has a single generic scoring Lambda that dispatches to the right kind — no problem-specific code in the platform. That keeps the operational surface small."
+**Talking point.** "Scoring is one of six built-in kinds — `flag`, `multi-flag`, `uptime-flat`, `uptime-multi`, `phased-polling`, `attack-detection`. Each problem picks one. The platform has a single generic scoring Lambda that dispatches to the right kind — no problem-specific code in the platform. That keeps the operational surface small."
 
 **Pricing hint.** Real-time scoreboard refresh, multi-team dashboards, and disruption-phase visibility ship at Hosted Event tier and above. Starter has the same scoring path with simpler dashboards.
 
@@ -69,7 +69,7 @@ This is the 15-minute version of the quickstart, intended for facilitators runni
 
 Cover three points:
 
-1. **Reality check.** What we ship today: cross-account isolated deploy, five scoring kinds, EventBridge state reconciliation (`ADR-014`), polling-based UI (no SSE — see `AGENTS.md`). What we are working toward: voting-based community catalog (`ADR-024`), provider-specific runtimes for non-AWS (`ADR-023`). We do not claim "production-grade multi-cloud" or "full SOC2" today.
+1. **Reality check.** What we ship today: cross-account isolated deploy, six scoring kinds, EventBridge state reconciliation (`ADR-014`), polling-based UI (no SSE — see `AGENTS.md`). What we are working toward: voting-based community catalog (`ADR-024`), provider-specific runtimes for non-AWS (`ADR-023`). We do not claim "production-grade multi-cloud" or "full SOC2" today.
 2. **Operating model.** Lite mode = `make deploy`, 1 organizer / 1 event, 10-minute setup. SaaS mode = `make deploy-saas`, multi-tenant, pooled + silo tier mix, 15 to 20 minutes to bring up the control plane.
 3. **CTA.** Pick a starter problem (`hello-world`, `s3-public-bucket`, `lambda-cold-start`). Run one dry-run with your own SRE team. The longest commitment is one `make deploy` run.
 
@@ -79,7 +79,7 @@ Cover three points:
 | ------------------------------------------- | ------------------------------------------------------------------------------------ |
 | "Our training is slides; nothing sticks."   | Hands-on real-AWS problems with deterministic scoring path.                          |
 | "Sandbox accounts blow up our blast RADIUS."| Per-team isolated account + `ExternalId` AssumeRole + scoped `ParticipantViewerRole`. |
-| "Each event needs custom scoring."          | Five scoring kinds (`flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`). |
+| "Each event needs custom scoring."          | Six scoring kinds (`flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`). |
 | "We need event-day operations to be calm."  | EventBridge-driven reconciliation (ADR-014), polling-based UI, idempotent teardown.  |
 | "We want our SRE team to author problems."  | Three files per problem. `ADR-012` problem-plugin architecture. No platform fork.    |
 | "We may want to leave AWS in the future."   | `ADR-023` provider-specific runtime roadmap. Today: AWS only; honest about scope.    |

--- a/docs/problems/AI-WORKFLOW.html
+++ b/docs/problems/AI-WORKFLOW.html
@@ -79,7 +79,7 @@ Prerequisite: read <a href="./CONTRIBUTING.md"><code>CONTRIBUTING.md</code></a> 
 <li><strong>Title and 1-line description.</strong> What is the problem called and what does the contestant do in one sentence?</li>
 <li><strong>Learning goals.</strong> Two or three bullets describing what the contestant should walk away understanding.</li>
 <li><strong>Difficulty and duration.</strong> 1 = entry, 5 = expert. Duration is a free-form string like <code>60〜90 分</code>.</li>
-<li><strong>Scoring kind.</strong> The skill walks you through the decision tree from <code>CONTRIBUTING.md</code>. Pick exactly one of the five built-ins.</li>
+<li><strong>Scoring kind.</strong> The skill walks you through the decision tree from <code>CONTRIBUTING.md</code>. Pick exactly one of the six built-ins.</li>
 <li><strong>Scaffold generation.</strong> The skill invokes <code>bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;</code> and shows the resulting files.</li>
 <li><strong>Edit guidance.</strong> The skill enumerates every <code>__PLACEHOLDER__</code> left in the scaffold and prompts for replacement values.</li>
 </ol>
@@ -121,7 +121,7 @@ bun run scripts/tenkacloud-problem.ts inspect &lt;id&gt;
 - learning goals: &lt;bullets&gt;
 - difficulty: &lt;1-5&gt;
 - duration: &quot;&lt;free text&gt;&quot;
-- scoring kind: &lt;one of flag / uptime-flat / uptime-multi / phased-polling / attack-detection&gt;
+- scoring kind: &lt;one of flag / multi-flag / uptime-flat / uptime-multi / phased-polling / attack-detection&gt;
 
 Use the CLI:
   bun run scripts/tenkacloud-problem.ts create &lt;id&gt; --kind &lt;kind&gt;

--- a/docs/problems/AI-WORKFLOW.md
+++ b/docs/problems/AI-WORKFLOW.md
@@ -41,7 +41,7 @@ The skill walks through:
 1. **Title and 1-line description.** What is the problem called and what does the contestant do in one sentence?
 2. **Learning goals.** Two or three bullets describing what the contestant should walk away understanding.
 3. **Difficulty and duration.** 1 = entry, 5 = expert. Duration is a free-form string like `60〜90 分`.
-4. **Scoring kind.** The skill walks you through the decision tree from `CONTRIBUTING.md`. Pick exactly one of the five built-ins.
+4. **Scoring kind.** The skill walks you through the decision tree from `CONTRIBUTING.md`. Pick exactly one of the six built-ins.
 5. **Scaffold generation.** The skill invokes `bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>` and shows the resulting files.
 6. **Edit guidance.** The skill enumerates every `__PLACEHOLDER__` left in the scaffold and prompts for replacement values.
 
@@ -103,7 +103,7 @@ Draft a new TenkaCloud problem with these properties:
 - learning goals: <bullets>
 - difficulty: <1-5>
 - duration: "<free text>"
-- scoring kind: <one of flag / uptime-flat / uptime-multi / phased-polling / attack-detection>
+- scoring kind: <one of flag / multi-flag / uptime-flat / uptime-multi / phased-polling / attack-detection>
 
 Use the CLI:
   bun run scripts/tenkacloud-problem.ts create <id> --kind <kind>

--- a/docs/problems/AUTHORING.html
+++ b/docs/problems/AUTHORING.html
@@ -119,7 +119,7 @@
 <section id="decide-kind">
 <h2>2. Step 0 — 採点 kind を決める</h2>
 
-<p>scoring engine (= ADR-012 Phase 3 の generic scoring Lambda) は <strong>5 種の builtin kind</strong> をサポートする。 1 問題 1 kind。 最初に「この問題はどう採点するか」 を決めると後の選択肢が全部決まる。</p>
+<p>scoring engine (= ADR-012 Phase 3 の generic scoring Lambda) は <strong>6 種の builtin kind</strong> をサポートする。 1 問題 1 kind。 最初に「この問題はどう採点するか」 を決めると後の選択肢が全部決まる。</p>
 
 <table>
 <thead>
@@ -131,6 +131,12 @@
     <td>Challenge</td>
     <td>1 deploy で 1 回 flag 提出。 CFn Output 値と submitted flag が一致したら <code>points</code> 加算</td>
     <td>CTF 風 (= AWS Console で値を発見する Challenge)</td>
+  </tr>
+  <tr>
+    <td><code>multi-flag</code></td>
+    <td>Challenge</td>
+    <td>1 問題に N 個の独立 flag を持ち、 各 flag を個別提出して部分点を与える。 <code>flags[].points</code> の合計が満点</td>
+    <td>ストーリー連作 Challenge を 1 問に統合 (= 単一 flag で足りるなら <code>flag</code> を使う)</td>
   </tr>
   <tr>
     <td><code>uptime-flat</code> (旧 <code>uptime</code>)</td>
@@ -163,6 +169,7 @@
 <strong>決定木:</strong>
 <ul>
   <li>1 回提出で終わるか? → <code>flag</code></li>
+  <li>1 問で複数の独立 flag を部分点採点するか? → <code>multi-flag</code></li>
   <li>endpoint が常に生きていることが採点軸か? → 1 endpoint なら <code>uptime-flat</code>、 N endpoint で「全部生きている」 を求めるなら <code>uptime-multi</code></li>
   <li>途中で rule が変わるか? → <code>phased-polling</code></li>
   <li>攻撃検知数で勝敗が決まるか? → <code>attack-detection</code></li>
@@ -404,7 +411,7 @@ aws cloudformation deploy \
 <ul>
   <li>☐ <code>metadata.json</code> の <code>id</code> が dir 名と完全一致</li>
   <li>☐ <code>category</code> が <code>Battle</code> / <code>Challenge</code> (大文字始まり)</li>
-  <li>☐ <code>scoring.kind</code> が 5 種のいずれか</li>
+  <li>☐ <code>scoring.kind</code> が 6 種のいずれか</li>
   <li>☐ <code>cfnTemplate</code> で参照する <code>template.yaml</code> が同 dir にある</li>
   <li>☐ template.yaml の Parameters に <code>NamePrefix</code> を含む</li>
   <li>☐ 全リソース名 / タグに <code>${NamePrefix}</code> が冠されている</li>

--- a/docs/problems/CONTRIBUTING.html
+++ b/docs/problems/CONTRIBUTING.html
@@ -72,10 +72,15 @@ make install
 </code></pre>
 <h2>30-minute quickstart (= scaffold → edit → validate → PR)</h2>
 <h3>1. Pick the scoring kind (= the most important decision)</h3>
-<p>A TenkaCloud problem ships exactly one of five built-in scoring kinds. The platform&#39;s generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a>.</p>
+<p>A TenkaCloud problem ships exactly one of six built-in scoring kinds. The platform&#39;s generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a>.</p>
 <p>Use this decision tree:</p>
 <pre><code class="language-text">Does the competitor submit a single value (a &quot;flag&quot;) to win?
-├── Yes → kind = &quot;flag&quot;               (Challenge, e.g. read an SSM Parameter, find an S3 object)
+├── Yes
+│   │
+│   Is it one flag, or several independent flags scored separately (partial credit)?
+│   ├── One flag → kind = &quot;flag&quot;      (Challenge, e.g. read an SSM Parameter, find an S3 object)
+│   └── N independent flags → kind = &quot;multi-flag&quot;
+│       (Challenge, one problem poses several sub-challenges; sum of flags[].points is the max score)
 └── No
     │
     Does the competitor have to keep something running?
@@ -215,7 +220,7 @@ gh pr create --repo susumutomita/TenkaCloudChallenge \
 <tbody><tr>
 <td><code>scoring.kind=&quot;...&quot; is not a recognized kind</code></td>
 <td>Typo in <code>scoring.kind</code></td>
-<td>Set it to exactly one of <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>.</td>
+<td>Set it to exactly one of <code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code>.</td>
 </tr>
 <tr>
 <td><code>scoring.flagOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
@@ -285,7 +290,7 @@ gh pr create --repo susumutomita/TenkaCloudChallenge \
 <li><input disabled="" type="checkbox"> <code>metadata.id</code> matches the directory name.</li>
 <li><input disabled="" type="checkbox"> <code>category</code> is <code>&quot;Battle&quot;</code> or <code>&quot;Challenge&quot;</code> (capitalized).</li>
 <li><input disabled="" type="checkbox"> <code>status</code> is <code>&quot;draft&quot;</code> for a first submission.</li>
-<li><input disabled="" type="checkbox"> <code>scoring.kind</code> is one of the five built-ins.</li>
+<li><input disabled="" type="checkbox"> <code>scoring.kind</code> is one of the six built-ins.</li>
 <li><input disabled="" type="checkbox"> Every <code>__PLACEHOLDER__</code> in <code>metadata.json</code> has been replaced.</li>
 <li><input disabled="" type="checkbox"> Every endpoint / scoring key referenced from <code>metadata.json</code> exists as a key in <code>template.yaml</code> <code>Outputs:</code>.</li>
 <li><input disabled="" type="checkbox"> Every resource name in <code>template.yaml</code> is prefixed with <code>${NamePrefix}</code>.</li>

--- a/docs/problems/CONTRIBUTING.ja.html
+++ b/docs/problems/CONTRIBUTING.ja.html
@@ -72,10 +72,15 @@ make install
 </code></pre>
 <h2>30 分 quickstart (= scaffold → edit → validate → PR)</h2>
 <h3>1. 採点 kind を選ぶ (= 最重要)</h3>
-<p>TenkaCloud の 1 問題は 5 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> で禁止。</p>
+<p>TenkaCloud の 1 問題は 6 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は <a href="../architecture/adr-012-problem-plugin-architecture.html">ADR-012</a> で禁止。</p>
 <p>決定木は次のとおりです。</p>
-<pre><code class="language-text">競技者が 1 つの値 (= &quot;flag&quot;) を提出して終わるか?
-├── Yes → kind = &quot;flag&quot;               (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+<pre><code class="language-text">競技者が値 (= &quot;flag&quot;) を提出して終わるか?
+├── Yes
+│   │
+│   flag は 1 個か、 独立した複数 flag を個別採点 (= 部分点) するか?
+│   ├── 1 個 → kind = &quot;flag&quot;          (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+│   └── N 個の独立 flag → kind = &quot;multi-flag&quot;
+│       (Challenge / 1 問に複数 sub-challenge。 flags[].points の合計が満点)
 └── No
     │
     競技者が何かを稼働させ続ける必要があるか?
@@ -215,7 +220,7 @@ gh pr create --repo susumutomita/TenkaCloudChallenge \
 <tbody><tr>
 <td><code>scoring.kind=&quot;...&quot; is not a recognized kind</code></td>
 <td><code>scoring.kind</code> の typo</td>
-<td>値を <code>flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code> のどれかに修正する。</td>
+<td>値を <code>flag</code> / <code>multi-flag</code> / <code>uptime-flat</code> / <code>uptime-multi</code> / <code>phased-polling</code> / <code>attack-detection</code> のどれかに修正する。</td>
 </tr>
 <tr>
 <td><code>scoring.flagOutputKey=&quot;X&quot; not found in template.yaml Outputs</code></td>
@@ -285,7 +290,7 @@ gh pr create --repo susumutomita/TenkaCloudChallenge \
 <li><input disabled="" type="checkbox"> <code>metadata.id</code> と dir 名が完全一致。</li>
 <li><input disabled="" type="checkbox"> <code>category</code> は <code>&quot;Battle&quot;</code> または <code>&quot;Challenge&quot;</code> (= 大文字始まり)。</li>
 <li><input disabled="" type="checkbox"> <code>status</code> は <code>&quot;draft&quot;</code> (= 初回 submission)。</li>
-<li><input disabled="" type="checkbox"> <code>scoring.kind</code> は 5 種のいずれか。</li>
+<li><input disabled="" type="checkbox"> <code>scoring.kind</code> は 6 種のいずれか。</li>
 <li><input disabled="" type="checkbox"> <code>metadata.json</code> 内の <code>__PLACEHOLDER__</code> を全部置換済。</li>
 <li><input disabled="" type="checkbox"> <code>metadata.json</code> が参照する endpoint / scoring key が <code>template.yaml</code> <code>Outputs:</code> に存在する。</li>
 <li><input disabled="" type="checkbox"> <code>template.yaml</code> の全リソース名に <code>${NamePrefix}</code> が冠されている。</li>

--- a/docs/problems/CONTRIBUTING.ja.md
+++ b/docs/problems/CONTRIBUTING.ja.md
@@ -39,13 +39,18 @@ git submodule update --init --recursive problems
 
 ### 1. 採点 kind を選ぶ (= 最重要)
 
-TenkaCloud の 1 問題は 5 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) で禁止。
+TenkaCloud の 1 問題は 6 種の built-in scoring kind のいずれか 1 つで採点する。 platform 側の generic scoring Lambda がこの値で dispatch する。 問題固有の scoring code は [ADR-012](../architecture/adr-012-problem-plugin-architecture.html) で禁止。
 
 決定木は次のとおりです。
 
 ```text
-競技者が 1 つの値 (= "flag") を提出して終わるか?
-├── Yes → kind = "flag"               (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+競技者が値 (= "flag") を提出して終わるか?
+├── Yes
+│   │
+│   flag は 1 個か、 独立した複数 flag を個別採点 (= 部分点) するか?
+│   ├── 1 個 → kind = "flag"          (Challenge / SSM Parameter を読む、 S3 object を見つける等)
+│   └── N 個の独立 flag → kind = "multi-flag"
+│       (Challenge / 1 問に複数 sub-challenge。 flags[].points の合計が満点)
 └── No
     │
     競技者が何かを稼働させ続ける必要があるか?
@@ -175,7 +180,7 @@ CLI validator (`scripts/tenkacloud-problem.ts validate`) と `make validate-prob
 
 | エラー (= 部分一致)                                                       | 原因                                                                              | Fix                                                                                                                       |
 | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `scoring.kind="..." is not a recognized kind`                            | `scoring.kind` の typo                                                            | 値を `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection` のどれかに修正する。                  |
+| `scoring.kind="..." is not a recognized kind`                            | `scoring.kind` の typo                                                            | 値を `flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection` のどれかに修正する。   |
 | `scoring.flagOutputKey="X" not found in template.yaml Outputs`           | `metadata.scoring.flagOutputKey` の値が CFn `Output` key に存在しない              | `template.yaml` に `Outputs.X:` を追加するか、 metadata 側の key を template の実際の Output key に揃える。               |
 | `scoring.statsOutputKey="X" not found in template.yaml Outputs`          | `attack-detection` で同上                                                          | `Outputs.X:` を追加。 `Value` は攻撃検知数 (= 整数 string)。                                                              |
 | `endpoints[slot=N].default.key="X" not found in template.yaml Outputs`   | `endpoints[].default.key` が存在しない Output を指す                              | `Outputs.X:` を追加 (= typically 公開 endpoint URL)。                                                                     |
@@ -208,7 +213,7 @@ Claude Code には `/create-problem` skill が同梱されており、 同じ sc
 - [ ] `metadata.id` と dir 名が完全一致。
 - [ ] `category` は `"Battle"` または `"Challenge"` (= 大文字始まり)。
 - [ ] `status` は `"draft"` (= 初回 submission)。
-- [ ] `scoring.kind` は 5 種のいずれか。
+- [ ] `scoring.kind` は 6 種のいずれか。
 - [ ] `metadata.json` 内の `__PLACEHOLDER__` を全部置換済。
 - [ ] `metadata.json` が参照する endpoint / scoring key が `template.yaml` `Outputs:` に存在する。
 - [ ] `template.yaml` の全リソース名に `${NamePrefix}` が冠されている。

--- a/docs/problems/CONTRIBUTING.md
+++ b/docs/problems/CONTRIBUTING.md
@@ -39,13 +39,18 @@ git submodule update --init --recursive problems
 
 ### 1. Pick the scoring kind (= the most important decision)
 
-A TenkaCloud problem ships exactly one of five built-in scoring kinds. The platform's generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by [ADR-012](../architecture/adr-012-problem-plugin-architecture.html).
+A TenkaCloud problem ships exactly one of six built-in scoring kinds. The platform's generic scoring Lambda dispatches on this value; problem-specific scoring code is forbidden by [ADR-012](../architecture/adr-012-problem-plugin-architecture.html).
 
 Use this decision tree:
 
 ```text
 Does the competitor submit a single value (a "flag") to win?
-├── Yes → kind = "flag"               (Challenge, e.g. read an SSM Parameter, find an S3 object)
+├── Yes
+│   │
+│   Is it one flag, or several independent flags scored separately (partial credit)?
+│   ├── One flag → kind = "flag"      (Challenge, e.g. read an SSM Parameter, find an S3 object)
+│   └── N independent flags → kind = "multi-flag"
+│       (Challenge, one problem poses several sub-challenges; sum of flags[].points is the max score)
 └── No
     │
     Does the competitor have to keep something running?
@@ -175,7 +180,7 @@ The CLI validator (`scripts/tenkacloud-problem.ts validate`) and `make validate-
 
 | Symptom (substring of the error)                                            | Likely cause                                                                       | Fix                                                                                                                                  |
 | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `scoring.kind="..." is not a recognized kind`                               | Typo in `scoring.kind`                                                             | Set it to exactly one of `flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`.                            |
+| `scoring.kind="..." is not a recognized kind`                               | Typo in `scoring.kind`                                                             | Set it to exactly one of `flag` / `multi-flag` / `uptime-flat` / `uptime-multi` / `phased-polling` / `attack-detection`.             |
 | `scoring.flagOutputKey="X" not found in template.yaml Outputs`              | `metadata.scoring.flagOutputKey` references a CFn `Output` key that doesn't exist  | Open `template.yaml`, add an `Outputs.X:` entry, or fix the metadata key. Both sides must match exactly.                             |
 | `scoring.statsOutputKey="X" not found in template.yaml Outputs`             | Same as above for `attack-detection`                                               | Add an `Outputs.X:` entry whose `Value` is the integer attack count.                                                                 |
 | `endpoints[slot=N].default.key="X" not found in template.yaml Outputs`      | `endpoints[].default.key` points at a missing Output                               | Add the `Outputs.X:` entry (typically the public URL of the endpoint slot).                                                          |
@@ -208,7 +213,7 @@ Claude Code ships with a `/create-problem` skill that runs the same scaffold + e
 - [ ] `metadata.id` matches the directory name.
 - [ ] `category` is `"Battle"` or `"Challenge"` (capitalized).
 - [ ] `status` is `"draft"` for a first submission.
-- [ ] `scoring.kind` is one of the five built-ins.
+- [ ] `scoring.kind` is one of the six built-ins.
 - [ ] Every `__PLACEHOLDER__` in `metadata.json` has been replaced.
 - [ ] Every endpoint / scoring key referenced from `metadata.json` exists as a key in `template.yaml` `Outputs:`.
 - [ ] Every resource name in `template.yaml` is prefixed with `${NamePrefix}`.

--- a/infrastructure/lib/utils/scoring-metadata.ts
+++ b/infrastructure/lib/utils/scoring-metadata.ts
@@ -7,12 +7,16 @@ import { decodeLargeEnvValue } from "./env-encoding.js";
  * (Portal `submit-flag`、Generic scoring dispatcher、`lookup.toView`) の両方で参照する
  * ため、ここに 1 箇所に集約する。SCHEMA.json と整合させる。
  *
- * ADR-012 Phase 3.B で 5 種の builtin kind をサポートする:
- *   - `flag`              — 1 回提出型 (Challenge)
+ * ADR-012 Phase 3.B の 5 種 + #1796 拡張の multi-flag = 6 種の builtin kind をサポートする:
+ *   - `flag`              — 1 回提出型 (Challenge、提出採点)
+ *   - `multi-flag`        — 1 問に N 個の独立 flag、各個別提出で部分点 (#1796、提出採点)
  *   - `uptime-flat`       — 固定 endpoint 群を独立 probe、全 OK で配点 (legacy alias `uptime`)
  *   - `uptime-multi`      — N slot を AND probe、全 OK で配点 / 1 つでも fail で penalty
  *   - `phased-polling`    — 時刻で score rule が変わる、platform 分類 + bonus 対応
  *   - `attack-detection`  — stack output 内の counter 増分検知で配点
+ *
+ * `flag` / `multi-flag` は提出採点 (participant-handler の submit-flag)、 残り 4 種は generic
+ * scoring Lambda の polling 採点。
  */
 
 /**

--- a/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
+++ b/infrastructure/test/problem-deploy/problem-template-participant-viewer-role.test.ts
@@ -111,7 +111,12 @@ describe("problem template ParticipantViewerRole (#744)", () => {
       expect(template).toContain("TenkaCloudAccountId:");
       expect(template).toContain("ExternalId:");
       expect(role).toContain("Type: AWS::IAM::Role");
-      expect(role).toContain(`RoleName: !Sub "\${NamePrefix}-participant-viewer"`);
+      // TenkaCloudChallenge #77 dropped the explicit `RoleName: !Sub "${NamePrefix}-participant-viewer"`:
+      // `${NamePrefix}` (= tc-{problemSlug}-{teamSlug}) overflowed IAM's 64-char RoleName limit for long
+      // slugs, blocking deploys. CloudFormation now auto-names the role. This is safe (so RoleName is no
+      // longer asserted): the role is consumed by its GetAtt ARN via the `ParticipantViewerRoleArn`
+      // Output (asserted below), the cross-account AssumeRole caller (CompetitorDeployRole) holds
+      // AdministratorAccess, and the trust is account-id + ExternalId based — all name-independent.
       expect(role).toContain(`AWS: !Sub "arn:aws:iam::\${TenkaCloudAccountId}:root"`);
       expect(role).toContain("sts:ExternalId: !Ref ExternalId");
       expect(role).toContain("PolicyName: ProblemSpecific");

--- a/infrastructure/test/scripts/check-template-name-limits.test.ts
+++ b/infrastructure/test/scripts/check-template-name-limits.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { findNameLimitFindings } from "../../../scripts/check-template-name-limits";
+
+/**
+ * `scripts/check-template-name-limits.ts` の挙動を pin する unit test。
+ *
+ * #1812 class の regression 防止: 問題 template が IAM Role の `RoleName` / Lambda の
+ * `FunctionName` を `${NamePrefix}` 込みの明示名で宣言すると、 `NamePrefix`
+ * (= `tc-{slug(problemId)[:40]}-{slug(teamName)[:40]}` 最大 84 文字) が AWS の 64 文字
+ * 上限を超え、 deploy が CREATE_FAILED する (synth / lint は通るので静かに壊れる)。
+ *
+ * 公開 contract: `findNameLimitFindings` は `${NamePrefix}` を含む `RoleName:` /
+ * `FunctionName:` 行を (行番号 + property + 値つきで) 返す。 それ以外は返さない。
+ */
+
+describe("findNameLimitFindings", () => {
+  it("should flag a RoleName built from the NamePrefix placeholder", () => {
+    const yaml = [
+      "Resources:",
+      "  MyRole:",
+      "    Type: AWS::IAM::Role",
+      "    Properties:",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+      '      RoleName: !Sub "${NamePrefix}-participant-viewer"',
+    ].join("\n");
+    const findings = findNameLimitFindings(yaml);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.property).toBe("RoleName");
+    expect(findings[0]?.line).toBe(5);
+  });
+
+  it("should flag a FunctionName built from the NamePrefix placeholder", () => {
+    const yaml = [
+      "  Fn:",
+      "    Type: AWS::Lambda::Function",
+      "    Properties:",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+      '      FunctionName: !Sub "${NamePrefix}-bucket-cleanup"',
+    ].join("\n");
+    const findings = findNameLimitFindings(yaml);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.property).toBe("FunctionName");
+  });
+
+  it("should flag every overflowable name in a template", () => {
+    const yaml = [
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+      '      RoleName: !Sub "${NamePrefix}-a"',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+      '      FunctionName: !Sub "${NamePrefix}-b"',
+    ].join("\n");
+    expect(findNameLimitFindings(yaml)).toHaveLength(2);
+  });
+
+  it("should NOT flag a fixed RoleName that does not use the NamePrefix placeholder", () => {
+    const yaml = ["    Properties:", "      RoleName: my-fixed-short-name"].join("\n");
+    expect(findNameLimitFindings(yaml)).toEqual([]);
+  });
+
+  it("should NOT flag LogGroupName (512-char limit, safe for NamePrefix)", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+    const yaml = '      LogGroupName: !Sub "/aws/lambda/${NamePrefix}-bucket-cleanup"';
+    expect(findNameLimitFindings(yaml)).toEqual([]);
+  });
+
+  it("should NOT match a property whose key merely ends in RoleName", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub literal を pin
+    const yaml = '      ServiceLinkedRoleName: !Sub "${NamePrefix}-x"';
+    expect(findNameLimitFindings(yaml)).toEqual([]);
+  });
+
+  it("should return nothing for a template with no explicit names", () => {
+    const yaml = [
+      "  MyRole:",
+      "    Type: AWS::IAM::Role",
+      "    Properties:",
+      "      AssumeRolePolicyDocument:",
+      "        Version: '2012-10-17'",
+    ].join("\n");
+    expect(findNameLimitFindings(yaml)).toEqual([]);
+  });
+});

--- a/infrastructure/test/scripts/scaffolds-validate.test.ts
+++ b/infrastructure/test/scripts/scaffolds-validate.test.ts
@@ -5,7 +5,7 @@ import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
 
 /**
- * Issue #951 sub #1: `.claude/templates/problems/<kind>/metadata.json` の 5 種 scaffold が
+ * Issue #951 sub #1: `.claude/templates/problems/<kind>/metadata.json` の 6 種 scaffold が
  * `__PROBLEM_ID__` / `__PROBLEM_NAME__` を CLI が置換した後、 `problems/SCHEMA.json` に
  * 通ることを保証する。
  *
@@ -46,8 +46,15 @@ describe("Problem scaffold templates", () => {
 
   const kinds = listKinds();
 
-  it("should have scaffold directories for all 5 builtin kinds", () => {
-    const expected = ["attack-detection", "flag", "phased-polling", "uptime-flat", "uptime-multi"];
+  it("should have scaffold directories for all 6 builtin kinds", () => {
+    const expected = [
+      "attack-detection",
+      "flag",
+      "multi-flag",
+      "phased-polling",
+      "uptime-flat",
+      "uptime-multi",
+    ];
     expect(kinds).toEqual(expected);
   });
 

--- a/scripts/check-template-name-limits.ts
+++ b/scripts/check-template-name-limits.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env bun
+/**
+ * 問題 template.yaml が AWS の 64 文字上限を持つ物理名を `${NamePrefix}` 込みで明示宣言
+ * していないか検査する (#1812 class の regression 防止)。
+ *
+ * 背景: `NamePrefix = tc-{slug(problemId)[:40]}-{slug(teamName)[:40]}` は最大 84 文字に
+ * なり得る。 IAM `RoleName` / Lambda `FunctionName` は **64 文字上限**のため、 長い team 名で
+ * `RoleName: !Sub "${NamePrefix}-..."` が CFn deploy 時に CREATE_FAILED する。 これは
+ * `cdk synth` / lint / `validate-problems` を全て通過するため、 merge 後の deploy で初めて
+ * 静かに落ちる class (= em-dash #664/#70・UserData 16KB #76 と同じ 「synth は通るが deploy で
+ * 落ちる CFn 制約」)。
+ *
+ * 修正方針 (#1812): 明示 `RoleName` / `FunctionName` を削除する。 CloudFormation が上限内に
+ * 収まる物理名を自動生成し、 consumer は `!GetAtt <Resource>.Arn` (= 名前非依存) を Output
+ * 経由で読むため安全。 予測可能な log group 名が要る場合は `LoggingConfig.LogGroup` +
+ * 明示 `AWS::Logs::LogGroup` (LogGroupName 上限 512、 NamePrefix でも overflow しない) を使う。
+ *
+ * 検出ルール:
+ *   - 各行が `^<indent>RoleName:` または `^<indent>FunctionName:` の **key** で、 かつ
+ *     値 (= 行の残り) に `${NamePrefix}` を含む場合に flag する。
+ *   - `XxxRoleName:` のように key の末尾が一致するだけの property は除外 (key 全体一致)。
+ *   - `LogGroupName` (512) / `ManagedPolicyName` (128) など上限に余裕がある物理名は対象外。
+ *
+ * `make before-commit` の check 群に加える。 fail-fast (exit 1) で問題作成者に早期 feedback。
+ */
+
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PROBLEMS_DIR = join(REPO_ROOT, "problems");
+
+/** 64 文字上限を持つ物理名 property (= `${NamePrefix}` 込みで overflow し得る)。 */
+const OVERFLOWABLE_NAME_PROPERTIES = ["RoleName", "FunctionName"] as const;
+
+export interface NameFinding {
+  /** 1-origin の行番号。 */
+  readonly line: number;
+  readonly property: (typeof OVERFLOWABLE_NAME_PROPERTIES)[number];
+  /** flag した行 (trim 済)。 */
+  readonly text: string;
+}
+
+/**
+ * yaml 文字列から `${NamePrefix}` 込みの `RoleName:` / `FunctionName:` 宣言を抽出する。
+ * CFn の `!Sub` 等の tag をそのまま扱うため YAML loader は使わず行ベースで走査する
+ * (= check-template-cfn-refs / cli-access と同方針)。
+ */
+export function findNameLimitFindings(yaml: string): NameFinding[] {
+  const findings: NameFinding[] = [];
+  const lines = yaml.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    for (const property of OVERFLOWABLE_NAME_PROPERTIES) {
+      // key 全体一致 (= 先頭は空白のみ、 直後は ":")。 `XxxRoleName:` を誤検出しない。
+      const keyMatch = new RegExp(`^\\s*${property}:`).test(line);
+      if (!keyMatch) continue;
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: CFn !Sub の literal token を検出対象として照合する意図
+      if (!line.includes("${NamePrefix}")) continue;
+      findings.push({ line: i + 1, property, text: line.trim() });
+    }
+  }
+  return findings;
+}
+
+interface FileFindings {
+  readonly templatePath: string;
+  readonly findings: readonly NameFinding[];
+}
+
+export function checkTemplate(templatePath: string): FileFindings | undefined {
+  const yaml = readFileSync(templatePath, "utf8");
+  const findings = findNameLimitFindings(yaml);
+  return findings.length > 0 ? { templatePath, findings } : undefined;
+}
+
+function findTemplates(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry === "template.yaml" || entry === "template.yml") out.push(full);
+    }
+  };
+  walk(PROBLEMS_DIR);
+  return out;
+}
+
+function main(): void {
+  const templates = findTemplates();
+  if (templates.length === 0) {
+    console.log("No template.yaml found under problems/.");
+    return;
+  }
+  const all: FileFindings[] = [];
+  for (const tpl of templates) {
+    const r = checkTemplate(tpl);
+    if (r) all.push(r);
+  }
+  if (all.length === 0) {
+    console.log(
+      `OK: ${templates.length} template(s) スキャン、` +
+        " 64 文字上限の物理名 (RoleName / FunctionName) を NamePrefix 込みで明示宣言した箇所なし (#1812)",
+    );
+    return;
+  }
+  for (const f of all) {
+    const rel = relative(REPO_ROOT, f.templatePath);
+    for (const n of f.findings) {
+      console.error(
+        `NG ${rel}:${n.line}: ${n.property} が \${NamePrefix} 込みの明示名 — ` +
+          "NamePrefix は最大 84 文字で 64 文字上限を超え deploy が CREATE_FAILED します (#1812)",
+      );
+      console.error(`    ${n.text}`);
+    }
+  }
+  console.error("");
+  console.error(
+    "修正方法: 明示 RoleName / FunctionName を削除し CloudFormation の自動命名に任せてください。",
+  );
+  console.error(
+    "  consumer は !GetAtt <Resource>.Arn (= 名前非依存) を Output 経由で読むため安全です。",
+  );
+  console.error(
+    "  予測可能な log group 名が要る場合は LoggingConfig.LogGroup + 明示 AWS::Logs::LogGroup",
+  );
+  console.error("  (LogGroupName 上限 512) を使ってください。");
+  process.exit(1);
+}
+
+if (import.meta.main) main();

--- a/scripts/problem-cli/constants.ts
+++ b/scripts/problem-cli/constants.ts
@@ -10,6 +10,7 @@ export const PROBLEMS_ROOT = join(REPO_ROOT, "problems");
 
 export const KINDS = [
   "flag",
+  "multi-flag",
   "uptime-flat",
   "uptime-multi",
   "phased-polling",
@@ -24,6 +25,7 @@ export type Kind = (typeof KINDS)[number];
  */
 export const KIND_TO_DEFAULT_CATEGORY: Record<Kind, "Battle" | "Challenge"> = {
   flag: "Challenge",
+  "multi-flag": "Challenge",
   "uptime-flat": "Battle",
   "uptime-multi": "Battle",
   "phased-polling": "Battle",

--- a/scripts/problem-cli/inspect.ts
+++ b/scripts/problem-cli/inspect.ts
@@ -67,6 +67,7 @@ function appendScoring(lines: string[], kind: string, scoring: Record<string, un
 
 function appendKindScoring(lines: string[], kind: string, scoring: Record<string, unknown>): void {
   if (kind === "flag") appendFlagScoring(lines, scoring);
+  else if (kind === "multi-flag") appendMultiFlagScoring(lines, scoring);
   else if (kind === "uptime-flat" || kind === "uptime") appendUptimeFlatScoring(lines, scoring);
   else if (kind === "uptime-multi") appendUptimeMultiScoring(lines, scoring);
   else if (kind === "phased-polling") appendPhasedPollingScoring(lines, scoring);
@@ -78,6 +79,21 @@ function appendFlagScoring(lines: string[], scoring: Record<string, unknown>): v
   lines.push(`points:           ${String(scoring.points ?? "(missing)")}`);
   if (scoring.wrongAnswerPenalty)
     lines.push(`wrongAnswerPenalty: ${String(scoring.wrongAnswerPenalty)}`);
+}
+
+function appendMultiFlagScoring(lines: string[], scoring: Record<string, unknown>): void {
+  const flags = Array.isArray(scoring.flags) ? scoring.flags : [];
+  const total = (flags as Array<Record<string, unknown>>).reduce(
+    (sum, f) => sum + (typeof f.points === "number" ? f.points : 0),
+    0,
+  );
+  lines.push(`flags:            ${flags.length} (= 各 flag 個別提出 / 部分点 合計 ${total})`);
+  for (const f of flags as Array<Record<string, unknown>>) {
+    const penalty = f.wrongAnswerPenalty ? ` penalty=${String(f.wrongAnswerPenalty)}` : "";
+    lines.push(
+      `                  - id=${String(f.id ?? "?")} key=${String(f.flagOutputKey ?? "?")} points=${String(f.points ?? "?")}${penalty}`,
+    );
+  }
 }
 
 function appendUptimeFlatScoring(lines: string[], scoring: Record<string, unknown>): void {
@@ -255,9 +271,29 @@ function appendScoringCrossRefIssues(
     const k = String(scoring.flagOutputKey ?? "");
     if (k && !outputNames.includes(k)) issues.push(`flagOutputKey="${k}" not in Outputs`);
   }
+  if (kind === "multi-flag") {
+    appendMultiFlagCrossRefIssues(issues, scoring, outputNames);
+  }
   if (kind === "attack-detection") {
     const k = String(scoring.statsOutputKey ?? "");
     if (k && !outputNames.includes(k)) issues.push(`statsOutputKey="${k}" not in Outputs`);
+  }
+}
+
+/**
+ * multi-flag (#1796): flags[] の各 flagOutputKey が Outputs に居るかを個別検査する。
+ */
+function appendMultiFlagCrossRefIssues(
+  issues: string[],
+  scoring: Record<string, unknown>,
+  outputNames: readonly string[],
+): void {
+  const flags = Array.isArray(scoring.flags) ? scoring.flags : [];
+  for (const f of flags as Array<Record<string, unknown>>) {
+    const k = String(f.flagOutputKey ?? "");
+    if (k && !outputNames.includes(k)) {
+      issues.push(`flags[id=${String(f.id)}].flagOutputKey="${k}" not in Outputs`);
+    }
   }
 }
 

--- a/scripts/problem-cli/interactive.ts
+++ b/scripts/problem-cli/interactive.ts
@@ -4,13 +4,14 @@ import { type CreateResult, runCreate } from "./create";
 import { findProblemDir } from "./problem-loader";
 
 /**
- * Issue #954: 5 kind の対話用ラベル + 1 行の使い分け説明。 issue 本文の onboarding flow と
+ * Issue #954: 6 kind の対話用ラベル + 1 行の使い分け説明。 issue 本文の onboarding flow と
  * 揃える (= 「Flag Challenge / Uptime Battle / Multi-service Battle / Attack Detection /
  * Migration Battle」)。 「Migration Battle」 は phased-polling kind に対応する (= 段階的に
  * 移行する system を polling して各 phase の状態を採点する典型 use case)。
  */
 const KIND_INTERACTIVE_LABELS: Record<Kind, string> = {
   flag: "Flag Challenge       — SSM Parameter / CFn output を flag として提出",
+  "multi-flag": "Multi-flag Challenge — 1 問に N 個の独立 flag、 個別提出で部分点採点",
   "uptime-flat": "Uptime Flat Battle   — 1 endpoint × N cycles の SLA 測定",
   "uptime-multi": "Multi-service Battle — N endpoints × N cycles、 全 OK で加点",
   "phased-polling":
@@ -61,10 +62,11 @@ async function promptKind({ ask, print }: InteractivePrompts): Promise<Kind> {
   print("");
   print("決定木 (= 迷ったら):");
   print("  競技者が 1 つの値 (flag) を提出して終わる        → 1 (flag)");
-  print("  endpoint が 1 つ、 常時 200 で加点               → 2 (uptime-flat)");
-  print("  endpoint が複数、 全部同時 200 で加点             → 3 (uptime-multi)");
-  print("  時間経過で rule が変わる (= 移行 deadline 等)     → 4 (phased-polling)");
-  print("  攻撃検知数で勝敗が決まる                          → 5 (attack-detection)");
+  print("  1 問に独立した複数 flag、 個別提出で部分点         → 2 (multi-flag)");
+  print("  endpoint が 1 つ、 常時 200 で加点               → 3 (uptime-flat)");
+  print("  endpoint が複数、 全部同時 200 で加点             → 4 (uptime-multi)");
+  print("  時間経過で rule が変わる (= 移行 deadline 等)     → 5 (phased-polling)");
+  print("  攻撃検知数で勝敗が決まる                          → 6 (attack-detection)");
   print("");
   print("(詳細: docs/problems/CONTRIBUTING.md 'Pick the scoring kind')");
   print("");
@@ -74,7 +76,7 @@ async function promptKind({ ask, print }: InteractivePrompts): Promise<Kind> {
   }
   let kind: Kind | undefined;
   while (!kind) {
-    const raw = (await ask("> 番号 (1-5) または kind 名: ")).trim();
+    const raw = (await ask("> 番号 (1-6) または kind 名: ")).trim();
     if (raw.length === 0) continue;
     const idx = Number.parseInt(raw, 10);
     if (Number.isFinite(idx) && idx >= 1 && idx <= orderedKinds.length) {
@@ -86,7 +88,7 @@ async function promptKind({ ask, print }: InteractivePrompts): Promise<Kind> {
       break;
     }
     print(
-      `  ✗ "${raw}" は無効です。 1-5 の番号か kind 名 (${KINDS.join(" / ")}) を入力してください。`,
+      `  ✗ "${raw}" は無効です。 1-6 の番号か kind 名 (${KINDS.join(" / ")}) を入力してください。`,
     );
   }
   print(`  → kind: ${kind}`);
@@ -200,5 +202,12 @@ function printCreatedFiles(
 }
 
 function getOrderedKinds(): readonly Kind[] {
-  return ["flag", "uptime-flat", "uptime-multi", "phased-polling", "attack-detection"];
+  return [
+    "flag",
+    "multi-flag",
+    "uptime-flat",
+    "uptime-multi",
+    "phased-polling",
+    "attack-detection",
+  ];
 }

--- a/scripts/problem-cli/validate.ts
+++ b/scripts/problem-cli/validate.ts
@@ -142,11 +142,33 @@ function validateScoringOutputKey(
       );
     }
   }
+  if (kind === "multi-flag") {
+    validateMultiFlagOutputKeys(scoring, yaml, errors);
+  }
   if (kind === "attack-detection") {
     const statsKey = scoring.statsOutputKey;
     if (typeof statsKey === "string" && !yaml.includes(`${statsKey}:`)) {
       errors.push(
         `scoring.statsOutputKey="${statsKey}" not found in template.yaml Outputs — add an "Outputs.${statsKey}:" entry whose Value is the integer attack count`,
+      );
+    }
+  }
+}
+
+/**
+ * multi-flag (#1796): flags[] の各 flagOutputKey が template.yaml Outputs に居るかを個別検査。
+ */
+function validateMultiFlagOutputKeys(
+  scoring: Record<string, unknown>,
+  yaml: string,
+  errors: string[],
+): void {
+  const flags = Array.isArray(scoring.flags) ? scoring.flags : [];
+  for (const f of flags as Array<Record<string, unknown>>) {
+    const flagKey = f.flagOutputKey;
+    if (typeof flagKey === "string" && !yaml.includes(`${flagKey}:`)) {
+      errors.push(
+        `scoring.flags[id=${String(f.id)}].flagOutputKey="${flagKey}" not found in template.yaml Outputs (= scoring engine が読めない) — add an "Outputs.${flagKey}:" entry to template.yaml or fix the metadata key`,
       );
     }
   }

--- a/scripts/validate-problems.ts
+++ b/scripts/validate-problems.ts
@@ -219,10 +219,38 @@ function checkScoringOutputRefs(
     }
   }
 
+  if (kind === "multi-flag") {
+    errors.push(...checkMultiFlagOutputRefs(scoring, yaml, cfnTemplate));
+  }
+
   if (kind === "attack-detection") {
     const statsKey = scoring?.statsOutputKey;
     if (typeof statsKey === "string" && !yaml.includes(`${statsKey}:`)) {
       errors.push(`scoring.statsOutputKey="${statsKey}" not found in ${cfnTemplate} Outputs`);
+    }
+  }
+  return errors;
+}
+
+/**
+ * multi-flag (#1796): 1 問に N 個の独立 flag。 各 flags[].flagOutputKey が template.yaml の
+ * Outputs に存在するかを個別に検査する (= scoring engine が flag ごとに値を読めること)。
+ */
+function checkMultiFlagOutputRefs(
+  scoring: Record<string, unknown> | undefined,
+  yaml: string,
+  cfnTemplate: string,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const flags = (Array.isArray(scoring?.flags) ? scoring?.flags : []) as Array<
+    Record<string, unknown>
+  >;
+  for (const f of flags) {
+    const flagKey = f.flagOutputKey;
+    if (typeof flagKey === "string" && !yaml.includes(`${flagKey}:`)) {
+      errors.push(
+        `scoring.flags[id=${String(f.id)}].flagOutputKey="${flagKey}" not found in ${cfnTemplate} Outputs (= scoring engine が読めない)`,
+      );
     }
   }
   return errors;


### PR DESCRIPTION
## Summary

multi-flag (1 問に N 個の独立 flag、 各 flag を個別提出して部分点) は、 scoring runtime が #1808 で、 metadata SCHEMA が Challenge #75 で landing したものの、 **author 側の作成導線が 5-kind のまま**で新 kind の問題を作れなかった。 この PR で multi-flag を 6 番目の scoring kind として完全に導入する (CLI / scaffold / 検証 / 全 docs / ADR)。

加えて、 同じ pin bump で取り込む Challenge 修正により **2 件のリグレッション / deploy-blocker も解消**する (下記)。

- **CLI** (`scripts/problem-cli/`): `KINDS` + default category、 対話メニュー label + 決定木 + `(1-6)` prompt、 inspect の scoring 表示、 flags[].flagOutputKey の cross-ref 検査
- **Validators** (`validate.ts` / `validate-problems.ts`): `flags[]` の各 `flagOutputKey` が `template.yaml` Outputs に存在するかを個別検査 (helper 抽出で cognitive-complexity 閾値内に維持)
- **Scaffold** (`.claude/templates/problems/multi-flag/`): 3-flag の skeleton (metadata + template、 SSM Parameter ×3 / Output ×3)
- **Docs**: AUTHORING / AI-WORKFLOW / CONTRIBUTING (ja+en) / SKILL / AGENTS / community ONBOARDING / demos (sales-pitch・architecture-tour ja+en md+html) を 5→6 kind に更新。 ADR-012 は自身の拡張条項 (L139) に従い拡張節で multi-flag (提出採点) を追記し、 `scoring-metadata.ts` の supported-kind コメントを 6 種に同期
- **Submodule**: 親 repo の `problems` pin を Challenge main (`ecdfcea1`) へ更新 (multi-flag SCHEMA #75 + deploy-blocker 修正 #77 を含む)

## Fixes #1812 (deploy CREATE_FAILED — IAM RoleName 64-char overflow)

`ecdfcea1` が含む Challenge #77 が、 問題 template の IAM Role / Lambda から 64 文字上限を超える明示 `RoleName` / `FunctionName` を削除 (`${NamePrefix}=tc-{problemSlug}-{teamSlug}` は最大 84 文字)。 #1812 は親 repo の issue で、 fix は Challenge repo (cross-repo = auto-close 不可) のため **この PR の pin bump が #1812 を解消する唯一の経路**。 検証: `ecdfcea1` の全 template に 64-char-overflow する明示 RoleName/FunctionName は残っていない (唯一残る stackstack の `LogGroupName` は 512 上限内 + `LoggingConfig.LogGroup` で auto-named function に正しく wiring 済 = 意図的設計、 deploy-blocker でない)。

## Test plan

- 全 workspace test green: infra 265 files / **2891 tests**、 admin-console 318、 application-admin 1012、 participant-portal 626 (計 5847)
- `scaffolds-validate.test.ts` が新 SCHEMA で 6 kind 全 scaffold を検証 / `validate:problems` 10/10 OK
- `tsc --noEmit` clean (全 workspace) / biome clean / markdownlint 0 / textlint 0 / harness 0 (adr-self-contained 含む) / SPA build ×3 green

## Regression analysis

- **検出・修正した regression**: pin bump (`ec55f8a3 → ecdfcea1`) が parent の #744 test (`problem-template-participant-viewer-role.test.ts`) を 4 件 break させていた。 原因 = Challenge #77 が ParticipantViewerRole から明示 RoleName を削除したが parent test が旧 contract を要求し続けたこと。 obsolete な RoleName assertion のみ除去して修正 (security assertion = ExternalId / ADR-021 Resource:* guard / Sid allowlist / GetAtt Output は全据え置き)。 安全性 end-to-end 検証済 (role は GetAtt Output ARN 経由で消費 sso.ts:250、 caller CompetitorDeployRole は AdministratorAccess、 trust は account+ExternalId = 全て name 非依存)。
- 既存 5 kind の作成・検証フローは分岐追加のみで挙動不変。 kind dispatcher 3 箇所は multi-flag branch を helper 抽出しただけ。
- 既存 10 問題が引き続き validate に通ることを確認済み。 doc の dispatcher 参照 (5 builtin handlers) と hints 説明 (top-level hints = 5 種) は multi-flag が該当しないため意図的に据え置き。

## Physical impact

- **問題 template (競技者 account に deploy される CFn)**: pin bump により IAM Role の `RoleName` / Lambda の `FunctionName` が削除され、 **CloudFormation が物理名を自動生成する (= REPLACE on redeploy)**。 これは #1812 の修正そのもの — 従来 64 文字超で CREATE_FAILED していた長い team 名の deploy が成功するようになる。 ParticipantViewerRoleArn 等の Output は `!GetAtt` で name 非依存のため consumer 側 (sso.ts) への影響なし。
- **親 stack (Control Plane / App Plane / Problem Deploy backend)**: **NO-OP** (CDK 変更なし)。 変更は author-side ツール + docs + scaffold + submodule pin + parent test に限定。 DynamoDB capacity / 親 IAM への変更なし。

Relates #1796
Relates #1808
Fixes #1812
