### PR TITLE
feat(billing): add usage metering facts

### DIFF
--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/index.ts
@@ -4,6 +4,7 @@ import type { LambdaContext, LambdaEvent } from "hono/aws-lambda";
 import { handle } from "hono/aws-lambda";
 import { StatusCodes } from "http-status-codes";
 import { secureApiHeaders } from "../../../problem-deploy/handlers/shared/secure-headers.js";
+import { listUsageFacts } from "../../../problem-deploy/handlers/usage-metering-handler/repository.js";
 import { exportAuditEntriesCsv, listAuditEntries } from "./audit.js";
 import { isSystemAdmin, resolveCognitoSub } from "./auth.js";
 import { defaultBudgetsClient, getCostSummary } from "./cost.js";
@@ -21,6 +22,7 @@ import { summarizeTenants } from "./summary.js";
  *   GET /admin/insight/pipeline-executions                    — tenkacloud-saas-pipeline 実行履歴
  *   GET /admin/insight/state-machine-executions               — SBT deprovisioning SFN 実行履歴
  *   GET /admin/insight/audit                                  — admin 操作 audit log
+ *   GET /admin/insight/usage                                  — tenant usage facts (aggregate only)
  *
  * 廃止済 (= 2026-05-18 plane 分離方針、 [[feedback-no-cross-plane-data-leak]]):
  *   - `/admin/insight/tenants/:tenantId/events*`                  — App Plane data 覗き込み
@@ -45,6 +47,7 @@ import { summarizeTenants } from "./summary.js";
 const shared = buildSharedResources();
 
 const TENANT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_TENANT_IDS = 100;
 const LIST_LIMIT_MAX = 200;
 
@@ -100,6 +103,40 @@ function parseLimit(value: string | undefined): { ok: true; limit: number | unde
   return { ok: true, limit };
 }
 
