### PR TITLE
fix(landing): anchor suminagashi ink behind the hero headline

### DIFF
--- a/landing/ink-bg.js
+++ b/landing/ink-bg.js
@@ -4,12 +4,14 @@
  * Shares the visual language of the pitch deck (landing/pitch): a single Jos Stam
  * "stable fluids" simulation whose velocity field advects three subtractive-ink
  * pigment channels (藍 indigo / 縹 blue / 緑青 green — the LP palette), so inks flow,
- * mix, and fade. Pointer movement over the hero injects ink; it is faint enough to
- * sit behind the headline without hurting readability.
+ * mix, and fade. The marble is anchored behind the hero headline via a fixed,
+ * deterministic seed at the headline's grid position (re-topped every 7s) — never
+ * seeded at random positions — and is faint enough to sit behind the copy without
+ * hurting readability.
  *
  * Cheap by construction: a coarse 96×96 grid blitted (bilinear-upscaled) onto the
  * hero canvas, paused whenever the hero scrolls out of view or the tab is hidden,
- * and asleep between gestures once the surface clears. Honors prefers-reduced-motion
+ * and asleep between top-ups once the surface clears. Honors prefers-reduced-motion
  * (renders one static marble) and is purely decorative (aria-hidden).
  */
 (() => {
@@ -235,17 +237,23 @@
     }
   }
 
+  // Anchor the marble behind the hero headline (matches the CSS mask centre at 22%/42%),
+  // so the ink consistently sits behind the copy instead of seeding random points across
+  // the whole hero — which surfaced as a stray smudge in empty space. No Math.random: the
+  // position is deterministic and never wanders.
+  const HX = N * 0.22;
+  const HY = N * 0.42;
   function seed(strength) {
-    for (let i = 0; i < 5; i++) {
-      inject(
-        8 + Math.random() * (N - 16),
-        8 + Math.random() * (N - 16),
-        (Math.random() - 0.5) * 1.6,
-        (Math.random() - 0.5) * 1.6,
-        strength,
-        5,
-      );
-    }
+    // Symmetric, low-velocity injections (net drift ≈ 0) so the marble swirls in place
+    // around the anchor instead of advecting out of the headline mask window.
+    const pts = [
+      [HX - 6, HY - 4, 0.35, 0.25],
+      [HX + 6, HY - 4, -0.35, 0.25],
+      [HX - 6, HY + 4, 0.35, -0.25],
+      [HX + 6, HY + 4, -0.35, -0.25],
+      [HX, HY, 0, 0],
+    ];
+    for (const [x, y, dx, dy] of pts) inject(x, y, dx, dy, strength, 6);
   }
 
   resize();
@@ -274,44 +282,10 @@
 
   setInterval(() => {
     if (document.visibilityState !== "visible" || !visible) return;
-    inject(
-      8 + Math.random() * (N - 16),
-      8 + Math.random() * (N - 16),
-      (Math.random() - 0.5) * 1.2,
-      (Math.random() - 0.5) * 1.2,
-      1.5,
-      4,
-    );
+    seed(1.1); // deterministic top-up at the same headline anchor (no random position)
     wake();
   }, 7000);
 
-  let lx = null;
-  let ly = null;
-  window.addEventListener(
-    "pointermove",
-    (e) => {
-      const rect = canvas.getBoundingClientRect();
-      if (!rect.width || !rect.height) return;
-      const gx = ((e.clientX - rect.left) / rect.width) * N;
-      const gy = ((e.clientY - rect.top) / rect.height) * N;
-      if (gx < 0 || gx > N || gy < 0 || gy > N) {
-        lx = null;
-        return;
-      }
-      let dgx = 0;
-      let dgy = 0;
-      if (lx !== null) {
-        dgx = ((e.clientX - lx) / rect.width) * N;
-        dgy = ((e.clientY - ly) / rect.height) * N;
-        if (dgx * dgx + dgy * dgy < 0.04) return;
-      }
-      lx = e.clientX;
-      ly = e.clientY;
-      inject(gx, gy, dgx, dgy, 0.9, 3);
-      wake();
-    },
-    { passive: true },
-  );
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible" && mass >= 12) wake();
   });

--- a/landing/styles/main.css
+++ b/landing/styles/main.css
@@ -96,9 +96,10 @@ p { margin: 0; }
 
 /* ============== HERO ============== */
 .hero { padding: 72px 0 26px; position: relative; overflow: hidden; }
-/* 墨流し (suminagashi) interactive canvas — sits behind the hero copy, faint, and
-   feathered at the edges so it blends into the page. Pointer-driven (see ink-bg.js);
-   purely decorative. */
+/* 墨流し (suminagashi) canvas — anchored behind the hero headline (left column),
+   faint and feathered so it blends into the page. The mask centre (22% 44%) matches
+   the deterministic ink seed in ink-bg.js and fades out before the right column so the
+   ink never bleeds into the empty gap. Purely decorative. */
 .hero .ink-bg {
   position: absolute;
   inset: 0;
@@ -107,8 +108,8 @@ p { margin: 0; }
   z-index: 0;
   pointer-events: none;
   opacity: 0.85;
-  -webkit-mask-image: radial-gradient(125% 120% at 50% 38%, #000 55%, transparent 100%);
-  mask-image: radial-gradient(125% 120% at 50% 38%, #000 55%, transparent 100%);
+  -webkit-mask-image: radial-gradient(30% 44% at 22% 44%, #000 28%, transparent 100%);
+  mask-image: radial-gradient(30% 44% at 22% 44%, #000 28%, transparent 100%);
 }
 .hero-grid {
   position: relative;


### PR DESCRIPTION
fix(landing): anchor suminagashi ink behind the hero headline

The hero ink-marbling seeded at random positions across the whole hero and the
CSS mask was centred at 50% (the empty gap between the headline column and the
product mock), so the ink surfaced as a stray smudge in random spots that read
like a rendering glitch.

Anchor it deterministically behind the headline instead:
- ink-bg.js: replace the Math.random seed (and the random 7s top-up) with a fixed,
  symmetric, low-velocity cluster at the headline's grid position (22%/42%) so the
  marble swirls in place; remove the pointer-follow injection so it never wanders.
- main.css: move the mask centre to 22%/44% with a tighter ellipse that fades out
  before the right column, so the ink stays behind the copy.

Verified with agent-browser at 1440x900: the ink centroid is now identical across
reloads (no randomness) and lands within the headline column; text stays readable.

## Regression analysis
- Pure presentational change to the static landing page; no app/infra/test code.
- Mobile is unaffected (`.hero .ink-bg { display:none }` at <=narrow breakpoints).
- prefers-reduced-motion path now seeds the same fixed anchor (static single marble).

## Physical impact
- No CloudFormation / CDK changes. `landing/` static assets only. NO-OP for all
  infrastructure resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the decorative ink background effect on the landing page with improved visual masking and fading to prevent unwanted bleeding.
  * Updated the ink animation to operate on a fixed schedule with consistent, predictable behavior rather than gesture-based interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->