### PR TITLE
fix(pages): restore required top-level name in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,13 +4,16 @@
 # script (see package.json) builds the participant-portal demo and stages it
 # under `landing/portal-demo/` so the landing page can embed a live mock.
 #
-# Only the repo-relative output directory lives here, because it is the same
-# for every fork and environment AND because its presence is what unlocks the
-# "build output directory" field in the Cloudflare Pages dashboard.
+# `name` is the Cloudflare Pages project name. Cloudflare's Pages config
+# validation requires it at the top level and it cannot be supplied via an
+# environment variable, so a fork or other deployment replaces this single
+# line with its own project name.
 #
-# Deployment-specific settings are intentionally NOT committed:
-#   - the Pages project name is set per-environment in the dashboard (a
-#     Git-connected project already owns its own name);
-#   - `compatibility_date` is only needed for Pages Functions, which this
-#     static site does not use.
+# `pages_build_output_dir` is the repo-relative publish directory — identical
+# for every environment — and its presence unlocks the dashboard's
+# "build output directory" field.
+#
+# `compatibility_date` is intentionally omitted: it is only needed for Pages
+# Functions, which this static site does not use.
+name = "tenkacloud-www"
 pages_build_output_dir = "landing"


### PR DESCRIPTION
## なぜ
Cloudflare Pages の Git ビルドが設定ファイル検証で失敗する:

```
ERROR Running configuration file validation for Pages:
  - Missing top-level field "name" in configuration file.
```

PR #1842 で portability のため `name` を削除したが、Cloudflare Pages は top-level `name` を**必須**としており（環境変数からも注入できない）、削除するとビルドが起動しない。

## 何を
- `wrangler.toml` に `name = "tenkacloud-www"` を復活。コメントで「Cloudflare が必須／env では渡せない／fork はこの 1 行を差し替える」ことを明記。
- `compatibility_date` は引き続き省略（Pages Functions 用で、この静的サイトには不要）。残るハードコードは Cloudflare が機能的に要求する `name` のみ。

## Regression analysis
- 変更は `wrangler.toml` のみ。アプリ／インフラ／テストに影響なし。`build:pages` スクリプトは不変。
- これにより Cloudflare Pages の設定検証が通り、ビルドが起動する（直前は検証段階で fail）。

## Physical impact
- CloudFormation / CDK 変更なし。`wrangler.toml`（Cloudflare Pages 専用、AWS 資源外）のみ。AWS リソースは **NO-OP**。Cloudflare 側は検証 fail → pass に変わりビルドが走るようになる。