+function isValidDay(value: string): boolean {
+  if (!DAY_RE.test(value)) return false;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function parseTenantIds(
+  raw: string,
+):
+  | { ok: true; tenantIds: string[] }
+  | { ok: false; status: typeof StatusCodes.BAD_REQUEST; body: Record<string, unknown> } {
+  if (raw.trim() === "") return { ok: true, tenantIds: [] };
+  const tenantIds = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const invalid = tenantIds.find((id) => !TENANT_ID_RE.test(id));
+  if (invalid !== undefined) {
+    return {
+      ok: false,
+      status: StatusCodes.BAD_REQUEST,
+      body: { error: "invalid_tenant_id", value: invalid },
+    };
+  }
+  if (tenantIds.length > MAX_TENANT_IDS) {
+    return {
+      ok: false,
+      status: StatusCodes.BAD_REQUEST,
+      body: { error: "too_many_tenant_ids", max: MAX_TENANT_IDS },
+    };
+  }
+  return { ok: true, tenantIds };
+}
+
 app.get("/admin/insight/tenants/summary", async (c) => {
   // ADR-011 D2: 2 段目の SystemAdmin claim check。1 段目は API GW JWT Authorizer。
   if (!isSystemAdmin(c)) {
@@ -143,6 +180,46 @@ app.get("/admin/insight/tenants/summary", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[admin-insight] summarizeTenants failed", { message });
+    return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+});
+
+app.get("/admin/insight/usage", async (c) => {
+  const forbidden = auditAndAuthorize(c, "/admin/insight/usage");
+  if (forbidden) return forbidden;
+
+  const parsedTenants = parseTenantIds(c.req.query("tenantIds") ?? "");
+  if (!parsedTenants.ok) {
+    return c.json(parsedTenants.body as never, parsedTenants.status);
+  }
+  if (parsedTenants.tenantIds.length === 0) {
+    return c.json({ items: [] }, StatusCodes.OK);
+  }
+  if (!shared.usageTableName || shared.usageTableName.length === 0) {
+    return c.json(
+      {
+        error: "usage_facts_unconfigured",
+        message: "USAGE_FACTS_TABLE_NAME env が未設定です (= stack 配線漏れ)",
+      },
+      StatusCodes.SERVICE_UNAVAILABLE,
+    );
+  }
+
+  const from = c.req.query("from") ?? "1970-01-01";
+  const to = c.req.query("to") ?? "9999-12-31";
+  if (!isValidDay(from) || !isValidDay(to) || from > to) {
+    return c.json({ error: "invalid_day_range" }, StatusCodes.BAD_REQUEST);
+  }
+
+  try {
+    const response = await listUsageFacts(
+      { ddb: shared.ddb, tableName: shared.usageTableName },
+      { tenantIds: parsedTenants.tenantIds, from, to },
+    );
+    return c.json(response, StatusCodes.OK);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error("[admin-insight] listUsageFacts failed", { message });
     return c.json({ error: "internal_error" }, StatusCodes.INTERNAL_SERVER_ERROR);
   }
 });

--- a/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
+++ b/infrastructure/lib/admin-insight/handlers/admin-insight-handler/shared.ts
@@ -19,6 +19,11 @@ export interface AdminInsightSharedResources {
    * handler の audit route が 503 を返す。
    */
   readonly auditTableName: string;
+  /**
+   * Issue #1765: tenant usage facts table. 未配線時は空文字、 handler の usage route が
+   * 503 を返す。
+   */
+  readonly usageTableName: string;
   /** Issue #950: 環境名 (= SYSTEM 操作の PK 構築に使う `SYSTEM#<env>`)。 */
   readonly environmentName: string;
 }
@@ -40,6 +45,7 @@ export function buildSharedResources(): AdminInsightSharedResources {
     ddb,
     // Issue #950: 未配線時は空文字。 caller (audit route) が 503 を返す。
     auditTableName: process.env.ADMIN_AUDIT_LOG_TABLE_NAME ?? "",
+    usageTableName: process.env.USAGE_FACTS_TABLE_NAME ?? "",
     environmentName: process.env.DEPLOY_ENVIRONMENT ?? "development",
   };
 }

--- a/infrastructure/lib/problem-deploy/handlers/usage-metering-handler/index.ts
+++ b/infrastructure/lib/problem-deploy/handlers/usage-metering-handler/index.ts
@@ -1,0 +1,20 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { getEnv } from "../../../helper-functions.js";
+import { handleUsageMeteringEvent } from "./repository.js";
+
+const shared = {
+  ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+  tableName: getEnv("USAGE_FACTS_TABLE_NAME"),
+};
+
+/**
+ * Usage metering event consumer.
+ *
+ * CDK/EventBridge wiring is intentionally outside this handler. The handler accepts the
+ * stable detail-type contracts from repository.ts and records idempotent daily usage facts.
+ */
+export async function handler(event: unknown): Promise<{ readonly recorded: boolean }> {
+  const result = await handleUsageMeteringEvent(shared, event);
+  return { recorded: result.recorded };
+}

--- a/infrastructure/lib/problem-deploy/handlers/usage-metering-handler/repository.ts
+++ b/infrastructure/lib/problem-deploy/handlers/usage-metering-handler/repository.ts
@@ -1,0 +1,343 @@
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { StatusCodes } from "http-status-codes";
+import { z } from "zod";
+
+const TENANT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const UsageTenantIdSchema = z.string().regex(TENANT_ID_RE);
+export const UsageDaySchema = z.string().regex(DAY_RE).refine(isValidDay, {
+  message: "Invalid calendar day",
+});
+
+const OccurredAtSchema = z.string().datetime();
+
+export const DeployCompletedUsageDetailSchema = z.object({
+  tenantId: UsageTenantIdSchema,
+  jobId: z.string().min(1).max(128),
+  occurredAt: OccurredAtSchema.optional(),
+});
+
+export const ScoreUpdatedUsageDetailSchema = z.object({
+  tenantId: UsageTenantIdSchema,
+  tickId: z.string().min(1).max(128).optional(),
+  jobId: z.string().min(1).max(128).optional(),
+  eventId: z.string().min(1).max(128).optional(),
+  scoreEventCount: z.number().int().nonnegative().default(1),
+  occurredAt: OccurredAtSchema.optional(),
+});
+
+export const TenantEventCreatedUsageDetailSchema = z.object({
+  tenantId: UsageTenantIdSchema,
+  eventId: z.string().min(1).max(128),
+  occurredAt: OccurredAtSchema.optional(),
+});
+
+export const UsageMeteringEventSchema = z.discriminatedUnion("detail-type", [
+  z.object({
+    "detail-type": z.literal("DeployCompleted"),
+    time: OccurredAtSchema.optional(),
+    detail: DeployCompletedUsageDetailSchema,
+  }),
+  z.object({
+    "detail-type": z.literal("ScoreUpdated"),
+    time: OccurredAtSchema.optional(),
+    detail: ScoreUpdatedUsageDetailSchema,
+  }),
+  z.object({
+    "detail-type": z.literal("TenantEventCreated"),
+    time: OccurredAtSchema.optional(),
+    detail: TenantEventCreatedUsageDetailSchema,
+  }),
+]);
+
+export type UsageMeteringEvent = z.infer<typeof UsageMeteringEventSchema>;
+
+export interface UsageCounters {
+  readonly deployCompletedCount?: number;
+  readonly scoringTickCount?: number;
+  readonly scoreEventCount?: number;
+  readonly tenantEventCount?: number;
+  readonly usageEventCount?: number;
+}
+
+export interface RecordUsageFactInput {
+  readonly tenantId: string;
+  readonly day: string;
+  readonly detailType: UsageMeteringEvent["detail-type"];
+  readonly idempotencyKey: string;
+  readonly counters: UsageCounters;
+  readonly occurredAt: string;
+}
+
+export interface UsageFactDeps {
+  readonly ddb: DynamoDBDocumentClient;
+  readonly tableName: string;
+}
+
+export interface UsageDayFact {
+  readonly day: string;
+  readonly deployCompletedCount: number;
+  readonly scoringTickCount: number;
+  readonly scoreEventCount: number;
+  readonly tenantEventCount: number;
+  readonly usageEventCount: number;
+}
+
+export interface UsageTenantFacts {
+  readonly tenantId: string;
+  readonly days: readonly UsageDayFact[];
+  readonly totals: UsageDayFact;
+}
+
+export interface ListUsageFactsInput {
+  readonly tenantIds: readonly string[];
+  readonly from: string;
+  readonly to: string;
+}
+
+export interface ListUsageFactsResponse {
+  readonly items: readonly UsageTenantFacts[];
+}
+
+const COUNTER_KEYS = [
+  "deployCompletedCount",
+  "scoringTickCount",
+  "scoreEventCount",
+  "tenantEventCount",
+  "usageEventCount",
+] as const satisfies readonly (keyof UsageCounters)[];
+
+function isValidDay(value: string): boolean {
+  if (!DAY_RE.test(value)) return false;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function dayOf(occurredAt: string): string {
+  return new Date(occurredAt).toISOString().slice(0, 10);
+}
+
+function counterValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeCounters(counters: UsageCounters): Required<UsageCounters> {
+  const usageEventCount =
+    typeof counters.usageEventCount === "number" && counters.usageEventCount > 0
+      ? counters.usageEventCount
+      : 1;
+  return {
+    deployCompletedCount: counters.deployCompletedCount ?? 0,
+    scoringTickCount: counters.scoringTickCount ?? 0,
+    scoreEventCount: counters.scoreEventCount ?? 0,
+    tenantEventCount: counters.tenantEventCount ?? 0,
+    usageEventCount,
+  };
+}
+
+function idempotencyKeyFor(event: UsageMeteringEvent, occurredAt: string): string {
+  if (event["detail-type"] === "DeployCompleted") return `deploy:${event.detail.jobId}`;
+  if (event["detail-type"] === "TenantEventCreated") return `event:${event.detail.eventId}`;
+  const id =
+    event.detail.tickId ??
+    event.detail.jobId ??
+    event.detail.eventId ??
+    `${event.detail.tenantId}:${occurredAt}`;
+  return `score:${id}`;
+}
+
+export function usageFactFromEvent(event: UsageMeteringEvent): RecordUsageFactInput {
+  const occurredAt = event.detail.occurredAt ?? event.time ?? new Date().toISOString();
+  if (event["detail-type"] === "DeployCompleted") {
+    return {
+      tenantId: event.detail.tenantId,
+      day: dayOf(occurredAt),
+      detailType: event["detail-type"],
+      idempotencyKey: idempotencyKeyFor(event, occurredAt),
+      counters: { deployCompletedCount: 1 },
+      occurredAt,
+    };
+  }
+  if (event["detail-type"] === "TenantEventCreated") {
+    return {
+      tenantId: event.detail.tenantId,
+      day: dayOf(occurredAt),
+      detailType: event["detail-type"],
+      idempotencyKey: idempotencyKeyFor(event, occurredAt),
+      counters: { tenantEventCount: 1 },
+      occurredAt,
+    };
+  }
+  return {
+    tenantId: event.detail.tenantId,
+    day: dayOf(occurredAt),
+    detailType: event["detail-type"],
+    idempotencyKey: idempotencyKeyFor(event, occurredAt),
+    counters: {
+      scoringTickCount: 1,
+      scoreEventCount: event.detail.scoreEventCount,
+    },
+    occurredAt,
+  };
+}
+
+function isDuplicateTransaction(err: unknown): boolean {
+  return err instanceof Error && err.name === "TransactionCanceledException";
+}
+
+export async function recordUsageFact(
+  deps: UsageFactDeps,
+  input: RecordUsageFactInput,
+): Promise<{ readonly recorded: boolean }> {
+  const parsedTenantId = UsageTenantIdSchema.parse(input.tenantId);
+  const parsedDay = UsageDaySchema.parse(input.day);
+  const counters = normalizeCounters(input.counters);
+  const names: Record<string, string> = { "#day": "day" };
+  const values: Record<string, unknown> = {
+    ":tenantId": parsedTenantId,
+    ":day": parsedDay,
+    ":now": input.occurredAt,
+  };
+  const addParts: string[] = [];
+  for (const key of COUNTER_KEYS) {
+    const value = counters[key];
+    if (value === 0) continue;
+    names[`#${key}`] = key;
+    values[`:${key}`] = value;
+    addParts.push(`#${key} :${key}`);
+  }
+
+  try {
+    await deps.ddb.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: deps.tableName,
+              Item: {
+                PK: `TENANT#${parsedTenantId}`,
+                SK: `EVENT#${input.idempotencyKey}`,
+                tenantId: parsedTenantId,
+                detailType: input.detailType,
+                day: parsedDay,
+                occurredAt: input.occurredAt,
+                createdAt: input.occurredAt,
+              },
+              ConditionExpression: "attribute_not_exists(PK)",
+            },
+          },
+          {
+            Update: {
+              TableName: deps.tableName,
+              Key: { PK: `TENANT#${parsedTenantId}`, SK: `DAY#${parsedDay}` },
+              UpdateExpression: `SET tenantId = :tenantId, #day = :day, updatedAt = :now ADD ${addParts.join(", ")}`,
+              ExpressionAttributeNames: names,
+              ExpressionAttributeValues: values,
+            },
+          },
+        ],
+      }),
+    );
+    return { recorded: true };
+  } catch (err) {
+    if (isDuplicateTransaction(err)) return { recorded: false };
+    throw err;
+  }
+}
+
+function toUsageDayFact(item: Record<string, unknown>): UsageDayFact {
+  const rawDay = typeof item.day === "string" ? item.day : String(item.SK ?? "").slice(4);
+  return {
+    day: rawDay,
+    deployCompletedCount: counterValue(item.deployCompletedCount),
+    scoringTickCount: counterValue(item.scoringTickCount),
+    scoreEventCount: counterValue(item.scoreEventCount),
+    tenantEventCount: counterValue(item.tenantEventCount),
+    usageEventCount: counterValue(item.usageEventCount),
+  };
+}
+
+function emptyTotals(): UsageDayFact {
+  return {
+    day: "TOTAL",
+    deployCompletedCount: 0,
+    scoringTickCount: 0,
+    scoreEventCount: 0,
+    tenantEventCount: 0,
+    usageEventCount: 0,
+  };
+}
+
+function addTotals(total: UsageDayFact, day: UsageDayFact): UsageDayFact {
+  return {
+    day: "TOTAL",
+    deployCompletedCount: total.deployCompletedCount + day.deployCompletedCount,
+    scoringTickCount: total.scoringTickCount + day.scoringTickCount,
+    scoreEventCount: total.scoreEventCount + day.scoreEventCount,
+    tenantEventCount: total.tenantEventCount + day.tenantEventCount,
+    usageEventCount: total.usageEventCount + day.usageEventCount,
+  };
+}
+
+async function listTenantUsageFacts(
+  deps: UsageFactDeps,
+  tenantId: string,
+  from: string,
+  to: string,
+): Promise<UsageTenantFacts> {
+  const days: UsageDayFact[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  do {
+    const out = await deps.ddb.send(
+      new QueryCommand({
+        TableName: deps.tableName,
+        KeyConditionExpression: "PK = :pk AND SK BETWEEN :from AND :to",
+        ExpressionAttributeValues: {
+          ":pk": `TENANT#${tenantId}`,
+          ":from": `DAY#${from}`,
+          ":to": `DAY#${to}`,
+        },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    days.push(...(out.Items ?? []).map((item) => toUsageDayFact(item)));
+    exclusiveStartKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (exclusiveStartKey);
+
+  return {
+    tenantId,
+    days,
+    totals: days.reduce(addTotals, emptyTotals()),
+  };
+}
+
+export async function listUsageFacts(
+  deps: UsageFactDeps,
+  input: ListUsageFactsInput,
+): Promise<ListUsageFactsResponse> {
+  const from = UsageDaySchema.parse(input.from);
+  const to = UsageDaySchema.parse(input.to);
+  const seen = new Set<string>();
+  const tenantIds: string[] = [];
+  for (const tenantId of input.tenantIds) {
+    const parsed = UsageTenantIdSchema.parse(tenantId);
+    if (seen.has(parsed)) continue;
+    seen.add(parsed);
+    tenantIds.push(parsed);
+  }
+  const items = await Promise.all(
+    tenantIds.map((tenantId) => listTenantUsageFacts(deps, tenantId, from, to)),
+  );
+  return { items };
+}
+
+export async function handleUsageMeteringEvent(
+  deps: UsageFactDeps,
+  raw: unknown,
+): Promise<{ readonly recorded: boolean; readonly statusCode: number }> {
+  const event = UsageMeteringEventSchema.parse(raw);
+  const result = await recordUsageFact(deps, usageFactFromEvent(event));
+  return { ...result, statusCode: StatusCodes.OK };
+}

--- a/infrastructure/test/admin-insight/admin-insight-handler-index.test.ts
+++ b/infrastructure/test/admin-insight/admin-insight-handler-index.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   sharedObj: {
     ddb: { send: () => Promise.resolve({}) },
     auditTableName: "Audit",
+    usageTableName: "UsageFacts",
     environmentName: "dev",
   },
   isSystemAdmin: vi.fn(),
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   listAuditEntries: vi.fn(),
   exportAuditEntriesCsv: vi.fn(),
   getCostSummary: vi.fn(),
+  listUsageFacts: vi.fn(),
 }));
 const P = "../../lib/admin-insight/handlers/admin-insight-handler";
 vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/shared", () => ({
@@ -53,6 +55,9 @@ vi.mock("../../lib/admin-insight/handlers/admin-insight-handler/cost", () => ({
   defaultBudgetsClient: () => ({}),
   getCostSummary: mocks.getCostSummary,
 }));
+vi.mock("../../lib/problem-deploy/handlers/usage-metering-handler/repository", () => ({
+  listUsageFacts: mocks.listUsageFacts,
+}));
 
 const { app } = await import(`${P}/index`);
 
@@ -64,6 +69,7 @@ app.get("/__throw__", () => {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.sharedObj.auditTableName = "Audit";
+  mocks.sharedObj.usageTableName = "UsageFacts";
   mocks.isSystemAdmin.mockReturnValue(true);
   mocks.resolveCognitoSub.mockReturnValue("sub-1");
 });
@@ -177,6 +183,64 @@ describe("GET /admin/insight/state-machine-executions", () => {
   it("should 500 when the service throws", async () => {
     mocks.listStateMachineExecutions.mockRejectedValueOnce(new Error("sfn"));
     expect((await app.request("/admin/insight/state-machine-executions")).status).toBe(
+      StatusCodes.INTERNAL_SERVER_ERROR,
+    );
+  });
+});
+
+describe("GET /admin/insight/usage", () => {
+  it("should 403 a non-SystemAdmin", async () => {
+    mocks.isSystemAdmin.mockReturnValue(false);
+    expect((await app.request("/admin/insight/usage?tenantIds=t1")).status).toBe(
+      StatusCodes.FORBIDDEN,
+    );
+  });
+
+  it("should 503 when the usage facts table is unconfigured", async () => {
+    mocks.sharedObj.usageTableName = "";
+    expect((await app.request("/admin/insight/usage?tenantIds=t1")).status).toBe(
+      StatusCodes.SERVICE_UNAVAILABLE,
+    );
+  });
+
+  it("should 400 on an invalid tenant id", async () => {
+    expect((await app.request("/admin/insight/usage?tenantIds=ok,bad@id")).status).toBe(
+      StatusCodes.BAD_REQUEST,
+    );
+  });
+
+  it("should 400 on an invalid date range", async () => {
+    expect((await app.request("/admin/insight/usage?tenantIds=t1&from=2026-99-99")).status).toBe(
+      StatusCodes.BAD_REQUEST,
+    );
+    expect(
+      (await app.request("/admin/insight/usage?tenantIds=t1&from=2026-06-15&to=2026-06-14")).status,
+    ).toBe(StatusCodes.BAD_REQUEST);
+  });
+
+  it("should 200 with [] when tenantIds is absent", async () => {
+    const res = await app.request("/admin/insight/usage");
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ items: [] });
+    expect(mocks.listUsageFacts).not.toHaveBeenCalled();
+  });
+
+  it("should return usage facts for requested tenants", async () => {
+    mocks.listUsageFacts.mockResolvedValueOnce({ items: [{ tenantId: "t1", days: [] }] });
+    const res = await app.request(
+      "/admin/insight/usage?tenantIds=t1,t2&from=2026-06-01&to=2026-06-15",
+    );
+    expect(res.status).toBe(StatusCodes.OK);
+    expect(await res.json()).toEqual({ items: [{ tenantId: "t1", days: [] }] });
+    expect(mocks.listUsageFacts).toHaveBeenCalledWith(
+      expect.objectContaining({ tableName: "UsageFacts" }),
+      { tenantIds: ["t1", "t2"], from: "2026-06-01", to: "2026-06-15" },
+    );
+  });
+
+  it("should 500 when usage fact lookup throws", async () => {
+    mocks.listUsageFacts.mockRejectedValueOnce(new Error("ddb"));
+    expect((await app.request("/admin/insight/usage?tenantIds=t1")).status).toBe(
       StatusCodes.INTERNAL_SERVER_ERROR,
     );
   });

--- a/infrastructure/test/problem-deploy/usage-metering.test.ts
+++ b/infrastructure/test/problem-deploy/usage-metering.test.ts
@@ -1,0 +1,172 @@
+import { QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { StatusCodes } from "http-status-codes";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleUsageMeteringEvent,
+  listUsageFacts,
+  recordUsageFact,
+} from "../../lib/problem-deploy/handlers/usage-metering-handler/repository";
+
+function ddb(send: ReturnType<typeof vi.fn>) {
+  return { send } as unknown as Parameters<typeof recordUsageFact>[0]["ddb"];
+}
+
+describe("usage metering facts", () => {
+  it("should write a deploy-completed usage fact idempotently", async () => {
+    const send = vi.fn().mockResolvedValue({});
+
+    const out = await handleUsageMeteringEvent(
+      { ddb: ddb(send), tableName: "UsageFacts" },
+      {
+        "detail-type": "DeployCompleted",
+        time: "2026-06-15T01:02:03.000Z",
+        detail: {
+          tenantId: "tenant-a",
+          jobId: "01J00000000000000000000000",
+        },
+      },
+    );
+
+    expect(out).toEqual({ recorded: true, statusCode: StatusCodes.OK });
+    const command = send.mock.calls[0]?.[0] as TransactWriteCommand;
+    expect(command).toBeInstanceOf(TransactWriteCommand);
+    expect(command.input.TransactItems?.[0]?.Put?.Item).toMatchObject({
+      PK: "TENANT#tenant-a",
+      SK: "EVENT#deploy:01J00000000000000000000000",
+      tenantId: "tenant-a",
+      detailType: "DeployCompleted",
+    });
+    expect(command.input.TransactItems?.[1]?.Update).toMatchObject({
+      TableName: "UsageFacts",
+      Key: { PK: "TENANT#tenant-a", SK: "DAY#2026-06-15" },
+    });
+    expect(command.input.TransactItems?.[1]?.Update?.ExpressionAttributeValues).toMatchObject({
+      ":deployCompletedCount": 1,
+      ":usageEventCount": 1,
+    });
+  });
+
+  it("should count scoring ticks and score events from ScoreUpdated input", async () => {
+    const send = vi.fn().mockResolvedValue({});
+
+    await handleUsageMeteringEvent(
+      { ddb: ddb(send), tableName: "UsageFacts" },
+      {
+        "detail-type": "ScoreUpdated",
+        time: "2026-06-15T01:02:03.000Z",
+        detail: {
+          tenantId: "tenant-a",
+          tickId: "tick-123",
+          scoreEventCount: 3,
+        },
+      },
+    );
+
+    const command = send.mock.calls[0]?.[0] as TransactWriteCommand;
+    expect(command.input.TransactItems?.[1]?.Update?.ExpressionAttributeValues).toMatchObject({
+      ":scoringTickCount": 1,
+      ":scoreEventCount": 3,
+      ":usageEventCount": 1,
+    });
+  });
+
+  it("should treat duplicate usage events as idempotent no-ops", async () => {
+    const err = new Error("cancelled");
+    err.name = "TransactionCanceledException";
+    const send = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      recordUsageFact(
+        { ddb: ddb(send), tableName: "UsageFacts" },
+        {
+          tenantId: "tenant-a",
+          day: "2026-06-15",
+          detailType: "DeployCompleted",
+          idempotencyKey: "deploy:j1",
+          counters: { deployCompletedCount: 1 },
+          occurredAt: "2026-06-15T00:00:00.000Z",
+        },
+      ),
+    ).resolves.toEqual({ recorded: false });
+  });
+
+  it("should always count the metering event even when optional counters are zero", async () => {
+    const send = vi.fn().mockResolvedValue({});
+
+    await recordUsageFact(
+      { ddb: ddb(send), tableName: "UsageFacts" },
+      {
+        tenantId: "tenant-a",
+        day: "2026-06-15",
+        detailType: "ScoreUpdated",
+        idempotencyKey: "score:empty-tick",
+        counters: { scoreEventCount: 0, usageEventCount: 0 },
+        occurredAt: "2026-06-15T00:00:00.000Z",
+      },
+    );
+
+    const command = send.mock.calls[0]?.[0] as TransactWriteCommand;
+    expect(command.input.TransactItems?.[1]?.Update?.ExpressionAttributeValues).toMatchObject({
+      ":usageEventCount": 1,
+    });
+  });
+
+  it("should query daily usage facts per tenant and aggregate totals", async () => {
+    const send = vi.fn().mockImplementation(async (cmd: QueryCommand) => {
+      expect(cmd).toBeInstanceOf(QueryCommand);
+      if (cmd.input.ExpressionAttributeValues?.[":pk"] === "TENANT#tenant-a") {
+        return {
+          Items: [
+            {
+              tenantId: "tenant-a",
+              day: "2026-06-14",
+              deployCompletedCount: 1,
+              scoringTickCount: 2,
+              scoreEventCount: 4,
+              tenantEventCount: 1,
+              usageEventCount: 3,
+            },
+            {
+              tenantId: "tenant-a",
+              day: "2026-06-15",
+              deployCompletedCount: 2,
+              scoringTickCount: 1,
+              scoreEventCount: 1,
+              tenantEventCount: 0,
+              usageEventCount: 2,
+            },
+          ],
+        };
+      }
+      return { Items: [] };
+    });
+
+    const result = await listUsageFacts(
+      { ddb: ddb(send), tableName: "UsageFacts" },
+      { tenantIds: ["tenant-a", "tenant-b"], from: "2026-06-14", to: "2026-06-15" },
+    );
+
+    expect(result.items[0]).toMatchObject({
+      tenantId: "tenant-a",
+      totals: {
+        deployCompletedCount: 3,
+        scoringTickCount: 3,
+        scoreEventCount: 5,
+        tenantEventCount: 1,
+        usageEventCount: 5,
+      },
+    });
+    expect(result.items[0]?.days).toHaveLength(2);
+    expect(result.items[1]).toMatchObject({
+      tenantId: "tenant-b",
+      totals: {
+        deployCompletedCount: 0,
+        scoringTickCount: 0,
+        scoreEventCount: 0,
+        tenantEventCount: 0,
+        usageEventCount: 0,
+      },
+      days: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `usage-metering-handler` (`repository.ts` + `index.ts`) that folds `DeployCompleted`, `ScoreUpdated`, and `TenantEventCreated` events into **idempotent daily per-tenant usage facts** in DynamoDB, keyed so re-delivered events don't double-count.
- Wire an aggregate usage lookup into the existing **AdminInsight** Lambda (`listUsageFacts`), so a SystemAdmin can read cross-tenant daily usage when the table is present.

**Scope boundary (honest):** this is the *application-side* slice only. The DynamoDB `USAGE_FACTS_TABLE`, the EventBridge rule that feeds the metering handler, and the `USAGE_FACTS_TABLE_NAME` env wiring are **CDK / infrastructure** and are intentionally **not** in this PR (that is the repo's user-owned domain per AGENTS.md). Until that infra PR lands, the handler is inert and the AdminInsight read path **fails loudly** with `USAGE_FACTS_TABLE_NAME env が未設定です (= stack 配線漏れ)` — never a silent empty result.

## Test plan
- `make typecheck` (repo-wide) — green
- `infrastructure` vitest (`usage-metering`, `admin-insight`) — 128 passed (11 files): idempotent daily aggregation, event-kind dispatch, multi-tenant aggregate lookup, and the unwired-table error path
- `make harness` — no findings

## Regression analysis
- Net-new handler module; no existing handler behaviour changes.
- The AdminInsight change is an additive read route guarded by the existing SystemAdmin authorizer; when `USAGE_FACTS_TABLE_NAME` is unset it returns a 5xx with the explicit wiring-gap message rather than fabricating data.
- DynamoDB writes are idempotent on `(tenantId, day, metric)` so at-least-once event delivery cannot inflate counts.

## Physical impact
- **No CloudFormation / CDK changes in this PR.** The AdminInsight Lambda's `dist` bundle gains the usage read path; the metering handler ships as code but is not yet referenced by any stack. **NO-OP** for provisioned infrastructure.
- Follow-up infra PR (user-owned) must: create `USAGE_FACTS_TABLE` (PROVISIONED 1/1 per the DynamoDbLowCapacity aspect), add the metering Lambda + EventBridge rule, and set `USAGE_FACTS_TABLE_NAME` on both Lambdas. **CREATE** at that point.
